### PR TITLE
fix: abort no-fix checkup after provider failure

### DIFF
--- a/pdd/agentic_checkup_orchestrator.py
+++ b/pdd/agentic_checkup_orchestrator.py
@@ -542,6 +542,9 @@ def run_agentic_checkup_orchestrator(
             github_comment_id=github_comment_id,
         )
 
+    def _is_provider_failure(output: str) -> bool:
+        return "All agent providers failed" in output
+
     def _handle_step_result(
         step_num: Union[int, float],
         success: bool,
@@ -586,7 +589,7 @@ def run_agentic_checkup_orchestrator(
             consecutive_provider_failures = 0
         else:
             step_outputs[step_key] = f"FAILED: {output}"
-            if "All agent providers failed" in output:
+            if _is_provider_failure(output):
                 consecutive_provider_failures += 1
                 if consecutive_provider_failures >= 3:
                     _save_state()
@@ -672,6 +675,13 @@ def run_agentic_checkup_orchestrator(
             abort = _handle_step_result(step_num, success, output, cost, model)
             if abort is not None:
                 return abort
+            if not success and _is_provider_failure(output):
+                return (
+                    False,
+                    f"Aborting after Step {step_num}: agent providers unavailable",
+                    total_cost,
+                    last_model_used,
+                )
 
         # Skip step 6 sub-steps.
         for sub_step in (6.1, 6.2, 6.3):

--- a/tests/test_agentic_checkup_orchestrator.py
+++ b/tests/test_agentic_checkup_orchestrator.py
@@ -202,6 +202,49 @@ class TestNoFixMode:
 
         mock_worktree.assert_not_called()
 
+    def test_provider_failure_on_step_5_aborts_no_fix_before_step_7(
+        self, mock_dependencies, default_args, tmp_path
+    ):
+        """A provider failure in step 5 should stop --no-fix before step 7."""
+        mock_run, _, _, _ = mock_dependencies
+        default_args["no_fix"] = True
+        default_args["cwd"] = tmp_path
+
+        saved_states = []
+
+        def side_effect(*args, **kwargs):
+            label = kwargs.get("label", "")
+            if label == "step5":
+                return (False, "All agent providers failed: openai: Timeout expired", 0.0, "")
+            return (True, f"Output for {label}", 0.1, "gpt-4")
+
+        def capture_state(cwd, issue_number, workflow_type, state, state_dir,
+                          repo_owner, repo_name, use_github_state=True,
+                          github_comment_id=None):
+            saved_states.append(state.copy())
+            return None
+
+        mock_run.side_effect = side_effect
+
+        with patch("pdd.agentic_checkup_orchestrator.save_workflow_state",
+                   side_effect=capture_state):
+            success, msg, cost, model = run_agentic_checkup_orchestrator(**default_args)
+
+        assert success is False
+        assert "agent providers unavailable" in msg
+        assert "Step 5" in msg
+        assert mock_run.call_count == 5
+
+        called_labels = [c.kwargs["label"] for c in mock_run.call_args_list]
+        assert "step7" not in called_labels
+
+        final_state = saved_states[-1]
+        assert final_state["last_completed_step"] == 4
+        assert final_state["step_outputs"]["5"] == (
+            "FAILED: All agent providers failed: openai: Timeout expired"
+        )
+        assert "6_1" not in final_state["step_outputs"]
+
 
 # ---------------------------------------------------------------------------
 # Worktree Handling


### PR DESCRIPTION
## Summary
- abort `checkup --no-fix` immediately when Step 5 returns an `All agent providers failed...` error
- keep the broader soft-failure behavior unchanged outside the `--no-fix` path
- add a regression covering resume-at-step-5 and verifying Step 7 is not reached

## Why
A real prod smoke resumed a `checkup --no-fix` run at Step 5, hit `All agent providers failed: openai: Timeout expired`, and still continued into skipped Step 6 bookkeeping and Step 7. That left the executor running long after the actual failure point.

## Testing
- `python3 -m pytest -q tests/test_agentic_checkup_orchestrator.py`
- deterministic CLI smoke: seeded resume state at step 4, ran `pdd checkup --no-fix --no-github-state`, confirmed exit code `1`, only `step5` ran, and no `6_1` or `7` outputs were written