### PR TITLE
Fix pdd example postprocessing and path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Fix
+
+- forward `language` from `postprocess()` into `llm_invoke()` so non-Python example extraction no longer trips Python-syntax cache-bypass retries
+- when `architecture.json` points to a nested filepath stem (for example `lib/sse.py`) but basename-derived artifacts already exist (`lib_sse_example.py`, `test_lib_sse.py`), prefer the existing flattened artifacts and log when that override activates
+
 ## v0.0.215 (2026-04-21)
 
 ### Fix

--- a/pdd/postprocess.py
+++ b/pdd/postprocess.py
@@ -121,6 +121,7 @@ def postprocess(
             strength=strength,
             temperature=temperature,
             time=time,
+            language=language,
             output_pydantic=ExtractedCode,
             verbose=verbose,
         )

--- a/pdd/sync_determine_operation.py
+++ b/pdd/sync_determine_operation.py
@@ -947,8 +947,20 @@ def get_pdd_file_paths(basename: str, language: str, prompts_dir: str = "prompts
                 example_path = project_root / f"{example_dir}{code_stem}_example.{extension}"
                 test_path = project_root / f"{test_dir}test_{code_stem}.{extension}"
 
+                # If the flattened prompt basename already has corresponding example/test
+                # artifacts, prefer those over the architecture filepath stem. This keeps
+                # command summaries and sync behavior aligned with repos that intentionally
+                # namespace files such as lib_sse_example.ts or test_api_route.ts.
+                if name != code_stem:
+                    basename_example_path = project_root / f"{example_dir}{name}_example.{extension}"
+                    basename_test_path = project_root / f"{test_dir}test_{name}.{extension}"
+                    if basename_example_path.exists():
+                        example_path = basename_example_path
+                    if basename_test_path.exists():
+                        test_path = basename_test_path
+
                 test_dir_path = test_path.parent
-                test_stem = f"test_{code_stem}"
+                test_stem = glob.escape(test_path.stem)
                 if test_dir_path.exists():
                     matching_test_files = sorted(test_dir_path.glob(f"{test_stem}*.{extension}"))
                 else:

--- a/pdd/sync_determine_operation.py
+++ b/pdd/sync_determine_operation.py
@@ -954,10 +954,23 @@ def get_pdd_file_paths(basename: str, language: str, prompts_dir: str = "prompts
                 if name != code_stem:
                     basename_example_path = project_root / f"{example_dir}{name}_example.{extension}"
                     basename_test_path = project_root / f"{test_dir}test_{name}.{extension}"
+                    preferred_example = False
+                    preferred_test = False
                     if basename_example_path.exists():
                         example_path = basename_example_path
+                        preferred_example = True
                     if basename_test_path.exists():
                         test_path = basename_test_path
+                        preferred_test = True
+                    if preferred_example or preferred_test:
+                        logger.info(
+                            "Preferring basename-derived artifacts for %s over architecture stem %s "
+                            "(example=%s, test=%s)",
+                            name,
+                            code_stem,
+                            preferred_example,
+                            preferred_test,
+                        )
 
                 test_dir_path = test_path.parent
                 test_stem = glob.escape(test_path.stem)

--- a/tests/test_issue_225_paths_and_includes.py
+++ b/tests/test_issue_225_paths_and_includes.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import textwrap
 from pathlib import Path
@@ -162,7 +163,9 @@ def test_get_pdd_file_paths_preserves_nested_prompt_path_when_architecture_filen
 def test_get_pdd_file_paths_prefers_existing_basename_artifacts_with_architecture_filepath(
     tmp_path: Path,
     monkeypatch,
+    caplog,
 ) -> None:
+    caplog.set_level(logging.INFO)
     monkeypatch.chdir(tmp_path)
     (tmp_path / ".pddrc").write_text(
         textwrap.dedent(
@@ -200,3 +203,4 @@ def test_get_pdd_file_paths_prefers_existing_basename_artifacts_with_architectur
     assert paths["example"] == existing_example
     assert paths["test"] == existing_test
     assert existing_test in paths["test_files"]
+    assert "Preferring basename-derived artifacts for lib_sse over architecture stem sse" in caplog.text

--- a/tests/test_issue_225_paths_and_includes.py
+++ b/tests/test_issue_225_paths_and_includes.py
@@ -157,3 +157,46 @@ def test_get_pdd_file_paths_preserves_nested_prompt_path_when_architecture_filen
 
     assert paths["prompt"] == prompt_path
     assert paths["code"] == tmp_path / "src" / "models" / "user.py"
+
+
+def test_get_pdd_file_paths_prefers_existing_basename_artifacts_with_architecture_filepath(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".pddrc").write_text(
+        textwrap.dedent(
+            """\
+            version: "1.0"
+            contexts:
+              default:
+                defaults:
+                  generate_output_path: "lib/"
+                  test_output_path: "tests/"
+                  example_output_path: "examples/"
+            """
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "prompts").mkdir()
+    (tmp_path / "prompts" / "lib_sse_python.prompt").write_text("prompt", encoding="utf-8")
+    (tmp_path / "architecture.json").write_text(
+        (
+            '[{"filename":"lib_sse_python.prompt","filepath":"lib/sse.py",'
+            '"priority":1,"dependencies":[],"description":"x"}]'
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "examples").mkdir()
+    (tmp_path / "tests").mkdir()
+    existing_example = tmp_path / "examples" / "lib_sse_example.py"
+    existing_test = tmp_path / "tests" / "test_lib_sse.py"
+    existing_example.write_text("# example", encoding="utf-8")
+    existing_test.write_text("def test_it():\n    assert True\n", encoding="utf-8")
+
+    paths = get_pdd_file_paths("lib_sse", "python", prompts_dir="prompts")
+
+    assert paths["code"] == tmp_path / "lib" / "sse.py"
+    assert paths["example"] == existing_example
+    assert paths["test"] == existing_test
+    assert existing_test in paths["test_files"]

--- a/tests/test_llm_invoke.py
+++ b/tests/test_llm_invoke.py
@@ -980,6 +980,45 @@ def test_llm_invoke_retries_on_invalid_python_code(mock_load_models, mock_set_ll
                 assert "invalid Python syntax" in caplog.text.lower() or "cache bypass retry" in caplog.text.lower()
 
 
+def test_llm_invoke_skips_python_validation_retry_for_typescript_language(
+    mock_load_models,
+    mock_set_llm_cache,
+    caplog,
+):
+    """Valid TypeScript in a code field should not trigger Python-syntax retry."""
+    model_key_name = "OPENAI_API_KEY"
+    typescript_code = (
+        "import React from 'react';\n\n"
+        "export const WaitlistPending = ({ email, position }: { email: string; position: number }) => {\n"
+        "  return <p>{email} #{position}</p>;\n"
+        "};\n"
+    )
+    response_json = json.dumps({"explanation": "Generated TS", "code": typescript_code})
+
+    with patch.dict(os.environ, {model_key_name: "fake_key_value"}):
+        with patch("pdd.llm_invoke.litellm.completion") as mock_completion:
+            mock_response = create_mock_litellm_response(response_json, model_name="gpt-5-nano")
+            mock_completion.return_value = mock_response
+
+            mock_cost = 0.0001
+            with patch("pdd.llm_invoke._LAST_CALLBACK_DATA", {"cost": mock_cost, "input_tokens": 10, "output_tokens": 10}):
+                response = llm_invoke(
+                    prompt="Generate code for {task}",
+                    input_json={"task": "test"},
+                    strength=0.5,
+                    temperature=0.7,
+                    verbose=True,
+                    output_pydantic=CodeOutputModel,
+                    language="typescript",
+                )
+
+            assert mock_completion.call_count == 1
+            assert isinstance(response["result"], CodeOutputModel)
+            assert response["result"].code == typescript_code
+            assert "invalid Python syntax" not in caplog.text
+            assert "cache bypass retry" not in caplog.text.lower()
+
+
 def test_llm_invoke_uses_repaired_code_without_retry(mock_load_models, mock_set_llm_cache):
     """Test that llm_invoke uses repaired code without retry when repair succeeds."""
     model_key_name = "OPENAI_API_KEY"

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -380,6 +380,7 @@ def test_strength_gt_0_parameters_passed_to_llm_invoke(mock_llm_invoke, mock_loa
     assert kwargs['strength'] == strength_val
     assert kwargs['temperature'] == temperature_val
     assert kwargs['time'] == time_val
+    assert kwargs['language'] == language_val
     assert kwargs['verbose'] == verbose_val
     assert kwargs['output_pydantic'] == ExtractedCode
 
@@ -405,6 +406,7 @@ def test_default_parameters(mock_llm_invoke, mock_load_template):
     assert kwargs['strength'] == DEFAULT_STRENGTH  # Default strength
     assert kwargs['temperature'] == 0    # Default temperature
     assert kwargs['time'] == DEFAULT_TIME # Default time
+    assert kwargs['language'] == language_val
     assert kwargs['verbose'] == False   # Default verbose
     assert kwargs['output_pydantic'] == ExtractedCode
 


### PR DESCRIPTION
## Summary
- pass the requested language through postprocess() so non-Python examples are extracted with the correct structured-output settings
- prefer existing basename-derived example/test artifacts when architecture.json points to a nested filepath stem like lib/sse.ts
- add regression coverage for both behaviors

## Testing
- python3 -m pytest tests/test_postprocess.py tests/test_issue_225_paths_and_includes.py -q