### PR TITLE
fix: address review findings from PR #474 firecrawl caching

### DIFF
--- a/pdd/firecrawl_cache.py
+++ b/pdd/firecrawl_cache.py
@@ -94,8 +94,17 @@ class FirecrawlCache:
                 logger.warning(f"Invalid FIRECRAWL_CACHE_TTL_HOURS: {ttl_env}, using default {self.default_ttl_hours}")
 
         # Size management configuration
-        self.max_cache_size_mb = int(os.getenv("FIRECRAWL_CACHE_MAX_SIZE_MB", "100"))
-        self.max_entries = int(os.getenv("FIRECRAWL_CACHE_MAX_ENTRIES", "1000"))
+        try:
+            self.max_cache_size_mb = int(os.getenv("FIRECRAWL_CACHE_MAX_SIZE_MB", "100"))
+        except ValueError:
+            self.max_cache_size_mb = 100
+            logger.warning(f"Invalid FIRECRAWL_CACHE_MAX_SIZE_MB: {os.getenv('FIRECRAWL_CACHE_MAX_SIZE_MB')}, using default 100")
+
+        try:
+            self.max_entries = int(os.getenv("FIRECRAWL_CACHE_MAX_ENTRIES", "1000"))
+        except ValueError:
+            self.max_entries = 1000
+            logger.warning(f"Invalid FIRECRAWL_CACHE_MAX_ENTRIES: {os.getenv('FIRECRAWL_CACHE_MAX_ENTRIES')}, using default 1000")
 
         logger.debug(
             f"Cache config: TTL={self.default_ttl_hours}h, MaxSize={self.max_cache_size_mb}MB, "
@@ -152,7 +161,7 @@ class FirecrawlCache:
             # Keep only essential parameters, remove tracking ones
             essential_params = []
             tracking_prefixes = {'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content',
-                               'fbclid', 'gclid', 'ref', 'source', '_ga', '_gid'}
+                               'fbclid', 'gclid', '_ga', '_gid'}
             for param in params.split('&'):
                 if param:
                     param_name = param.split('=')[0].lower()
@@ -248,28 +257,20 @@ class FirecrawlCache:
 
         try:
             with sqlite3.connect(self.cache_path) as conn:
-                # Check if entry exists
-                cursor = conn.execute('SELECT url_hash FROM cache WHERE url_hash = ?', (url_hash,))
-                exists = cursor.fetchone() is not None
-
-                if exists:
-                    # Update existing entry
-                    conn.execute(
-                        '''UPDATE cache SET content = ?, timestamp = ?, expires_at = ?,
-                           content_hash = ?, metadata = ?, last_accessed = ?
-                           WHERE url_hash = ?''',
-                        (content, current_time, expires_at, content_hash,
-                         json.dumps(metadata), current_time, url_hash)
-                    )
-                else:
-                    # Insert new entry
-                    conn.execute(
-                        '''INSERT INTO cache
-                           (url_hash, url, content, timestamp, expires_at, content_hash, metadata, last_accessed)
-                           VALUES (?, ?, ?, ?, ?, ?, ?, ?)''',
-                        (url_hash, url, content, current_time, expires_at,
-                         content_hash, json.dumps(metadata), current_time)
-                    )
+                conn.execute(
+                    '''INSERT INTO cache
+                       (url_hash, url, content, timestamp, expires_at, content_hash, metadata, access_count, last_accessed)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)
+                       ON CONFLICT(url_hash) DO UPDATE SET
+                           content = excluded.content,
+                           timestamp = excluded.timestamp,
+                           expires_at = excluded.expires_at,
+                           content_hash = excluded.content_hash,
+                           metadata = excluded.metadata,
+                           last_accessed = excluded.last_accessed''',
+                    (url_hash, url, content, current_time, expires_at,
+                     content_hash, json.dumps(metadata), current_time)
+                )
 
                 conn.commit()
 

--- a/pdd/preprocess.py
+++ b/pdd/preprocess.py
@@ -314,16 +314,17 @@ def process_web_tags(text: str, recursive: bool) -> str:
         if recursive:
             # Defer network operations until after env var expansion
             return match.group(0)
-        
+
         # Get cache instance
         cache = get_firecrawl_cache()
-        
+
         # Check cache first
         cached_content = cache.get(url)
         if cached_content is not None:
             console.print(f"Using cached content for: [cyan]{url}[/cyan]")
             return cached_content
-        
+
+
         console.print(f"Scraping web content from: [cyan]{url}[/cyan]")
         _dbg(f"Web tag URL: {url}")
         try:
@@ -341,9 +342,6 @@ def process_web_tags(text: str, recursive: bool) -> str:
 
             app = Firecrawl(api_key=api_key)
 
-            # Get cache TTL from environment or use default
-            cache_ttl_hours = int(os.environ.get('FIRECRAWL_CACHE_TTL_HOURS', 24))
-
             response = app.scrape(url, formats=['markdown'])
 
             # Handle both dict response (new API) and object response (legacy)
@@ -357,7 +355,7 @@ def process_web_tags(text: str, recursive: bool) -> str:
 
             if content:
                 # Cache the result for future use
-                cache.set(url, content, ttl_hours=cache_ttl_hours)
+                cache.set(url, content)
                 return content
             else:
                 console.print(f"[bold yellow]Warning:[/bold yellow] No markdown content returned for {url}")


### PR DESCRIPTION
## Summary

Follow-up fixes from code review of PR #474 (firecrawl caching). All issues were developed TDD-style with failing tests written first.

- **Bug fix**: Remove duplicate TTL parsing in `preprocess.py` that crashed on invalid `FIRECRAWL_CACHE_TTL_HOURS` values — cache already handles this internally
- **Bug fix**: Add try/except for `FIRECRAWL_CACHE_MAX_SIZE_MB` and `FIRECRAWL_CACHE_MAX_ENTRIES` env vars (bare `int()` would crash on invalid values)
- **Bug fix**: Remove `ref` and `source` from URL normalization `tracking_prefixes` — these are legitimate query params (e.g., GitHub `?ref=main`)
- **Code quality**: Replace SELECT+UPDATE/INSERT with atomic `INSERT ... ON CONFLICT DO UPDATE` (UPSERT) in `cache.set()`
- **Cleanup**: Remove `sys.path.insert` hack in tests, remove deprecated `test_cache_size_limits`, fix trailing whitespace

## Test plan

- [x] 4 new regression tests added (one per bug fix)
- [x] All 147 tests pass: `pytest -vv tests/test_firecrawl_cache.py tests/test_commands_firecrawl.py tests/test_preprocess.py`

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)