### PR TITLE
Docs: clarifying SHELL variable setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ pdd setup
 The command installs tab completion, walks you through API key entry, and seeds local configuration files.
 If you postpone this step, the CLI detects the missing setup artifacts the first time you run another command and shows a reminder banner so you can complete it later (the banner is suppressed once `~/.pdd/api-env` exists or when your project already provides credentials via `.env` or `.pdd/`).
 
+If you see the error message `Unsupported shell: ` after running the setup command, it most likely means your `SHELL` environment variable is not set. Configure the `SHELL` variable with the path of your desired shell (e.g., $env:SHELL = “~\bash”).
+
 ### Alternative: pip Installation
 
 If you prefer using pip, you can install PDD with:


### PR DESCRIPTION
Updating the README to account for error during "pdd setup" command not recognizing the user's shell.