### PR TITLE
fix: thread-safe cost extraction from response objects (#375)

### DIFF
--- a/pdd/llm_invoke.py
+++ b/pdd/llm_invoke.py
@@ -2808,8 +2808,8 @@ def llm_invoke(
                 if verbose:
                     # Extract tokens directly from last response (thread-safe)
                     last_usage = getattr(response_list[-1], 'usage', None) if response_list else None
-                    input_tokens = getattr(last_usage, 'prompt_tokens', 0) or 0
-                    output_tokens = getattr(last_usage, 'completion_tokens', 0) or 0
+                    input_tokens = getattr(last_usage, 'prompt_tokens', None) or getattr(last_usage, 'input_tokens', 0) or 0
+                    output_tokens = getattr(last_usage, 'completion_tokens', None) or getattr(last_usage, 'output_tokens', 0) or 0
 
                     cost_input_pm = model_info.get('input', 0.0) if pd.notna(model_info.get('input')) else 0.0
                     cost_output_pm = model_info.get('output', 0.0) if pd.notna(model_info.get('output')) else 0.0

--- a/tests/test_llm_invoke.py
+++ b/tests/test_llm_invoke.py
@@ -2897,7 +2897,6 @@ def test_default_base_model_can_be_none():
 # Issue #375: Thread-safe cost extraction tests
 # ==============================================================================
 
-import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 


### PR DESCRIPTION
## Summary

- **Fixes race condition** in concurrent LLM cost tracking (issue #375) by reading cost directly from each response object instead of the shared `_LAST_CALLBACK_DATA` global dict
- **Extracts `_get_response_cost()`** — reads `response._hidden_params['response_cost']` (pre-computed by LiteLLM), falls back to `_calculate_completion_cost()` (public API)
- **Extracts `_calculate_completion_cost()`** — 3-tier fallback: `litellm.completion_cost(response)` → `litellm.completion_cost(model, tokens)` → manual CSV rates
- **Adds 7 new tests** covering thread safety (10 concurrent threads), batch mode, empty response list, exception handling, and `_hidden_params` fallback behavior

## Test plan

- [x] All 92 existing + new tests pass (`pytest tests/test_llm_invoke.py`)
- [x] Thread safety test: 10 concurrent threads each get correct per-response cost (no cross-thread contamination)
- [x] Validated with real `pdd sync` runs (5 rounds, sequential + 3 parallel syncs) — all report correct non-zero costs
- [x] Backward compatible: `_LAST_CALLBACK_DATA` callback still populated for single-threaded CLI usage