### PR TITLE
Fix sync runner dependency failure scheduling

### DIFF
--- a/architecture.json
+++ b/architecture.json
@@ -7193,7 +7193,7 @@
   },
   {
     "reason": "Parallel sync engine with env-configurable per-module timeout (PDD_MODULE_TIMEOUT_SECONDS, default 2700s) plus per-run --timeout-adder forwarded via sync_options['timeout_adder'], phase-aware heartbeat, and live GitHub progress updates.",
-    "description": "Manages pdd sync subprocesses using ThreadPoolExecutor, preserves architecture subdirectory basenames, respects dependency ordering from architecture.json, enforces total-budget sequential execution when requested, posts live progress to GitHub issue comments, and pauses on failure.",
+    "description": "Manages pdd sync subprocesses using ThreadPoolExecutor, preserves architecture subdirectory basenames, respects dependency ordering from architecture.json, enforces total-budget sequential execution when requested, posts live progress to GitHub issue comments, keeps unrelated ready modules running after a module failure while blocking transitive failed-dependency dependents, and stops all new scheduling when total budget is exhausted.",
     "dependencies": [
       "architecture_sync_python.prompt",
       "agentic_langtest_python.prompt",

--- a/context/agentic_sync_runner_example.py
+++ b/context/agentic_sync_runner_example.py
@@ -98,6 +98,12 @@ def main():
     print("\n--- Module States ---")
     for name, state in runner.module_states.items():
         print(f"  {name}: {state.status} (cost: ${state.cost:.2f})")
+    print(
+        "A failed module blocks only modules that depend on it; unrelated "
+        "modules continue when their own dependencies are satisfied. The "
+        "blocked set is transitive, and total-budget exhaustion still stops "
+        "all new scheduling."
+    )
 
     # --- Comment Body Preview ---
     print("\n--- GitHub Comment Preview ---")

--- a/pdd/agentic_sync_runner.py
+++ b/pdd/agentic_sync_runner.py
@@ -478,20 +478,24 @@ class AsyncSyncRunner:
             futures: Dict[Any, str] = {}  # Future -> basename
 
             while not self._all_done():
-                if not self.failed and self._budget_exhausted():
+                if not self.budget_exhausted and self._budget_exhausted():
                     self.failed = True
                     self.budget_exhausted = True
 
                 # Find modules whose deps are all "success"
                 ready = self._get_ready_modules()
 
-                if self.failed:
-                    # Don't start new modules; wait for running ones to finish
+                if self.budget_exhausted:
+                    # Don't start new modules once the global budget is spent;
+                    # wait for already-running modules to finish.
                     if not futures:
                         break
                 else:
                     # Only submit up to available worker slots so modules
                     # aren't marked "running" while queued in the executor.
+                    # A failed module is handled through the dependency graph:
+                    # dependents remain pending, while unrelated ready modules
+                    # can still sync and be checkpointed.
                     available_slots = self.max_workers - len(futures)
                     for basename in ready[:available_slots]:
                         with self.lock:
@@ -519,11 +523,11 @@ class AsyncSyncRunner:
                         success, cost, error = False, 0.0, str(e)
                     self._record_result(basename, success, cost, error)
                     self._update_github_comment()
-                    if not success:
-                        self.failed = True
-                    elif self._budget_exhausted():
+                    if self._budget_exhausted():
                         self.failed = True
                         self.budget_exhausted = True
+                    elif not success:
+                        self.failed = True
 
         # Final update
         self._update_github_comment()
@@ -533,6 +537,9 @@ class AsyncSyncRunner:
         succeeded = [b for b, s in self.module_states.items() if s.status == "success"]
         failed = [b for b, s in self.module_states.items() if s.status == "failed"]
         pending = [b for b, s in self.module_states.items() if s.status == "pending"]
+        blocked = self._get_blocked_modules()
+        blocked_set = set(blocked)
+        not_run = [b for b in pending if b not in blocked_set]
 
         if self.budget_exhausted:
             budget = float(self.total_budget)
@@ -548,8 +555,10 @@ class AsyncSyncRunner:
             return False, msg, total_cost
         if failed:
             msg = f"Failed: {failed}. Succeeded: {succeeded}."
-            if pending:
-                msg += f" Skipped (blocked): {pending}."
+            if blocked:
+                msg += f" Skipped (blocked): {blocked}."
+            if not_run:
+                msg += f" Skipped (not run): {not_run}."
             # Include error details for failed modules
             for b in failed:
                 err = self.module_states[b].error
@@ -560,7 +569,11 @@ class AsyncSyncRunner:
             self._save_state()
             return False, msg, total_cost
         elif pending:
-            msg = f"Succeeded: {succeeded}. Skipped (blocked): {pending}."
+            msg = f"Succeeded: {succeeded}."
+            if blocked:
+                msg += f" Skipped (blocked): {blocked}."
+            if not_run:
+                msg += f" Skipped (not run): {not_run}."
             self._save_state()
             return False, msg, total_cost
         else:
@@ -594,19 +607,43 @@ class AsyncSyncRunner:
         return ready
 
     def _get_blocked_modules(self) -> List[str]:
-        """Get modules that are pending but blocked by non-success deps."""
+        """Get pending modules blocked by a failed dependency chain."""
         blocked = []
         with self.lock:
+            blocked_cache: Dict[str, bool] = {}
+
+            def is_blocked_by_failure(module: str, visiting: set[str]) -> bool:
+                cached = blocked_cache.get(module)
+                if cached is not None:
+                    return cached
+                if module in visiting:
+                    blocked_cache[module] = False
+                    return False
+
+                visiting.add(module)
+                for dep in self.dep_graph.get(module, []):
+                    dep_state = self.module_states.get(dep)
+                    if dep_state is None:
+                        continue
+                    if dep_state.status == "failed":
+                        blocked_cache[module] = True
+                        visiting.remove(module)
+                        return True
+                    if dep_state.status == "pending" and is_blocked_by_failure(
+                        dep, visiting
+                    ):
+                        blocked_cache[module] = True
+                        visiting.remove(module)
+                        return True
+                visiting.remove(module)
+                blocked_cache[module] = False
+                return False
+
             for basename in self.basenames:
                 state = self.module_states[basename]
                 if state.status != "pending":
                     continue
-                deps = self.dep_graph.get(basename, [])
-                has_failed_dep = any(
-                    self.module_states.get(d, ModuleState(status="success")).status == "failed"
-                    for d in deps
-                )
-                if has_failed_dep:
+                if is_blocked_by_failure(basename, set()):
                     blocked.append(basename)
         return blocked
 
@@ -1101,9 +1138,15 @@ class AsyncSyncRunner:
 
         # Status line
         failed_modules = [b for b, s in self.module_states.items() if s.status == "failed"]
+        running_modules = [b for b, s in self.module_states.items() if s.status == "running"]
         all_done = all(s.status in ("success", "failed") for s in self.module_states.values())
 
-        if failed_modules:
+        if failed_modules and running_modules:
+            lines.append(
+                f"**⚠️ `{'`, `'.join(failed_modules)}` failed; "
+                f"Continuing independent module(s): `{'`, `'.join(running_modules)}`**"
+            )
+        elif failed_modules:
             lines.append(f"**⚠️ Paused: `{'`, `'.join(failed_modules)}` failed**")
         elif all_done:
             lines.append(f"**✅ All {total} modules synced successfully**")

--- a/pdd/prompts/agentic_sync_runner_python.prompt
+++ b/pdd/prompts/agentic_sync_runner_python.prompt
@@ -23,7 +23,7 @@ Parallel sync engine that runs `pdd sync` for multiple modules concurrently usin
 3. Use `concurrent.futures.ThreadPoolExecutor` with `MAX_WORKERS = 4`; when `sync_options["total_budget"]` is set, run sequentially and pass only the remaining total budget to each child process so the total budget is not multiplied per module.
 4. Dependency-aware scheduling: a module starts only when all its dependencies (within target set) have status "success"
 5. Dependencies outside `basenames` are omitted from `dep_graph` (partial sync). Callers should rely on `build_dep_graph_from_architecture` warnings for visibility when an architecture edge points outside the target set; the runner still assumes those deps are out of scope for this run.
-6. Pause-on-failure: when any module fails, set `self.failed = True`; let running modules finish but don't start new ones
+6. Failure scheduling: when a module fails, set `self.failed = True`, but do not globally pause the queue. Failed modules block only modules that depend on them through `dep_graph`; unrelated modules whose own dependencies are satisfied must continue to run so partial progress is preserved and future retries can resume from more completed modules. Blocked-module classification must be transitive: if `a` fails and `b` depends on `a`, then pending modules that depend on `b` are also blocked. Only total-budget exhaustion stops new scheduling globally, and `_budget_exhausted()` must be checked after every completed future, including failed module results, before scheduling more work.
 7. Each module runs as a `pdd sync` subprocess with `--force`, `--agentic`, `--no-steer` flags; append global `--local` before `sync` if `sync_options["local"]` is truthy; append `--target-coverage` if `sync_options["target_coverage"]` is not None; append `--one-session` if `sync_options["one_session"]` is truthy
 8. Use `PDD_OUTPUT_COST_PATH` env var for cost capture from subprocess (CSV format)
 9. Sync failure detection: exit code != 0 OR "Overall status:" line contains "Failed"
@@ -58,7 +58,7 @@ Parallel sync engine that runs `pdd sync` for multiple modules concurrently usin
 - Markdown table format: Module | Status | Phase | Duration | Cost
 - Phase column: running modules show `current_phase (N done)`, completed modules show `N phases` or `-`
 - Status icons: pending (hourglass), running (sync), success (checkmark), failed (cross)
-- Footer: total cost (initial_cost + sum of per-module costs), overall status (in progress / paused / all success)
+- Footer: total cost (initial_cost + sum of per-module costs), overall status (in progress / continuing independent modules after failure / paused / all success)
 
 % NamedTuple: `DepGraphFromArchitectureResult`
 - `graph: Dict[str, List[str]]` — basename -> list of dependency basenames **within the target set only** (scheduled subgraph)

--- a/tests/test_agentic_sync_runner.py
+++ b/tests/test_agentic_sync_runner.py
@@ -197,6 +197,18 @@ class TestGetBlockedModules:
         blocked = runner._get_blocked_modules()
         assert blocked == []
 
+    def test_blocked_by_transitive_failed_dep(self):
+        runner = AsyncSyncRunner(
+            basenames=["a", "b", "c"],
+            dep_graph={"a": [], "b": ["a"], "c": ["b"]},
+            sync_options={},
+            github_info=None,
+            quiet=True,
+        )
+        runner.module_states["a"].status = "failed"
+        blocked = runner._get_blocked_modules()
+        assert blocked == ["b", "c"]
+
 
 # ---------------------------------------------------------------------------
 # AsyncSyncRunner._build_comment_body
@@ -255,6 +267,25 @@ class TestBuildCommentBody:
 
         body = runner._build_comment_body(5)
         assert "Paused" in body
+        assert "`a` failed" in body
+
+    def test_failure_with_running_modules_shows_continuing(self):
+        runner = AsyncSyncRunner(
+            basenames=["a", "b"],
+            dep_graph={"a": [], "b": []},
+            sync_options={},
+            github_info=None,
+            quiet=True,
+        )
+        runner.module_states["a"].status = "failed"
+        runner.module_states["a"].start_time = 0.0
+        runner.module_states["a"].end_time = 10.0
+        runner.module_states["b"].status = "running"
+        runner.module_states["b"].start_time = 0.0
+
+        body = runner._build_comment_body(5)
+        assert "Continuing independent module(s)" in body
+        assert "Paused" not in body
         assert "`a` failed" in body
 
     def test_all_success(self):
@@ -669,7 +700,7 @@ class TestAsyncSyncRunnerRun:
     @patch.object(AsyncSyncRunner, "_sync_one_module")
     @patch.object(AsyncSyncRunner, "_update_github_comment")
     def test_failure_pauses_new_modules(self, mock_comment, mock_sync):
-        """When a module fails, pending modules should not start."""
+        """When a dependency fails, dependent modules should not start."""
 
         def fake_sync(basename):
             if basename == "a":
@@ -691,6 +722,65 @@ class TestAsyncSyncRunnerRun:
         assert runner.module_states["a"].status == "failed"
         # b should remain pending (blocked by failed a)
         assert runner.module_states["b"].status == "pending"
+
+    @patch.object(AsyncSyncRunner, "_sync_one_module")
+    @patch.object(AsyncSyncRunner, "_update_github_comment")
+    def test_failure_does_not_block_independent_ready_modules(
+        self, mock_comment, mock_sync
+    ):
+        """Regression for #798: an unrelated failure must not strand ready work.
+
+        In the #798 run, ``cli_detector`` failed architecture conformance while
+        ``agentic_common`` was still running. ``setup_tool`` was genuinely
+        blocked by ``cli_detector``, but ``agentic_update`` only depended on
+        the successful ``agentic_common`` module. The runner should still start
+        that independent dependent once its own dependency succeeds.
+        """
+        calls = []
+
+        def fake_sync(basename):
+            calls.append(basename)
+            if basename == "cli_detector":
+                return (False, 0.01, "Architecture conformance error")
+            if basename == "agentic_common":
+                time.sleep(0.05)
+                return (True, 0.02, "")
+            if basename == "agentic_update":
+                return (True, 0.03, "")
+            raise AssertionError(f"{basename} should remain blocked")
+
+        mock_sync.side_effect = fake_sync
+
+        runner = AsyncSyncRunner(
+            basenames=[
+                "cli_detector",
+                "agentic_common",
+                "setup_tool",
+                "agentic_update",
+            ],
+            dep_graph={
+                "cli_detector": [],
+                "agentic_common": [],
+                "setup_tool": ["cli_detector"],
+                "agentic_update": ["agentic_common"],
+            },
+            sync_options={},
+            github_info=None,
+            quiet=True,
+        )
+
+        success, msg, cost = runner.run()
+
+        assert not success
+        assert cost == pytest.approx(0.06)
+        assert runner.module_states["cli_detector"].status == "failed"
+        assert runner.module_states["agentic_common"].status == "success"
+        assert runner.module_states["agentic_update"].status == "success"
+        assert runner.module_states["setup_tool"].status == "pending"
+        assert "agentic_update" in calls
+        assert "setup_tool" not in calls
+        assert "Skipped (blocked): ['setup_tool']" in msg
+        assert "agentic_update" not in msg.split("Skipped (blocked):", 1)[-1]
 
     @patch.object(AsyncSyncRunner, "_sync_one_module")
     @patch.object(AsyncSyncRunner, "_update_github_comment")
@@ -742,6 +832,40 @@ class TestAsyncSyncRunnerRun:
         assert runner.module_states["a"].status == "success"
         assert runner.module_states["b"].status == "pending"
         assert runner.module_states["c"].status == "pending"
+
+    @patch.object(AsyncSyncRunner, "_sync_one_module")
+    @patch.object(AsyncSyncRunner, "_update_github_comment")
+    def test_total_budget_exhaustion_after_failed_module_stops_new_modules(
+        self, mock_comment, mock_sync
+    ):
+        """A failed module's cost can exhaust the global budget."""
+        calls = []
+
+        def fake_sync(basename):
+            calls.append(basename)
+            if basename == "a":
+                return (False, 1.0, "sync failed after spending budget")
+            return (True, 0.5, "")
+
+        mock_sync.side_effect = fake_sync
+
+        runner = AsyncSyncRunner(
+            basenames=["a", "b"],
+            dep_graph={"a": [], "b": []},
+            sync_options={"total_budget": 1.0},
+            github_info=None,
+            quiet=True,
+        )
+
+        success, msg, cost = runner.run()
+
+        assert not success
+        assert runner.budget_exhausted is True
+        assert calls == ["a"]
+        assert cost == pytest.approx(1.0)
+        assert "Budget exhausted" in msg
+        assert runner.module_states["a"].status == "failed"
+        assert runner.module_states["b"].status == "pending"
 
     @patch.object(AsyncSyncRunner, "_sync_one_module")
     @patch.object(AsyncSyncRunner, "_update_github_comment")
@@ -2107,6 +2231,89 @@ def _make_fake_pdd_shim(tmp_path, stdout_text: str, stderr_text: str, exit_code:
     )
     shim.chmod(0o755)
     return shim
+
+
+def _make_issue_798_scheduler_shim(tmp_path) -> Path:
+    """Fake pdd executable that reproduces the #798 sync schedule."""
+    shim = tmp_path / "fake_pdd_issue_798"
+    shim.write_text(
+        f"#!{sys.executable}\n"
+        + textwrap.dedent(
+            """\
+            import sys
+            import time
+
+            basename = ""
+            if "sync" in sys.argv:
+                idx = sys.argv.index("sync")
+                if idx + 1 < len(sys.argv):
+                    basename = sys.argv[idx + 1]
+
+            if basename == "cli_detector":
+                sys.stdout.write("Overall status: Failed\\n")
+                sys.stderr.write(
+                    "Architecture conformance error for "
+                    "cli_detector_python.prompt: declared symbols missing "
+                    "from generated code\\n"
+                )
+                sys.exit(1)
+            if basename == "agentic_common":
+                time.sleep(0.2)
+                sys.stdout.write("Overall status: Success\\n")
+                sys.exit(0)
+            if basename == "agentic_update":
+                sys.stdout.write("Overall status: Success\\n")
+                sys.exit(0)
+            if basename == "setup_tool":
+                sys.stderr.write("setup_tool should have stayed blocked\\n")
+                sys.exit(9)
+
+            sys.stderr.write(f"unexpected basename: {basename}\\n")
+            sys.exit(8)
+            """
+        )
+    )
+    shim.chmod(0o755)
+    return shim
+
+
+class TestAsyncSyncRunnerRunE2E:
+    """End-to-end scheduler coverage with real child subprocesses."""
+
+    def test_issue_798_failure_only_blocks_failed_dependency_dependents(self, tmp_path):
+        shim = _make_issue_798_scheduler_shim(tmp_path)
+        runner = AsyncSyncRunner(
+            basenames=[
+                "cli_detector",
+                "agentic_common",
+                "setup_tool",
+                "agentic_update",
+            ],
+            dep_graph={
+                "cli_detector": [],
+                "agentic_common": [],
+                "setup_tool": ["cli_detector"],
+                "agentic_update": ["agentic_common"],
+            },
+            sync_options={},
+            github_info=None,
+            quiet=True,
+        )
+
+        with patch(
+            "pdd.agentic_sync_runner._find_pdd_executable",
+            return_value=str(shim),
+        ):
+            success, msg, cost = runner.run()
+
+        assert not success
+        assert cost == pytest.approx(0.0)
+        assert runner.module_states["cli_detector"].status == "failed"
+        assert runner.module_states["agentic_common"].status == "success"
+        assert runner.module_states["agentic_update"].status == "success"
+        assert runner.module_states["setup_tool"].status == "pending"
+        assert "Skipped (blocked): ['setup_tool']" in msg
+        assert "agentic_update" not in msg.split("Skipped (blocked):", 1)[-1]
 
 
 class TestSyncOneModuleE2E:


### PR DESCRIPTION
## Summary

- Continue scheduling modules whose own dependencies are satisfied after an unrelated sync module fails.
- Report pending modules as `Skipped (blocked)` only when they actually depend on a failed module; otherwise report them separately as `Skipped (not run)`.
- Update the progress footer to show that independent modules are still continuing after a failure, plus refresh the prompt/context/architecture metadata for `agentic_sync_runner`.

## Root Cause

In the #798 rerun, `cli_detector` failed architecture conformance while `agentic_common` was still running. `setup_tool` was correctly blocked because it depends on `cli_detector`, but `agentic_update` only depends on `agentic_common`. The runner set `self.failed = True` after the first failure and then globally stopped starting new modules, so `agentic_update` was stranded even though its own dependency later succeeded. The final summary then labeled every pending module as `Skipped (blocked)`, hiding the difference between a real failed-dependency block and a global fail-fast skip.

## Tests

- `pytest tests/test_agentic_sync_runner.py -q` — 118 passed
- `pytest tests/test_agentic_sync.py tests/test_agentic_sync_runner.py -q` — 268 passed
- `python -m compileall -q pdd/agentic_sync_runner.py`
- `python -m json.tool architecture.json >/dev/null`
- `git diff --check`
- `python -m pdd checkup --validate-arch-includes`
