### PR TITLE
fix: prevent os.killpg(1) from crashing pytest-xdist workers in CI

### DIFF
--- a/tests/test_agentic_sync_runner.py
+++ b/tests/test_agentic_sync_runner.py
@@ -28,6 +28,7 @@ def _make_mock_popen(stdout_text: str = "", stderr_text: str = "", exit_code: in
     mock_proc.stdout = io.StringIO(stdout_text)
     mock_proc.stderr = io.StringIO(stderr_text)
     mock_proc.wait.return_value = exit_code
+    mock_proc.pid = 99999  # Prevent os.killpg(MagicMock) from resolving to pgid 1
     return mock_proc
 
 


### PR DESCRIPTION
## Summary

- `_make_mock_popen()` returned a `MagicMock` without setting `.pid`, so `MagicMock().__index__()` resolved to `1`
- `test_timeout_terminates_process` then called `os.killpg(1, SIGTERM)`, sending SIGTERM to process group 1
- This killed the entire pytest-xdist worker ~40ms in, causing CI to die at exactly 26% on every run

**Fix:** set `mock_proc.pid = 99999` so the kill targets a nonexistent PID and raises `ProcessLookupError`, which the production code already catches safely.

## Test plan

- [x] `pytest tests/test_agentic_sync_runner.py -v` passes all 84 tests locally
- [ ] CI "Unit Tests" workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)