### PR TITLE
fix: budget tracker drops test costs due to tuple index bug

### DIFF
--- a/pdd/sync_orchestration.py
+++ b/pdd/sync_orchestration.py
@@ -1775,8 +1775,10 @@ def sync_orchestration(
                                  model_name = result.get('model', 'unknown')
                             elif isinstance(result, tuple) and len(result) >= 3:
                                  # cmd_test_main returns 4-tuple: (content, cost, model, agentic_success)
-                                 # Other commands return 3-tuple: (content, cost, model)
-                                 # Use explicit indexing for test operation to handle 4-tuple correctly
+                                 # Other commands may return either:
+                                 #   - 3-tuple: (content, cost, model), e.g. some context operations
+                                 #   - 4-tuple: (content, was_incremental, cost, model_name), e.g. code_generator_main
+                                 # For tests, cost is at index 1; for most other 4+ tuples, cost is at index -2 and model at -1.
                                  if operation in ('test', 'test_extend') and len(result) >= 4:
                                      actual_cost = result[1] if isinstance(result[1], (int, float)) else 0.0
                                      model_name = result[2] if isinstance(result[2], str) else 'unknown'

--- a/tests/test_e2e_issue_508_budget_test_cost.py
+++ b/tests/test_e2e_issue_508_budget_test_cost.py
@@ -46,14 +46,14 @@ class TestBudgetCostExtraction:
             f"test_extend cost should be {result[1]} but got {cost}."
         )
 
-    def test_3_tuple_generate_cost_extraction(self):
-        """3-tuple operations (generate, etc.) work correctly with result[-2] — regression guard."""
-        # 3-tuple: (content, cost, model)
-        result = ("generated code", 0.0005551, "gpt-4o-mini")
+    def test_4_tuple_generate_cost_extraction(self):
+        """4-tuple generate operation works correctly with result[-2] — regression guard."""
+        # 4-tuple from code_generator_main: (content, was_incremental, cost, model_name)
+        result = ("generated code", False, 0.0005551, "gpt-4o-mini")
 
         cost = self._extract_cost(result, operation='generate')
 
-        # For 3-tuples, result[-2] = result[1] = cost float — this works by accident
+        # For this 4-tuple, result[-2] is the cost at index 2
         assert cost == pytest.approx(0.0005551)
 
     def test_budget_enforcement_with_test_costs(self):

--- a/tests/test_e2e_issue_508_sync_budget_tracking.py
+++ b/tests/test_e2e_issue_508_sync_budget_tracking.py
@@ -133,7 +133,7 @@ class TestE2ESyncBudgetTracking:
                 _make_decision('test_extend', 'More coverage'),
             ],
             op_results={
-                'generate': ("code", 0.05, "gpt-4o-mini"),
+                'generate': ("code", False, 0.05, "gpt-4o-mini"),
                 'test': ("tests", 0.10, "gpt-4o-mini", True),
             },
             budget=0.12,


### PR DESCRIPTION
## Summary
- 5 failing unit tests reproducing the tuple index bug at `sync_orchestration.py:1752`
- 2 failing E2E tests verifying budget tracking at integration level
- `result[-2]` on a 4-tuple returns model name string instead of cost float, silently dropping test/test_extend costs

## Root Cause
`result[-2]` on `(content, cost, model, agentic_success)` returns `result[2]` (model), not `result[1]` (cost). The `isinstance(..., (int, float))` check fails silently, defaulting to `$0.00`.


Fixes #508