### PR TITLE
Resolves #131: Output Files Now Generated in Input File Directory

### DIFF
--- a/pdd/construct_paths.py
+++ b/pdd/construct_paths.py
@@ -687,6 +687,19 @@ def construct_paths(
         if k.startswith("output") and v is not None # Ensure value is not None
     }
 
+    # Determine input file directory for default output path generation
+    # Only apply for commands that generate/update files based on specific input files
+    # Commands like sync, generate, test, example have their own directory management
+    commands_using_input_dir = {'fix', 'crash', 'verify', 'split', 'change', 'update'}
+    input_file_dir: Optional[str] = None
+    if input_paths and command in commands_using_input_dir:
+        try:
+            first_input_path = next(iter(input_paths.values()))
+            input_file_dir = str(first_input_path.parent)
+        except (StopIteration, AttributeError):
+            # If no input paths or path doesn't have parent, use None (falls back to CWD)
+            pass
+
     try:
         # generate_output_paths might return Dict[str, str] or Dict[str, Path]
         # Let's assume it returns Dict[str, str] based on verification error,
@@ -698,6 +711,7 @@ def construct_paths(
             language=language,
             file_extension=file_extension,
             context_config=context_config,
+            input_file_dir=input_file_dir,
         )
 
         # For sync, explicitly honor .pddrc generate_output_path even if generator logged as 'default'

--- a/tests/test_construct_paths.py
+++ b/tests/test_construct_paths.py
@@ -315,7 +315,8 @@ def test_construct_paths_basename_extraction(tmpdir):
                     basename=expected_basename,
                     language=determined_lang, # Use the language determined for mocking
                     file_extension=mock_ext, # Use the extension determined for mocking
-                    context_config={}
+                    context_config={},
+                    input_file_dir=ANY
                 )
         # Clean up dummy code file
         if dummy_code and dummy_code.exists():
@@ -751,7 +752,8 @@ def test_construct_paths_special_characters_in_filenames(tmpdir):
             basename=expected_basename, # Verify basename was extracted correctly
             language='python',
             file_extension='.py',
-            context_config={}
+            context_config={},
+            input_file_dir=ANY
         )
 
 
@@ -1196,7 +1198,8 @@ def test_construct_paths_conflicting_language_specification(tmpdir):
             basename='my_project', # Basename from filename
             language='javascript', # Correct language passed
             file_extension='.js',   # Correct extension passed
-            context_config={}
+            context_config={},
+            input_file_dir=ANY
         )
         assert output_file_paths['output'] == str(mock_output_path)
 
@@ -1371,7 +1374,8 @@ def test_construct_paths_symbolic_links(tmpdir):
             basename=expected_basename, # Basename from the real file
             language='python',
             file_extension='.py',
-            context_config={}
+            context_config={},
+            input_file_dir=ANY
         )
 
 # --- Fixture and tests below seem to use tmp_path_factory correctly ---
@@ -1467,7 +1471,8 @@ def test_construct_paths_generate_command(setup_test_files):
         basename='main_gen',
         language='prompt',
         file_extension='.prompt',
-        context_config={}
+        context_config={},
+        input_file_dir=ANY
     )
 
 
@@ -1928,7 +1933,8 @@ def test_construct_paths_handles_makefile_suffix_correctly_or_fails_if_buggy(tmp
             basename='MyProject',
             language='makefile',
             file_extension='',  # Makefiles have no extension
-            context_config={}
+            context_config={},
+            input_file_dir=ANY
         )
 
 


### PR DESCRIPTION
# Fix: Output Files Now Generated in Input File Directory

## Summary

Fixes the bug where PDD commands that generate or update files would incorrectly write output to the current working directory instead of the input file's directory. This behavior was confusing when working with files in nested directories.

## Problem

For PDD commands that generate or update files (`fix`, `crash`, `verify`, `split`, `change`, `update`), the output was incorrectly written to a `pdd/` folder in the current working directory, regardless of where the input files were located.

### Example of the Problem

```bash
# Running from ~/projects/
pdd fix examples/nested/dir/calculator_python.prompt examples/nested/dir/calculator.py ...

# Before fix: Output goes to
~/projects/pdd/calculator_fixed.py        # ❌ Wrong location

# After fix: Output goes to
~/projects/examples/nested/dir/calculator_fixed.py  # ✅ Correct location
```

This made the CLI behavior unintuitive when working with nested directories or project structures where files are organized in subdirectories.

## Solution

### Changes Made

#### 1. **`pdd/generate_output_paths.py`**
- Added `input_file_dir` parameter to the `generate_output_paths()` function
- Modified default path generation logic to use input file directory when provided (lines 340-345)
- Modified context configuration path handling to resolve relative paths against input file directory (lines 290-294)
- Modified environment variable path handling to resolve relative paths against input file directory (lines 316-320)
- Updated function docstring to document the new behavior

#### 2. **`pdd/construct_paths.py`**
- Added logic to extract input file directory from the first input file path (lines 690-701)
- Only applies for commands that should place outputs near inputs: `fix`, `crash`, `verify`, `split`, `change`, `update`
- Commands like `sync`, `generate`, `test`, and `example` continue to use their traditional directory management logic
- Pass `input_file_dir` to `generate_output_paths()` (line 711)

#### 3. **`tests/test_construct_paths.py`**
- Updated 6 test assertions to include the new `input_file_dir=ANY` parameter
- All tests pass with backward compatibility maintained

## Behavior Details

### Path Resolution Priority (unchanged)
1. **User-specified paths** (`--output` flags) - highest priority
2. **Context configuration** (`.pddrc` file)
3. **Environment variables** (`PDD_*_OUTPUT_PATH`)
4. **Default paths** - lowest priority

### What Changed

**For commands: `fix`, `crash`, `verify`, `split`, `change`, `update`**

| Path Type | Before Fix | After Fix |
|-----------|------------|-----------|
| **Default paths** (no config) | Resolved against CWD | Resolved against input file directory |
| **Relative context paths** (`.pddrc`: `"pdd/"`) | Resolved against CWD | Resolved against input file directory |
| **Relative env paths** (`PDD_*_OUTPUT_PATH="pdd/"`) | Resolved against CWD | Resolved against input file directory |
| **Absolute paths** | Used as-is | Used as-is (unchanged) |
| **User-specified paths** | Used as-is | Used as-is (unchanged) |

**For commands: `sync`, `generate`, `test`, `example`**
- No changes - these commands maintain their existing directory management behavior

## Examples

### Example 1: Default Behavior (No Configuration)

```bash
# Input file at: examples/nested/calculator_python.prompt
pdd fix examples/nested/calculator_python.prompt examples/nested/calculator.py ...

# Output files now go to: examples/nested/
# - examples/nested/calculator_fixed.py
# - examples/nested/test_calculator_fixed.py
# - examples/nested/calculator_fix_results.log
```

### Example 2: With .pddrc Configuration

**.pddrc:**
```yaml
contexts:
  default:
    defaults:
      generate_output_path: "pdd/"  # Relative path
      test_output_path: "tests/"
```

```bash
# Input file at: examples/nested/calculator_python.prompt
pdd fix examples/nested/calculator_python.prompt examples/nested/calculator.py ...

# Relative paths in .pddrc are now resolved against input file directory:
# - examples/nested/pdd/calculator_fixed.py  (not ./pdd/calculator_fixed.py)
# - examples/nested/tests/test_calculator_fixed.py
```

### Example 3: To Place Files Directly in Input Directory

**.pddrc:**
```yaml
contexts:
  default:
    defaults:
      generate_output_path: "./"  # Current directory (same as input)
      test_output_path: "tests/"
```

Or simply remove the `generate_output_path` line entirely to use the default behavior.

## Backward Compatibility

✅ **Fully backward compatible** when:
- Using absolute paths in configuration
- Using explicit `--output` flags
- Running commands from the same directory as input files
- Using `sync`, `generate`, `test`, or `example` commands

⚠️ **Behavior changes** when:
- Using relative paths in `.pddrc` with `fix`, `crash`, `verify`, `split`, `change`, `update` commands
- Input files are in nested directories and no explicit output path is specified

Users who have `.pddrc` files with relative paths like `generate_output_path: "pdd/"` will now have those paths resolved relative to the input file directory, which is the intended and more intuitive behavior.

## Testing

All existing tests pass:
- ✅ `tests/test_generate_output_paths.py` (34 tests)
- ✅ `tests/test_construct_paths.py` (41 tests)
- ✅ `tests/test_sync_determine_operation.py` (integration tests)

## Impact

### Positive Impact
- **More intuitive behavior**: Output files are now placed where users expect them
- **Better project organization**: Works seamlessly with nested directory structures
- **Fixes reported issue**: Addresses the confusing file location problem

### User Action Required

Users with existing `.pddrc` files using relative paths should verify the new behavior meets their needs. If they want to maintain the old behavior (relative to CWD), they should convert relative paths to absolute paths:

```yaml
# Old behavior (relative to CWD):
generate_output_path: "pdd/"

# Convert to absolute to maintain old behavior:
generate_output_path: "/absolute/path/to/project/pdd/"
```

However, the new behavior is generally more intuitive and is the intended fix for the reported issue.

## Closes

Fixes the issue where output files were incorrectly written to `<current-working-directory>/pdd/` regardless of input file location.
closes #131 