### PR TITLE
Fixes #84: Add setup instructions for Windows users

### DIFF
--- a/SETUP_WITH_WINDOWS.md
+++ b/SETUP_WITH_WINDOWS.md
@@ -106,7 +106,7 @@ To make them permanent, add the variable to your system environment variables:
 git clone https://github.com/promptdriven/pdd.git  
 cd pdd/examples/hello  
 ```  
-Set environment key PDD_PATH to the location of the cloned repo.
+Set environment variable PDD_PATH to the location of the cloned repo.
 
 If you are having trouble with API keys, check out README.md or SETUP_WITH_GEMINI.md for more setup information.
 


### PR DESCRIPTION
Fixes #84.

Created SETUP_WITH_WINDOWS.md to help guide Windows users through setup/update. Steps 2 and 6 cover the "Unsupported shell:" error and step 3 gives additional information regarding PDD_PATH variable. 

---

In pdd\setup_tool.py, the following code (line 286) gives the “Unsupported shell:” error if variable “SHELL” is not set and “/bin/bash” is not recognized:

```bash
def detect_shell() -> str:
    """Detect user's default shell"""
    try:
        shell_path = os.getenv('SHELL', '/bin/bash')
        shell_name = os.path.basename(shell_path)
        return shell_name
    except:
        return 'bash'
```

Solution: set PATH variable properly.

---

In pdd\auto_update.py, the following code (line 11) gives the same shell error:

```bash
def detect_installation_method(sys_executable):
    if any(marker in sys_executable for marker in ["/uv/tools/", ".local/share/uv/"]):
        return "uv"
    return "pip"  # Default to pip for all other cases
```

This if statement will never pass if `uv` is installed somewhere else and will then try to run `pip` through `uv`. Use `uv` to update manually instead.