### PR TITLE
Resolves #136: Improve agentic fix output logging; Improve output path construction

### DIFF
--- a/pdd/construct_paths.py
+++ b/pdd/construct_paths.py
@@ -692,10 +692,32 @@ def construct_paths(
     # Commands like sync, generate, test, example have their own directory management
     commands_using_input_dir = {'fix', 'crash', 'verify', 'split', 'change', 'update'}
     input_file_dir: Optional[str] = None
+    input_file_dirs: Dict[str, Optional[str]] = {}
     if input_paths and command in commands_using_input_dir:
         try:
-            first_input_path = next(iter(input_paths.values()))
-            input_file_dir = str(first_input_path.parent)
+            # For fix/crash/verify commands, use specific file directories for each output
+            if command in {'fix', 'crash', 'verify'}:
+                # Map output keys to their corresponding input file keys
+                input_key_map = {
+                    'fix': {'output_code': 'code_file', 'output_test': 'unit_test_file', 'output_results': 'code_file'},
+                    'crash': {'output': 'code_file', 'output_program': 'program_file'},
+                    'verify': {'output_code': 'code_file', 'output_program': 'verification_program', 'output_results': 'code_file'},
+                }
+
+                for output_key, input_key in input_key_map.get(command, {}).items():
+                    if input_key in input_paths:
+                        input_file_dirs[output_key] = str(input_paths[input_key].parent)
+
+                # Set default input_file_dir to code_file directory as fallback
+                if 'code_file' in input_paths:
+                    input_file_dir = str(input_paths['code_file'].parent)
+                else:
+                    first_input_path = next(iter(input_paths.values()))
+                    input_file_dir = str(first_input_path.parent)
+            else:
+                # For other commands, use first input path
+                first_input_path = next(iter(input_paths.values()))
+                input_file_dir = str(first_input_path.parent)
         except (StopIteration, AttributeError):
             # If no input paths or path doesn't have parent, use None (falls back to CWD)
             pass
@@ -712,6 +734,7 @@ def construct_paths(
             file_extension=file_extension,
             context_config=context_config,
             input_file_dir=input_file_dir,
+            input_file_dirs=input_file_dirs,
         )
 
         # For sync, explicitly honor .pddrc generate_output_path even if generator logged as 'default'

--- a/pdd/fix_main.py
+++ b/pdd/fix_main.py
@@ -143,11 +143,15 @@ def fix_main(
 
         # Save fixed files
         if fixed_unit_test:
-            with open(output_file_paths["output_test"], 'w') as f:
+            output_test_path = Path(output_file_paths["output_test"])
+            output_test_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(output_test_path, 'w') as f:
                 f.write(fixed_unit_test)
 
         if fixed_code:
-            with open(output_file_paths["output_code"], 'w') as f:
+            output_code_path = Path(output_file_paths["output_code"])
+            output_code_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(output_code_path, 'w') as f:
                 f.write(fixed_code)
 
         # Provide user feedback

--- a/pdd/fix_verification_main.py
+++ b/pdd/fix_verification_main.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import click
 import logging
+from pathlib import Path
 from typing import Optional, Tuple, List, Dict, Any
 
 # Use Rich for pretty printing to the console
@@ -411,7 +412,9 @@ def fix_verification_main(
         try:
             if verbose:
                 rich_print(f"[cyan bold DEBUG] In fix_verification_main, ATTEMPTING to write code to: {output_code_path!r}")
-            with open(output_code_path, "w") as f:
+            output_code_path_obj = Path(output_code_path)
+            output_code_path_obj.parent.mkdir(parents=True, exist_ok=True)
+            with open(output_code_path_obj, "w") as f:
                 f.write(final_code)
             saved_code_path = output_code_path
             if not quiet:
@@ -431,7 +434,9 @@ def fix_verification_main(
         try:
             if verbose:
                 rich_print(f"[cyan bold DEBUG] In fix_verification_main, ATTEMPTING to write program to: {output_program_path!r}")
-            with open(output_program_path, "w") as f:
+            output_program_path_obj = Path(output_program_path)
+            output_program_path_obj.parent.mkdir(parents=True, exist_ok=True)
+            with open(output_program_path_obj, "w") as f:
                 f.write(final_program)
             saved_program_path = output_program_path
             if not quiet:
@@ -441,7 +446,9 @@ def fix_verification_main(
 
     if not loop and output_results_path:
         try:
-            with open(output_results_path, "w") as f:
+            output_results_path_obj = Path(output_results_path)
+            output_results_path_obj.parent.mkdir(parents=True, exist_ok=True)
+            with open(output_results_path_obj, "w") as f:
                 f.write(results_log_content)
             saved_results_path = output_results_path
             if not quiet:

--- a/pdd/generate_output_paths.py
+++ b/pdd/generate_output_paths.py
@@ -182,7 +182,8 @@ def generate_output_paths(
     language: str,
     file_extension: str,
     context_config: Optional[Dict[str, str]] = None,
-    input_file_dir: Optional[str] = None
+    input_file_dir: Optional[str] = None,
+    input_file_dirs: Optional[Dict[str, str]] = None
 ) -> Dict[str, str]:
     """
     Generates the full, absolute output paths for a given PDD command.
@@ -207,6 +208,9 @@ def generate_output_paths(
         input_file_dir: Optional path to the input file's directory. When provided,
                        default output files will be placed in this directory instead
                        of the current working directory.
+        input_file_dirs: Optional dictionary mapping output keys to specific input
+                        file directories. When provided, each output will use its
+                        corresponding input file directory (e.g., {'output_code': 'src/main/java'}).
 
     Returns:
         A dictionary where keys are the standardized output identifiers
@@ -217,9 +221,11 @@ def generate_output_paths(
     logger.debug(f"Generating output paths for command: {command}")
     logger.debug(f"User output locations: {output_locations}")
     logger.debug(f"Context config: {context_config}")
+    logger.debug(f"Input file dirs: {input_file_dirs}")
     logger.debug(f"Basename: {basename}, Language: {language}, Extension: {file_extension}")
 
     context_config = context_config or {}
+    input_file_dirs = input_file_dirs or {}
     result_paths: Dict[str, str] = {}
 
     if not basename:
@@ -350,8 +356,13 @@ def generate_output_paths(
                 final_path = os.path.join(examples_dir, default_filename)
                 logger.debug(f"Using default filename '{default_filename}' in examples directory.")
             else:
-                # Use input file directory if provided, otherwise use CWD
-                if input_file_dir:
+                # First check if there's a specific directory for this output key
+                specific_dir = input_file_dirs.get(output_key)
+                if specific_dir:
+                    final_path = os.path.join(specific_dir, default_filename)
+                    logger.debug(f"Using default filename '{default_filename}' in specific input file directory: {specific_dir}")
+                # Otherwise use the general input file directory if provided
+                elif input_file_dir:
                     final_path = os.path.join(input_file_dir, default_filename)
                     logger.debug(f"Using default filename '{default_filename}' in input file directory: {input_file_dir}")
                 else:

--- a/tests/test_agentic_fix.py
+++ b/tests/test_agentic_fix.py
@@ -57,8 +57,9 @@ def test_run_agentic_fix_success_via_harvest(monkeypatch, tmp_path, patch_env):
     # Short-circuit harvest path to succeed — NOTE: correct symbol (no leading underscore)
     monkeypatch.setattr("pdd.agentic_fix.try_harvest_then_verify", lambda *a, **k: True)
 
-    ok, msg, cost, model = run_agentic_fix(p_prompt, p_code, p_test, p_err)
+    ok, msg, cost, model, changed_files = run_agentic_fix(p_prompt, p_code, p_test, p_err)
     assert ok is True
+    assert isinstance(changed_files, list)
     assert "successful" in msg.lower()
     assert cost > 0.0
     assert model.startswith("agentic-")
@@ -75,12 +76,13 @@ def test_run_agentic_fix_handles_no_keys(monkeypatch, tmp_path):
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
-    ok, msg, cost, model = run_agentic_fix(
+    ok, msg, cost, model, changed_files = run_agentic_fix(
         prompt_file=str(p_prompt),
         code_file=str(p_code),
         unit_test_file=str(p_test),
         error_log_file=str(p_err),
     )
+    assert isinstance(changed_files, list)
     assert ok is False
     assert "No configured agent API keys" in msg
 
@@ -141,12 +143,13 @@ def test_run_agentic_fix_real_call_when_available(provider, env_key, cli, tmp_pa
 
     p_prompt, p_code, p_test, p_err = _mk_files(tmp_path)
 
-    ok, msg, cost, model = run_agentic_fix(
+    ok, msg, cost, model, changed_files = run_agentic_fix(
         prompt_file=str(p_prompt),
         code_file=str(p_code),
         unit_test_file=str(p_test),
         error_log_file=str(p_err),
     )
+    assert isinstance(changed_files, list)
 
     # Don’t require success; just verify the chosen agent tag
     assert model.startswith(f"agentic-{provider}")

--- a/tests/test_construct_paths.py
+++ b/tests/test_construct_paths.py
@@ -316,7 +316,8 @@ def test_construct_paths_basename_extraction(tmpdir):
                     language=determined_lang, # Use the language determined for mocking
                     file_extension=mock_ext, # Use the extension determined for mocking
                     context_config={},
-                    input_file_dir=ANY
+                    input_file_dir=ANY,
+                    input_file_dirs={}
                 )
         # Clean up dummy code file
         if dummy_code and dummy_code.exists():
@@ -753,7 +754,8 @@ def test_construct_paths_special_characters_in_filenames(tmpdir):
             language='python',
             file_extension='.py',
             context_config={},
-            input_file_dir=ANY
+            input_file_dir=ANY,
+            input_file_dirs={}
         )
 
 
@@ -1199,7 +1201,8 @@ def test_construct_paths_conflicting_language_specification(tmpdir):
             language='javascript', # Correct language passed
             file_extension='.js',   # Correct extension passed
             context_config={},
-            input_file_dir=ANY
+            input_file_dir=ANY,
+            input_file_dirs={}
         )
         assert output_file_paths['output'] == str(mock_output_path)
 
@@ -1375,7 +1378,8 @@ def test_construct_paths_symbolic_links(tmpdir):
             language='python',
             file_extension='.py',
             context_config={},
-            input_file_dir=ANY
+            input_file_dir=ANY,
+            input_file_dirs={}
         )
 
 # --- Fixture and tests below seem to use tmp_path_factory correctly ---
@@ -1472,7 +1476,8 @@ def test_construct_paths_generate_command(setup_test_files):
         language='prompt',
         file_extension='.prompt',
         context_config={},
-        input_file_dir=ANY
+        input_file_dir=ANY,
+        input_file_dirs={}
     )
 
 
@@ -1934,7 +1939,8 @@ def test_construct_paths_handles_makefile_suffix_correctly_or_fails_if_buggy(tmp
             language='makefile',
             file_extension='',  # Makefiles have no extension
             context_config={},
-            input_file_dir=ANY
+            input_file_dir=ANY,
+                        input_file_dirs=ANY
         )
 
 

--- a/tests/test_fix_main.py
+++ b/tests/test_fix_main.py
@@ -54,10 +54,21 @@ def test_fix_main_without_loop(
     and saves the outputs correctly.
     """
     # Arrange
-    # Configure the mock Path object's exists method
-    # Ensure Path('errors.log').exists() returns True
-    mock_path_instance = mock_path.return_value
-    mock_path_instance.exists.return_value = True
+    # Configure the mock Path to return real Path objects for output paths,
+    # but allow controlling exists() for error.log
+    from pathlib import Path as RealPath
+
+    def path_side_effect(path_str):
+        real_path = RealPath(path_str)
+        # For error.log, return a mock with controlled exists()
+        if 'errors.log' in str(path_str):
+            mock_error_path = MagicMock(spec=RealPath)
+            mock_error_path.exists.return_value = True
+            return mock_error_path
+        # For other paths, return real Path objects
+        return real_path
+
+    mock_path.side_effect = path_side_effect
 
     mock_construct_paths.return_value = (
         {},  # resolved_config
@@ -135,8 +146,9 @@ def test_fix_main_without_loop(
     assert total_cost == 0.75
     assert model_name == "gpt-4"
 
-    # Assert file writing
-    m_open.assert_called_once_with('output/test_code_fixed.py', 'w')
+    # Assert file writing - fix_main now uses Path objects
+    from pathlib import Path as PathLib
+    m_open.assert_called_once_with(PathLib('output/test_code_fixed.py'), 'w')
     handle = m_open()
     handle.write.assert_called_once_with("Fixed unit test content")
 
@@ -232,17 +244,17 @@ def test_fix_main_with_loop(
     assert total_cost == 1.25
     assert model_name == "gpt-4-loop"
 
-    # Assert file writing calls
+    # Assert file writing calls - fix_main now uses Path objects
+    from pathlib import Path as PathLib
     expected_calls = [
-        call('output/test_code_fixed.py', 'w'),
-        call('output/code_fixed.py', 'w')
+        call(PathLib('output/test_code_fixed.py'), 'w'),
+        call(PathLib('output/code_fixed.py'), 'w')
     ]
     m_open.assert_has_calls(expected_calls, any_order=True)
-    handle_test = m_open()
-    handle_code = m_open()
+    handle = m_open()
     # Check write calls - order might vary depending on dict iteration
     write_calls = [call("Iteratively fixed test"), call("Iteratively fixed code")]
-    handle_test.write.assert_has_calls(write_calls, any_order=True)
+    handle.write.assert_has_calls(write_calls, any_order=True)
 
 
 def test_fix_main_loop_requires_verification_program(mock_ctx):

--- a/tests/test_fix_verification_main.py
+++ b/tests/test_fix_verification_main.py
@@ -558,11 +558,13 @@ def test_output_code_write_error(
     # Define a simpler side_effect for mock_open_func
     def open_side_effect(filename_arg, mode_arg="r", *args, **kwargs):
         # nonlocal output_code_path # Not strictly needed due to closure
-        if filename_arg == output_code_path and "w" in mode_arg:
+        # Convert Path objects to strings for comparison
+        filename_str = str(filename_arg)
+        if filename_str == output_code_path and "w" in mode_arg:
             raise IOError("Disk full simulation")
-        
+
         # For other files, return a functional mock file handle
-        mock_file_handle = MagicMock() 
+        mock_file_handle = MagicMock()
         mock_file_handle.write = MagicMock()
         # mock_file_handle.read = MagicMock(return_value="Simulated read content") # Only if reads are expected
         mock_file_handle.__enter__.return_value = mock_file_handle
@@ -589,8 +591,10 @@ def test_output_code_write_error(
     expected_error_msg = f"[bold red]Error:[/bold red] Failed to write code file '{output_code_path}': OSError - Disk full simulation"
     mock_rich_print.assert_any_call(expected_error_msg)
 
-    mock_open_func.assert_any_call(output_results_path, "w")
-    mock_open_func.assert_any_call(output_program_path, "w")
+    # fix_verification_main now uses Path objects for file operations
+    from pathlib import Path
+    mock_open_func.assert_any_call(Path(output_results_path), "w")
+    mock_open_func.assert_any_call(Path(output_program_path), "w")
 
 
 @patch('pdd.fix_verification_main.fix_verification_errors_loop')


### PR DESCRIPTION
This PR fixes incorrect output path construction and improves agentic-fix logging.

Closes #136.

1. Output Path Construction Fix (Multi-Directory Support)
Problem

Previously, construct_output_path.py only supported writing outputs to directories relative to **one** input parameter. 
 When the source file lived in nested subdirectories, the fixed file was incorrectly written to a flattened path.

Example

Given file structure:

```example/src/tests/test1.py```


Old (incorrect) output:

```example/tests/test1_fixed.py```


New (correct) behavior (this PR):

```example/src/tests/test1_fixed.py```


This PR adds full multi-directory awareness, ensuring fixed files are saved in the correct mirrored structure relative to the input path.

2. Improved Agentic-Fix Logging

This PR also enhances logging for agentic fix mode.
The CLI will now clearly list all files modified by agents, even if they fall outside the dev-unit path provided to the pdd command.

Example Log Output
```
Agent modified 2 file(s):
  • /pdd/examples/agentic_fallback_example_java_gradle/src/main/java/Util.java
  • /pdd/examples/agentic_fallback_example_java_gradle/src/main/java/Main.java


Success to fix errors
Total attempts: 1
Total cost: $0.020000
Model used: agentic-anthropic

Fixed files saved:
  Test file:
    /pdd/examples/agentic_fallback_example_java_gradle/src/test/java/test_main_fixed.java

  Code file:
    /pdd/examples/agentic_fallback_example_java_gradle/src/main/java/main_fixed.java

  Results file:
    /pdd/examples/agentic_fallback_example_java_gradle/src/main/java/main_fix_results.log

```