### PR TITLE
feat(agentic): thread --time into provider subprocess reasoning flags

### DIFF
--- a/pdd/agentic_bug.py
+++ b/pdd/agentic_bug.py
@@ -178,6 +178,7 @@ def run_agentic_bug(
     quiet: bool = False,
     timeout_adder: float = 0.0,
     use_github_state: bool = True,
+    reasoning_time: Optional[float] = None,
     # Legacy/Manual mode arguments (handled via *args in a real CLI, but here explicit for type safety if called directly)
     manual_args: Optional[Tuple[str, str, str, str, str]] = None
 ) -> Tuple[bool, str, float, str, List[str]]:
@@ -309,7 +310,8 @@ def run_agentic_bug(
             verbose=verbose,
             quiet=quiet,
             timeout_adder=timeout_adder,
-            use_github_state=use_github_state
+            use_github_state=use_github_state,
+            reasoning_time=reasoning_time,
         )
         return success, message, cost, model, changed_files
 

--- a/pdd/agentic_bug_orchestrator.py
+++ b/pdd/agentic_bug_orchestrator.py
@@ -1322,7 +1322,8 @@ def run_agentic_bug_orchestrator(
     verbose: bool = False,
     quiet: bool = False,
     timeout_adder: float = 0.0,
-    use_github_state: bool = True
+    use_github_state: bool = True,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, str, float, str, List[str]]:
     """
     Orchestrates the 11-step agentic bug investigation workflow.
@@ -1668,6 +1669,7 @@ def run_agentic_bug_orchestrator(
             timeout=timeout,
             label=step_label,
             max_retries=DEFAULT_MAX_RETRIES,
+            reasoning_time=reasoning_time,
         )
 
         total_cost += step_cost
@@ -1839,6 +1841,7 @@ def run_agentic_bug_orchestrator(
                         timeout=timeout,
                         label="step6",
                         max_retries=DEFAULT_MAX_RETRIES,
+                        reasoning_time=reasoning_time,
                     )
                     total_cost += retry_cost
                     model_used = retry_model
@@ -2046,6 +2049,7 @@ def run_agentic_bug_orchestrator(
                     timeout=timeout,
                     label="step9",
                     max_retries=DEFAULT_MAX_RETRIES,
+                    reasoning_time=reasoning_time,
                 )
                 total_cost += retry_cost
                 model_used = retry_model
@@ -2133,6 +2137,7 @@ def run_agentic_bug_orchestrator(
                         timeout=timeout,
                         label="step9",
                         max_retries=DEFAULT_MAX_RETRIES,
+                        reasoning_time=reasoning_time,
                     )
                     total_cost += cv_cost
                     model_used = cv_model
@@ -2198,6 +2203,7 @@ def run_agentic_bug_orchestrator(
                         timeout=timeout,
                         label="step9",
                         max_retries=DEFAULT_MAX_RETRIES,
+                        reasoning_time=reasoning_time,
                     )
                     total_cost += cov_cost
                     model_used = cov_model

--- a/pdd/agentic_change.py
+++ b/pdd/agentic_change.py
@@ -143,7 +143,8 @@ def run_agentic_change(
     verbose: bool = False,
     quiet: bool = False,
     timeout_adder: float = 0.0,
-    use_github_state: bool = True
+    use_github_state: bool = True,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, str, float, str, List[str]]:
     """
     CLI entry point for the agentic change workflow.
@@ -243,5 +244,6 @@ def run_agentic_change(
         verbose=verbose,
         quiet=quiet,
         timeout_adder=timeout_adder,
-        use_github_state=use_github_state
+        use_github_state=use_github_state,
+        reasoning_time=reasoning_time,
     )

--- a/pdd/agentic_change_orchestrator.py
+++ b/pdd/agentic_change_orchestrator.py
@@ -838,7 +838,8 @@ def run_agentic_change_orchestrator(
     verbose: bool = False,
     quiet: bool = False,
     timeout_adder: float = 0.0,
-    use_github_state: bool = True
+    use_github_state: bool = True,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, str, float, str, List[str]]:
     """
     Orchestrates the 13-step agentic change workflow.
@@ -1067,6 +1068,7 @@ def run_agentic_change_orchestrator(
             timeout=timeout,
             label=f"step{step_num}",
             max_retries=DEFAULT_MAX_RETRIES,
+            reasoning_time=reasoning_time,
         )
 
         total_cost += step_cost
@@ -1274,7 +1276,7 @@ def run_agentic_change_orchestrator(
             s11_prompt = substitute_template_variables(s11_template, context)
             timeout11 = CHANGE_STEP_TIMEOUTS.get(11, 340.0) + timeout_adder
             s11_success, s11_output, s11_cost, s11_model = run_agentic_task(
-                instruction=s11_prompt, cwd=current_work_dir, verbose=verbose, quiet=quiet, timeout=timeout11, label=f"step11_iter{review_iteration}", max_retries=DEFAULT_MAX_RETRIES,
+                instruction=s11_prompt, cwd=current_work_dir, verbose=verbose, quiet=quiet, timeout=timeout11, label=f"step11_iter{review_iteration}", max_retries=DEFAULT_MAX_RETRIES, reasoning_time=reasoning_time,
             )
             total_cost += s11_cost; model_used = s11_model; state["total_cost"] = total_cost
             if _review_loop_no_issues(s11_output):
@@ -1291,7 +1293,7 @@ def run_agentic_change_orchestrator(
             s12_prompt = substitute_template_variables(s12_template, context)
             timeout12 = CHANGE_STEP_TIMEOUTS.get(12, 600.0) + timeout_adder
             s12_success, s12_output, s12_cost, s12_model = run_agentic_task(
-                instruction=s12_prompt, cwd=current_work_dir, verbose=verbose, quiet=quiet, timeout=timeout12, label=f"step12_iter{review_iteration}", max_retries=DEFAULT_MAX_RETRIES,
+                instruction=s12_prompt, cwd=current_work_dir, verbose=verbose, quiet=quiet, timeout=timeout12, label=f"step12_iter{review_iteration}", max_retries=DEFAULT_MAX_RETRIES, reasoning_time=reasoning_time,
             )
             total_cost += s12_cost; model_used = s12_model; state["total_cost"] = total_cost
             previous_fixes += f"\n\nIteration {review_iteration}:\n{s12_output}"
@@ -1379,7 +1381,7 @@ def run_agentic_change_orchestrator(
         s13_prompt = substitute_template_variables(s13_template, context)
         timeout13 = CHANGE_STEP_TIMEOUTS.get(13, 340.0) + timeout_adder
         s13_success, s13_output, s13_cost, s13_model = run_agentic_task(
-            instruction=s13_prompt, cwd=current_work_dir, verbose=verbose, quiet=quiet, timeout=timeout13, label="step13", max_retries=DEFAULT_MAX_RETRIES,
+            instruction=s13_prompt, cwd=current_work_dir, verbose=verbose, quiet=quiet, timeout=timeout13, label="step13", max_retries=DEFAULT_MAX_RETRIES, reasoning_time=reasoning_time,
         )
         total_cost += s13_cost; model_used = s13_model; state["total_cost"] = total_cost
         if not s13_success:

--- a/pdd/agentic_checkup.py
+++ b/pdd/agentic_checkup.py
@@ -149,6 +149,7 @@ def run_agentic_checkup(
     no_fix: bool = False,
     timeout_adder: float = 0.0,
     use_github_state: bool = True,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, str, float, str]:
     """Run agentic checkup workflow from a GitHub issue URL.
 
@@ -238,6 +239,7 @@ def run_agentic_checkup(
             no_fix=no_fix,
             timeout_adder=timeout_adder,
             use_github_state=use_github_state,
+            reasoning_time=reasoning_time,
         )
     except Exception as exc:
         msg = f"Orchestrator failed: {exc}"

--- a/pdd/agentic_checkup_orchestrator.py
+++ b/pdd/agentic_checkup_orchestrator.py
@@ -328,6 +328,7 @@ def _run_single_step(
     quiet: bool,
     label: str,
     timeout_adder: float,
+    reasoning_time: Optional[float] = None,
 ) -> Optional[Tuple[bool, str, float, str]]:
     """Load template, preprocess, format, and run a single LLM step.
 
@@ -362,6 +363,7 @@ def _run_single_step(
         label=label,
         timeout=CHECKUP_STEP_TIMEOUTS.get(step_num, 600.0) + timeout_adder,
         max_retries=DEFAULT_MAX_RETRIES,
+        reasoning_time=reasoning_time,
     )
     return (success, output, cost, model)
 
@@ -387,6 +389,7 @@ def run_agentic_checkup_orchestrator(
     no_fix: bool = False,
     timeout_adder: float = 0.0,
     use_github_state: bool = True,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, str, float, str]:
     """Orchestrate the 8-step agentic checkup workflow.
 
@@ -624,6 +627,7 @@ def run_agentic_checkup_orchestrator(
             verbose=verbose, quiet=quiet,
             label=f"step{step_num}",
             timeout_adder=timeout_adder,
+            reasoning_time=reasoning_time,
         )
 
         if result is None:
@@ -665,6 +669,7 @@ def run_agentic_checkup_orchestrator(
                 verbose=verbose, quiet=quiet,
                 label=f"step{step_num}",
                 timeout_adder=timeout_adder,
+                reasoning_time=reasoning_time,
             )
 
             if result is None:
@@ -711,6 +716,7 @@ def run_agentic_checkup_orchestrator(
                 verbose=verbose, quiet=quiet,
                 label="step7",
                 timeout_adder=timeout_adder,
+                reasoning_time=reasoning_time,
             )
 
             if result is None:
@@ -815,6 +821,7 @@ def run_agentic_checkup_orchestrator(
                     verbose=verbose, quiet=quiet,
                     label=iter_label,
                     timeout_adder=timeout_adder,
+                    reasoning_time=reasoning_time,
                 )
 
                 if result is None:
@@ -866,6 +873,7 @@ def run_agentic_checkup_orchestrator(
                 verbose=verbose, quiet=quiet,
                 label="step8",
                 timeout_adder=timeout_adder,
+                reasoning_time=reasoning_time,
             )
 
             if result is None:

--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -1146,14 +1146,20 @@ def _run_with_provider(
     # Read prompt content for providers that pipe via stdin
     prompt_content = prompt_path.read_text(encoding="utf-8") if prompt_path.exists() else ""
 
-    # Reasoning-effort plumbing. Two paths converge here:
-    # 1. Explicit ``reasoning_time`` kwarg threaded down from the command →
-    #    orchestrator → run_agentic_task chain (preferred — ctx.obj["time"]
-    #    provenance so per-call overrides don't need a global env mutation).
-    # 2. PDD_REASONING_EFFORT env var set by pdd/core/cli.py for call sites
-    #    that don't thread the kwarg. Kept so unplumbed callers (sync, split,
-    #    test_generate, update, verify, crash, etc.) still honor --time.
-    # Explicit kwarg wins; env is the fallback.
+    # Reasoning-effort plumbing. Three input paths converge here, in
+    # precedence order:
+    # 1. ``CODEX_REASONING_EFFORT`` env var — Codex-specific override, accepts
+    #    ``low|medium|high|xhigh`` (xhigh is Codex-only, used by the cloud
+    #    worker for GPT-5.4 routing). Only consulted when provider == "openai".
+    # 2. Explicit ``reasoning_time`` kwarg threaded down from a command that
+    #    saw ``--time`` on argv (cli.py only forwards when ``time_explicit`` is
+    #    True, so a default ``ctx.obj["time"]`` does NOT reach here).
+    # 3. ``PDD_REASONING_EFFORT`` env var set by pdd/core/cli.py for call
+    #    sites that don't thread the kwarg (sync, split, test_generate,
+    #    update, verify, crash, etc.).
+    # ``CODEX_REASONING_EFFORT`` only fires for the openai branch below; the
+    # generic ``reasoning_effort`` resolved here covers paths 2 and 3 and is
+    # what the anthropic/gemini logging notices read.
     if reasoning_time is not None:
         from .reasoning import time_to_effort_level
         reasoning_effort = time_to_effort_level(reasoning_time)
@@ -1229,8 +1235,20 @@ def _run_with_provider(
         cmd = [cli_path]
         # Codex accepts -c / --config only as a top-level flag before the
         # subcommand; appending after "exec" is silently ignored.
-        if reasoning_effort:
-            cmd.extend(["-c", f"model_reasoning_effort={reasoning_effort}"])
+        # Codex-specific override: CODEX_REASONING_EFFORT takes precedence
+        # over the generic reasoning_effort (kwarg / PDD_REASONING_EFFORT)
+        # and additionally accepts ``xhigh`` for GPT-5.4 routing — the
+        # cloud worker sets this env var directly when promoting Codex to
+        # an extra-high reasoning budget regardless of the user's --time.
+        codex_effort = (env.get("CODEX_REASONING_EFFORT") or "").strip().lower()
+        if codex_effort in {"low", "medium", "high", "xhigh"}:
+            effective_codex_effort: Optional[str] = codex_effort
+        elif reasoning_effort:
+            effective_codex_effort = reasoning_effort
+        else:
+            effective_codex_effort = None
+        if effective_codex_effort:
+            cmd.extend(["-c", f"model_reasoning_effort={effective_codex_effort}"])
         cmd.extend([
             "exec",
             "--sandbox", sandbox_mode,

--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -1134,6 +1134,14 @@ def _run_with_provider(
     # Read prompt content for providers that pipe via stdin
     prompt_content = prompt_path.read_text(encoding="utf-8") if prompt_path.exists() else ""
 
+    # Reasoning-effort plumbing. The top-level CLI sets PDD_REASONING_EFFORT
+    # from --time so provider subprocesses can honor the allocation. Only
+    # Codex exposes a matching CLI flag today; Anthropic and Gemini CLIs do
+    # not, so we log the miss once rather than silently dropping the signal.
+    reasoning_effort = (env.get("PDD_REASONING_EFFORT") or "").strip().lower()
+    if reasoning_effort not in {"low", "medium", "high"}:
+        reasoning_effort = ""
+
     # Construct Command using discovered cli_path (Issue #234 fix)
     if provider == "anthropic":
         # Use -p - to pipe prompt as direct user message via stdin.
@@ -1159,6 +1167,11 @@ def _run_with_provider(
         claude_model = env.get("CLAUDE_MODEL")
         if claude_model:
             cmd.extend(["--model", claude_model])
+        if reasoning_effort and verbose:
+            console.print(
+                f"[dim]PDD_REASONING_EFFORT={reasoning_effort} requested, but Claude Code CLI "
+                "has no reasoning-effort flag; effort not applied to this subprocess.[/dim]"
+            )
     elif provider == "google":
         # Do NOT use -p flag for Gemini. The -p flag passes text literally,
         # so passing a file path gives Gemini the path string instead of content.
@@ -1174,19 +1187,28 @@ def _run_with_provider(
         gemini_model = env.get("GEMINI_MODEL")
         if gemini_model:
             cmd.extend(["--model", gemini_model])
+        if reasoning_effort and verbose:
+            console.print(
+                f"[dim]PDD_REASONING_EFFORT={reasoning_effort} requested, but Gemini CLI "
+                "has no reasoning-effort flag; effort not applied to this subprocess.[/dim]"
+            )
     elif provider == "openai":
         # --full-auto sets --sandbox workspace-write (Landlock+seccomp), which
         # panics on gVisor (Cloud Run) and Docker-on-macOS. Since the PDD worker
         # container IS the sandbox boundary, use danger-full-access instead.
         # Ref: https://github.com/openai/codex/issues/6828
         sandbox_mode = env.get("CODEX_SANDBOX_MODE", "danger-full-access")
-        cmd = [
-            cli_path,
+        cmd = [cli_path]
+        # Codex accepts -c / --config only as a top-level flag before the
+        # subcommand; appending after "exec" is silently ignored.
+        if reasoning_effort:
+            cmd.extend(["-c", f"model_reasoning_effort={reasoning_effort}"])
+        cmd.extend([
             "exec",
             "--sandbox", sandbox_mode,
             "--json",
             str(prompt_path)
-        ]
+        ])
         # Allow model override via CODEX_MODEL env var (mirrors CLAUDE_MODEL for anthropic)
         codex_model = env.get("CODEX_MODEL")
         if codex_model:

--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -763,6 +763,7 @@ def run_agentic_task(
     retry_delay: float = DEFAULT_RETRY_DELAY,
     deadline: Optional[float] = None,
     use_playwright: bool = False,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, str, float, str]:
     """
     Runs an agentic task using available providers in preference order.
@@ -778,6 +779,10 @@ def run_agentic_task(
         retry_delay: Base delay in seconds for exponential backoff (default: DEFAULT_RETRY_DELAY)
         deadline: Optional Unix timestamp for job-level time budgeting
         use_playwright: Enable constrained tool access mode for browser-based testing
+        time: Reasoning-allocation float in [0.0, 1.0] forwarded from the
+            top-level ``pdd --time`` flag. When provided, overrides the
+            ``PDD_REASONING_EFFORT`` env var for argv injection. ``None``
+            means "fall back to env" so unplumbed call sites keep working.
 
     Returns:
         (success, output_text, cost_usd, provider_used)
@@ -867,6 +872,7 @@ def run_agentic_task(
                 success, output, cost = _run_with_provider(
                     provider, prompt_path, cwd, attempt_timeout, verbose, quiet,
                     use_playwright=use_playwright,
+                    reasoning_time=reasoning_time,
                 )
                 last_output = output
 
@@ -1091,6 +1097,7 @@ def _run_with_provider(
     cli_path: Optional[str] = None,
     label: str = "",
     use_playwright: bool = False,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, str, float]:
     """
     Internal helper to run a specific provider's CLI.
@@ -1106,6 +1113,11 @@ def _run_with_provider(
         cli_path: Optional explicit CLI path (if None, uses _find_cli_binary)
         label: Task label for heartbeat messages
         use_playwright: Enable constrained tool access for browser testing
+        time: Reasoning-allocation float in [0.0, 1.0]. When provided,
+            takes precedence over the ``PDD_REASONING_EFFORT`` env var.
+            ``None`` means "fall back to env" so unplumbed call sites
+            keep receiving the signal via the global variable set by
+            ``pdd/core/cli.py``.
     """
 
     # Prepare Environment
@@ -1134,13 +1146,21 @@ def _run_with_provider(
     # Read prompt content for providers that pipe via stdin
     prompt_content = prompt_path.read_text(encoding="utf-8") if prompt_path.exists() else ""
 
-    # Reasoning-effort plumbing. The top-level CLI sets PDD_REASONING_EFFORT
-    # from --time so provider subprocesses can honor the allocation. Only
-    # Codex exposes a matching CLI flag today; Anthropic and Gemini CLIs do
-    # not, so we log the miss once rather than silently dropping the signal.
-    reasoning_effort = (env.get("PDD_REASONING_EFFORT") or "").strip().lower()
-    if reasoning_effort not in {"low", "medium", "high"}:
-        reasoning_effort = ""
+    # Reasoning-effort plumbing. Two paths converge here:
+    # 1. Explicit ``reasoning_time`` kwarg threaded down from the command →
+    #    orchestrator → run_agentic_task chain (preferred — ctx.obj["time"]
+    #    provenance so per-call overrides don't need a global env mutation).
+    # 2. PDD_REASONING_EFFORT env var set by pdd/core/cli.py for call sites
+    #    that don't thread the kwarg. Kept so unplumbed callers (sync, split,
+    #    test_generate, update, verify, crash, etc.) still honor --time.
+    # Explicit kwarg wins; env is the fallback.
+    if reasoning_time is not None:
+        from .reasoning import time_to_effort_level
+        reasoning_effort = time_to_effort_level(reasoning_time)
+    else:
+        reasoning_effort = (env.get("PDD_REASONING_EFFORT") or "").strip().lower()
+        if reasoning_effort not in {"low", "medium", "high"}:
+            reasoning_effort = ""
 
     # Construct Command using discovered cli_path (Issue #234 fix)
     if provider == "anthropic":

--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -1167,10 +1167,16 @@ def _run_with_provider(
         claude_model = env.get("CLAUDE_MODEL")
         if claude_model:
             cmd.extend(["--model", claude_model])
-        if reasoning_effort and verbose:
+        if reasoning_effort and not quiet:
+            # Always surface outside --quiet mode — silently dropping the user's
+            # reasoning signal is a support-ticket generator. The Claude Code CLI
+            # has no --reasoning-effort flag today, so clarify that the effort
+            # applies to LiteLLM-invoked steps (analysis/verification) but not
+            # to this code-writing subprocess.
             console.print(
                 f"[dim]PDD_REASONING_EFFORT={reasoning_effort} requested, but Claude Code CLI "
-                "has no reasoning-effort flag; effort not applied to this subprocess.[/dim]"
+                "has no reasoning-effort flag; applies to llm_invoke steps only, "
+                "not this subprocess.[/dim]"
             )
     elif provider == "google":
         # Do NOT use -p flag for Gemini. The -p flag passes text literally,
@@ -1187,10 +1193,12 @@ def _run_with_provider(
         gemini_model = env.get("GEMINI_MODEL")
         if gemini_model:
             cmd.extend(["--model", gemini_model])
-        if reasoning_effort and verbose:
+        if reasoning_effort and not quiet:
+            # See Claude Code branch above for rationale — same constraint applies.
             console.print(
                 f"[dim]PDD_REASONING_EFFORT={reasoning_effort} requested, but Gemini CLI "
-                "has no reasoning-effort flag; effort not applied to this subprocess.[/dim]"
+                "has no reasoning-effort flag; applies to llm_invoke steps only, "
+                "not this subprocess.[/dim]"
             )
     elif provider == "openai":
         # --full-auto sets --sandbox workspace-write (Landlock+seccomp), which

--- a/pdd/agentic_e2e_fix.py
+++ b/pdd/agentic_e2e_fix.py
@@ -237,6 +237,7 @@ def run_agentic_e2e_fix(
     ci_retries: int = 3,
     skip_ci: bool = False,
     skip_cleanup: bool = False,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, str, float, str, List[str]]:
     """Run the agentic E2E fix workflow for a GitHub issue."""
     if not _check_gh_cli():
@@ -321,6 +322,7 @@ def run_agentic_e2e_fix(
             ci_retries=ci_retries,
             skip_ci=skip_ci,
             skip_cleanup=skip_cleanup,
+            reasoning_time=reasoning_time,
         )
     except Exception as exc:
         message = f"Orchestrator failed: {exc}"

--- a/pdd/agentic_e2e_fix_orchestrator.py
+++ b/pdd/agentic_e2e_fix_orchestrator.py
@@ -1290,6 +1290,7 @@ def _run_step11_code_cleanup(
     timeout_adder: float,
     verbose: bool,
     quiet: bool,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[float, List[str]]:
     """Run Step 11: Code cleanup before CI validation.
 
@@ -1376,6 +1377,7 @@ def _run_step11_code_cleanup(
         timeout=cleanup_timeout,
         label="step11_code_cleanup",
         max_retries=DEFAULT_MAX_RETRIES,
+        reasoning_time=reasoning_time,
     )
     total_cost += cleanup_cost
 
@@ -1463,6 +1465,7 @@ def run_agentic_e2e_fix_orchestrator(
     ci_retries: int = 3,
     skip_ci: bool = False,
     skip_cleanup: bool = False,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, str, float, str, List[str]]:
     """
     Orchestrator for the 11-step agentic e2e fix workflow.
@@ -1789,6 +1792,7 @@ def run_agentic_e2e_fix_orchestrator(
                     timeout=timeout,
                     label=f"cycle{current_cycle}_step{step_num}",
                     max_retries=DEFAULT_MAX_RETRIES,
+                    reasoning_time=reasoning_time,
                 )
 
                 # Step 1 timeout retry: retry once with increased timeout
@@ -1808,6 +1812,7 @@ def run_agentic_e2e_fix_orchestrator(
                         timeout=retry_timeout,
                         label=f"cycle{current_cycle}_step{step_num}_retry1",
                         max_retries=DEFAULT_MAX_RETRIES,
+                        reasoning_time=reasoning_time,
                     )
                     step_cost += retry_cost
 
@@ -2022,6 +2027,7 @@ def run_agentic_e2e_fix_orchestrator(
                             timeout=base_timeout + timeout_adder,
                             label=f"cycle{current_cycle}_step9_retry",
                             max_retries=DEFAULT_MAX_RETRIES,
+                            reasoning_time=reasoning_time,
                         )
                         total_cost += retry_cost
                         if retry_model:
@@ -2167,6 +2173,7 @@ def run_agentic_e2e_fix_orchestrator(
                     timeout_adder=timeout_adder,
                     verbose=verbose,
                     quiet=quiet,
+                    reasoning_time=reasoning_time,
                 )
 
             if skip_ci:

--- a/pdd/agentic_sync.py
+++ b/pdd/agentic_sync.py
@@ -396,6 +396,7 @@ def _llm_fix_dry_run_failure(
     dry_run_error: str,
     quiet: bool = False,
     verbose: bool = False,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, Optional[Path], float, str]:
     """Ask the LLM to suggest the correct cwd/command when dry-run fails.
 
@@ -454,6 +455,7 @@ def _llm_fix_dry_run_failure(
         verbose=verbose,
         quiet=quiet,
         label="agentic_sync_fix_dry_run",
+        reasoning_time=reasoning_time,
     )
 
     if not llm_success:
@@ -528,6 +530,7 @@ def _run_dry_run_validation(
     project_root: Path,
     quiet: bool = False,
     verbose: bool = False,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, Dict[str, Path], List[str], float]:
     """Run dry-run validation for each module with LLM fallback.
 
@@ -561,6 +564,7 @@ def _run_dry_run_validation(
             dry_run_error=err_output,
             quiet=quiet,
             verbose=verbose,
+            reasoning_time=reasoning_time,
         )
         total_llm_cost += llm_cost
 
@@ -773,6 +777,7 @@ def run_agentic_sync(
     timeout_adder: float = 0.0,
     use_github_state: bool = True,
     one_session: bool = False,
+    reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, str, float, str]:
     """
     Run agentic sync workflow: identify modules from a GitHub issue and sync in parallel.
@@ -889,6 +894,7 @@ def run_agentic_sync(
             verbose=verbose,
             quiet=quiet,
             label="agentic_sync_identify_modules",
+            reasoning_time=reasoning_time,
         )
 
         if not llm_success:
@@ -971,6 +977,7 @@ def run_agentic_sync(
         project_root=project_root,
         quiet=quiet,
         verbose=verbose,
+        reasoning_time=reasoning_time,
     )
     llm_cost += dry_run_cost
 

--- a/pdd/commands/analysis.py
+++ b/pdd/commands/analysis.py
@@ -244,7 +244,7 @@ def bug(
                 quiet=obj.get("quiet", False),
                 timeout_adder=timeout_adder,
                 use_github_state=not no_github_state,
-                reasoning_time=obj.get("time"),
+                reasoning_time=obj.get("time") if obj.get("time_explicit") else None,
             )
             
             result_str = f"Success: {success}\nMessage: {message}\nChanged Files: {changed_files}"

--- a/pdd/commands/analysis.py
+++ b/pdd/commands/analysis.py
@@ -244,6 +244,7 @@ def bug(
                 quiet=obj.get("quiet", False),
                 timeout_adder=timeout_adder,
                 use_github_state=not no_github_state,
+                reasoning_time=obj.get("time"),
             )
             
             result_str = f"Success: {success}\nMessage: {message}\nChanged Files: {changed_files}"

--- a/pdd/commands/checkup.py
+++ b/pdd/commands/checkup.py
@@ -110,7 +110,7 @@ def checkup(
             no_fix=no_fix,
             timeout_adder=timeout_adder,
             use_github_state=not no_github_state,
-            reasoning_time=ctx.obj.get("time"),
+            reasoning_time=ctx.obj.get("time") if ctx.obj.get("time_explicit") else None,
         )
 
         if not quiet:

--- a/pdd/commands/checkup.py
+++ b/pdd/commands/checkup.py
@@ -110,6 +110,7 @@ def checkup(
             no_fix=no_fix,
             timeout_adder=timeout_adder,
             use_github_state=not no_github_state,
+            reasoning_time=ctx.obj.get("time"),
         )
 
         if not quiet:

--- a/pdd/commands/fix.py
+++ b/pdd/commands/fix.py
@@ -153,6 +153,7 @@ def fix(
                 ci_retries=ci_retries,
                 skip_ci=skip_ci,
                 skip_cleanup=skip_cleanup,
+                reasoning_time=ctx.obj.get("time"),
             )
 
             if not quiet:

--- a/pdd/commands/fix.py
+++ b/pdd/commands/fix.py
@@ -153,7 +153,7 @@ def fix(
                 ci_retries=ci_retries,
                 skip_ci=skip_ci,
                 skip_cleanup=skip_cleanup,
-                reasoning_time=ctx.obj.get("time"),
+                reasoning_time=ctx.obj.get("time") if ctx.obj.get("time_explicit") else None,
             )
 
             if not quiet:

--- a/pdd/commands/maintenance.py
+++ b/pdd/commands/maintenance.py
@@ -205,6 +205,7 @@ def _run_agentic_sync_dispatch(
             timeout_adder=timeout_adder,
             use_github_state=not no_github_state,
             one_session=one_session,
+            reasoning_time=ctx.obj.get("time"),
         )
 
         if not quiet:

--- a/pdd/commands/maintenance.py
+++ b/pdd/commands/maintenance.py
@@ -205,7 +205,7 @@ def _run_agentic_sync_dispatch(
             timeout_adder=timeout_adder,
             use_github_state=not no_github_state,
             one_session=one_session,
-            reasoning_time=ctx.obj.get("time"),
+            reasoning_time=ctx.obj.get("time") if ctx.obj.get("time_explicit") else None,
         )
 
         if not quiet:

--- a/pdd/commands/modify.py
+++ b/pdd/commands/modify.py
@@ -262,7 +262,8 @@ def change(
                 verbose=verbose,
                 quiet=quiet,
                 timeout_adder=timeout_adder,
-                use_github_state=not no_github_state
+                use_github_state=not no_github_state,
+                reasoning_time=ctx.obj.get("time"),
             )
 
             # Display results using click.echo as requested

--- a/pdd/commands/modify.py
+++ b/pdd/commands/modify.py
@@ -263,7 +263,7 @@ def change(
                 quiet=quiet,
                 timeout_adder=timeout_adder,
                 use_github_state=not no_github_state,
-                reasoning_time=ctx.obj.get("time"),
+                reasoning_time=ctx.obj.get("time") if ctx.obj.get("time_explicit") else None,
             )
 
             # Display results using click.echo as requested

--- a/pdd/core/cli.py
+++ b/pdd/core/cli.py
@@ -382,6 +382,18 @@ def cli(
         os.environ['PDD_FORCE_LOCAL'] = '1'
     # Use DEFAULT_TIME if time is not provided
     ctx.obj["time"] = time if time is not None else DEFAULT_TIME
+    # Mirror --time into PDD_REASONING_EFFORT so agentic CLI subprocesses
+    # (Codex especially) honor the user's reasoning allocation. Env-var
+    # pattern matches CLAUDE_MODEL/CODEX_MODEL threading in _run_with_provider.
+    # Only set when the user explicitly passed --time; otherwise leave any
+    # pre-existing value (e.g. from the worker env.yaml) alone.
+    if time is not None:
+        if time > 0.7:
+            os.environ["PDD_REASONING_EFFORT"] = "high"
+        elif time > 0.3:
+            os.environ["PDD_REASONING_EFFORT"] = "medium"
+        else:
+            os.environ["PDD_REASONING_EFFORT"] = "low"
     # Persist context override for downstream calls
     ctx.obj["context"] = context_override
     ctx.obj["core_dump"] = core_dump

--- a/pdd/core/cli.py
+++ b/pdd/core/cli.py
@@ -382,11 +382,18 @@ def cli(
         os.environ['PDD_FORCE_LOCAL'] = '1'
     # Use DEFAULT_TIME if time is not provided
     ctx.obj["time"] = time if time is not None else DEFAULT_TIME
+    # Track whether the user explicitly supplied --time on the command line.
+    # ctx.obj["time"] is always populated (DEFAULT_TIME fallback), so callers
+    # that want to forward an explicit reasoning override per-call must gate
+    # on this flag — otherwise plain `pdd bug ...` would behave as if
+    # `--time DEFAULT_TIME` was passed and force-set provider effort.
+    ctx.obj["time_explicit"] = time is not None
     # Mirror --time into PDD_REASONING_EFFORT so agentic CLI subprocesses
     # (Codex especially) honor the user's reasoning allocation. Env-var
     # pattern matches CLAUDE_MODEL/CODEX_MODEL threading in _run_with_provider.
     # Only set when the user explicitly passed --time; otherwise leave any
-    # pre-existing value (e.g. from the worker env.yaml) alone.
+    # pre-existing value (e.g. from the worker env.yaml such as
+    # CODEX_REASONING_EFFORT=xhigh for GPT-5.4 routing) alone.
     if time is not None:
         from ..reasoning import time_to_effort_level
         os.environ["PDD_REASONING_EFFORT"] = time_to_effort_level(time)

--- a/pdd/core/cli.py
+++ b/pdd/core/cli.py
@@ -388,12 +388,8 @@ def cli(
     # Only set when the user explicitly passed --time; otherwise leave any
     # pre-existing value (e.g. from the worker env.yaml) alone.
     if time is not None:
-        if time > 0.7:
-            os.environ["PDD_REASONING_EFFORT"] = "high"
-        elif time > 0.3:
-            os.environ["PDD_REASONING_EFFORT"] = "medium"
-        else:
-            os.environ["PDD_REASONING_EFFORT"] = "low"
+        from ..reasoning import time_to_effort_level
+        os.environ["PDD_REASONING_EFFORT"] = time_to_effort_level(time)
     # Persist context override for downstream calls
     ctx.obj["context"] = context_override
     ctx.obj["core_dump"] = core_dump

--- a/pdd/llm_invoke.py
+++ b/pdd/llm_invoke.py
@@ -2242,11 +2242,8 @@ def llm_invoke(
                         logger.warning(f"[WARN] Reasoning type is 'budget' for {model_name_litellm}, but 'max_reasoning_tokens' is missing or zero in CSV. Reasoning parameter not sent.")
 
                 elif reasoning_type == 'effort':
-                    effort = "low"
-                    if time > 0.7:
-                        effort = "high"
-                    elif time > 0.3:
-                        effort = "medium"
+                    from .reasoning import time_to_effort_level
+                    effort = time_to_effort_level(time)
 
                     # Map effort parameter per-provider/model family
                     model_lower = str(model_name_litellm).lower()

--- a/pdd/reasoning.py
+++ b/pdd/reasoning.py
@@ -1,0 +1,27 @@
+"""Shared helpers for mapping --time floats to provider reasoning effort.
+
+Both the top-level CLI (which sets ``PDD_REASONING_EFFORT`` for provider
+subprocesses) and ``llm_invoke`` (which forwards an effort string to
+LiteLLM) need the same ``time -> {low, medium, high}`` mapping. Keeping
+the thresholds in a single helper prevents silent drift between the two
+call sites.
+"""
+
+from typing import Literal
+
+
+EffortLevel = Literal["low", "medium", "high"]
+
+
+def time_to_effort_level(time: float) -> EffortLevel:
+    """Map a --time float in [0.0, 1.0] to a reasoning-effort level.
+
+    Thresholds use strict ``>`` so 0.3 maps to ``"low"`` and 0.7 maps to
+    ``"medium"`` — matching the pre-existing behavior in
+    ``llm_invoke`` that this helper replaces.
+    """
+    if time > 0.7:
+        return "high"
+    if time > 0.3:
+        return "medium"
+    return "low"

--- a/tests/commands/test_fix.py
+++ b/tests/commands/test_fix.py
@@ -136,7 +136,9 @@ def test_agentic_mode_passes_all_options(runner: CliRunner, mock_deps) -> None:
     assert "Agentic fix completed" in result.output
 
     kwargs = mock_deps["run_agentic_e2e_fix"].call_args.kwargs
-    assert kwargs == {
+    # Assert superset so additive kwargs (reasoning_time for the --time
+    # plumbing) don't force this test to enumerate every future option.
+    expected = {
         "issue_url": issue_url,
         "timeout_adder": 10.0,
         "max_cycles": 7,
@@ -150,6 +152,11 @@ def test_agentic_mode_passes_all_options(runner: CliRunner, mock_deps) -> None:
         "skip_ci": True,
         "skip_cleanup": False,
     }
+    assert expected.items() <= kwargs.items(), (
+        f"missing or mismatched: {set(expected.items()) - set(kwargs.items())}"
+    )
+    # No --time was passed, so reasoning_time forwards as None.
+    assert kwargs.get("reasoning_time") is None
 
 
 def test_agentic_failure_prints_failure_message(runner: CliRunner, mock_deps) -> None:

--- a/tests/test_agentic_change_orchestrator.py
+++ b/tests/test_agentic_change_orchestrator.py
@@ -3195,7 +3195,7 @@ def test_step4_stop_with_stop_condition_prefix(mock_dependencies, temp_cwd):
 
     def side_effect(instruction, cwd, *, verbose=False, quiet=False, label="",
                     timeout=None, max_retries=1, retry_delay=5.0, deadline=None,
-                    use_playwright=False):
+                    use_playwright=False, **kwargs):
         if label == "step4":
             return (True, "I posted clarification questions.\nSTOP_CONDITION: Clarification needed", 0.1, "gpt-4")
         return (True, f"Output for {label}", 0.1, "gpt-4")
@@ -3225,7 +3225,7 @@ def test_step4_clarification_saves_step_minus_one(mock_dependencies, temp_cwd):
 
     def side_effect(instruction, cwd, *, verbose=False, quiet=False, label="",
                     timeout=None, max_retries=1, retry_delay=5.0, deadline=None,
-                    use_playwright=False):
+                    use_playwright=False, **kwargs):
         if label == "step4":
             return (True, "STOP_CONDITION: Clarification needed", 0.1, "gpt-4")
         return (True, f"Output for {label}", 0.1, "gpt-4")

--- a/tests/test_agentic_common.py
+++ b/tests/test_agentic_common.py
@@ -4900,3 +4900,105 @@ def test_claude_suppresses_effort_notice_when_quiet(
 
     captured = capsys.readouterr()
     assert "PDD_REASONING_EFFORT" not in captured.out
+
+
+# ---------------------------------------------------------------------------
+# reasoning_time kwarg threading (complements the PDD_REASONING_EFFORT env path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "reasoning_time, expected_effort",
+    [(0.2, "low"), (0.5, "medium"), (0.85, "high"), (0.0, "low"), (1.0, "high")],
+)
+def test_codex_injects_reasoning_effort_from_time_kwarg(
+    reasoning_time, expected_effort,
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess,
+):
+    """Explicit ``reasoning_time`` kwarg on _run_with_provider takes
+    precedence over (or works in the absence of) PDD_REASONING_EFFORT and
+    produces the correct Codex argv token. Greg's review #3 asks for
+    "tests that assert the effective provider command/env changes" — this
+    is that assertion for the kwarg-threaded path."""
+    from pdd.agentic_common import _run_with_provider
+
+    mock_shutil_which.return_value = "/bin/codex"
+    mock_subprocess.return_value.returncode = 0
+    mock_subprocess.return_value.stdout = json.dumps({
+        "type": "result", "output": "ok",
+        "usage": {"input_tokens": 10, "output_tokens": 10, "cached_input_tokens": 0},
+    })
+    mock_subprocess.return_value.stderr = ""
+
+    prompt_file = mock_cwd / ".agentic_prompt_test.txt"
+    prompt_file.write_text("hi")
+
+    # Env var intentionally left UNSET — kwarg alone must drive the argv.
+    os.environ.pop("PDD_REASONING_EFFORT", None)
+    _run_with_provider(
+        "openai", prompt_file, mock_cwd,
+        verbose=False, quiet=True, reasoning_time=reasoning_time,
+    )
+
+    args, _ = mock_subprocess.call_args
+    cmd = args[0]
+    assert "-c" in cmd
+    assert cmd[cmd.index("-c") + 1] == f"model_reasoning_effort={expected_effort}"
+    assert cmd.index("-c") < cmd.index("exec")
+
+
+def test_reasoning_time_kwarg_overrides_env_var(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess,
+):
+    """When both signals are present, the explicit kwarg wins. Prevents a
+    stale env var from silently overriding per-call choices made by the
+    command layer reading ctx.obj["time"]."""
+    from pdd.agentic_common import _run_with_provider
+
+    mock_shutil_which.return_value = "/bin/codex"
+    mock_subprocess.return_value.returncode = 0
+    mock_subprocess.return_value.stdout = json.dumps({
+        "type": "result", "output": "ok",
+        "usage": {"input_tokens": 10, "output_tokens": 10, "cached_input_tokens": 0},
+    })
+    mock_subprocess.return_value.stderr = ""
+
+    prompt_file = mock_cwd / ".agentic_prompt_test.txt"
+    prompt_file.write_text("hi")
+
+    os.environ["PDD_REASONING_EFFORT"] = "low"  # env says low
+    try:
+        _run_with_provider(
+            "openai", prompt_file, mock_cwd,
+            verbose=False, quiet=True, reasoning_time=0.85,  # kwarg says high
+        )
+    finally:
+        os.environ.pop("PDD_REASONING_EFFORT", None)
+
+    args, _ = mock_subprocess.call_args
+    cmd = args[0]
+    assert cmd[cmd.index("-c") + 1] == "model_reasoning_effort=high"
+
+
+def test_run_agentic_task_forwards_reasoning_time_to_provider(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess,
+):
+    """run_agentic_task must forward its ``reasoning_time`` kwarg to
+    _run_with_provider. Covers the middle seam that Greg's review #3
+    called out: "run_agentic_task has no reasoning/time input" — the
+    new kwarg fills that gap."""
+    mock_shutil_which.return_value = "/bin/codex"
+    os.environ["OPENAI_API_KEY"] = "key"
+    mock_subprocess.return_value.returncode = 0
+    mock_subprocess.return_value.stdout = json.dumps({
+        "type": "result", "output": "Codex output.",
+        "usage": {"input_tokens": 1, "output_tokens": 1, "cached_input_tokens": 0},
+    })
+
+    os.environ.pop("PDD_REASONING_EFFORT", None)
+    run_agentic_task("instruction", mock_cwd, reasoning_time=0.85)
+
+    args, _ = mock_subprocess.call_args
+    cmd = args[0]
+    assert "-c" in cmd
+    assert cmd[cmd.index("-c") + 1] == "model_reasoning_effort=high"

--- a/tests/test_agentic_common.py
+++ b/tests/test_agentic_common.py
@@ -4710,3 +4710,130 @@ def test_false_positive_falls_through_in_multi_provider_config(mock_cwd, mock_en
         "not retry the broken provider first."
     )
 
+
+
+# ---------------------------------------------------------------------------
+# PDD_REASONING_EFFORT -> provider argv plumbing
+# ---------------------------------------------------------------------------
+
+
+def _codex_cmd_with_effort(mock_cwd, mock_subprocess, mock_shutil_which, effort):
+    """Helper: invoke _run_with_provider for openai with the env var set and return argv."""
+    from pdd.agentic_common import _run_with_provider
+
+    mock_shutil_which.return_value = "/bin/codex"
+    mock_subprocess.return_value.returncode = 0
+    mock_subprocess.return_value.stdout = json.dumps({
+        "type": "result", "output": "ok",
+        "usage": {"input_tokens": 10, "output_tokens": 10, "cached_input_tokens": 0},
+    })
+    mock_subprocess.return_value.stderr = ""
+
+    prompt_file = mock_cwd / ".agentic_prompt_test.txt"
+    prompt_file.write_text("hi")
+
+    prev = os.environ.get("PDD_REASONING_EFFORT")
+    if effort is None:
+        os.environ.pop("PDD_REASONING_EFFORT", None)
+    else:
+        os.environ["PDD_REASONING_EFFORT"] = effort
+    try:
+        _run_with_provider("openai", prompt_file, mock_cwd, verbose=False, quiet=True)
+    finally:
+        if prev is None:
+            os.environ.pop("PDD_REASONING_EFFORT", None)
+        else:
+            os.environ["PDD_REASONING_EFFORT"] = prev
+
+    args, _ = mock_subprocess.call_args
+    return args[0]
+
+
+@pytest.mark.parametrize("effort", ["low", "medium", "high"])
+def test_codex_injects_reasoning_effort_before_exec(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess, effort
+):
+    """Codex -c / --config is only honored as a top-level flag BEFORE the subcommand."""
+    cmd = _codex_cmd_with_effort(mock_cwd, mock_subprocess, mock_shutil_which, effort)
+
+    assert cmd[0] == "/bin/codex"
+    assert "-c" in cmd
+    flag_idx = cmd.index("-c")
+    exec_idx = cmd.index("exec")
+    assert flag_idx < exec_idx, f"-c must precede 'exec' (got {cmd})"
+    assert cmd[flag_idx + 1] == f"model_reasoning_effort={effort}"
+
+
+def test_codex_without_effort_env_unchanged(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess
+):
+    """Unset PDD_REASONING_EFFORT -> argv has no -c flag (preserves prior behavior)."""
+    cmd = _codex_cmd_with_effort(mock_cwd, mock_subprocess, mock_shutil_which, None)
+    assert "-c" not in cmd
+    assert "model_reasoning_effort" not in " ".join(cmd)
+
+
+def test_codex_invalid_effort_value_ignored(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess
+):
+    """Values outside {low,medium,high} are rejected so bad env cannot poison argv."""
+    cmd = _codex_cmd_with_effort(mock_cwd, mock_subprocess, mock_shutil_which, "ultra")
+    assert "-c" not in cmd
+
+
+def test_anthropic_with_effort_does_not_modify_argv(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess
+):
+    """Claude Code CLI has no reasoning flag today — argv must stay identical."""
+    from pdd.agentic_common import _run_with_provider
+
+    mock_shutil_which.return_value = "/bin/claude"
+    mock_subprocess.return_value.returncode = 0
+    mock_subprocess.return_value.stdout = json.dumps({"response": "ok"})
+    mock_subprocess.return_value.stderr = ""
+
+    prompt_file = mock_cwd / ".agentic_prompt_test.txt"
+    prompt_file.write_text("hi")
+
+    os.environ["PDD_REASONING_EFFORT"] = "high"
+    try:
+        _run_with_provider("anthropic", prompt_file, mock_cwd, verbose=False, quiet=True)
+    finally:
+        os.environ.pop("PDD_REASONING_EFFORT", None)
+
+    args, _ = mock_subprocess.call_args
+    cmd = args[0]
+    # No reasoning-effort related token should have leaked into the Claude argv
+    joined = " ".join(cmd)
+    assert "reasoning_effort" not in joined
+    assert "reasoning-effort" not in joined
+
+
+def test_google_with_effort_does_not_modify_argv(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess
+):
+    """Gemini CLI has no reasoning flag today — argv must stay identical."""
+    from pdd.agentic_common import _run_with_provider
+
+    mock_shutil_which.return_value = "/bin/gemini"
+    mock_subprocess.return_value.returncode = 0
+    mock_subprocess.return_value.stdout = json.dumps({
+        "response": "ok",
+        "stats": {"models": {"gemini-2.5-pro": {"tokens": {"prompt": 1, "candidates": 1}}}},
+    })
+    mock_subprocess.return_value.stderr = ""
+
+    prompt_file = mock_cwd / ".agentic_prompt_test.txt"
+    prompt_file.write_text("hi")
+
+    os.environ["PDD_REASONING_EFFORT"] = "high"
+    try:
+        _run_with_provider("google", prompt_file, mock_cwd, verbose=False, quiet=True)
+    finally:
+        os.environ.pop("PDD_REASONING_EFFORT", None)
+
+    args, _ = mock_subprocess.call_args
+    cmd = args[0]
+    joined = " ".join(cmd)
+    assert "reasoning_effort" not in joined
+    assert "reasoning-effort" not in joined

--- a/tests/test_agentic_common.py
+++ b/tests/test_agentic_common.py
@@ -5002,3 +5002,120 @@ def test_run_agentic_task_forwards_reasoning_time_to_provider(
     cmd = args[0]
     assert "-c" in cmd
     assert cmd[cmd.index("-c") + 1] == "model_reasoning_effort=high"
+
+
+# ---------------------------------------------------------------------------
+# CODEX_REASONING_EFFORT precedence (cloud signal for GPT-5.4 routing)
+# Greg's PR #1293 review B2: cloud sets CODEX_REASONING_EFFORT=xhigh and the
+# legacy signal must survive alongside the generic PDD_REASONING_EFFORT path.
+# ---------------------------------------------------------------------------
+
+
+def _codex_cmd_with_codex_env(
+    mock_cwd, mock_subprocess, mock_shutil_which, codex_value, pdd_value=None, kwarg_time=None
+):
+    """Helper: invoke _run_with_provider for openai with CODEX_REASONING_EFFORT
+    set (and optionally PDD_REASONING_EFFORT and a reasoning_time kwarg) and
+    return argv."""
+    from pdd.agentic_common import _run_with_provider
+
+    mock_shutil_which.return_value = "/bin/codex"
+    mock_subprocess.return_value.returncode = 0
+    mock_subprocess.return_value.stdout = json.dumps({
+        "type": "result", "output": "ok",
+        "usage": {"input_tokens": 10, "output_tokens": 10, "cached_input_tokens": 0},
+    })
+    mock_subprocess.return_value.stderr = ""
+
+    prompt_file = mock_cwd / ".agentic_prompt_test.txt"
+    prompt_file.write_text("hi")
+
+    prev_codex = os.environ.get("CODEX_REASONING_EFFORT")
+    prev_pdd = os.environ.get("PDD_REASONING_EFFORT")
+    if codex_value is None:
+        os.environ.pop("CODEX_REASONING_EFFORT", None)
+    else:
+        os.environ["CODEX_REASONING_EFFORT"] = codex_value
+    if pdd_value is None:
+        os.environ.pop("PDD_REASONING_EFFORT", None)
+    else:
+        os.environ["PDD_REASONING_EFFORT"] = pdd_value
+
+    try:
+        _run_with_provider(
+            "openai", prompt_file, mock_cwd,
+            verbose=False, quiet=True, reasoning_time=kwarg_time,
+        )
+    finally:
+        for var, prev in (("CODEX_REASONING_EFFORT", prev_codex), ("PDD_REASONING_EFFORT", prev_pdd)):
+            if prev is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = prev
+
+    args, _ = mock_subprocess.call_args
+    return args[0]
+
+
+@pytest.mark.parametrize("codex_effort", ["low", "medium", "high", "xhigh"])
+def test_codex_reasoning_effort_env_accepts_xhigh_for_gpt54(
+    codex_effort, mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess
+):
+    """Codex argv must accept ``xhigh`` (in addition to low/medium/high) so
+    the cloud worker can promote GPT-5.4 to extra-high reasoning regardless
+    of the user's --time. The generic PDD_REASONING_EFFORT only allows the
+    standard three levels."""
+    cmd = _codex_cmd_with_codex_env(mock_cwd, mock_subprocess, mock_shutil_which, codex_effort)
+    assert "-c" in cmd
+    assert cmd[cmd.index("-c") + 1] == f"model_reasoning_effort={codex_effort}"
+
+
+def test_codex_env_takes_precedence_over_pdd_env(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess
+):
+    """When both env vars are set, CODEX_REASONING_EFFORT (provider-specific)
+    wins over PDD_REASONING_EFFORT (generic). Otherwise the generic env would
+    silently downgrade an explicit cloud xhigh to high."""
+    cmd = _codex_cmd_with_codex_env(
+        mock_cwd, mock_subprocess, mock_shutil_which,
+        codex_value="xhigh", pdd_value="low",
+    )
+    assert cmd[cmd.index("-c") + 1] == "model_reasoning_effort=xhigh"
+
+
+def test_codex_env_takes_precedence_over_kwarg(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess
+):
+    """An explicit reasoning_time kwarg (forwarded from --time) must NOT
+    override a cloud-side CODEX_REASONING_EFFORT=xhigh — the cloud sets the
+    Codex-specific signal precisely because it knows the routed model
+    benefits from it. This locks in the precedence ordering."""
+    cmd = _codex_cmd_with_codex_env(
+        mock_cwd, mock_subprocess, mock_shutil_which,
+        codex_value="xhigh", kwarg_time=0.5,  # kwarg would map to 'medium'
+    )
+    assert cmd[cmd.index("-c") + 1] == "model_reasoning_effort=xhigh"
+
+
+def test_codex_invalid_codex_env_falls_through_to_generic(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess
+):
+    """An invalid CODEX_REASONING_EFFORT value (not in {low,medium,high,xhigh})
+    is ignored, and PDD_REASONING_EFFORT becomes the effective source."""
+    cmd = _codex_cmd_with_codex_env(
+        mock_cwd, mock_subprocess, mock_shutil_which,
+        codex_value="ultra", pdd_value="medium",
+    )
+    assert cmd[cmd.index("-c") + 1] == "model_reasoning_effort=medium"
+
+
+def test_codex_invalid_codex_env_with_no_fallback_yields_no_flag(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess
+):
+    """No flag is injected when CODEX_REASONING_EFFORT is invalid AND no
+    other source provides a signal — preserves prior behavior."""
+    cmd = _codex_cmd_with_codex_env(
+        mock_cwd, mock_subprocess, mock_shutil_which,
+        codex_value="ultra",
+    )
+    assert "-c" not in cmd

--- a/tests/test_agentic_common.py
+++ b/tests/test_agentic_common.py
@@ -4837,3 +4837,66 @@ def test_google_with_effort_does_not_modify_argv(
     joined = " ".join(cmd)
     assert "reasoning_effort" not in joined
     assert "reasoning-effort" not in joined
+
+
+@pytest.mark.parametrize("raw", ["  High  ", "HIGH", "High", "high\n"])
+def test_codex_effort_env_is_case_and_whitespace_tolerant(
+    raw, mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess
+):
+    """`PDD_REASONING_EFFORT` arrives from many sources (shell, GitHub App,
+    env files). Tolerate mixed case and leading/trailing whitespace so a
+    harmless formatting difference does not silently drop the signal."""
+    cmd = _codex_cmd_with_effort(mock_cwd, mock_subprocess, mock_shutil_which, raw)
+    assert "-c" in cmd
+    assert cmd[cmd.index("-c") + 1] == "model_reasoning_effort=high"
+
+
+def test_claude_always_prints_effort_notice_when_not_quiet(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess, capsys
+):
+    """Silent-failure guard: dropping the user's reasoning request with no
+    feedback generates support tickets. The notice fires regardless of
+    --verbose, gated only by --quiet."""
+    from pdd.agentic_common import _run_with_provider
+
+    mock_shutil_which.return_value = "/bin/claude"
+    mock_subprocess.return_value.returncode = 0
+    mock_subprocess.return_value.stdout = json.dumps({"response": "ok"})
+    mock_subprocess.return_value.stderr = ""
+
+    prompt_file = mock_cwd / ".agentic_prompt_test.txt"
+    prompt_file.write_text("hi")
+
+    os.environ["PDD_REASONING_EFFORT"] = "high"
+    try:
+        _run_with_provider("anthropic", prompt_file, mock_cwd, verbose=False, quiet=False)
+    finally:
+        os.environ.pop("PDD_REASONING_EFFORT", None)
+
+    captured = capsys.readouterr()
+    assert "PDD_REASONING_EFFORT=high" in captured.out
+    assert "Claude Code CLI" in captured.out
+
+
+def test_claude_suppresses_effort_notice_when_quiet(
+    mock_cwd, mock_env, mock_load_model_data, mock_shutil_which, mock_subprocess, capsys
+):
+    """--quiet must stay quiet. The notice is informational, not diagnostic."""
+    from pdd.agentic_common import _run_with_provider
+
+    mock_shutil_which.return_value = "/bin/claude"
+    mock_subprocess.return_value.returncode = 0
+    mock_subprocess.return_value.stdout = json.dumps({"response": "ok"})
+    mock_subprocess.return_value.stderr = ""
+
+    prompt_file = mock_cwd / ".agentic_prompt_test.txt"
+    prompt_file.write_text("hi")
+
+    os.environ["PDD_REASONING_EFFORT"] = "high"
+    try:
+        _run_with_provider("anthropic", prompt_file, mock_cwd, verbose=False, quiet=True)
+    finally:
+        os.environ.pop("PDD_REASONING_EFFORT", None)
+
+    captured = capsys.readouterr()
+    assert "PDD_REASONING_EFFORT" not in captured.out

--- a/tests/test_e2e_issue_357_step9_keyerror.py
+++ b/tests/test_e2e_issue_357_step9_keyerror.py
@@ -204,7 +204,7 @@ class TestIssue357Step9KeyErrorE2E:
         # Track which steps were attempted
         steps_attempted = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """
             Mock that lets us track which steps are called and what prompts are used.
 

--- a/tests/test_e2e_issue_373_step5_keyerror.py
+++ b/tests/test_e2e_issue_373_step5_keyerror.py
@@ -465,7 +465,7 @@ class TestIssue373OrchestratorE2EIntegration:
         steps_attempted = []
         prompts_received = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """
             Mock that lets us track which steps are called and what prompts are used.
 
@@ -585,7 +585,7 @@ class TestIssue373OrchestratorE2EIntegration:
                 return expanded_template
             return real_loader(template_name)
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             match = re.search(r"step(\d+)", label)
             if match:
                 steps_attempted.append(int(match.group(1)))

--- a/tests/test_e2e_issue_419_cli_unpushed_commits.py
+++ b/tests/test_e2e_issue_419_cli_unpushed_commits.py
@@ -102,7 +102,7 @@ class TestIssue419CLIUnpushedCommitsE2E:
 
         step_calls = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Mock LLM agent: Step 1 creates commit, Step 2 returns ALL_TESTS_PASS."""
             step_calls.append(label)
 
@@ -218,7 +218,7 @@ def generate():
         monkeypatch.chdir(worktree_path)
         monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             if "_step1" in label:
                 generate_file = cwd / "pdd" / "commands" / "generate.py"
                 generate_file.write_text('"""Fixed."""\ndef generate():\n    return "Fixed"\n')

--- a/tests/test_e2e_issue_426_include_path_validation.py
+++ b/tests/test_e2e_issue_426_include_path_validation.py
@@ -87,7 +87,7 @@ Build a simple Python data model system with examples.
         # Track which steps were called and control their outputs
         step_calls = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Mock LLM agent for each step of the architecture workflow."""
             step_calls.append(label)
 

--- a/tests/test_e2e_issue_429_prompt_files_in_pr.py
+++ b/tests/test_e2e_issue_429_prompt_files_in_pr.py
@@ -136,7 +136,7 @@ class TestIssue429PromptFilesInPRE2E:
         files_to_stage_at_step10 = None
         step_calls = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Mock LLM agent for each step of the bug workflow."""
             nonlocal files_to_stage_at_step10
             step_calls.append(label)
@@ -306,7 +306,7 @@ def test_step10_prompt_references_files_to_stage():
         # Capture the full instruction sent to Step 10
         step10_instruction = None
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Mock LLM agent - capture Step 10 instruction."""
             nonlocal step10_instruction
 

--- a/tests/test_e2e_issue_445_worktree_resume.py
+++ b/tests/test_e2e_issue_445_worktree_resume.py
@@ -207,7 +207,7 @@ class TestIssue445WorktreeResumptionE2E:
         def mock_clear_state(*args, **kwargs):
             pass
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             return (True, f"Mock success for {label}", 0.001, "mock-model")
 
         with patch('pdd.agentic_change_orchestrator.load_workflow_state', side_effect=mock_load_state):
@@ -284,7 +284,7 @@ class TestIssue445WorktreeResumptionE2E:
 
         step_calls = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Mock LLM calls - verify we get to step 11 (requires worktree)."""
             step_calls.append(label)
             return (True, f"Mock success for {label}", 0.001, "mock-model")

--- a/tests/test_e2e_issue_448_change_orchestrator.py
+++ b/tests/test_e2e_issue_448_change_orchestrator.py
@@ -245,7 +245,7 @@ class TestIssue448OrchestratorIntegration:
         # Track which steps were attempted
         steps_attempted = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Mock LLM agent that returns success for each step."""
             import re
             match = re.search(r"step(\d+)", label)

--- a/tests/test_e2e_issue_468_not_a_bug_early_exit.py
+++ b/tests/test_e2e_issue_468_not_a_bug_early_exit.py
@@ -63,7 +63,7 @@ class TestIssue468NotABugEarlyExitE2E:
 
         steps_executed = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Mock LLM execution that returns NOT_A_BUG for Step 3."""
             match = re.search(r"step(\d+)", label)
             if match:
@@ -135,7 +135,7 @@ class TestIssue468NotABugEarlyExitE2E:
 
         steps_executed = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Mock LLM with verbose NOT_A_BUG response for Step 3."""
             match = re.search(r"step(\d+)", label)
             if match:
@@ -208,7 +208,7 @@ class TestIssue468NotABugEarlyExitE2E:
 
         steps_executed = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Mock LLM with CODE_BUG response for Step 3."""
             match = re.search(r"step(\d+)", label)
             if match:

--- a/tests/test_e2e_issue_469_duplicate_unresolved.py
+++ b/tests/test_e2e_issue_469_duplicate_unresolved.py
@@ -179,7 +179,7 @@ class TestIssue469DuplicateUnresolvedE2E:
 
         steps_executed = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Mock LLM that follows the fixed prompt for unresolved duplicates."""
             match = re.search(r"step(\d+(?:_\d+)?)", label)
             if match:
@@ -260,7 +260,7 @@ class TestIssue469DuplicateUnresolvedE2E:
 
         steps_executed = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Mock LLM that finds a resolved duplicate."""
             match = re.search(r"step(\d+(?:_\d+)?)", label)
             if match:

--- a/tests/test_e2e_issue_579_orchestrator_rerun.py
+++ b/tests/test_e2e_issue_579_orchestrator_rerun.py
@@ -157,7 +157,7 @@ class TestIssue579OrchestratorRerunE2E:
 
         step_calls = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Mock LLM calls — return success for all steps.
 
             Steps 1-6 produce outputs that don't trigger any hard-stop conditions.
@@ -299,7 +299,7 @@ class TestIssue579OrchestratorRerunE2E:
 
         step_calls = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             step_calls.append(label)
 
             # Step 10: Verify test
@@ -408,7 +408,7 @@ class TestIssue579OrchestratorRerunE2E:
         def mock_clear_state(*args, **kwargs):
             pass
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             return (True, f"Mock success for {label}", 0.001, "mock-model")
 
         with patch('pdd.agentic_change_orchestrator.load_workflow_state', side_effect=mock_load_state):

--- a/tests/test_e2e_issue_773_hard_stop.py
+++ b/tests/test_e2e_issue_773_hard_stop.py
@@ -55,7 +55,7 @@ class TestIssue773HardStopE2E:
 
         steps_attempted = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Track which steps are attempted."""
             match = re.search(r"step(\d+)", label)
             if match:
@@ -122,7 +122,7 @@ class TestIssue773HardStopE2E:
 
         steps_attempted = []
 
-        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries):
+        def mock_run_agentic_task(instruction, cwd, verbose, quiet, timeout, label, max_retries, **kwargs):
             """Track which steps are attempted."""
             match = re.search(r"step(\d+)", label)
             if match:

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -1,0 +1,27 @@
+"""Tests for the time-to-effort helper.
+
+Kept separate from the llm_invoke and cli test files so the helper's
+contract is pinned without requiring the rest of either module to import.
+"""
+
+import pytest
+
+from pdd.reasoning import time_to_effort_level
+
+
+@pytest.mark.parametrize(
+    "time, expected",
+    [
+        (0.0, "low"),
+        (0.1, "low"),
+        (0.3, "low"),      # strict > on the boundary
+        (0.31, "medium"),
+        (0.5, "medium"),
+        (0.7, "medium"),   # strict > on the boundary
+        (0.71, "high"),
+        (0.85, "high"),
+        (1.0, "high"),
+    ],
+)
+def test_time_to_effort_level_boundaries(time, expected):
+    assert time_to_effort_level(time) == expected

--- a/tests/test_time_reasoning_effort_env.py
+++ b/tests/test_time_reasoning_effort_env.py
@@ -218,3 +218,71 @@ def test_command_forwards_reasoning_time_to_orchestrator(
         f"{orchestrator_fn} did not receive reasoning_time=0.85; "
         f"got kwargs={captured['kwargs']!r}"
     )
+
+
+@pytest.mark.parametrize(
+    "command_name, orchestrator_mod, orchestrator_fn",
+    [
+        ("fix", "pdd.agentic_e2e_fix", "run_agentic_e2e_fix"),
+        ("bug", "pdd.agentic_bug", "run_agentic_bug"),
+        ("change", "pdd.agentic_change", "run_agentic_change"),
+        ("sync", "pdd.agentic_sync", "run_agentic_sync"),
+        ("checkup", "pdd.agentic_checkup", "run_agentic_checkup"),
+    ],
+)
+def test_command_does_not_forward_default_time_when_flag_omitted(
+    command_name, orchestrator_mod, orchestrator_fn,
+):
+    """Greg's PR #1293 review B1: when the user does NOT pass --time on the
+    command line, ``ctx.obj["time"]`` is still populated (DEFAULT_TIME
+    fallback), but the command must NOT forward it as ``reasoning_time``.
+    Otherwise plain ``pdd bug ...`` would force-set Codex effort to 'low'
+    and silently regress every existing user. This test pins the explicitness
+    gate: with no --time, ``reasoning_time`` arrives as None at the
+    orchestrator."""
+    from unittest.mock import patch
+
+    import pdd.cli  # noqa: F401  — registers commands onto cli group
+    from pdd.core.cli import cli
+
+    captured = {}
+
+    source_target = f"{orchestrator_mod}.{orchestrator_fn}"
+    cmd_bindings = {
+        "run_agentic_e2e_fix": None,
+        "run_agentic_bug": "pdd.commands.analysis.run_agentic_bug",
+        "run_agentic_change": "pdd.commands.modify.run_agentic_change",
+        "run_agentic_sync": "pdd.commands.maintenance.run_agentic_sync",
+        "run_agentic_checkup": "pdd.commands.checkup.run_agentic_checkup",
+    }
+
+    def fake_orch(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        if orchestrator_fn in {"run_agentic_checkup", "run_agentic_sync"}:
+            return (True, "ok", 0.0, "claude")
+        return (True, "ok", 0.0, "claude", [])
+
+    runner = CliRunner()
+    bound = cmd_bindings[orchestrator_fn]
+
+    with patch(source_target, side_effect=fake_orch):
+        ctx_patches = [patch(bound, side_effect=fake_orch)] if bound else []
+        for p in ctx_patches:
+            p.start()
+        try:
+            # No --time on argv this time.
+            args = [command_name, "https://github.com/owner/repo/issues/1"]
+            result = runner.invoke(cli, args)
+        finally:
+            for p in ctx_patches:
+                p.stop()
+
+    assert "kwargs" in captured, (
+        f"{orchestrator_fn} was never invoked by ``pdd {command_name}`` "
+        f"(CliRunner output: {result.output!r})"
+    )
+    assert captured["kwargs"].get("reasoning_time") is None, (
+        f"{orchestrator_fn} received reasoning_time={captured['kwargs'].get('reasoning_time')!r} "
+        f"despite no --time on argv — the explicitness gate failed and a "
+        f"plain command would silently force-set provider effort."
+    )

--- a/tests/test_time_reasoning_effort_env.py
+++ b/tests/test_time_reasoning_effort_env.py
@@ -11,6 +11,7 @@ import os
 from unittest.mock import patch
 
 import click
+import pytest
 from click.testing import CliRunner
 
 
@@ -146,3 +147,74 @@ def test_cli_env_survives_to_downstream_same_process():
         cli.commands.pop("_test_full_chain", None)
         os.environ.pop("_TEST_TMPDIR", None)
         os.environ.pop("PDD_REASONING_EFFORT", None)
+
+
+@pytest.mark.parametrize(
+    "command_name, orchestrator_mod, orchestrator_fn",
+    [
+        ("fix", "pdd.agentic_e2e_fix", "run_agentic_e2e_fix"),
+        ("bug", "pdd.agentic_bug", "run_agentic_bug"),
+        ("change", "pdd.agentic_change", "run_agentic_change"),
+        ("sync", "pdd.agentic_sync", "run_agentic_sync"),
+        ("checkup", "pdd.agentic_checkup", "run_agentic_checkup"),
+    ],
+)
+def test_command_forwards_reasoning_time_to_orchestrator(
+    command_name, orchestrator_mod, orchestrator_fn,
+):
+    """Greg's review #3: each issue-URL command must forward
+    ``ctx.obj["time"]`` into its agentic orchestrator via an explicit
+    kwarg. This parametrized test patches each orchestrator, runs its
+    command via CliRunner with ``--time 0.85``, and asserts the
+    orchestrator received ``reasoning_time=0.85``."""
+    import importlib
+    from unittest.mock import patch
+
+    # Side-effect-import registers all commands onto ``pdd.core.cli.cli``.
+    import pdd.cli  # noqa: F401
+    from pdd.core.cli import cli
+
+    captured = {}
+
+    # `fix` imports run_agentic_e2e_fix lazily inside its command body; the
+    # other commands import at module load time. Patch both the source
+    # module (covers lazy imports) and the already-bound name in the command
+    # module (covers early binding).
+    source_target = f"{orchestrator_mod}.{orchestrator_fn}"
+    cmd_bindings = {
+        "run_agentic_e2e_fix": None,  # fix imports lazily — only source patch needed
+        "run_agentic_bug": "pdd.commands.analysis.run_agentic_bug",
+        "run_agentic_change": "pdd.commands.modify.run_agentic_change",
+        "run_agentic_sync": "pdd.commands.maintenance.run_agentic_sync",
+        "run_agentic_checkup": "pdd.commands.checkup.run_agentic_checkup",
+    }
+
+    def fake_orch_with_exit(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        # checkup/sync return 4-tuple, fix/bug/change return 5-tuple
+        if orchestrator_fn in {"run_agentic_checkup", "run_agentic_sync"}:
+            return (True, "ok", 0.0, "claude")
+        return (True, "ok", 0.0, "claude", [])
+
+    runner = CliRunner()
+    bound = cmd_bindings[orchestrator_fn]
+
+    with patch(source_target, side_effect=fake_orch_with_exit):
+        ctx_patches = [patch(bound, side_effect=fake_orch_with_exit)] if bound else []
+        for p in ctx_patches:
+            p.start()
+        try:
+            args = ["--time", "0.85", command_name, "https://github.com/owner/repo/issues/1"]
+            result = runner.invoke(cli, args)
+        finally:
+            for p in ctx_patches:
+                p.stop()
+
+    assert "kwargs" in captured, (
+        f"{orchestrator_fn} was never invoked by ``pdd {command_name}`` "
+        f"(CliRunner output: {result.output!r})"
+    )
+    assert captured["kwargs"].get("reasoning_time") == 0.85, (
+        f"{orchestrator_fn} did not receive reasoning_time=0.85; "
+        f"got kwargs={captured['kwargs']!r}"
+    )

--- a/tests/test_time_reasoning_effort_env.py
+++ b/tests/test_time_reasoning_effort_env.py
@@ -66,3 +66,83 @@ def test_no_time_flag_leaves_env_unset():
     # When the user does not pass --time, we must not forcibly clobber
     # anything the worker env.yaml already set for the subprocess.
     assert _capture_env_for_time(None) == "NOT_SET"
+
+
+def test_zero_time_maps_to_low_effort():
+    # --time 0.0 is a valid value (click.FloatRange lower bound) and must
+    # map to "low" — the user did opt in.
+    assert _capture_env_for_time(0.0) == "low"
+
+
+def test_one_time_maps_to_high_effort():
+    # --time 1.0 is the click.FloatRange upper bound; must produce "high".
+    assert _capture_env_for_time(1.0) == "high"
+
+
+def test_exact_low_medium_boundary_maps_to_low():
+    # Thresholds use strict >; exact 0.3 stays "low".
+    assert _capture_env_for_time(0.3) == "low"
+
+
+def test_exact_medium_high_boundary_maps_to_medium():
+    # Thresholds use strict >; exact 0.7 stays "medium", does not flip to "high".
+    assert _capture_env_for_time(0.7) == "medium"
+
+
+def test_cli_env_survives_to_downstream_same_process():
+    """End-to-end: after the CLI callback fires with --time, a later call to
+    _run_with_provider in the same Python process sees the env var and
+    injects Codex's -c flag. Guards against the failure mode where one
+    end of the chain works in isolation but the seam silently breaks.
+    """
+    import json
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from pdd.agentic_common import _run_with_provider
+    from pdd.core.cli import cli
+
+    captured_cmd = {}
+
+    def fake_subprocess_run(cmd, **kwargs):
+        captured_cmd["cmd"] = cmd
+        import subprocess
+        return subprocess.CompletedProcess(
+            cmd, 0,
+            stdout=json.dumps({
+                "type": "result", "output": "ok",
+                "usage": {"input_tokens": 10, "output_tokens": 10, "cached_input_tokens": 0},
+            }),
+            stderr="",
+        )
+
+    runner = CliRunner()
+
+    @cli.command("_test_full_chain")
+    @click.pass_context
+    def _probe(ctx):
+        tmpdir = Path(os.environ["_TEST_TMPDIR"])
+        prompt_file = tmpdir / "prompt.txt"
+        prompt_file.write_text("hi")
+        with patch("pdd.agentic_common._subprocess_run", side_effect=fake_subprocess_run):
+            with patch("pdd.agentic_common._find_cli_binary", return_value="/bin/codex"):
+                _run_with_provider(
+                    "openai", prompt_file, tmpdir,
+                    verbose=False, quiet=True,
+                )
+
+    try:
+        with runner.isolated_filesystem() as tmpdir:
+            os.environ["_TEST_TMPDIR"] = str(tmpdir)
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("PDD_REASONING_EFFORT", None)
+                result = runner.invoke(cli, ["--time", "0.85", "_test_full_chain"])
+                assert result.exit_code == 0, result.output
+                cmd = captured_cmd.get("cmd") or []
+                assert "-c" in cmd, f"Codex -c flag missing from full-chain cmd: {cmd}"
+                assert cmd[cmd.index("-c") + 1] == "model_reasoning_effort=high"
+                assert cmd.index("-c") < cmd.index("exec")
+    finally:
+        cli.commands.pop("_test_full_chain", None)
+        os.environ.pop("_TEST_TMPDIR", None)
+        os.environ.pop("PDD_REASONING_EFFORT", None)

--- a/tests/test_time_reasoning_effort_env.py
+++ b/tests/test_time_reasoning_effort_env.py
@@ -1,0 +1,68 @@
+"""--time → PDD_REASONING_EFFORT plumbing.
+
+The top-level Click group must translate the user's --time value into a
+low/medium/high effort level and expose it as an environment variable so
+provider subprocesses (Codex, etc.) can forward it to the model. Without
+this signal the --time flag only affects LiteLLM-invoked steps and silently
+drops on the floor for agentic subprocess launches.
+"""
+
+import os
+from unittest.mock import patch
+
+import click
+from click.testing import CliRunner
+
+
+def _capture_env_for_time(time_arg):
+    from pdd.core.cli import cli
+
+    runner = CliRunner()
+    captured = {}
+
+    @cli.command("_test_effort_env")
+    @click.pass_context
+    def _probe(ctx):
+        captured["PDD_REASONING_EFFORT"] = os.environ.get(
+            "PDD_REASONING_EFFORT", "NOT_SET"
+        )
+
+    try:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PDD_REASONING_EFFORT", None)
+            args = []
+            if time_arg is not None:
+                args.extend(["--time", str(time_arg)])
+            args.append("_test_effort_env")
+            runner.invoke(cli, args)
+        return captured.get("PDD_REASONING_EFFORT", "NOT_SET")
+    finally:
+        cli.commands.pop("_test_effort_env", None)
+        os.environ.pop("PDD_REASONING_EFFORT", None)
+
+
+def test_high_time_maps_to_high_effort():
+    assert _capture_env_for_time(0.85) == "high"
+
+
+def test_medium_time_maps_to_medium_effort():
+    assert _capture_env_for_time(0.5) == "medium"
+
+
+def test_low_time_maps_to_low_effort():
+    assert _capture_env_for_time(0.2) == "low"
+
+
+def test_boundary_just_above_medium_threshold_is_medium():
+    # 0.3 exclusive lower bound for medium; 0.31 must bump to medium.
+    assert _capture_env_for_time(0.31) == "medium"
+
+
+def test_boundary_just_above_high_threshold_is_high():
+    assert _capture_env_for_time(0.71) == "high"
+
+
+def test_no_time_flag_leaves_env_unset():
+    # When the user does not pass --time, we must not forcibly clobber
+    # anything the worker env.yaml already set for the subprocess.
+    assert _capture_env_for_time(None) == "NOT_SET"


### PR DESCRIPTION
## Summary

Mirrors the CLI-side fix from `gltanaka/pdd#1293` onto the public `promptdriven/pdd` repo, since the GitHub App worker image installs from `promptdriven/pdd@main`.

Closes the gap between the top-level `--time` flag and the agentic subprocess launches used by `pdd fix <issue-url>`, `pdd analysis/bug <issue-url>`, and `pdd checkup <issue-url>`.

`ctx.obj["time"]` already routes into LiteLLM-driven steps (the analysis planner, verifier, classifier) via the CSV-driven `reasoning_effort` mapping in `llm_invoke.py`. But the subprocess calls that actually write code (`run_agentic_task` → `_run_with_provider` → Codex/Claude Code/Gemini CLIs) only ever forwarded `--model`, never a reasoning signal. A `--time 0.85` run produced the same provider argv as an unspecified run.

## What changed

### `pdd/core/cli.py`
Maps `--time` → `PDD_REASONING_EFFORT={low,medium,high}` using the same thresholds `llm_invoke.py` uses (>0.7 high, >0.3 medium, else low). When `--time` is omitted, the env var is left untouched.

### `pdd/agentic_common.py`
`_run_with_provider` reads `PDD_REASONING_EFFORT` (validated against `{low, medium, high}`) and:
- **Codex**: injects `-c model_reasoning_effort=<level>` **before** the `exec` subcommand.
- **Claude Code CLI**: no reasoning-effort flag today; logs once in verbose mode.
- **Gemini CLI**: same — no flag today, logged in verbose mode.

### Tests

- argv assertions for all three providers (parametrized Codex low/med/high with `-c` ordered strictly before `exec`; Anthropic and Gemini argv unchanged when env set).
- `CliRunner` coverage of `--time` → env mapping including boundary values.
- Suite: 196 passed.

## Why this PR exists

The companion GitHub App PR (`promptdriven/pdd_cloud#1162`) plumbs `pdd-effort-*` labels → `--time` argv position, but the worker installs the CLI from `promptdriven/pdd@main`. Without this PR merged first, the worker would install a CLI where `--time` reaches argv but doesn't change provider reasoning behavior.

**Merge order**: this PR first, then `pdd_cloud#1162` (rebased onto main, Dockerfile stays at `@main`).

## Test plan

- [x] Unit tests cover the mapping, argv flag ordering (Codex-specific), and per-provider no-op assertions.
- [x] Existing provider success tests still pass — change is additive (adds argv tokens only when env is set with valid value).
- [ ] End-to-end validation once `pdd_cloud#1162` lands on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)