### PR TITLE
Fix generated prompt include sanitization

### DIFF
--- a/pdd/auto_deps_main.py
+++ b/pdd/auto_deps_main.py
@@ -9,6 +9,7 @@ from rich import print as rprint
 from . import DEFAULT_STRENGTH, DEFAULT_TIME
 from .construct_paths import construct_paths
 from .insert_includes import insert_includes
+from .validate_prompt_includes import sanitize_prompt_output
 
 
 def auto_deps_main(
@@ -107,6 +108,15 @@ def auto_deps_main(
             # Save the modified prompt
             output_path = output_file_paths["output"]
             if output_path:
+                modified_prompt, invalid_includes = sanitize_prompt_output(
+                    modified_prompt,
+                    output_path,
+                )
+                if invalid_includes and not ctx.obj.get("quiet", False):
+                    rprint(
+                        "[yellow]Warning: Cleaned invalid <include> tag(s) "
+                        f"before saving {output_path}.[/yellow]"
+                    )
                 with open(output_path, 'w', encoding='utf-8') as f:
                     f.write(modified_prompt)
                 try:

--- a/pdd/change_main.py
+++ b/pdd/change_main.py
@@ -23,6 +23,7 @@ from .change import change as change_func
 from .process_csv_change import process_csv_change
 from .get_extension import get_extension
 from .user_story_tests import run_user_story_tests, discover_prompt_files
+from .validate_prompt_includes import sanitize_prompt_output
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -433,6 +434,15 @@ def change_main(
 
                         try:
                             logger.debug("Attempting to save file to: %s", individual_output_path)
+                            modified_content, invalid_includes = sanitize_prompt_output(
+                                modified_content,
+                                individual_output_path,
+                            )
+                            if invalid_includes and not quiet:
+                                rprint(
+                                    "[yellow]Warning: Cleaned invalid <include> tag(s) "
+                                    f"before saving {individual_output_path}.[/yellow]"
+                                )
                             with open(individual_output_path, 'w', encoding='utf-8') as output_file:
                                 output_file.write(modified_content)
                             logger.debug("Saved modified prompt to: %s", individual_output_path)
@@ -467,6 +477,15 @@ def change_main(
                 try:
                     output_path_obj.parent.mkdir(parents=True, exist_ok=True)  # Uses Path.mkdir, OK here
                     # Use open() for writing as expected by tests
+                    result_message, invalid_includes = sanitize_prompt_output(
+                        result_message,
+                        output_path_obj,
+                    )
+                    if invalid_includes and not quiet:
+                        rprint(
+                            "[yellow]Warning: Cleaned invalid <include> tag(s) "
+                            f"before saving {output_path_obj}.[/yellow]"
+                        )
                     with open(output_path_obj, 'w', encoding='utf-8') as output_file:
                         output_file.write(result_message)  # result_message contains the modified content here
                     if not quiet:

--- a/pdd/prompts/auto_deps_main_python.prompt
+++ b/pdd/prompts/auto_deps_main_python.prompt
@@ -13,6 +13,7 @@
 
 <pdd-dependency>construct_paths_python.prompt</pdd-dependency>
 <pdd-dependency>insert_includes_python.prompt</pdd-dependency>
+<pdd-dependency>validate_prompt_includes_python.prompt</pdd-dependency>
 
 % You are an expert Python engineer. Your goal is to write the `auto_deps_main` function that will be part of the `pdd` command-line program. This function will handle the core logic for the `auto-deps` command.
 
@@ -62,7 +63,8 @@
         • `insert_includes(input_prompt=input_strings["prompt_file"], directory_path=directory_path, csv_filename=csv_path, prompt_filename=prompt_file, strength=strength, temperature=temperature, time=time_budget, verbose=verbose, progress_callback=progress_callback, include_docs=include_docs, dedup=(not no_dedup), max_workers=concurrency)`
       Capture `(modified_prompt, csv_output, total_cost, model_name)`.
     - Save outputs:
-        • Write `modified_prompt` to `output_file_paths["output"]` (UTF-8).
+        • Before writing a `.prompt` output, call `sanitize_prompt_output(modified_prompt, output_file_paths["output"])` so missing or invalid selected `<include>` tags are cleaned instead of persisted for a later `pdd sync` failure.
+        • Write the cleaned `modified_prompt` to `output_file_paths["output"]` (UTF-8).
         • If `csv_output` is truthy (non-empty), write it to `csv_path` (UTF-8).
     - Console output (unless `quiet` is set), print using Rich formatting:
         • "[bold green]Successfully analyzed and inserted dependencies![/bold green]"
@@ -93,6 +95,10 @@
       <insert_includes_example>
       <include>context/insert_includes_example.py</include>
       </insert_includes_example>
+      - Use `sanitize_prompt_output` from `pdd.validate_prompt_includes` before writing the modified prompt:
+      <validate_prompt_includes>
+      <include select="def:sanitize_prompt_output">pdd/validate_prompt_includes.py</include>
+      </validate_prompt_includes>
    </internal_example_modules>
 </examples>
 

--- a/pdd/prompts/change_main_python.prompt
+++ b/pdd/prompts/change_main_python.prompt
@@ -42,6 +42,11 @@
       <process_csv_change_example>
       <include>context/process_csv_change_example.py</include>
       </process_csv_change_example>
+
+      - Using prompt include sanitization:
+      <validate_prompt_includes>
+      <include select="def:sanitize_prompt_output">pdd/validate_prompt_includes.py</include>
+      </validate_prompt_includes>
    </internal_example_modules>
 </examples>
 
@@ -81,11 +86,11 @@
       - For CSV mode:
         - Determine the output target based on the `output` argument.
         - If `output` specifies a CSV file path (ending in `.csv`): Create a new CSV file at this path with columns `file_name` and `modified_prompt`. Iterate through `modified_prompts_list` and write rows only for entries that have both keys and a non-None `modified_prompt`.
-        - If `output` is not specified, is a directory path, or is a non-CSV file path: Treat the target as a directory (using the parent directory if a non-CSV file path was given). Iterate through `modified_prompts_list`. For each dictionary, save the `modified_prompt` content as an individual file within the target directory, using the basename of the original `file_name`. Respect the `--force` flag when overwriting existing files.
+        - If `output` is not specified, is a directory path, or is a non-CSV file path: Treat the target as a directory (using the parent directory if a non-CSV file path was given). Iterate through `modified_prompts_list`. For each dictionary, save the `modified_prompt` content as an individual file within the target directory, using the basename of the original `file_name`. Before writing any `.prompt` file, pass the content and destination path through `sanitize_prompt_output` so missing or invalid selected `<include>` tags are cleaned instead of persisted for a later `pdd sync` failure. Respect the `--force` flag when overwriting existing files.
         - Create directories using `os.makedirs(dir, exist_ok=True)` for directory saves.
       - For non-CSV mode:
         - Determine the output file path. Use the `--output` argument if provided; otherwise use the default path (`output_prompt_file`) from `output_file_paths`. Ensure a valid path is determined.
-        - Write the modified prompt string to the output path, then set the return string to `"Modified prompt saved to <path>"`.
+        - Before writing a `.prompt` output, pass the modified prompt string and destination path through `sanitize_prompt_output`; then write the cleaned content to the output path and set the return string to `"Modified prompt saved to <path>"`.
         - Create parent directories using `Path(...).parent.mkdir(parents=True, exist_ok=True)`.
       - Ensure output directories are created if they don't exist.
 

--- a/pdd/prompts/split_main_python.prompt
+++ b/pdd/prompts/split_main_python.prompt
@@ -59,6 +59,11 @@
         <construct_paths_example>
             <include>context/construct_paths_example.py</include>
         </construct_paths_example>
+
+        For prompt output include cleanup:
+        <validate_prompt_includes>
+            <include select="def:sanitize_prompt_output">pdd/validate_prompt_includes.py</include>
+        </validate_prompt_includes>
     </internal_modules>
 
 % Here is the README for the cli command that has details of how the 'split' command works:
@@ -80,8 +85,9 @@
         - Unpack `sub_prompt, modified_prompt = result_tuple`.
 
     3. Persist outputs
-        - Write `sub_prompt` to `output_file_paths["output_sub"]`.
-        - Write `modified_prompt` to `output_file_paths["output_modified"]`.
+        - Before writing `.prompt` outputs, call `sanitize_prompt_output(content, destination_path)` for both `sub_prompt` and `modified_prompt` so missing or invalid selected `<include>` tags are cleaned instead of persisted for a later `pdd sync` failure.
+        - Write the cleaned `sub_prompt` to `output_file_paths["output_sub"]`.
+        - Write the cleaned `modified_prompt` to `output_file_paths["output_modified"]`.
 
     4. User feedback (respect `quiet`)
         - If not quiet, print success message, saved paths, model name, and total cost using Rich.

--- a/pdd/prompts/update_main_python.prompt
+++ b/pdd/prompts/update_main_python.prompt
@@ -18,6 +18,7 @@ Supports three modes: true update, regeneration, and repository-wide updates. Ro
 7. Validate prompt is non-empty before writing (true update mode).
 8. Without --output, overwrite input_prompt_file in place.
 9. use_git and input_code_file are mutually exclusive (raise ValueError).
+10. Before any legacy path writes generated/updated `.prompt` content, call `sanitize_prompt_output(content, destination_path)` so invalid `<include>` tags or selected includes are cleaned before a later `pdd sync` preprocess pass.
 
 % Modes
 1. **True update**: `input_prompt_file` + `modified_code_file` + (use_git OR `input_code_file`).
@@ -78,6 +79,7 @@ Supports three modes: true update, regeneration, and repository-wide updates. Ro
   <architecture_sync_example><include select="def:example_update_single_prompt,def:example_get_entry,def:example_sync_all,def:example_find_architecture_for_project,def:example_update_architecture_from_prompt">context/architecture_sync_example.py</include></architecture_sync_example>
   <operation_log_example><include select="def:example_save_fingerprint,def:example_infer_module_identity">context/operation_log_example.py</include></operation_log_example>
   <template_expander_example><include>context/template_expander_example.py</include></template_expander_example>
+  <validate_prompt_includes><include select="def:sanitize_prompt_output">pdd/validate_prompt_includes.py</include></validate_prompt_includes>
   <pdd.agentic_update><include select="def:example_no_agents_available,def:example_successful_update,def:example_agent_runs_but_no_change,def:example_missing_input_files">context/agentic_update_example.py</include></pdd.agentic_update>
 <pdd.api_key_scanner>
     <include>context/api_key_scanner_example.py</include>

--- a/pdd/prompts/validate_prompt_includes_python.prompt
+++ b/pdd/prompts/validate_prompt_includes_python.prompt
@@ -35,17 +35,19 @@
 
 % Implementation details:
     1. Use regex to find all `<include>...</include>` and self-closing `<include path="..." />` patterns in the content, including tags with attributes such as `select`, `lines`, `mode`, `query`, and `optional`.
-    2. For each match, extract the file path from `path=` or the tag body and check if the file exists relative to base_dir.
-    3. If the file exists and the include uses `select`, `lines`, or non-full `mode`, validate the selector by running `ContentSelector.select` against the target file. Invalid selectors are invalid includes.
-    4. If the file does not exist:
+    2. Skip include tags inside inline-code or fenced-code spans because those are literal syntax examples, not include directives. Mirror the preprocessor's code-span protection so documentation examples like `` `<include select="def:foo">path/to/file.py</include>` `` are preserved.
+    3. For each match, extract the file path from `path=` or the tag body and check if the file exists relative to base_dir.
+    4. Module prompt includes should use the same practical resolution semantics as sync/architecture code: exact path first, then case-insensitive final filename matching for prompt files, then recursive case-insensitive prompt filename lookup under nearby `prompts/` roots. This preserves valid includes such as `<include>parent_python.prompt</include>` when the real file is `parent_Python.prompt` on Linux.
+    5. If the file exists and the include uses `select`, `lines`, or non-full `mode`, validate the selector by running `ContentSelector.select` against the target file. Invalid selectors are invalid includes.
+    6. If the file does not exist:
         - If remove_invalid is True: Remove the entire XML block containing the `<include>` tag (e.g., `<dependency_name><include>...</include></dependency_name>`).
         - If remove_invalid is False: Replace the `<include>` tag with a comment describing the missing dependency (e.g., `<!-- Missing: path/to/file.py -->`).
         - If the tag is marked `optional`, remove the include tag silently instead of reporting it as invalid.
-    5. If a selector is invalid:
+    7. If a selector is invalid:
         - If remove_invalid is True: Remove the containing XML block, matching missing-file behavior.
         - If remove_invalid is False: Replace the `<include>` tag with a comment describing the invalid selector.
-    6. Track all invalid includes and return them along with the validated content.
-    7. Handle edge cases:
+    8. Track all invalid includes and return them along with the validated content.
+    9. Handle edge cases:
         - Nested tags (e.g., `<dependency><include>...</include></dependency>`)
         - Multiple includes on the same line
         - Include tags with attributes

--- a/pdd/prompts/validate_prompt_includes_python.prompt
+++ b/pdd/prompts/validate_prompt_includes_python.prompt
@@ -1,6 +1,6 @@
-% You are an expert Python Software Engineer. Your goal is to write a Python module that validates and cleans `<include>` tags in generated prompt files, removing or replacing references to non-existent files.
+% You are an expert Python Software Engineer. Your goal is to write a Python module that validates and cleans `<include>` tags in generated prompt files, removing or replacing references to non-existent files or invalid structural selectors.
 
-% This module addresses Issue #225: When using the generic/generate_prompt template, the LLM may generate `<include>` tags that reference files that don't exist (e.g., `<include>context/some_module_example.py</include>`). This module validates these references and cleans them up before the prompt is saved.
+% This module addresses Issue #225 and follow-up sync regressions: LLM-generated prompts may contain `<include>` tags that reference files that do not exist, or selected includes that point to existing files but request symbols/sections that are not present. The module validates these references and cleans them up before the prompt is saved so later `preprocess`/`pdd sync` does not silently fall back to full-file context.
 
 % Dependencies
 <pdd.auto_include>
@@ -25,21 +25,36 @@
         'validated_content' - A string containing the prompt with invalid `<include>` tags handled.
         'invalid_includes' - A list of strings containing the file paths that were found to be invalid.
 
+% Function 3: sanitize_prompt_output
+    Inputs:
+        'content' - A generated output string.
+        'output_path' - The intended destination path.
+    Outputs:
+        'validated_content' - Original content for non-`.prompt` paths, or cleaned prompt content for `.prompt` paths.
+        'invalid_includes' - A list of invalid include details found during cleanup.
+
 % Implementation details:
-    1. Use regex to find all `<include>...</include>` patterns in the content.
-    2. For each match, extract the file path and check if the file exists relative to base_dir.
-    3. If the file does not exist:
+    1. Use regex to find all `<include>...</include>` and self-closing `<include path="..." />` patterns in the content, including tags with attributes such as `select`, `lines`, `mode`, `query`, and `optional`.
+    2. For each match, extract the file path from `path=` or the tag body and check if the file exists relative to base_dir.
+    3. If the file exists and the include uses `select`, `lines`, or non-full `mode`, validate the selector by running `ContentSelector.select` against the target file. Invalid selectors are invalid includes.
+    4. If the file does not exist:
         - If remove_invalid is True: Remove the entire XML block containing the `<include>` tag (e.g., `<dependency_name><include>...</include></dependency_name>`).
         - If remove_invalid is False: Replace the `<include>` tag with a comment describing the missing dependency (e.g., `<!-- Missing: path/to/file.py -->`).
-    4. Track all invalid includes and return them along with the validated content.
-    5. Handle edge cases:
+        - If the tag is marked `optional`, remove the include tag silently instead of reporting it as invalid.
+    5. If a selector is invalid:
+        - If remove_invalid is True: Remove the containing XML block, matching missing-file behavior.
+        - If remove_invalid is False: Replace the `<include>` tag with a comment describing the invalid selector.
+    6. Track all invalid includes and return them along with the validated content.
+    7. Handle edge cases:
         - Nested tags (e.g., `<dependency><include>...</include></dependency>`)
         - Multiple includes on the same line
+        - Include tags with attributes
+        - Self-closing include tags with `path=`
         - Paths with special characters or spaces
 
 % Example usage:
 ```python
-from pdd.validate_prompt_includes import validate_prompt_includes
+from pdd.validate_prompt_includes import sanitize_prompt_output, validate_prompt_includes
 
 content = '''
 Dependencies
@@ -54,6 +69,7 @@ Dependencies
 validated, invalid = validate_prompt_includes(content, base_dir=".", remove_invalid=False)
 # invalid will contain ['context/database_models_example.py', 'context/auth_utils_example.py']
 # if those files don't exist
+saved_prompt, invalid = sanitize_prompt_output(content, "prompts/new_module_python.prompt")
 ```
 
 % The module should:

--- a/pdd/split_main.py
+++ b/pdd/split_main.py
@@ -8,6 +8,7 @@ from rich.console import Console
 
 from .construct_paths import construct_paths
 from .split import split
+from .validate_prompt_includes import sanitize_prompt_output
 
 console = Console()
 
@@ -87,6 +88,22 @@ def split_main(
 
         # Save the output files
         try:
+            sub_prompt, invalid_sub_includes = sanitize_prompt_output(
+                sub_prompt,
+                output_file_paths["output_sub"],
+            )
+            modified_prompt, invalid_modified_includes = sanitize_prompt_output(
+                modified_prompt,
+                output_file_paths["output_modified"],
+            )
+            if (
+                (invalid_sub_includes or invalid_modified_includes)
+                and not ctx.obj.get("quiet", False)
+            ):
+                console.print(
+                    "[yellow]Warning: Cleaned invalid <include> tag(s) "
+                    "before saving split prompt outputs.[/yellow]"
+                )
             with open(output_file_paths["output_sub"], "w") as f:
                 f.write(sub_prompt)
             with open(output_file_paths["output_modified"], "w") as f:

--- a/pdd/update_main.py
+++ b/pdd/update_main.py
@@ -33,6 +33,7 @@ from .git_update import git_update
 from .agentic_common import get_available_agents
 from .agentic_update import run_agentic_update
 from .sync_determine_operation import calculate_sha256, extract_include_deps, read_fingerprint
+from .validate_prompt_includes import sanitize_prompt_output
 from . import DEFAULT_TIME
 
 # Config/data files that should not get prompts in repo-scan mode.
@@ -789,6 +790,15 @@ def update_file_pair(
         if modified_prompt is not None:
             # Overwrite the original prompt file
             with open(prompt_file, "w") as f:
+                modified_prompt, invalid_includes = sanitize_prompt_output(
+                    modified_prompt,
+                    prompt_file,
+                )
+                if invalid_includes and not quiet:
+                    rprint(
+                        "[yellow]Warning: Cleaned invalid <include> tag(s) "
+                        f"before saving {prompt_file}.[/yellow]"
+                    )
                 f.write(modified_prompt)
             return {
                 "prompt_file": prompt_file,
@@ -1405,6 +1415,15 @@ def update_main(
 
             # Write the result to the derived/correct prompt path.
             with open(prompt_path, "w") as f:
+                modified_prompt, invalid_includes = sanitize_prompt_output(
+                    modified_prompt,
+                    prompt_path,
+                )
+                if invalid_includes and not quiet:
+                    rprint(
+                        "[yellow]Warning: Cleaned invalid <include> tag(s) "
+                        f"before saving {prompt_path}.[/yellow]"
+                    )
                 f.write(modified_prompt)
 
             if not quiet:
@@ -1541,6 +1560,15 @@ def update_main(
                 )
 
             with open(output_file_paths["output"], "w") as f:
+                modified_prompt, invalid_includes = sanitize_prompt_output(
+                    modified_prompt,
+                    output_file_paths["output"],
+                )
+                if invalid_includes and not quiet:
+                    rprint(
+                        "[yellow]Warning: Cleaned invalid <include> tag(s) "
+                        f"before saving {output_file_paths['output']}.[/yellow]"
+                    )
                 f.write(modified_prompt)
 
             if not quiet:

--- a/pdd/validate_prompt_includes.py
+++ b/pdd/validate_prompt_includes.py
@@ -14,11 +14,12 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Match, Tuple
 
 
 _INCLUDE_TAG_RE = re.compile(
-    r"<include>(.*?)</include>",
+    r"<include(?P<attrs>\s+[^>]*?)?>(?P<content>.*?)</include>|"
+    r"<include(?P<attrs_self>\s+[^>]*?)\s*/>",
     re.DOTALL | re.IGNORECASE,
 )
 
@@ -61,6 +62,64 @@ def _resolve_include_against_base_dir(rel_or_abs: str, base_dir: Path) -> Path:
             break
         cur = parent
     return (base / rel).resolve()
+
+
+def _parse_attrs(attr_str: str) -> Dict[str, str]:
+    """Parse XML-ish include attributes used by preprocess.py."""
+    attrs: Dict[str, str] = {}
+    if not attr_str:
+        return attrs
+    for match in re.finditer(r'(\w+)\s*=\s*["\']([^"\']*)["\']', attr_str):
+        attrs[match.group(1)] = match.group(2)
+    if "optional" not in attrs and re.search(
+        r"(?<![A-Za-z0-9_])optional(?![A-Za-z0-9_])",
+        attr_str,
+    ):
+        attrs["optional"] = "true"
+    return attrs
+
+
+def _optional_attr_is_truthy(attrs: Dict[str, str]) -> bool:
+    optional_val = attrs.get("optional")
+    if optional_val is None:
+        return False
+    return str(optional_val).strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _include_match_path_and_attrs(match: Match[str]) -> Tuple[str, Dict[str, str]]:
+    attrs_str = match.group("attrs") or match.group("attrs_self") or ""
+    attrs = _parse_attrs(attrs_str)
+    content = match.group("content") if match.group("content") is not None else ""
+    raw_path = (attrs.get("path") or content.strip()).strip()
+    return raw_path, attrs
+
+
+def _selector_error_for_include(path: Path, attrs: Dict[str, str]) -> str | None:
+    selectors_str = attrs.get("select")
+    lines_str = attrs.get("lines")
+    mode = attrs.get("mode", "full")
+    if not selectors_str and not lines_str and mode == "full":
+        return None
+
+    selectors: List[str] = []
+    if selectors_str:
+        selectors.extend(selector.strip() for selector in selectors_str.split(","))
+    if lines_str:
+        selectors.append(f"lines:{lines_str}")
+    selectors = [selector for selector in selectors if selector]
+
+    try:
+        from pdd.content_selector import ContentSelector
+
+        ContentSelector().select(
+            content=path.read_text(encoding="utf-8"),
+            selectors=selectors,
+            file_path=str(path),
+            mode=mode,
+        )
+    except Exception as exc:  # noqa: BLE001 - validation reports any selector failure
+        return str(exc)
+    return None
 
 
 def validate_include_tag(file_path: str, base_dir: str) -> bool:
@@ -175,7 +234,7 @@ def _find_parent_element_span(
     parent: Tuple[int, int] | None = None
     parent_size = None
 
-    for name, start, end in elements:
+    for _name, start, end in elements:
         if start <= child_start and child_end <= end:
             # Exclude the element if it is exactly the child span (e.g., <include> itself)
             if start == child_start and end == child_end:
@@ -262,7 +321,9 @@ def validate_prompt_includes(
 
     for m in _INCLUDE_TAG_RE.finditer(content):
         inc_start, inc_end = m.span()
-        raw_path = m.group(1).strip()
+        raw_path, attrs = _include_match_path_and_attrs(m)
+        if not raw_path:
+            continue
 
         # Normalize possible "Error processing include:" prefix but preserve
         # the original raw_path for reporting.
@@ -280,6 +341,28 @@ def validate_prompt_includes(
             exists_cache[p] = exists
 
         if exists:
+            selector_error = _selector_error_for_include(p, attrs)
+            if selector_error is None:
+                continue
+
+            invalid_label = (
+                f"{raw_path} select=\"{attrs.get('select', '')}\": {selector_error}"
+            )
+            invalid_includes.append(invalid_label)
+
+            if remove_invalid:
+                parent_span = _find_parent_element_span(elements, inc_start, inc_end)
+                if parent_span is None:
+                    block_start, block_end = inc_start, inc_end
+                else:
+                    block_start, block_end = parent_span
+                if (block_start, block_end) in removed_blocks:
+                    continue
+                removed_blocks.add((block_start, block_end))
+                edits.append((block_start, block_end, ""))
+            else:
+                replacement = f"<!-- Invalid selector for {raw_path}: {selector_error} -->"
+                edits.append((inc_start, inc_end, replacement))
             continue
 
         parent_element = _find_parent_element(elements, inc_start, inc_end)
@@ -293,6 +376,10 @@ def validate_prompt_includes(
             if (block_start, block_end) not in removed_blocks:
                 removed_blocks.add((block_start, block_end))
                 edits.append((block_start, block_end, ""))
+            continue
+
+        if _optional_attr_is_truthy(attrs):
+            edits.append((inc_start, inc_end, ""))
             continue
 
         # Track invalid include using the raw string from the tag
@@ -328,3 +415,24 @@ def validate_prompt_includes(
         content = "".join(chars)
 
     return content, invalid_includes
+
+
+def sanitize_prompt_output(
+    content: str,
+    output_path: str | Path,
+) -> Tuple[str, List[str]]:
+    """
+    Validate generated prompt content before writing it to ``output_path``.
+
+    Non-prompt outputs are returned unchanged. Prompt outputs are validated
+    relative to the output file's parent directory, matching the post-generation
+    cleanup used by ``pdd generate``.
+    """
+    path = Path(output_path)
+    if path.suffix != ".prompt":
+        return content, []
+    return validate_prompt_includes(
+        content,
+        base_dir=path.parent,
+        remove_invalid=False,
+    )

--- a/pdd/validate_prompt_includes.py
+++ b/pdd/validate_prompt_includes.py
@@ -36,6 +36,71 @@ _OPTIONAL_SHARED_CONTEXT_BLOCKS = {
 }
 
 
+def _is_module_prompt_include(path_str: str) -> bool:
+    """Return True when ``path_str`` names a PDD module prompt include."""
+    try:
+        from pdd.sync_order import extract_module_from_include
+
+        return extract_module_from_include(path_str) is not None
+    except Exception:
+        p = Path(path_str)
+        return p.suffix == ".prompt" and "_" in p.stem
+
+
+def _case_insensitive_file_lookup(candidate: Path) -> Path | None:
+    """Resolve ``candidate`` by case-insensitive filename match in its parent."""
+    if not candidate.parent.is_dir():
+        return None
+    target_lower = candidate.name.lower()
+    fallback_match: Path | None = None
+    for sibling in candidate.parent.iterdir():
+        if not sibling.is_file():
+            continue
+        if sibling.name == candidate.name:
+            return sibling.resolve()
+        if fallback_match is None and sibling.name.lower() == target_lower:
+            fallback_match = sibling
+    return fallback_match.resolve() if fallback_match is not None else None
+
+
+def _prompt_roots_for_base(base_dir: Path) -> List[Path]:
+    """Return plausible prompt roots near ``base_dir`` for module prompt lookup."""
+    roots: List[Path] = []
+
+    def add(root: Path) -> None:
+        resolved = root.resolve()
+        if resolved.is_dir() and resolved not in roots:
+            roots.append(resolved)
+
+    cur = base_dir.resolve()
+    for _ in range(128):
+        if cur.name == "prompts":
+            add(cur)
+        add(cur / "prompts")
+        parent = cur.parent
+        if parent == cur:
+            break
+        cur = parent
+    return roots
+
+
+def _recursive_prompt_lookup(rel_or_abs: str, base_dir: Path) -> Path | None:
+    """Find a module prompt by case-insensitive filename under nearby prompts roots."""
+    if not _is_module_prompt_include(rel_or_abs):
+        return None
+    target_lower = Path(rel_or_abs).name.lower()
+    for prompts_root in _prompt_roots_for_base(base_dir):
+        matches = [
+            candidate
+            for candidate in prompts_root.rglob("*.prompt")
+            if candidate.is_file() and candidate.name.lower() == target_lower
+        ]
+        if matches:
+            matches.sort(key=lambda p: (len(p.parts), str(p)))
+            return matches[0].resolve()
+    return None
+
+
 def _resolve_include_against_base_dir(rel_or_abs: str, base_dir: Path) -> Path:
     """
     Resolve a path from an ``<include>`` tag for existence checks.
@@ -49,6 +114,12 @@ def _resolve_include_against_base_dir(rel_or_abs: str, base_dir: Path) -> Path:
     raw = (rel_or_abs or "").strip()
     p = Path(raw)
     if p.is_absolute():
+        if p.exists():
+            return p.resolve()
+        if _is_module_prompt_include(raw):
+            resolved = _case_insensitive_file_lookup(p)
+            if resolved is not None:
+                return resolved
         return p.resolve()
     rel = p
     base = base_dir.resolve()
@@ -57,10 +128,17 @@ def _resolve_include_against_base_dir(rel_or_abs: str, base_dir: Path) -> Path:
         candidate = (cur / rel).resolve()
         if candidate.exists():
             return candidate
+        if _is_module_prompt_include(raw):
+            resolved = _case_insensitive_file_lookup(candidate)
+            if resolved is not None:
+                return resolved
         parent = cur.parent
         if parent == cur:
             break
         cur = parent
+    prompt_match = _recursive_prompt_lookup(raw, base)
+    if prompt_match is not None:
+        return prompt_match
     return (base / rel).resolve()
 
 
@@ -120,6 +198,32 @@ def _selector_error_for_include(path: Path, attrs: Dict[str, str]) -> str | None
     except Exception as exc:  # noqa: BLE001 - validation reports any selector failure
         return str(exc)
     return None
+
+
+def _extract_fence_spans(text: str) -> List[Tuple[int, int]]:
+    """Return fenced-code block spans so literal include examples are ignored."""
+    spans: List[Tuple[int, int]] = []
+    for match in re.finditer(
+        r"(?m)^[ \t]*([`~]{3,})[^\n]*\n[\s\S]*?\n[ \t]*\1[ \t]*(?:\n|$)",
+        text,
+    ):
+        spans.append(match.span())
+    return spans
+
+
+def _extract_inline_code_spans(text: str) -> List[Tuple[int, int]]:
+    """Return inline-code spans so literal include examples are ignored."""
+    return [match.span() for match in re.finditer(r"(?<!`)(`+)([^\n]*?)\1", text)]
+
+
+def _extract_code_spans(text: str) -> List[Tuple[int, int]]:
+    spans = _extract_fence_spans(text)
+    spans.extend(_extract_inline_code_spans(text))
+    return sorted(spans, key=lambda span: span[0])
+
+
+def _intersects_any_span(start: int, end: int, spans: List[Tuple[int, int]]) -> bool:
+    return any(start < span_end and end > span_start for span_start, span_end in spans)
 
 
 def validate_include_tag(file_path: str, base_dir: str) -> bool:
@@ -312,6 +416,7 @@ def validate_prompt_includes(
         * Paths with spaces or special characters (non-greedy matching)
     """
     elements = _build_element_spans(content)
+    code_spans = _extract_code_spans(content)
     base_path = Path(base_dir).resolve()
 
     invalid_includes: List[str] = []
@@ -321,6 +426,8 @@ def validate_prompt_includes(
 
     for m in _INCLUDE_TAG_RE.finditer(content):
         inc_start, inc_end = m.span()
+        if _intersects_any_span(inc_start, inc_end, code_spans):
+            continue
         raw_path, attrs = _include_match_path_and_attrs(m)
         if not raw_path:
             continue

--- a/tests/test_auto_deps_main.py
+++ b/tests/test_auto_deps_main.py
@@ -113,6 +113,53 @@ def test_auto_deps_normal_operation(
     assert os.path.exists(csv_path)
 
 
+@patch("pdd.auto_deps_main.construct_paths")
+@patch("pdd.auto_deps_main.insert_includes")
+def test_auto_deps_sanitizes_invalid_prompt_includes_before_writing(
+    mock_insert_includes,
+    mock_construct_paths,
+    mock_ctx,
+    tmp_path,
+):
+    """Auto-deps prompt output should not persist selectors that sync will warn on."""
+    mock_ctx.obj["quiet"] = True
+    (tmp_path / "context").mkdir()
+    (tmp_path / "context" / "llm_invoke_example.py").write_text(
+        "def run_llm_invoke_examples():\n    pass\n",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "output.prompt"
+    csv_path = tmp_path / "deps.csv"
+    bad_prompt = (
+        '<include select="class:TokenMatch,def:detect_control_token">'
+        "context/llm_invoke_example.py</include>"
+    )
+
+    mock_construct_paths.return_value = _make_construct_paths_return(
+        str(output_path),
+        str(csv_path),
+    )
+    mock_insert_includes.return_value = _make_insert_includes_return(
+        modified_prompt=bad_prompt,
+    )
+
+    modified_prompt, total_cost, model_name = auto_deps_main(
+        ctx=mock_ctx,
+        prompt_file="sample_prompt_python.prompt",
+        directory_path="context/",
+        auto_deps_csv_path=None,
+        output=None,
+        force_scan=False,
+    )
+
+    saved = output_path.read_text(encoding="utf-8")
+    assert "Invalid selector" in saved
+    assert "class:TokenMatch" not in saved
+    assert modified_prompt == saved
+    assert total_cost == pytest.approx(0.123456)
+    assert model_name == "test-model"
+
+
 # ---------------------------------------------------------------------------
 # 2. Force scan deletes CSV
 # ---------------------------------------------------------------------------

--- a/tests/test_change_main.py
+++ b/tests/test_change_main.py
@@ -1440,6 +1440,66 @@ def test_change_main_non_csv_uses_construct_paths_default_output(tmp_path):
     assert model_name == "model-x"
 
 
+def test_change_main_sanitizes_invalid_prompt_includes_before_writing(tmp_path):
+    """Prompt-changing commands should not persist selectors that preprocess will warn on."""
+    change_file = tmp_path / "change.prompt"
+    prompt_file = tmp_path / "input.prompt"
+    code_file = tmp_path / "code.py"
+    output_file = tmp_path / "agentic_common_python.prompt"
+    (tmp_path / "context").mkdir()
+    (tmp_path / "prompts").mkdir()
+    change_file.write_text("change", encoding="utf-8")
+    prompt_file.write_text("prompt", encoding="utf-8")
+    code_file.write_text("print('x')", encoding="utf-8")
+    (tmp_path / "context" / "llm_invoke_example.py").write_text(
+        "def run_llm_invoke_examples():\n    pass\n",
+        encoding="utf-8",
+    )
+
+    bad_prompt = (
+        "% Dependencies\n"
+        "<pdd.llm_invoke>\n"
+        '  <include select="class:TokenMatch,def:detect_control_token">'
+        "context/llm_invoke_example.py</include>\n"
+        "</pdd.llm_invoke>\n"
+    )
+    ctx_instance = create_mock_context(obj={"quiet": True, "skip_user_stories": True})
+
+    with patch("pdd.change_main.construct_paths") as mock_construct, \
+         patch("pdd.change_main.resolve_effective_config") as mock_config, \
+         patch("pdd.change_main.change_func") as mock_change:
+        mock_construct.return_value = (
+            {"prompts_dir": str(tmp_path / "prompts")},
+            {
+                "change_prompt_file": "change",
+                "input_code": "print('x')",
+                "input_prompt_file": "prompt",
+            },
+            {"output_prompt_file": str(output_file)},
+            "python",
+        )
+        mock_config.return_value = {"strength": 0.2, "temperature": 0.0, "time": 0.25}
+        mock_change.return_value = (bad_prompt, 0.2, "model-x")
+
+        message, total_cost, model_name = change_main(
+            ctx=ctx_instance,
+            change_prompt_file=str(change_file),
+            input_code=str(code_file),
+            input_prompt_file=str(prompt_file),
+            output=None,
+            use_csv=False,
+            budget=5.0,
+        )
+
+    saved = output_file.read_text(encoding="utf-8")
+    assert message == f"Modified prompt saved to {output_file.resolve()}"
+    assert "Invalid selector" in saved
+    assert "class:TokenMatch" not in saved
+    assert "context/llm_invoke_example.py" in saved
+    assert total_cost == pytest.approx(0.2)
+    assert model_name == "model-x"
+
+
 def test_change_main_non_csv_missing_output_path(tmp_path):
     change_file = tmp_path / "change.prompt"
     prompt_file = tmp_path / "input.prompt"

--- a/tests/test_issue_225_paths_and_includes.py
+++ b/tests/test_issue_225_paths_and_includes.py
@@ -91,6 +91,99 @@ def test_validate_prompt_includes_removes_optional_shared_context_blocks_when_fi
     assert "Requirements" in validated
 
 
+def test_validate_prompt_includes_validates_attributed_missing_include(tmp_path, monkeypatch):
+    """Attributed include tags must get the same missing-file cleanup as bare tags."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts").mkdir()
+
+    content = '<include select="def:missing_symbol">context/missing.py</include>'
+
+    validated, invalid = validate_prompt_includes(
+        content,
+        base_dir=tmp_path / "prompts",
+        remove_invalid=False,
+    )
+
+    assert invalid == ["context/missing.py"]
+    assert validated == "<!-- Missing: context/missing.py -->"
+
+
+def test_validate_prompt_includes_validates_self_closing_path_include(tmp_path, monkeypatch):
+    """Self-closing include tags with path= are real include tags and need validation."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts").mkdir()
+
+    content = '<dependency><include path="context/missing.py" /></dependency>'
+
+    validated, invalid = validate_prompt_includes(
+        content,
+        base_dir=tmp_path / "prompts",
+        remove_invalid=False,
+    )
+
+    assert invalid == ["context/missing.py"]
+    assert "<!-- Missing: context/missing.py -->" in validated
+    assert "path=\"context/missing.py\"" not in validated
+
+
+def test_validate_prompt_includes_rejects_invalid_selected_symbols(tmp_path, monkeypatch):
+    """Regression for issue #798: selected includes must not silently fall back."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "context").mkdir()
+    (tmp_path / "prompts").mkdir()
+    (tmp_path / "context" / "llm_invoke_example.py").write_text(
+        "def run_llm_invoke_examples():\n    pass\n",
+        encoding="utf-8",
+    )
+
+    content = (
+        "<pdd.llm_invoke>"
+        '<include select="class:TokenMatch,def:detect_control_token,'
+        'def:classify_step_output,def:substitute_template_variables">'
+        "context/llm_invoke_example.py"
+        "</include>"
+        "</pdd.llm_invoke>"
+    )
+
+    validated, invalid = validate_prompt_includes(
+        content,
+        base_dir=tmp_path / "prompts",
+        remove_invalid=False,
+    )
+
+    assert len(invalid) == 1
+    assert invalid[0].startswith("context/llm_invoke_example.py")
+    assert "TokenMatch" in invalid[0]
+    assert "Invalid selector" in validated
+    assert "class:TokenMatch" not in validated
+
+
+def test_validate_prompt_includes_allows_valid_selected_symbols(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "context").mkdir()
+    (tmp_path / "prompts").mkdir()
+    (tmp_path / "context" / "agentic_common.py").write_text(
+        "class TokenMatch:\n    pass\n\n"
+        "def detect_control_token():\n    pass\n",
+        encoding="utf-8",
+    )
+
+    content = (
+        '<include select="class:TokenMatch,def:detect_control_token">'
+        "context/agentic_common.py"
+        "</include>"
+    )
+
+    validated, invalid = validate_prompt_includes(
+        content,
+        base_dir=tmp_path / "prompts",
+        remove_invalid=False,
+    )
+
+    assert invalid == []
+    assert validated == content
+
+
 def test_get_pdd_file_paths_uses_architecture_filepath_for_flattened_prompt_names(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / ".pddrc").write_text(

--- a/tests/test_issue_225_paths_and_includes.py
+++ b/tests/test_issue_225_paths_and_includes.py
@@ -126,6 +126,75 @@ def test_validate_prompt_includes_validates_self_closing_path_include(tmp_path, 
     assert "path=\"context/missing.py\"" not in validated
 
 
+def test_validate_prompt_includes_preserves_case_insensitive_module_prompt_include(
+    tmp_path,
+    monkeypatch,
+):
+    """Linux-safe regression: module prompt includes follow architecture/sync casing semantics."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts").mkdir()
+    (tmp_path / "prompts" / "parent_Python.prompt").write_text("%\n", encoding="utf-8")
+    content = "<include>parent_python.prompt</include>"
+    original_exists = Path.exists
+
+    def case_sensitive_exists(path: Path) -> bool:
+        if path.name == "parent_python.prompt":
+            return False
+        return original_exists(path)
+
+    monkeypatch.setattr(Path, "exists", case_sensitive_exists)
+
+    validated, invalid = validate_prompt_includes(
+        content,
+        base_dir=tmp_path / "prompts",
+        remove_invalid=False,
+    )
+
+    assert invalid == []
+    assert validated == content
+
+
+def test_validate_prompt_includes_ignores_inline_code_include_examples(tmp_path, monkeypatch):
+    """Literal include syntax in inline code is documentation, not a real directive."""
+    monkeypatch.chdir(tmp_path)
+    content = (
+        'Use `<include select="def:foo">path/to/file.py</include>` for deterministic '
+        'selection and `<include query="summarize auth">path/to/file.py</include>` '
+        "for semantic extraction."
+    )
+
+    validated, invalid = validate_prompt_includes(
+        content,
+        base_dir=tmp_path,
+        remove_invalid=False,
+    )
+
+    assert invalid == []
+    assert validated == content
+
+
+def test_validate_prompt_includes_ignores_fenced_code_include_examples(tmp_path, monkeypatch):
+    """Literal include syntax in fenced code is documentation, not a real directive."""
+    monkeypatch.chdir(tmp_path)
+    content = textwrap.dedent(
+        """\
+        ```prompt
+        <include select="def:foo">path/to/file.py</include>
+        <include query="summarize auth">path/to/other.py</include>
+        ```
+        """
+    )
+
+    validated, invalid = validate_prompt_includes(
+        content,
+        base_dir=tmp_path,
+        remove_invalid=False,
+    )
+
+    assert invalid == []
+    assert validated == content
+
+
 def test_validate_prompt_includes_rejects_invalid_selected_symbols(tmp_path, monkeypatch):
     """Regression for issue #798: selected includes must not silently fall back."""
     monkeypatch.chdir(tmp_path)

--- a/tests/test_split_main.py
+++ b/tests/test_split_main.py
@@ -127,6 +127,60 @@ def test_split_main_success(mock_ctx, quiet_mode, capsys):
             assert "modified_prompt.prompt" in captured.out
             assert f"Total cost: $0.123456" in captured.out
 
+
+def test_split_main_sanitizes_invalid_prompt_includes_before_writing(mock_ctx, tmp_path):
+    """Split outputs are generated prompts and should not persist bad selectors."""
+    mock_ctx.obj["quiet"] = True
+    (tmp_path / "context").mkdir()
+    (tmp_path / "context" / "llm_invoke_example.py").write_text(
+        "def run_llm_invoke_examples():\n    pass\n",
+        encoding="utf-8",
+    )
+    sub_output = tmp_path / "sub.prompt"
+    modified_output = tmp_path / "modified.prompt"
+    bad_prompt = (
+        '<include select="class:TokenMatch,def:detect_control_token">'
+        "context/llm_invoke_example.py</include>"
+    )
+
+    with patch("pdd.split_main.construct_paths") as mock_construct_paths, \
+         patch("pdd.split_main.split") as mock_split:
+        mock_construct_paths.return_value = (
+            {},
+            {
+                "input_prompt": "prompt content",
+                "input_code": "code content",
+                "example_code": "example code content",
+            },
+            {
+                "output_sub": str(sub_output),
+                "output_modified": str(modified_output),
+            },
+            "python",
+        )
+        mock_split.return_value = ((bad_prompt, bad_prompt), 0.1, "model-x")
+
+        result_data, total_cost, model_name = split_main(
+            mock_ctx,
+            "input_prompt_file.prompt",
+            "input_code_file.py",
+            "example_code_file.py",
+            None,
+            None,
+        )
+
+    saved_sub = sub_output.read_text(encoding="utf-8")
+    saved_modified = modified_output.read_text(encoding="utf-8")
+    assert "Invalid selector" in saved_sub
+    assert "Invalid selector" in saved_modified
+    assert "class:TokenMatch" not in saved_sub
+    assert "class:TokenMatch" not in saved_modified
+    assert result_data["sub_prompt_content"] == saved_sub
+    assert result_data["modified_prompt_content"] == saved_modified
+    assert total_cost == pytest.approx(0.1)
+    assert model_name == "model-x"
+
+
 def test_split_main_file_not_found(mock_ctx, capsys):
     """
     Test that split_main properly handles FileNotFoundError

--- a/tests/test_update_main.py
+++ b/tests/test_update_main.py
@@ -149,6 +149,65 @@ def test_update_main_with_input_code_and_no_git(
     # The open function should be called to write the updated prompt
     mock_open_file.assert_called_once_with("updated_prompt.prompt", "w")
 
+
+def test_update_main_sanitizes_invalid_prompt_includes_before_writing(tmp_path, mock_get_available_agents):
+    (tmp_path / "context").mkdir()
+    (tmp_path / "prompts").mkdir()
+    source_prompt = tmp_path / "source.prompt"
+    modified_code = tmp_path / "module.py"
+    original_code = tmp_path / "module_old.py"
+    output_prompt = tmp_path / "updated.prompt"
+    source_prompt.write_text("existing prompt", encoding="utf-8")
+    modified_code.write_text("def new(): pass\n", encoding="utf-8")
+    original_code.write_text("def old(): pass\n", encoding="utf-8")
+    (tmp_path / "context" / "llm_invoke_example.py").write_text(
+        "def run_llm_invoke_examples():\n    pass\n",
+        encoding="utf-8",
+    )
+
+    bad_prompt = (
+        '<include select="class:TokenMatch,def:detect_control_token">'
+        "context/llm_invoke_example.py</include>"
+    )
+    ctx = click.Context(click.Command("update"))
+    ctx.params = {"force": True, "quiet": True}
+    ctx.obj = {
+        "strength": 0.5,
+        "temperature": 0.0,
+        "verbose": False,
+        "quiet": True,
+        "time": 0.25,
+    }
+
+    with patch("pdd.update_main.construct_paths") as mock_construct, \
+         patch("pdd.update_main.update_prompt") as mock_update_prompt:
+        mock_construct.return_value = (
+            {},
+            {
+                "input_prompt_file": "existing prompt",
+                "modified_code_file": "def new(): pass",
+                "input_code_file": "def old(): pass",
+            },
+            {"output": str(output_prompt)},
+            None,
+        )
+        mock_update_prompt.return_value = (bad_prompt, 0.01, "mock-model")
+
+        result = update_main(
+            ctx=ctx,
+            input_prompt_file=str(source_prompt),
+            modified_code_file=str(modified_code),
+            input_code_file=str(original_code),
+            output=str(output_prompt),
+            use_git=False,
+        )
+
+    saved = output_prompt.read_text(encoding="utf-8")
+    assert result == (saved, 0.01, "mock-model")
+    assert "Invalid selector" in saved
+    assert "class:TokenMatch" not in saved
+
+
 def test_update_main_with_git_no_input_code(
     mock_ctx,
     minimal_input_files,


### PR DESCRIPTION
## Summary
- Validate attributed and self-closing prompt `<include>` tags, including selected includes backed by `ContentSelector`.
- Sanitize generated `.prompt` output before `change`, `update`, `split`, and `auto-deps` persist prompt files.
- Update prompt specs and add regressions for the issue #798 bad-selector shape.

## Root Cause
`pdd issue` produced a prompt change that selected `TokenMatch` symbols from `context/llm_invoke_example.py`, where those symbols do not exist. The existing validator only handled bare `<include>path</include>` tags and only checked file existence, so attributed selected includes were persisted and later caused `pdd sync`/preprocess to fall back to full-file context with a `ContentSelector failed` warning.

## Test Plan
- `conda run -n pdd --no-capture-output env PDD_PATH=$PWD PYTHONPATH=$PWD python -m pytest tests/test_issue_225_paths_and_includes.py tests/test_change_main.py tests/test_update_main.py tests/test_split_main.py tests/test_auto_deps_main.py tests/test_preprocess.py tests/test_code_generator_main.py tests/test_agentic_sync_runner.py tests/test_auto_include.py tests/test_insert_includes.py -q`
- `conda run -n pdd --no-capture-output env PYTHONPATH=$PWD python -m py_compile pdd/validate_prompt_includes.py pdd/change_main.py pdd/update_main.py pdd/split_main.py pdd/auto_deps_main.py`
- Focused issue #798 selector reproduction using `origin/change/issue-798`: validator catches the bad selected include, and preprocess emits no `ContentSelector failed` warning after sanitization.
- `git diff --check`