### PR TITLE
fix: preserve path-qualified sync dependencies

### DIFF
--- a/pdd/agentic_sync_runner.py
+++ b/pdd/agentic_sync_runner.py
@@ -116,6 +116,49 @@ def _basename_from_architecture_filename(filename: str) -> Optional[str]:
     return str(path.parent / basename)
 
 
+def _basename_from_architecture_filepath(filepath: str) -> Optional[str]:
+    """Return a sync basename from an architecture filepath."""
+    if not filepath:
+        return None
+
+    path = Path(filepath)
+    if path.suffix:
+        path = path.with_suffix("")
+    return path.as_posix()
+
+
+def _architecture_entry_aliases(entry: Dict[str, Any]) -> set[str]:
+    """Return all sync basenames that may identify an architecture entry."""
+    aliases: set[str] = set()
+
+    filename_basename = _basename_from_architecture_filename(
+        str(entry.get("filename", "") or "")
+    )
+    if filename_basename:
+        aliases.add(filename_basename)
+
+    filepath_basename = _basename_from_architecture_filepath(
+        str(entry.get("filepath", "") or "")
+    )
+    if filepath_basename:
+        aliases.add(filepath_basename)
+
+    return aliases
+
+
+def _target_basename_aliases(target_basename: str) -> set[str]:
+    """Return aliases that should match a requested sync target."""
+    aliases = {target_basename}
+    path = Path(target_basename)
+    stripped_name = extract_module_from_include(path.name + ".prompt")
+    if stripped_name:
+        if path.parent == Path("."):
+            aliases.add(stripped_name)
+        else:
+            aliases.add((path.parent / stripped_name).as_posix())
+    return aliases
+
+
 def build_dep_graph_from_architecture(
     arch_path: Path, target_basenames: List[str]
 ) -> DepGraphFromArchitectureResult:
@@ -163,52 +206,56 @@ def build_dep_graph_from_architecture_data(
     if not modules:
         return empty
 
-    # Map prompt filename -> stripped basename (e.g., "crm_models_Python.prompt" -> "crm_models")
-    filename_to_basename: Dict[str, str] = {}
+    target_aliases_by_target = {
+        target: _target_basename_aliases(target) for target in target_basenames
+    }
+
+    # Map architecture filename -> original requested target basename. Architecture
+    # entries commonly store bare prompt filenames (config_Python.prompt) while
+    # branch-diff sync targets may be path-qualified for .pddrc context routing
+    # (src/config). Match via both filename-derived and filepath-derived aliases,
+    # but keep graph keys as the original target strings the runner must execute.
+    filename_to_target: Dict[str, str] = {}
+    filename_to_aliases: Dict[str, set[str]] = {}
     for entry in modules:
-        filename = entry.get("filename", "")
-        basename = _basename_from_architecture_filename(filename)
-        if basename:
-            filename_to_basename[filename] = basename
-
-    # Target basenames may include a language suffix (e.g., "crm_models_Python")
-    # that extract_module_from_include strips. Build a lookup from stripped name
-    # to the original target basename so we can match architecture entries.
-    stripped_to_target: Dict[str, str] = {}
-    for tb in target_basenames:
-        stripped_to_target[tb] = tb  # exact match first
-        stripped = extract_module_from_include(tb + ".prompt")
-        if stripped:
-            stripped_to_target[stripped] = tb
-
-    target_set = set(stripped_to_target.keys())
+        filename = str(entry.get("filename", "") or "")
+        aliases = _architecture_entry_aliases(entry)
+        if not filename or not aliases:
+            continue
+        filename_to_aliases[filename] = aliases
+        for target in target_basenames:
+            if aliases & target_aliases_by_target[target]:
+                filename_to_target[filename] = target
+                break
 
     warnings: List[str] = []
     # Build graph using original target basenames
     graph: Dict[str, List[str]] = {}
     for entry in modules:
-        basename = filename_to_basename.get(entry.get("filename", ""))
-        if basename and basename in target_set:
-            target_name = stripped_to_target[basename]
+        filename = str(entry.get("filename", "") or "")
+        target_name = filename_to_target.get(filename)
+        if target_name:
             deps = []
             for dep_filename in entry.get("dependencies", []):
-                dep_basename = filename_to_basename.get(dep_filename)
-                if dep_basename is None:
+                dep_aliases = filename_to_aliases.get(dep_filename)
+                if dep_aliases is None:
                     warnings.append(
                         f"Orphan dependency {dep_filename!r} on architecture entry "
                         f"{entry.get('filename', '')!r}: no matching module entry in {source_name}"
                     )
                     continue
-                if dep_basename == basename:
+                dep_target = filename_to_target.get(dep_filename)
+                if dep_target == target_name:
                     continue
-                if dep_basename not in target_set:
+                if dep_target is None:
+                    dep_display = sorted(dep_aliases)[0]
                     warnings.append(
-                        f"Partial sync: module {target_name!r} depends on {dep_basename!r} "
+                        f"Partial sync: module {target_name!r} depends on {dep_display!r} "
                         f"(via {dep_filename!r}), which is not in the sync target set; "
                         "dependency edge omitted from graph"
                     )
                     continue
-                deps.append(stripped_to_target[dep_basename])
+                deps.append(dep_target)
             graph[target_name] = deps
 
     # Ensure all target basenames are in graph

--- a/pdd/prompts/agentic_sync_runner_python.prompt
+++ b/pdd/prompts/agentic_sync_runner_python.prompt
@@ -64,7 +64,8 @@ Parallel sync engine that runs `pdd sync` for multiple modules concurrently usin
 - `warnings: List[str]` — human-readable issues that did **not** prevent building the subgraph; operators use these to see silent omissions
 
 % Function: `build_dep_graph_from_architecture(arch_path: Path, target_basenames: List[str]) -> DepGraphFromArchitectureResult`
-- Load architecture.json, map prompt filename -> basename via `_basename_from_architecture_filename`
+- Load architecture.json and match target basenames against architecture entries using both prompt `filename` aliases and code `filepath` aliases. This is required for branch-diff targets such as `src/config`, where `filename` may be only `config_Python.prompt` but `filepath` is `src/config.py`.
+- Preserve the original `target_basenames` strings as graph keys/dependencies; do not normalize `src/config` to `config` before scheduling, because those path-qualified strings are needed for .pddrc context routing.
 - Build subgraph: only include edges where **both** endpoints resolve to basenames in `target_basenames` (partial sync: edges to modules outside the target set are **omitted** from `graph`, not added as fake nodes)
 - Exclude self-dependencies
 - Return empty deps for basenames not found in architecture.json
@@ -79,6 +80,16 @@ Parallel sync engine that runs `pdd sync` for multiple modules concurrently usin
 % Helper: `_basename_from_architecture_filename(filename: str) -> Optional[str]`
 - Convert an architecture `filename` to a sync basename while preserving subdirectory prefixes.
 - Examples: `agentic_sync_python.prompt` -> `agentic_sync`; `commands/maintenance_python.prompt` -> `commands/maintenance`; `_LLM.prompt` entries return `None`.
+
+% Helper: `_basename_from_architecture_filepath(filepath: str) -> Optional[str]`
+- Convert an architecture `filepath` to a sync basename by removing the final file extension and preserving directories.
+- Examples: `src/config.py` -> `src/config`; `src/clients/firestore_client.py` -> `src/clients/firestore_client`.
+
+% Helper: `_architecture_entry_aliases(entry: Dict[str, Any]) -> set[str]`
+- Return every basename that can identify an architecture entry, including `_basename_from_architecture_filename(entry["filename"])` and `_basename_from_architecture_filepath(entry["filepath"])` when present.
+
+% Helper: `_target_basename_aliases(target_basename: str) -> set[str]`
+- Return aliases for a requested sync target, including the original target and the language-suffix-stripped variant while preserving directories (for example `src/config_Python` -> `src/config`).
 
 % Helper Functions
 - `_find_pdd_executable() -> Optional[str]`: find pdd binary (same pattern as `server/jobs.py`)

--- a/tests/test_agentic_sync.py
+++ b/tests/test_agentic_sync.py
@@ -227,6 +227,74 @@ class TestBuildDepGraphFromArchitecture:
         assert result.graph["commands/maintenance"] == ["agentic_sync"]
         assert result.graph["agentic_sync"] == []
 
+    def test_preserves_dependencies_for_path_qualified_targets(self, tmp_path):
+        """Regression for #1382: branch-diff targets may be code paths."""
+        arch = [
+            {
+                "filename": "config_Python.prompt",
+                "filepath": "src/config.py",
+                "dependencies": [],
+            },
+            {
+                "filename": "models_Python.prompt",
+                "filepath": "src/models.py",
+                "dependencies": ["config_Python.prompt"],
+            },
+            {
+                "filename": "firestore_client_Python.prompt",
+                "filepath": "src/clients/firestore_client.py",
+                "dependencies": ["config_Python.prompt", "models_Python.prompt"],
+            },
+            {
+                "filename": "solving_orchestrator_Python.prompt",
+                "filepath": "src/services/solving_orchestrator.py",
+                "dependencies": [
+                    "config_Python.prompt",
+                    "models_Python.prompt",
+                    "firestore_client_Python.prompt",
+                ],
+            },
+            {
+                "filename": "worker_app_Python.prompt",
+                "filepath": "src/worker_app.py",
+                "dependencies": [
+                    "config_Python.prompt",
+                    "models_Python.prompt",
+                    "firestore_client_Python.prompt",
+                ],
+            },
+        ]
+        arch_path = tmp_path / "architecture.json"
+        arch_path.write_text(json.dumps(arch))
+
+        result = build_dep_graph_from_architecture(
+            arch_path,
+            [
+                "src/clients/firestore_client",
+                "src/config",
+                "src/models",
+                "src/services/solving_orchestrator",
+                "src/worker_app",
+            ],
+        )
+
+        assert result.graph == {
+            "src/config": [],
+            "src/models": ["src/config"],
+            "src/clients/firestore_client": ["src/config", "src/models"],
+            "src/services/solving_orchestrator": [
+                "src/config",
+                "src/models",
+                "src/clients/firestore_client",
+            ],
+            "src/worker_app": [
+                "src/config",
+                "src/models",
+                "src/clients/firestore_client",
+            ],
+        }
+        assert result.warnings == []
+
 
 # ---------------------------------------------------------------------------
 # Global sync helpers


### PR DESCRIPTION
## Summary

Fixes #834.

Agentic `pdd sync` can receive branch-diff modules as path-qualified targets such as `src/config` and `src/clients/firestore_client`. Those names must be preserved for `.pddrc` context routing, but the architecture dependency graph previously matched only prompt `filename` basenames such as `config` and `firestore_client`.

This caused architecture dependencies to be dropped for repos whose entries use bare prompt filenames plus `filepath`, which let large dependent modules start in parallel and hit cloud timeouts. This matches the observed `promptdriven/pdd_cloud#1340` / PR `promptdriven/pdd_cloud#1345` failure shape.

Related downstream mirror issue/PR: `gltanaka/pdd#1382`, `gltanaka/pdd#1383`.

## Changes

- Match architecture entries by both prompt `filename` aliases and code `filepath` aliases.
- Preserve the original requested sync target strings as graph keys and dependency values.
- Update the generated prompt contract for `agentic_sync_runner`.
- Add a regression test using the pdd_cloud module shape: `src/config`, `src/models`, `src/clients/firestore_client`, `src/services/solving_orchestrator`, `src/worker_app`.

## Verification

- `PYTHONPATH=$PWD python -m pytest tests/test_agentic_sync.py tests/test_agentic_sync_runner.py -q` -> 228 passed
- `PYTHONPATH=$PWD python -m pytest tests/test_agentic_sync.py::TestBuildDepGraphFromArchitecture::test_preserves_dependencies_for_path_qualified_targets -q` -> 1 passed
- `PYTHONPATH=$PWD python -m ruff check pdd/agentic_sync_runner.py` -> passed
- `git diff --check` -> passed

Note: `ruff check tests/test_agentic_sync.py` still reports pre-existing lint issues in that file; this PR does not touch those unrelated cleanups.
