### PR TITLE
Resolves #210: False positive success in pdd sync with --skip-verify 

### DIFF
--- a/pdd/sync_determine_operation.py
+++ b/pdd/sync_determine_operation.py
@@ -733,6 +733,14 @@ def _is_workflow_complete(paths: Dict[str, Path], skip_tests: bool = False, skip
             if fingerprint and fingerprint.command not in ['verify', 'test', 'fix', 'update']:
                 return False
 
+        # CRITICAL FIX: Check tests have been run (unless skip_tests)
+        # Without this, workflow would be "complete" after verify even though tests haven't run
+        # This prevents false positive success when skip_verify=True but tests are still required
+        if not skip_tests:
+            fp = read_fingerprint(basename, language)
+            if fp and fp.command not in ['test', 'fix', 'update']:
+                return False
+
     return True
 
 

--- a/pdd/sync_orchestration.py
+++ b/pdd/sync_orchestration.py
@@ -969,12 +969,15 @@ def sync_orchestration(
                                 else:
                                     # No crash - save run report with exit_code=0 so sync_determine_operation
                                     # knows the example was tested and passed (prevents infinite loop)
+                                    # Include test_hash for staleness detection
+                                    test_hash = calculate_sha256(pdd_files['test']) if pdd_files['test'].exists() else None
                                     report = RunReport(
                                         datetime.datetime.now(datetime.timezone.utc).isoformat(),
                                         exit_code=0,
                                         tests_passed=1,
                                         tests_failed=0,
-                                        coverage=0.0
+                                        coverage=0.0,
+                                        test_hash=test_hash
                                     )
                                     save_run_report(asdict(report), basename, language)
                                     skipped_operations.append('crash')
@@ -1107,7 +1110,9 @@ def sync_orchestration(
                                  cwd=str(pdd_files['example'].parent),
                                  timeout=60
                              )
-                             report = RunReport(datetime.datetime.now(datetime.timezone.utc).isoformat(), returncode, 1 if returncode==0 else 0, 0 if returncode==0 else 1, 100.0 if returncode==0 else 0.0)
+                             # Include test_hash for staleness detection
+                             test_hash = calculate_sha256(pdd_files['test']) if pdd_files['test'].exists() else None
+                             report = RunReport(datetime.datetime.now(datetime.timezone.utc).isoformat(), returncode, 1 if returncode==0 else 0, 0 if returncode==0 else 1, 100.0 if returncode==0 else 0.0, test_hash=test_hash)
                              save_run_report(asdict(report), basename, language)
                         except:
                              pass


### PR DESCRIPTION
closes #210 
  ### Problem                                                                                                        
                                                                                                                     
  When running `pdd sync <basename> --skip-verify`, the command incorrectly reported success without running tests or applying fixes, even when unit tests would fail.
                                                                                                                     
  **Reproduction scenario:**                                                                                         
  1. User runs sync → 'example' operation completes, fingerprint saved with `command='example'`                      
  2. Crash check runs example → creates run_report with `exit_code=0, tests_failed=0`                                
  3. User modifies test file (adds failing tests)                                                                    
  4. User runs `pdd sync --skip-verify`                                                                              
  5. **Bug:** Sync reports "Success" with $0.00 cost, no operations run                                              
                                                                                                                     
  ### Root Causes                                                                                                    
                                                                                                                     
  1. **Missing `test_hash` in RunReport**: Run reports created after crash checks (lines 972-979, 1113 in `sync_orchestration.py`) didn't include `test_hash`, causing staleness detection to fail.
                                                                                                                     
  2. **Missing test completion check in `_is_workflow_complete()`**: The function only checked if verify was done (unless `skip_verify=True`). When `skip_verify=True` and `fingerprint.command='example'`, workflow was incorrectly marked complete even though tests never ran.
                                                                                                                     
  ### Fix                                                                                                            
                                                                                                                     
  1. **`sync_orchestration.py`**: Added `test_hash` to RunReport objects created during crash checks                 
                                                                                                                     
  2. **`sync_determine_operation.py`**: Added test completion check in `_is_workflow_complete()`:                    
     ```python                                                                                                       
     if not skip_tests:                                                                                              
         fp = read_fingerprint(basename, language)                                                                   
         if fp and fp.command not in ['test', 'fix', 'update']:                                                      
             return False                                                                                            
                                                                                                                     
  Testing                                                                                                            
                                                                                                                     
  - Added regression tests in TestFalsePositiveSuccessBugRegression                                                  
  - Verified tests fail on old code (bug reproduced)                                                                 
  - Verified tests pass with fix applied                                                                             
  - All 72 existing tests pass                                                                                       
                                                                                                                     
  Files Changed                                                                                                      
                                                                                                                     
  | File                                   | Changes                                                |                
  |----------------------------------------|--------------------------------------------------------|                
  | pdd/sync_orchestration.py              | Added test_hash to 2 RunReport creations               |                
  | pdd/sync_determine_operation.py        | Added test completion check in _is_workflow_complete() |                
  | tests/test_sync_determine_operation.py | Added 2 regression tests                               |                
                                                                                                                     
  Fixes #210                                                                                                         
  ```                                   