### PR TITLE
fix: report pdd version from package metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -699,7 +699,7 @@ release: check-deps check-suspicious-files
 		$(MAKE) publish; \
 	else \
 		echo "Bumping version with commitizen"; \
-		python -m commitizen bump --increment PATCH --yes; \
+		python -m commitizen bump --increment PATCH --yes --check-consistency; \
 		echo "Pushing to origin before publishing"; \
 		git push origin main --tags; \
 		echo "Publishing new version"; \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDD (Prompt-Driven Development) Command Line Interface
 
-![PDD-CLI Version](https://img.shields.io/badge/pdd--cli-v0.0.179-blue) [![Discord](https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white)](https://discord.gg/Yp4RTh8bG7)
+![PDD-CLI Version](https://img.shields.io/badge/pdd--cli-v0.0.227-blue) [![Discord](https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white)](https://discord.gg/Yp4RTh8bG7)
 
 ## Introduction
 
@@ -359,7 +359,7 @@ For proper model identifiers to use in your custom configuration, refer to the [
 
 ## Version
 
-Current version: 0.0.179
+Current version: 0.0.227
 
 To check your installed version, run:
 ```

--- a/pdd/__init__.py
+++ b/pdd/__init__.py
@@ -1,8 +1,18 @@
 """PDD - Prompt Driven Development"""
 
+from importlib.metadata import PackageNotFoundError, version as _metadata_version
 import os
 
-__version__ = "0.0.179"
+
+def _load_package_version() -> str:
+    """Return the installed pdd-cli distribution version."""
+    try:
+        return _metadata_version("pdd-cli")
+    except PackageNotFoundError:
+        return "0.0.0+unknown"
+
+
+__version__ = _load_package_version()
 
 # Strength parameter used for LLM extraction across the codebase
 # Used in postprocessing, XML tagging, code generation, and other extraction

--- a/pdd/pdd_completion.sh
+++ b/pdd/pdd_completion.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # PDD CLI Bash Completion Script
-# Version: 0.0.5
+# Version: 0.0.227
 # Supports all PDD commands and options with filename completion
 
 _pdd() {

--- a/pdd/setup.py
+++ b/pdd/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pdd-cli",
-    version="0.0.179",
+    version="0.0.227",
     author="pdd-auto-heal[bot]",
     author_email="pdd-auto-heal[bot]@users.noreply.github.com",
     description="PDD (Prompt-Driven Development) - A toolkit for AI-powered code generation and maintenance",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ version = "0.0.227"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",
-    "pdd/__init__.py:__version__",
+    "pdd/setup.py:version=\"(.*?)\"",
     "README.md:Current version: (.*?)$",
     "README.md:https://img.shields.io/badge/pdd--cli-v(.*?)-blue",
     "pdd/pdd_completion.sh:# Version: (.*?)",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,30 @@
+"""Tests for package version reporting."""
+
+from importlib.metadata import version as metadata_version
+from pathlib import Path
+import tomllib
+
+from click.testing import CliRunner
+
+import pdd
+from pdd.core.cli import cli as cli_command
+
+
+def test_package_version_matches_distribution_metadata():
+    """pdd.__version__ should report the installed pdd-cli version."""
+    project_root = Path(__file__).resolve().parents[1]
+    pyproject = tomllib.loads((project_root / "pyproject.toml").read_text())
+    expected_version = pyproject["project"]["version"]
+
+    assert metadata_version("pdd-cli") == expected_version
+    assert pdd.__version__ == expected_version
+
+
+def test_cli_version_reports_distribution_metadata():
+    """`pdd --version` should report the installed pdd-cli version."""
+    expected_version = metadata_version("pdd-cli")
+
+    result = CliRunner().invoke(cli_command, ["--version"])
+
+    assert result.exit_code == 0
+    assert f"version {expected_version}" in result.output


### PR DESCRIPTION
Fixes #811.

## Summary
- read `pdd.__version__` from installed `pdd-cli` distribution metadata instead of a stale literal
- sync stale version surfaces in README, bash completion, and bundled setup.py
- enforce Commitizen version-file consistency during release bumps
- add regression tests for package metadata and `pdd --version` output

## Tests
- `python -m pytest tests/test_version.py tests/core/test_cli.py::test_cli_version -q`
- `pdd --version`