### PR TITLE
feat: add pdd summary command for project activity dashboard (#495)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2469,7 +2469,44 @@ pdd sessions cleanup --all --force
 
 **When to use**: Use `sessions list` to discover available remote sessions, `sessions info` to check session details, and `sessions cleanup` to remove stale or orphaned sessions.
 
-### 20. Firecrawl Web Scraping Cache
+### 20. `pdd summary` - Project Activity Dashboard
+
+View aggregated project activity data from sync operation logs — cost, timing, success rates, and per-module breakdown. No LLM calls; reads existing `.pdd/meta/*_sync.log` files.
+
+```bash
+pdd summary                  # Full dashboard
+pdd summary --days 7         # Filter to last N days
+pdd summary --json           # Machine-readable JSON output
+pdd summary --csv            # CSV export
+pdd summary history          # Full operation history with errors
+pdd summary history -n 10    # Last N operations
+pdd summary by-model         # Cost/time breakdown by LLM model
+pdd summary by-command       # Cost/time breakdown by command
+pdd summary by-module        # Activity breakdown by prompt module
+```
+
+**Default dashboard output includes:**
+- Project info — PDD version, current context, .pddrc status, prompt count
+- Stat panels — total cost, total time, success rate, active modules
+- Highlights — slowest and costliest single operation
+- By Command table — cost, runs, success rate, avg/total time per command
+- By Model table — cost, runs, % of total cost per model
+- Recent Operations — last 5 operations with cost, duration, model, status
+
+**Options:**
+- `--days INT`: Filter operations to the last N days
+- `--json`: Output in JSON format (for automation)
+- `--csv`: Output in CSV format (for spreadsheet analysis)
+
+**Subcommands:**
+- `history`: Show full operation log with error details. Use `-n INT` to limit entries.
+- `by-model`: Break down cost and time by LLM model.
+- `by-command`: Break down cost and time by PDD command (generate, fix, etc.).
+- `by-module`: Break down activity by prompt module.
+
+**When to use**: Use `pdd summary` to understand project-wide LLM costs, identify expensive modules, track success rates, and export activity data for reporting.
+
+### 21. Firecrawl Web Scraping Cache
 
 **Automatic caching** for web content scraped via `<web>` tags in prompts. Reduces API credit usage by caching results for 24 hours by default.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -476,3 +476,9 @@ The AI development landscape has a tool for every project size. PDD's strength i
 -   **Small Projects / Demos**: Tools like **Lovable** or **Bolt** are fantastic for getting quick results with minimal setup.
 -   **Medium-Sized Features / Prototyping**: Interactive, chat-based tools like **Cursor** or the **Claude Code** are excellent for iterative refinement and exploration.
 -   **Production-Scale, Long-Lived Systems**: **PDD** is the best choice when you need deterministic, maintainable, and version-controlled code generation that can scale with your team and project complexity."*
+
+---
+
+**Q: How do I see how much my project's LLM calls have cost?**
+
+A: Run `pdd summary` for a full dashboard showing total cost, timing, success rates, and per-module breakdowns. Use `pdd summary --days 7` to filter to a specific time window, or `pdd summary --json` for machine-readable output. For detailed breakdowns, try `pdd summary by-model` or `pdd summary by-command`.

--- a/pdd/prompts/commands/summary_python.prompt
+++ b/pdd/prompts/commands/summary_python.prompt
@@ -1,0 +1,44 @@
+<include>context/python_preamble.prompt</include>
+
+<pdd-reason>Aggregates and displays project activity data from sync operation logs as a CLI dashboard.</pdd-reason>
+
+<pdd-interface>
+{
+  "type": "command",
+  "command": {
+    "commands": [
+      {"name": "summary", "description": "Project activity dashboard with cost, timing, and success rate aggregation"},
+      {"name": "summary history", "description": "Full operation history with error details"},
+      {"name": "summary by-model", "description": "Cost and time breakdown by LLM model"},
+      {"name": "summary by-command", "description": "Cost and time breakdown by PDD command"},
+      {"name": "summary by-module", "description": "Activity breakdown by prompt module"}
+    ]
+  }
+}
+</pdd-interface>
+
+% Goal
+Implement the `pdd summary` CLI command that aggregates and displays project activity data from `.pdd/meta/*_sync.log` JSONL files.
+
+% Role & Scope
+A Click command group providing a project activity dashboard and breakdown subcommands. Reads existing sync log data (no LLM calls, no state mutations). Outputs rich terminal tables by default, with JSON and CSV export options.
+
+% Requirements
+1. `summary` is a Click group with `invoke_without_command=True`; when invoked alone, display the full dashboard
+2. Dashboard panels: project info (PDD version, context, .pddrc status, prompt count), stat panels (total cost, total time, success rate, active modules), highlights (slowest and costliest operation), by-command table, by-model table, recent operations (last 5)
+3. Data source: glob all `.pdd/meta/*_sync.log` JSONL files; parse each line as JSON; filter out event-type entries (entries without an `operation` field)
+4. `--days N` option on the group: filter entries to last N days via ISO timestamp comparison; default shows all time
+5. `--json` flag: output all aggregated data as JSON to stdout (no rich formatting)
+6. `--csv` flag: output tabular data as CSV to stdout (consistent with `--output-cost` pattern)
+7. `history` subcommand: display full operation log with error details; `-n N` option limits to last N entries
+8. `by-model`, `by-command`, `by-module` subcommands: show cost, runs, success rate, avg time, total time grouped by the respective dimension
+9. Guard against zero-division errors on empty data; handle missing fields via `.get()` with sensible defaults
+10. Use `rich` for tables and panels in terminal output
+
+% Dependencies
+<operation_log>
+<include>context/operation_log_example.py</include>
+</operation_log>
+
+% Deliverables
+- Code: `pdd/commands/summary.py`


### PR DESCRIPTION
## Summary

Add the `pdd summary` command prompt and documentation for a project activity dashboard that aggregates cost, timing, and success rate data from `.pdd/meta/` sync logs.

Closes #495

## Changes Made

### Prompts Added
- `pdd/prompts/commands/summary_python.prompt` — Defines a Click command group with dashboard view and 4 subcommands (`history`, `by-model`, `by-command`, `by-module`), with `--days`, `--json`, and `--csv` filtering/export options

### Documentation Updated
- `README.md` — Added summary command to command reference table and usage examples
- `docs/faq.md` — Added FAQ entry about viewing project activity and cost data

## Review Checklist

- [ ] Prompt syntax is valid
- [ ] PDD conventions followed
- [ ] Documentation is up to date

## Next Steps After Merge

1. Regenerate code from modified prompts in dependency order:
   ```bash
   ./sync_order.sh
   ```
   Or manually:
   ```
   pdd sync summary
   ```
2. Run tests to verify functionality
3. Deploy if applicable

---
*Created by pdd change workflow*