### PR TITLE
Fixes #84 Docs: clarify fix for 'Unsupported shell: ' error during 'pdd setup'

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,19 @@ pdd setup
 The command installs tab completion, walks you through API key entry, and seeds local configuration files.
 If you postpone this step, the CLI detects the missing setup artifacts the first time you run another command and shows a reminder banner so you can complete it later (the banner is suppressed once `~/.pdd/api-env` exists or when your project already provides credentials via `.env` or `.pdd/`).
 
-If you see the error message `Unsupported shell: ` after running the setup command, it most likely means your `SHELL` environment variable is not set. Configure the `SHELL` variable with the path of your desired shell (e.g., `$env:SHELL = “~\bash”`).
+If you see the error message `Unsupported shell: ` after running the setup command, it most likely means your `SHELL` environment variable is not set. Configure `SHELL` to the full path of a valid shell executable, e.g.:
+```bash
+# Powershell:
+$env:SHELL="~\bash"
+
+# CMD:
+set SHELL=~\bash
+
+# Git Bash
+export SHELL="~\bash"
+```
+Note: The above commands set the `SHELL` variable only for the current session. Upon closing your terminal, the setting will be lost. To make the change permanent, add the variable to your shell's startup file or to your user/system environment variables. 
+
 
 ### Alternative: pip Installation
 


### PR DESCRIPTION
Update README to account for 'pdd setup' not recognizing the user shell. 