### PR TITLE
Guard existing module prompt contracts

### DIFF
--- a/pdd/architecture_include_validation.py
+++ b/pdd/architecture_include_validation.py
@@ -157,12 +157,23 @@ class _IncludeReference:
     attrs: Dict[str, str]
 
     @property
+    def is_interface_mode(self) -> bool:
+        """Return True when the include asks preprocessing to strip bodies."""
+        return self.attrs.get("mode", "").strip().lower() == "interface"
+
+    @property
     def is_partial(self) -> bool:
-        """Return True when the include selects only part of a source file."""
-        return any(self.attrs.get(k, "").strip() for k in ("select", "lines", "query"))
+        """Return True when the include does not provide full implementation source."""
+        return self.is_interface_mode or any(
+            self.attrs.get(k, "").strip() for k in ("select", "lines", "query")
+        )
 
 
-_INCLUDE_RE = re.compile(r"<include\b([^>]*)>(.*?)</include>", re.IGNORECASE | re.DOTALL)
+_INCLUDE_RE = re.compile(
+    r"<include(?P<attrs>\s+[^>]*?)?>(?P<content>.*?)</include>|"
+    r"<include(?P<attrs_self>\s+[^>]*?)\s*/>",
+    re.IGNORECASE | re.DOTALL,
+)
 _ATTR_RE = re.compile(
     r"""([A-Za-z_:][\w:.-]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))"""
 )
@@ -185,11 +196,40 @@ def _extract_include_references(prompt_content: str) -> List[_IncludeReference]:
     """Return parsed ``<include>`` tags with their target paths and attributes."""
     refs: List[_IncludeReference] = []
     for match in _INCLUDE_RE.finditer(prompt_content or ""):
-        path = (match.group(2) or "").strip()
+        attrs = _parse_include_attrs(
+            match.group("attrs") or match.group("attrs_self") or ""
+        )
+        body_path = (match.group("content") or "").strip()
+        path = (attrs.get("path") or body_path).strip()
         if not path:
             continue
-        refs.append(_IncludeReference(path=path, attrs=_parse_include_attrs(match.group(1))))
+        refs.append(_IncludeReference(path=path, attrs=attrs))
     return refs
+
+
+@dataclass(frozen=True)
+class _PythonSymbolSpan:
+    """A public Python symbol and its 1-based inclusive source line span."""
+
+    name: str
+    start_line: int
+    end_line: int
+
+
+def _node_line_span(node: ast.AST) -> tuple[int, int]:
+    """Return the 1-based inclusive source span for an AST node."""
+    start_line = getattr(node, "lineno", 0) or 0
+    decorators = getattr(node, "decorator_list", [])
+    if decorators:
+        start_line = min(
+            [start_line]
+            + [
+                getattr(decorator, "lineno", start_line) or start_line
+                for decorator in decorators
+            ]
+        )
+    end_line = getattr(node, "end_lineno", None) or start_line
+    return start_line, end_line
 
 
 def _collect_python_public_symbols(body: List[ast.stmt], prefix: str = "") -> List[str]:
@@ -219,6 +259,43 @@ def _collect_python_public_symbols(body: List[ast.stmt], prefix: str = "") -> Li
     return symbols
 
 
+def _collect_python_public_symbol_spans(
+    body: List[ast.stmt], prefix: str = ""
+) -> List[_PythonSymbolSpan]:
+    """Collect public Python exports with their source line spans."""
+    spans: List[_PythonSymbolSpan] = []
+    for node in body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not node.name.startswith("_"):
+                start_line, end_line = _node_line_span(node)
+                spans.append(
+                    _PythonSymbolSpan(f"{prefix}{node.name}", start_line, end_line)
+                )
+        elif isinstance(node, ast.ClassDef):
+            if not node.name.startswith("_"):
+                class_name = f"{prefix}{node.name}"
+                start_line, end_line = _node_line_span(node)
+                spans.append(_PythonSymbolSpan(class_name, start_line, end_line))
+                spans.extend(
+                    _collect_python_public_symbol_spans(node.body, f"{class_name}.")
+                )
+        elif not prefix and isinstance(node, ast.Assign):
+            start_line, end_line = _node_line_span(node)
+            for target in node.targets:
+                if isinstance(target, ast.Name) and not target.id.startswith("_"):
+                    spans.append(_PythonSymbolSpan(target.id, start_line, end_line))
+        elif (
+            not prefix
+            and isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.value is not None
+            and not node.target.id.startswith("_")
+        ):
+            start_line, end_line = _node_line_span(node)
+            spans.append(_PythonSymbolSpan(node.target.id, start_line, end_line))
+    return spans
+
+
 def _python_top_level_public_symbols(source: str) -> List[str]:
     """Return public symbols exported by a Python source file."""
     try:
@@ -232,6 +309,19 @@ def _python_top_level_public_symbols(source: str) -> List[str]:
             seen.add(symbol)
             ordered.append(symbol)
     return ordered
+
+
+def _python_public_symbol_spans(source: str) -> Dict[str, _PythonSymbolSpan]:
+    """Return public Python symbol source spans keyed by symbol name."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return {}
+
+    spans: Dict[str, _PythonSymbolSpan] = {}
+    for span in _collect_python_public_symbol_spans(tree.body):
+        spans.setdefault(span.name, span)
+    return spans
 
 
 def _interface_function_names(interface: Any) -> List[str]:
@@ -348,7 +438,59 @@ def _include_matches_output(include_path: str, output_path: Path, project_root: 
         return False
 
 
-def _symbols_covered_by_selectors(selectors: List[str], existing_symbols: List[str]) -> Set[str]:
+def _parse_line_ranges(lines_value: str, total_lines: int) -> List[tuple[int, int]]:
+    """
+    Parse ContentSelector ``lines:`` syntax into 1-based inclusive spans.
+
+    Supported forms intentionally mirror ``pdd.content_selector``: ``N``, ``N-M``,
+    ``N-``, ``-M``, and comma-separated combinations.
+    """
+    ranges: List[tuple[int, int]] = []
+    for part in (lines_value or "").split(","):
+        token = part.strip()
+        if not token:
+            continue
+        try:
+            if "-" in token:
+                split_at = token.index("-")
+                left = token[:split_at].strip()
+                right = token[split_at + 1 :].strip()
+                if left == "" and right == "":
+                    continue
+                start = int(left) if left else 1
+                end = int(right) if right else total_lines
+            else:
+                start = end = int(token)
+        except ValueError:
+            continue
+
+        start = max(1, start)
+        end = min(total_lines, end)
+        if start <= end:
+            ranges.append((start, end))
+    return ranges
+
+
+def _symbols_covered_by_line_ranges(source: str, lines_value: str) -> Set[str]:
+    """Map deterministic ``lines=``/``lines:`` selectors to covered symbols."""
+    line_ranges = _parse_line_ranges(lines_value, len(source.splitlines()))
+    if not line_ranges:
+        return set()
+
+    covered: Set[str] = set()
+    for symbol, span in _python_public_symbol_spans(source).items():
+        if any(
+            start <= span.start_line and span.end_line <= end for start, end in line_ranges
+        ):
+            covered.add(symbol)
+    return covered
+
+
+def _symbols_covered_by_selectors(
+    selectors: List[str],
+    existing_symbols: List[str],
+    existing_source: str,
+) -> Set[str]:
     """Map ``<include select=...>`` selectors to covered source symbols."""
     covered: Set[str] = set()
     symbol_set = set(existing_symbols)
@@ -369,9 +511,53 @@ def _symbols_covered_by_selectors(selectors: List[str], existing_symbols: List[s
                 for symbol in existing_symbols:
                     if symbol == value or symbol.startswith(f"{value}."):
                         covered.add(symbol)
+            elif kind == "lines":
+                covered.update(_symbols_covered_by_line_ranges(existing_source, value))
             elif value in symbol_set:
                 covered.add(value)
     return covered
+
+
+def _symbols_covered_by_partial_includes(
+    self_includes: List[_IncludeReference],
+    existing_symbols: List[str],
+    existing_source: str,
+) -> tuple[Set[str], List[str]]:
+    """Return deterministic implementation symbols covered by partial self-includes."""
+    covered: Set[str] = set()
+    unsupported: List[str] = []
+
+    for ref in self_includes:
+        select_value = ref.attrs.get("select", "").strip()
+        query_value = ref.attrs.get("query", "").strip()
+        lines_value = ref.attrs.get("lines", "").strip()
+
+        if ref.is_interface_mode:
+            unsupported.append(
+                'mode="interface" self-include does not provide implementation context'
+            )
+            continue
+
+        if select_value:
+            covered.update(
+                _symbols_covered_by_selectors(
+                    [select_value],
+                    existing_symbols,
+                    existing_source,
+                )
+            )
+            if lines_value:
+                covered.update(_symbols_covered_by_line_ranges(existing_source, lines_value))
+            continue
+
+        if query_value:
+            unsupported.append("query= self-include cannot prove symbol coverage")
+            continue
+
+        if lines_value:
+            covered.update(_symbols_covered_by_line_ranges(existing_source, lines_value))
+
+    return covered, unsupported
 
 
 def validate_prompt_contract_context(
@@ -435,22 +621,28 @@ def validate_prompt_contract_context(
     if any(not ref.is_partial for ref in self_includes):
         return []
 
-    covered = _symbols_covered_by_selectors(
-        [ref.attrs.get("select", "") for ref in self_includes if ref.attrs.get("select")],
+    covered, unsupported = _symbols_covered_by_partial_includes(
+        self_includes,
         existing_symbols,
+        existing_source,
     )
     missing = [symbol for symbol in declared_existing if symbol not in covered]
     if not missing:
         return []
 
     covered_declared_count = len([s for s in declared_existing if s in covered])
+    unsupported_note = ""
+    if unsupported:
+        unsupported_note = " Unsupported partial self-include context: " + "; ".join(
+            sorted(set(unsupported))
+        ) + "."
     return [
         (
             f"{prompt_path}: prompt declares {len(declared_existing)} public symbols "
             f"already present in {output_path} but only includes source context for "
             f"{covered_declared_count}: missing {', '.join(missing)}. "
             "Use a full <include> of the existing module or select every declared "
-            "existing public symbol."
+            f"existing public symbol.{unsupported_note}"
         )
     ]
 

--- a/pdd/architecture_include_validation.py
+++ b/pdd/architecture_include_validation.py
@@ -7,8 +7,11 @@ prompts the LLM actually pulls in via <include>.
 from __future__ import annotations
 
 import json
+import ast
+import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, FrozenSet, List, Optional
+from typing import Any, Dict, FrozenSet, List, Optional, Set
 
 from .architecture_registry import extract_modules
 from .sync_order import extract_includes_from_file, extract_module_from_include
@@ -144,6 +147,312 @@ def _resolve_architecture_prompt_path(filename: str, project_root: Path) -> Path
 def resolve_architecture_prompt_path(filename: str, project_root: Path) -> Path:
     """Public API for resolving an architecture ``filename`` to an on-disk path."""
     return _resolve_architecture_prompt_path(filename, project_root)
+
+
+@dataclass(frozen=True)
+class _IncludeReference:
+    """A parsed prompt ``<include>`` tag."""
+
+    path: str
+    attrs: Dict[str, str]
+
+    @property
+    def is_partial(self) -> bool:
+        """Return True when the include selects only part of a source file."""
+        return any(self.attrs.get(k, "").strip() for k in ("select", "lines", "query"))
+
+
+_INCLUDE_RE = re.compile(r"<include\b([^>]*)>(.*?)</include>", re.IGNORECASE | re.DOTALL)
+_ATTR_RE = re.compile(
+    r"""([A-Za-z_:][\w:.-]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))"""
+)
+
+
+def _parse_include_attrs(raw_attrs: str) -> Dict[str, str]:
+    """Parse simple XML-style attributes from an ``<include>`` tag."""
+    attrs: Dict[str, str] = {}
+    for match in _ATTR_RE.finditer(raw_attrs or ""):
+        value = match.group(2)
+        if value is None:
+            value = match.group(3)
+        if value is None:
+            value = match.group(4)
+        attrs[match.group(1).lower()] = value or ""
+    return attrs
+
+
+def _extract_include_references(prompt_content: str) -> List[_IncludeReference]:
+    """Return parsed ``<include>`` tags with their target paths and attributes."""
+    refs: List[_IncludeReference] = []
+    for match in _INCLUDE_RE.finditer(prompt_content or ""):
+        path = (match.group(2) or "").strip()
+        if not path:
+            continue
+        refs.append(_IncludeReference(path=path, attrs=_parse_include_attrs(match.group(1))))
+    return refs
+
+
+def _collect_python_public_symbols(body: List[ast.stmt], prefix: str = "") -> List[str]:
+    """Collect public Python exports using the same shape as architecture conformance."""
+    symbols: List[str] = []
+    for node in body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not node.name.startswith("_"):
+                symbols.append(f"{prefix}{node.name}")
+        elif isinstance(node, ast.ClassDef):
+            if not node.name.startswith("_"):
+                class_name = f"{prefix}{node.name}"
+                symbols.append(class_name)
+                symbols.extend(_collect_python_public_symbols(node.body, f"{class_name}."))
+        elif not prefix and isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and not target.id.startswith("_"):
+                    symbols.append(target.id)
+        elif (
+            not prefix
+            and isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.value is not None
+            and not node.target.id.startswith("_")
+        ):
+            symbols.append(node.target.id)
+    return symbols
+
+
+def _python_top_level_public_symbols(source: str) -> List[str]:
+    """Return public symbols exported by a Python source file."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    seen: Set[str] = set()
+    ordered: List[str] = []
+    for symbol in _collect_python_public_symbols(tree.body):
+        if symbol not in seen:
+            seen.add(symbol)
+            ordered.append(symbol)
+    return ordered
+
+
+def _interface_function_names(interface: Any) -> List[str]:
+    """Extract declared public symbols from an architecture/prompt interface block."""
+    if not isinstance(interface, dict):
+        return []
+    if interface.get("type") != "module":
+        return []
+
+    module_spec = interface.get("module")
+    if not isinstance(module_spec, dict):
+        return []
+
+    names: List[str] = []
+    for key in ("functions", "classes", "constants", "exports"):
+        values = module_spec.get(key, [])
+        if not isinstance(values, list):
+            continue
+        for value in values:
+            name: Optional[str] = None
+            if isinstance(value, dict):
+                raw_name = value.get("name")
+                if isinstance(raw_name, str):
+                    name = raw_name
+            elif isinstance(value, str):
+                name = value
+            if name and not name.startswith("_") and name not in names:
+                names.append(name)
+    return names
+
+
+def _prompt_interface(prompt_content: str) -> Optional[Dict[str, Any]]:
+    """Extract the prompt-local ``<pdd-interface>`` block if present."""
+    try:
+        from .architecture_sync import parse_prompt_tags
+
+        interface = parse_prompt_tags(prompt_content).get("interface")
+    except Exception:
+        return None
+    return interface if isinstance(interface, dict) else None
+
+
+def _entry_matches_prompt_or_output(
+    entry: Dict[str, Any],
+    prompt_path: Path,
+    output_path: Path,
+    project_root: Path,
+) -> bool:
+    """Return True when an architecture entry names the prompt or output path."""
+    filename = str(entry.get("filename") or "").replace("\\", "/")
+    prompt_name = prompt_path.name
+    if filename:
+        if filename == prompt_name or Path(filename).name == prompt_name:
+            return True
+        if Path(filename).stem == prompt_path.stem:
+            return True
+
+    filepath = entry.get("filepath")
+    if isinstance(filepath, str) and filepath.strip():
+        normalized = filepath.replace("\\", "/").lstrip("/")
+        try:
+            if (project_root / normalized).resolve() == output_path.resolve():
+                return True
+        except OSError:
+            pass
+        try:
+            rel_output = output_path.resolve().relative_to(project_root.resolve()).as_posix()
+            if rel_output == normalized:
+                return True
+        except ValueError:
+            pass
+    return False
+
+
+def _load_architecture_interface(
+    architecture_path: Optional[Path],
+    prompt_path: Path,
+    output_path: Path,
+    project_root: Path,
+) -> Optional[Dict[str, Any]]:
+    """Load the matching architecture.json interface block, if any."""
+    arch_path = architecture_path or (project_root / "architecture.json")
+    if not arch_path.exists():
+        return None
+    try:
+        arch_data = json.loads(arch_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    for entry in extract_modules(arch_data):
+        if _entry_matches_prompt_or_output(entry, prompt_path, output_path, project_root):
+            interface = entry.get("interface")
+            return interface if isinstance(interface, dict) else None
+    return None
+
+
+def _include_matches_output(include_path: str, output_path: Path, project_root: Path) -> bool:
+    """Return True when an include target is the same file as the output path."""
+    raw = include_path.replace("\\", "/").strip()
+    if not raw:
+        return False
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        candidate = project_root / raw
+    try:
+        if candidate.resolve() == output_path.resolve():
+            return True
+    except OSError:
+        pass
+    try:
+        rel_output = output_path.resolve().relative_to(project_root.resolve()).as_posix()
+        return raw.lstrip("/") == rel_output
+    except ValueError:
+        return False
+
+
+def _symbols_covered_by_selectors(selectors: List[str], existing_symbols: List[str]) -> Set[str]:
+    """Map ``<include select=...>`` selectors to covered source symbols."""
+    covered: Set[str] = set()
+    symbol_set = set(existing_symbols)
+    for selector_list in selectors:
+        for raw_token in (selector_list or "").split(","):
+            token = raw_token.strip()
+            if not token:
+                continue
+            kind = ""
+            value = token
+            if ":" in token:
+                kind, value = token.split(":", 1)
+                kind = kind.strip().lower()
+                value = value.strip()
+            if not value:
+                continue
+            if kind in {"class", "cls"}:
+                for symbol in existing_symbols:
+                    if symbol == value or symbol.startswith(f"{value}."):
+                        covered.add(symbol)
+            elif value in symbol_set:
+                covered.add(value)
+    return covered
+
+
+def validate_prompt_contract_context(
+    prompt_path: Path,
+    output_path: Path,
+    project_root: Path,
+    architecture_path: Optional[Path] = None,
+    prompt_content: Optional[str] = None,
+) -> List[str]:
+    """
+    Validate that broad module interface declarations have matching source context.
+
+    This preflight catches the issue-798 failure shape: an existing module prompt
+    declares a wide public interface but includes only a small selected slice of
+    the existing implementation, leaving the LLM without enough context to
+    preserve declared exports. A full self-include satisfies the contract. A
+    partial self-include must select every declared symbol that already exists in
+    the output source file.
+    """
+    prompt_path = Path(prompt_path)
+    output_path = Path(output_path)
+    project_root = Path(project_root)
+
+    if prompt_content is None:
+        try:
+            prompt_content = prompt_path.read_text(encoding="utf-8")
+        except OSError:
+            return []
+
+    try:
+        existing_source = output_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    if not existing_source.strip():
+        return []
+
+    declared_symbols: List[str] = []
+    for interface in (
+        _prompt_interface(prompt_content),
+        _load_architecture_interface(architecture_path, prompt_path, output_path, project_root),
+    ):
+        for symbol in _interface_function_names(interface):
+            if symbol not in declared_symbols:
+                declared_symbols.append(symbol)
+    if not declared_symbols:
+        return []
+
+    existing_symbols = _python_top_level_public_symbols(existing_source)
+    existing_symbol_set = set(existing_symbols)
+    declared_existing = [symbol for symbol in declared_symbols if symbol in existing_symbol_set]
+    if not declared_existing:
+        return []
+
+    self_includes = [
+        ref
+        for ref in _extract_include_references(prompt_content)
+        if _include_matches_output(ref.path, output_path, project_root)
+    ]
+    if not self_includes:
+        return []
+    if any(not ref.is_partial for ref in self_includes):
+        return []
+
+    covered = _symbols_covered_by_selectors(
+        [ref.attrs.get("select", "") for ref in self_includes if ref.attrs.get("select")],
+        existing_symbols,
+    )
+    missing = [symbol for symbol in declared_existing if symbol not in covered]
+    if not missing:
+        return []
+
+    covered_declared_count = len([s for s in declared_existing if s in covered])
+    return [
+        (
+            f"{prompt_path}: prompt declares {len(declared_existing)} public symbols "
+            f"already present in {output_path} but only includes source context for "
+            f"{covered_declared_count}: missing {', '.join(missing)}. "
+            "Use a full <include> of the existing module or select every declared "
+            "existing public symbol."
+        )
+    ]
 
 
 def _pdd_dependency_modules(prompt_path: Path, self_mod: str) -> set[str]:

--- a/pdd/code_generator_main.py
+++ b/pdd/code_generator_main.py
@@ -31,6 +31,7 @@ from .architecture_sync import (
     generate_tags_from_architecture,
 )
 from .architecture_registry import extract_modules
+from .architecture_include_validation import validate_prompt_contract_context
 from .validate_prompt_includes import validate_prompt_includes
 
 console = Console()
@@ -66,6 +67,47 @@ def _should_wire_generated_exports(output_path: str) -> bool:
     if _env_flag_enabled("PDD_SKIP_WIRING"):
         return False
     return _env_flag_enabled("PDD_ENABLE_WIRING")
+
+
+def _find_prompt_contract_project_root(prompt_path: str, output_path: Optional[str]) -> pathlib.Path:
+    """Find the project root used for prompt contract preflight resolution."""
+    starts: List[pathlib.Path] = []
+    try:
+        starts.append(pathlib.Path(prompt_path).resolve().parent)
+    except Exception:
+        pass
+    if output_path:
+        try:
+            starts.append(pathlib.Path(output_path).resolve().parent)
+        except Exception:
+            pass
+    starts.append(pathlib.Path.cwd().resolve())
+
+    seen: set[pathlib.Path] = set()
+    for start in starts:
+        if start in seen:
+            continue
+        seen.add(start)
+        current = start
+        while True:
+            if (current / "architecture.json").exists():
+                return current
+            if current.parent == current:
+                break
+            current = current.parent
+
+    try:
+        current = pathlib.Path(prompt_path).resolve().parent
+        while True:
+            if current.name == "prompts":
+                return current.parent
+            if current.parent == current:
+                break
+            current = current.parent
+    except Exception:
+        pass
+
+    return pathlib.Path.cwd().resolve()
 
 # --- Git Helper Functions ---
 def _run_git_command(command: List[str], cwd: Optional[str] = None) -> Tuple[int, str, str]:
@@ -811,6 +853,25 @@ def code_generator_main(
     # Honor front-matter language if provided (overrides detection for both local and cloud)
     if fm_meta and isinstance(fm_meta.get("language"), str) and fm_meta.get("language"):
         language = fm_meta.get("language")
+
+    if (
+        llm_enabled
+        and output_path
+        and not _env_flag_enabled("PDD_SKIP_PROMPT_CONTRACT_PREFLIGHT")
+    ):
+        contract_root = _find_prompt_contract_project_root(prompt_file, output_path)
+        contract_arch_path = contract_root / "architecture.json"
+        contract_errors = validate_prompt_contract_context(
+            prompt_path=pathlib.Path(prompt_file),
+            output_path=pathlib.Path(output_path),
+            project_root=contract_root,
+            architecture_path=contract_arch_path if contract_arch_path.exists() else None,
+            prompt_content=prompt_content,
+        )
+        if contract_errors:
+            raise click.UsageError(
+                "Prompt contract preflight failed:\n- " + "\n- ".join(contract_errors)
+            )
 
     if output_path and pathlib.Path(output_path).exists():
         try:

--- a/pdd/prompts/agentic_arch_step1b_complexity_LLM.prompt
+++ b/pdd/prompts/agentic_arch_step1b_complexity_LLM.prompt
@@ -195,5 +195,9 @@ To override and generate as a single project, use:
 - When in doubt, lean toward MANAGEABLE — let Step 5b catch any coverage gaps
 - Always output `COMPLEXITY_RESULT: MANAGEABLE` or `COMPLEXITY_RESULT: COMPLEX`
 - If COMPLEX: MUST create sub-issues and post summary comment before outputting
-- Sub-issues should be self-contained enough to generate independently
+- Splitting is a last resort. Keep one issue when the work is a tightly coupled workflow or primarily changes one established module.
+- A split is valid only when every child sub-issue is independently implementable and independently verifiable.
+- Create 2 sub-issues by default; create 3 only when there are genuinely separate product or workflow ownership areas. Never create more than 3.
+- Do NOT create prompt-only, architecture-only, test-only, or review-only sub-issues. Split by independently shippable behavior, not by workflow phase.
+- Preserve one parent-level acceptance test/checklist that verifies the combined end-to-end behavior after all children are complete.
 - Each sub-issue should reference the parent issue number

--- a/pdd/prompts/agentic_arch_step9_prompts_LLM.prompt
+++ b/pdd/prompts/agentic_arch_step9_prompts_LLM.prompt
@@ -202,6 +202,26 @@ Check with: `ls prompts/_context/data_dictionary.yaml 2>/dev/null`
    - `prompts/_context/data_dictionary.yaml` is authoritative when it exists
    - architecture.json `interface` fields are authoritative for function signatures
 
+% Existing Module Contract Context (CRITICAL)
+
+For existing modules, the declared interface and LLM context must stay aligned.
+Before writing a prompt for a module whose `filepath` already exists, inspect the
+existing source file and list its public functions/classes. Compare that list to
+the module's architecture `interface`.
+
+If the prompt declares an existing public symbol in `<pdd-interface>`, include
+enough source context for the LLM to preserve it:
+- Use a full `<include>` of that source file for established/shared modules or
+  modules whose prompt is expected to preserve existing behavior.
+- Or use a targeted `<include select="...">` that covers every existing public symbol
+  declared in `<pdd-interface>`.
+- Or explicitly state that the module is a replacement/new implementation and narrow
+  the declared interface to only the exports the generated code must provide.
+
+Do NOT declare a broad public API while including only a small selected slice of the
+existing implementation. `<pdd-dependency>` is architecture metadata, not LLM context;
+it does not provide source text to the code generation model.
+
 % Cross-Language Field Name Mapping (for multi-language projects)
    - For every prompt that defines or consumes a shared data type used across languages (e.g., Python backend + TypeScript frontend):
      - Include a "Field Name Mapping" table showing the exact field names in each language:

--- a/pdd/prompts/agentic_common_python.prompt
+++ b/pdd/prompts/agentic_common_python.prompt
@@ -133,7 +133,7 @@ Instruction: `"Read the file {prompt_file} for instructions. You have full file 
     <include select="def:llm_invoke">pdd/llm_invoke.py</include>
 </pdd.llm_invoke>
 <agentic_common_existing_impl>
-    <include select="class:TokenMatch,def:detect_control_token,def:classify_step_output,def:substitute_template_variables">pdd/agentic_common.py</include>
+    <include>pdd/agentic_common.py</include>
 </agentic_common_existing_impl>
 <utils.api_key_scanner>
     <include>context/api_key_scanner_example.py</include>

--- a/pdd/prompts/architecture_include_validation_python.prompt
+++ b/pdd/prompts/architecture_include_validation_python.prompt
@@ -72,10 +72,18 @@
 
 % _IncludeReference dataclass
 %   - Fields: path: str, attrs: Dict[str, str].
-%   - Property is_partial: True when select=, lines=, or query= is present.
+%   - Property is_interface_mode: True when mode="interface".
+%   - Property is_partial: True when select=, lines=, query=, or mode="interface"
+%     is present, because those forms do not guarantee full implementation source.
 
 % _extract_include_references(prompt_content: str) -> List[_IncludeReference]
-%   - Parse raw <include ...>target</include> tags, preserving include attributes.
+%   - Parse raw <include ...>target</include> and self-closing
+%     <include path="..." /> tags, preserving include attributes.
+%   - Match preprocess include grammar:
+%       * body path: <include>path.py</include>
+%       * path attribute: <include path="path.py">ignored_body.py</include>
+%       * self-closing path attribute: <include path="path.py" />
+%   - When path= is present, it takes precedence over body content.
 %   - This must parse plain prompt text and not require the prompt to be valid XML.
 
 % _interface_function_names(interface: Any) -> List[str]
@@ -85,6 +93,31 @@
 % _python_top_level_public_symbols(source: str) -> List[str]
 %   - Parse Python source with ast and return public top-level functions/classes/constants.
 %   - Include class methods as dotted symbols when discovered.
+%
+% _python_public_symbol_spans(source: str) -> Dict[str, _PythonSymbolSpan]
+%   - Parse Python source with ast and return public symbols with 1-based inclusive
+%     line spans.
+%   - Use the same public symbol shape as _python_top_level_public_symbols.
+%
+% _symbols_covered_by_line_ranges(source: str, lines_value: str) -> Set[str]
+%   - Map deterministic ContentSelector line ranges to public symbols whose full
+%     source span is contained in the selected range.
+%   - Support the same line syntax as ContentSelector: N, N-M, N-, -M, comma-separated.
+%
+% _symbols_covered_by_selectors(selectors, existing_symbols, existing_source) -> Set[str]
+%   - Map deterministic select= tokens to covered public symbols.
+%   - def:name covers that symbol; class:Name covers the class and dotted members.
+%   - lines:N-M selectors cover symbols via _symbols_covered_by_line_ranges.
+%
+% _symbols_covered_by_partial_includes(self_includes, existing_symbols, existing_source)
+%   -> tuple[Set[str], List[str]]
+%   - Return symbols covered by deterministic implementation-bearing partial
+%     self-includes plus explicit unsupported context notes.
+%   - select= wins over query=, matching preprocess behavior.
+%   - query= without select= is unsupported for this preflight because semantic
+%     extraction is non-deterministic and cannot prove symbol coverage.
+%   - mode="interface" self-includes do not count as implementation context because
+%     interface mode strips bodies.
 
 % validate_prompt_contract_context(
 %     prompt_path: Path,
@@ -96,9 +129,11 @@
 %   - Generation-time preflight used before the LLM is called.
 %   - Load declared module symbols from both <pdd-interface> and matching architecture.json.
 %   - If the prompt includes the output source file with a full <include>, return [].
-%   - If the prompt includes the output source file with select=/lines=/query=, require
-%     selected context to cover every declared public symbol that already exists in
-%     output_path.
+%   - If the prompt includes the output source file with select=/lines=/query= or
+%     mode="interface", require deterministic implementation context to cover every
+%     declared public symbol that already exists in output_path.
+%   - Treat query-only self-includes and mode="interface" self-includes as unsupported
+%     partial context and include that reason in the hard-failure message.
 %   - Return a hard-failure message when declared existing symbols are missing from
 %     partial self-include context.
 %   - Return [] when the prompt has no self-include so legacy prompts are not broken by

--- a/pdd/prompts/architecture_include_validation_python.prompt
+++ b/pdd/prompts/architecture_include_validation_python.prompt
@@ -25,6 +25,12 @@
 %      prompt file has no <include> or <pdd-dependency> referencing that module's prompt.
 %   2. Reverse mismatch: a prompt <include>s another module's prompt, but
 %      architecture.json dependencies do not list that module.
+% It also provides a generation-time contract preflight for existing modules:
+%   3. Prompt contract/context mismatch: a prompt declares a broad module interface
+%      while <include>ing only a selected slice of the existing output source.
+%      For existing modules, a partial self-include must cover every declared public
+%      symbol that already exists in the output file, or the prompt must use a full
+%      self-include.
 
 % ============================================================
 % Internal helpers
@@ -63,6 +69,40 @@
 %   - Uses parse_prompt_tags from .architecture_sync to extract "dependencies" tags.
 %   - Filters out self_mod and uses extract_module_from_include for each dependency.
 %   - Returns empty set on OSError or empty content.
+
+% _IncludeReference dataclass
+%   - Fields: path: str, attrs: Dict[str, str].
+%   - Property is_partial: True when select=, lines=, or query= is present.
+
+% _extract_include_references(prompt_content: str) -> List[_IncludeReference]
+%   - Parse raw <include ...>target</include> tags, preserving include attributes.
+%   - This must parse plain prompt text and not require the prompt to be valid XML.
+
+% _interface_function_names(interface: Any) -> List[str]
+%   - Extract public module symbols declared in architecture/prompt interface blocks.
+%   - Reads module.functions, module.classes, module.constants, and module.exports.
+
+% _python_top_level_public_symbols(source: str) -> List[str]
+%   - Parse Python source with ast and return public top-level functions/classes/constants.
+%   - Include class methods as dotted symbols when discovered.
+
+% validate_prompt_contract_context(
+%     prompt_path: Path,
+%     output_path: Path,
+%     project_root: Path,
+%     architecture_path: Optional[Path] = None,
+%     prompt_content: Optional[str] = None,
+% ) -> List[str]
+%   - Generation-time preflight used before the LLM is called.
+%   - Load declared module symbols from both <pdd-interface> and matching architecture.json.
+%   - If the prompt includes the output source file with a full <include>, return [].
+%   - If the prompt includes the output source file with select=/lines=/query=, require
+%     selected context to cover every declared public symbol that already exists in
+%     output_path.
+%   - Return a hard-failure message when declared existing symbols are missing from
+%     partial self-include context.
+%   - Return [] when the prompt has no self-include so legacy prompts are not broken by
+%     this scoped preflight.
 
 % ============================================================
 % Core validation function
@@ -161,7 +201,8 @@
 % Generate a single Python module with:
 %   - Module docstring describing Phase 5 cross-validation purpose.
 %   - from __future__ import annotations
-%   - Imports: json, pathlib.Path, typing (Any, Dict, FrozenSet, List, Optional)
+%   - Imports: ast, json, re, dataclasses.dataclass, pathlib.Path, typing
+%     (Any, Dict, FrozenSet, List, Optional, Set)
 %   - Relative imports from .architecture_registry and .sync_order at top level.
 %   - Lazy imports of click, rich, .architecture_sync, .architecture_registry inside
 %     functions that need them (to avoid circular imports).

--- a/tests/test_agentic_arch_complexity_prompt.py
+++ b/tests/test_agentic_arch_complexity_prompt.py
@@ -1,0 +1,36 @@
+"""Prompt contract tests for issue-level complexity splitting."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_complexity_prompt_requires_independently_shippable_splits() -> None:
+    prompt = Path("pdd/prompts/agentic_arch_step1b_complexity_LLM.prompt").read_text(
+        encoding="utf-8"
+    )
+
+    required_phrases = [
+        "independently implementable and independently verifiable",
+        "Do NOT create prompt-only, architecture-only, test-only, or review-only sub-issues",
+        "Create 2 sub-issues by default; create 3 only when",
+        "Preserve one parent-level acceptance test",
+    ]
+
+    missing = [phrase for phrase in required_phrases if phrase not in prompt]
+    assert missing == []
+
+
+def test_step9_prompt_requires_existing_module_contract_context() -> None:
+    prompt = Path("pdd/prompts/agentic_arch_step9_prompts_LLM.prompt").read_text(
+        encoding="utf-8"
+    )
+
+    required_phrases = [
+        "For existing modules, the declared interface and LLM context must stay aligned.",
+        "full `<include>` of that source file",
+        "targeted `<include select=\"...\">` that covers every existing public symbol",
+        "`<pdd-dependency>` is architecture metadata, not LLM context",
+    ]
+
+    missing = [phrase for phrase in required_phrases if phrase not in prompt]
+    assert missing == []

--- a/tests/test_prompt_contract_validation.py
+++ b/tests/test_prompt_contract_validation.py
@@ -1,0 +1,180 @@
+"""Regression tests for prompt interface/context contract validation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import click
+import pytest
+
+from pdd.code_generator_main import code_generator_main
+from pdd.architecture_include_validation import validate_prompt_contract_context
+
+
+def _write_issue_798_shape(
+    root: Path,
+    *,
+    full_include: bool = False,
+    prompt_dir: str = "prompts",
+) -> tuple[Path, Path, Path]:
+    prompts = root / prompt_dir
+    prompts.mkdir(parents=True)
+    source = root / "pdd" / "agentic_common.py"
+    source.parent.mkdir(exist_ok=True)
+    source.write_text(
+        "def keep_me():\n"
+        "    return True\n\n"
+        "def missing_from_context():\n"
+        "    return False\n",
+        encoding="utf-8",
+    )
+
+    include = (
+        "<include>pdd/agentic_common.py</include>"
+        if full_include
+        else '<include select="def:keep_me">pdd/agentic_common.py</include>'
+    )
+    prompt = prompts / "agentic_common_python.prompt"
+    prompt.write_text(
+        '<pdd-interface>{"type":"module","module":{"functions":['
+        '{"name":"keep_me","signature":"()","returns":"bool"},'
+        '{"name":"missing_from_context","signature":"()","returns":"bool"}'
+        "]}}</pdd-interface>\n"
+        "% Goal\n"
+        "Preserve the existing module and make a small change.\n"
+        f"<existing_impl>{include}</existing_impl>\n",
+        encoding="utf-8",
+    )
+    arch = [
+        {
+            "filename": "agentic_common_python.prompt",
+            "filepath": "pdd/agentic_common.py",
+            "interface": {
+                "type": "module",
+                "module": {
+                    "functions": [
+                        {"name": "keep_me", "signature": "()", "returns": "bool"},
+                        {
+                            "name": "missing_from_context",
+                            "signature": "()",
+                            "returns": "bool",
+                        },
+                    ]
+                },
+            },
+        }
+    ]
+    (root / "architecture.json").write_text(json.dumps(arch), encoding="utf-8")
+    return prompt, source, root / "architecture.json"
+
+
+def test_issue_798_partial_self_include_fails_contract_preflight(tmp_path: Path) -> None:
+    prompt, source, arch = _write_issue_798_shape(tmp_path)
+
+    errors = validate_prompt_contract_context(
+        prompt_path=prompt,
+        output_path=source,
+        project_root=tmp_path,
+        architecture_path=arch,
+    )
+
+    assert len(errors) == 1
+    assert "missing_from_context" in errors[0]
+    assert "declares 2 public symbols" in errors[0]
+    assert "only includes source context for 1" in errors[0]
+
+
+def test_full_existing_source_include_satisfies_contract(tmp_path: Path) -> None:
+    prompt, source, arch = _write_issue_798_shape(tmp_path, full_include=True)
+
+    assert (
+        validate_prompt_contract_context(
+            prompt_path=prompt,
+            output_path=source,
+            project_root=tmp_path,
+            architecture_path=arch,
+        )
+        == []
+    )
+
+
+def test_code_generator_main_aborts_before_llm_on_contract_gap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    prompt, source, _arch = _write_issue_798_shape(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PDD_SKIP_CONFORMANCE", "1")
+    monkeypatch.delenv("PDD_SKIP_PROMPT_CONTRACT_PREFLIGHT", raising=False)
+
+    mock_generator = MagicMock(return_value=("def keep_me():\n    return True\n", 0.0, "mock"))
+    monkeypatch.setattr("pdd.code_generator_main.local_code_generator_func", mock_generator)
+    monkeypatch.setattr(
+        "pdd.code_generator_main.construct_paths",
+        MagicMock(return_value=({}, {"prompt_file": prompt.read_text()}, {"output": str(source)}, "python")),
+    )
+    monkeypatch.setattr("pdd.code_generator_main.CloudConfig.is_running_in_cloud", lambda: True)
+
+    ctx = click.Context(click.Command("generate"))
+    ctx.obj = {
+        "local": True,
+        "strength": 0.5,
+        "temperature": 0.0,
+        "time": 0.25,
+        "verbose": False,
+        "force": True,
+        "quiet": True,
+        "context": None,
+    }
+
+    with pytest.raises(click.UsageError, match="Prompt contract preflight failed"):
+        code_generator_main(
+            ctx,
+            str(prompt),
+            str(source),
+            original_prompt_file_path=None,
+            force_incremental_flag=False,
+            language="python",
+        )
+
+    mock_generator.assert_not_called()
+
+
+def test_code_generator_main_finds_root_architecture_for_nested_pdd_prompts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    prompt, source, _arch = _write_issue_798_shape(tmp_path, prompt_dir="pdd/prompts")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PDD_SKIP_CONFORMANCE", "1")
+
+    mock_generator = MagicMock(return_value=("def keep_me():\n    return True\n", 0.0, "mock"))
+    monkeypatch.setattr("pdd.code_generator_main.local_code_generator_func", mock_generator)
+    monkeypatch.setattr(
+        "pdd.code_generator_main.construct_paths",
+        MagicMock(return_value=({}, {"prompt_file": prompt.read_text()}, {"output": str(source)}, "python")),
+    )
+    monkeypatch.setattr("pdd.code_generator_main.CloudConfig.is_running_in_cloud", lambda: True)
+
+    ctx = click.Context(click.Command("generate"))
+    ctx.obj = {
+        "local": True,
+        "strength": 0.5,
+        "temperature": 0.0,
+        "time": 0.25,
+        "verbose": False,
+        "force": True,
+        "quiet": True,
+        "context": None,
+    }
+
+    with pytest.raises(click.UsageError, match="missing_from_context"):
+        code_generator_main(
+            ctx,
+            str(prompt),
+            str(source),
+            original_prompt_file_path=None,
+            force_incremental_flag=False,
+            language="python",
+        )
+
+    mock_generator.assert_not_called()

--- a/tests/test_prompt_contract_validation.py
+++ b/tests/test_prompt_contract_validation.py
@@ -17,6 +17,7 @@ def _write_issue_798_shape(
     *,
     full_include: bool = False,
     prompt_dir: str = "prompts",
+    include_override: str | None = None,
 ) -> tuple[Path, Path, Path]:
     prompts = root / prompt_dir
     prompts.mkdir(parents=True)
@@ -30,11 +31,14 @@ def _write_issue_798_shape(
         encoding="utf-8",
     )
 
-    include = (
-        "<include>pdd/agentic_common.py</include>"
-        if full_include
-        else '<include select="def:keep_me">pdd/agentic_common.py</include>'
-    )
+    if include_override is not None:
+        include = include_override
+    else:
+        include = (
+            "<include>pdd/agentic_common.py</include>"
+            if full_include
+            else '<include select="def:keep_me">pdd/agentic_common.py</include>'
+        )
     prompt = prompts / "agentic_common_python.prompt"
     prompt.write_text(
         '<pdd-interface>{"type":"module","module":{"functions":['
@@ -96,6 +100,148 @@ def test_full_existing_source_include_satisfies_contract(tmp_path: Path) -> None
             architecture_path=arch,
         )
         == []
+    )
+
+
+def test_self_closing_path_attribute_partial_self_include_fails_contract_preflight(
+    tmp_path: Path,
+) -> None:
+    prompt, source, arch = _write_issue_798_shape(
+        tmp_path,
+        include_override='<include select="def:keep_me" path="pdd/agentic_common.py" />',
+    )
+
+    errors = validate_prompt_contract_context(
+        prompt_path=prompt,
+        output_path=source,
+        project_root=tmp_path,
+        architecture_path=arch,
+    )
+
+    assert len(errors) == 1
+    assert "missing_from_context" in errors[0]
+    assert "only includes source context for 1" in errors[0]
+
+
+def test_body_include_path_attribute_takes_precedence_for_self_include(
+    tmp_path: Path,
+) -> None:
+    prompt, source, arch = _write_issue_798_shape(
+        tmp_path,
+        include_override=(
+            '<include select="def:keep_me" path="pdd/agentic_common.py">'
+            "context/not_the_output.py"
+            "</include>"
+        ),
+    )
+
+    errors = validate_prompt_contract_context(
+        prompt_path=prompt,
+        output_path=source,
+        project_root=tmp_path,
+        architecture_path=arch,
+    )
+
+    assert len(errors) == 1
+    assert "missing_from_context" in errors[0]
+
+
+def test_line_range_self_include_covers_declared_existing_symbols(
+    tmp_path: Path,
+) -> None:
+    prompt, source, arch = _write_issue_798_shape(
+        tmp_path,
+        include_override='<include lines="1-5">pdd/agentic_common.py</include>',
+    )
+
+    assert (
+        validate_prompt_contract_context(
+            prompt_path=prompt,
+            output_path=source,
+            project_root=tmp_path,
+            architecture_path=arch,
+        )
+        == []
+    )
+
+
+def test_select_lines_selector_covers_declared_existing_symbols(
+    tmp_path: Path,
+) -> None:
+    prompt, source, arch = _write_issue_798_shape(
+        tmp_path,
+        include_override='<include select="lines:1-5">pdd/agentic_common.py</include>',
+    )
+
+    assert (
+        validate_prompt_contract_context(
+            prompt_path=prompt,
+            output_path=source,
+            project_root=tmp_path,
+            architecture_path=arch,
+        )
+        == []
+    )
+
+
+def test_line_range_self_include_reports_symbols_outside_range(
+    tmp_path: Path,
+) -> None:
+    prompt, source, arch = _write_issue_798_shape(
+        tmp_path,
+        include_override='<include lines="1-2">pdd/agentic_common.py</include>',
+    )
+
+    errors = validate_prompt_contract_context(
+        prompt_path=prompt,
+        output_path=source,
+        project_root=tmp_path,
+        architecture_path=arch,
+    )
+
+    assert len(errors) == 1
+    assert "missing_from_context" in errors[0]
+    assert "only includes source context for 1" in errors[0]
+
+
+def test_query_self_include_fails_with_explicit_unsupported_context_message(
+    tmp_path: Path,
+) -> None:
+    prompt, source, arch = _write_issue_798_shape(
+        tmp_path,
+        include_override='<include query="implementation details">pdd/agentic_common.py</include>',
+    )
+
+    errors = validate_prompt_contract_context(
+        prompt_path=prompt,
+        output_path=source,
+        project_root=tmp_path,
+        architecture_path=arch,
+    )
+
+    assert len(errors) == 1
+    assert "query= self-include cannot prove symbol coverage" in errors[0]
+
+
+def test_interface_mode_self_include_is_not_full_source_context(
+    tmp_path: Path,
+) -> None:
+    prompt, source, arch = _write_issue_798_shape(
+        tmp_path,
+        include_override='<include mode="interface">pdd/agentic_common.py</include>',
+    )
+
+    errors = validate_prompt_contract_context(
+        prompt_path=prompt,
+        output_path=source,
+        project_root=tmp_path,
+        architecture_path=arch,
+    )
+
+    assert len(errors) == 1
+    assert (
+        'mode="interface" self-include does not provide implementation context'
+        in errors[0]
     )
 
 


### PR DESCRIPTION
## Summary

- Add a generation-time prompt contract preflight for existing modules whose prompt declares a broad public interface while only including a selected slice of the existing output source.
- Update the issue complexity and prompt-generation prompts so future splits are independently shippable/verifiable and existing-module prompt context stays aligned with declared interfaces.
- Switch `agentic_common_python.prompt` to include the full existing `pdd/agentic_common.py` source so declared exports are preserved.

## Context

This addresses the #798-style failure mode where `pdd sync` can correctly fail architecture conformance after the generated code drops symbols declared in `<pdd-interface>` / `architecture.json`, because the LLM only saw partial existing source context.

## Test Plan

- `git diff --check`
- `pytest -q tests/test_prompt_contract_validation.py tests/test_agentic_arch_complexity_prompt.py tests/test_architecture_include_validation.py tests/test_code_generator_main.py tests/test_agentic_sync.py`
- `pytest -q tests/test_sync_main.py -k "code_generator_main or front_matter or processes_real_language or skips_llm_only or accepts_bracket_basename"`
- `pytest -q tests/test_e2e_issue_553_circular_includes_non_recursive.py::TestIssue553CircularIncludesNonRecursiveE2E::test_non_circular_includes_still_work tests/test_e2e_issue_553_circular_includes_non_recursive.py::TestIssue553CircularIncludesNonRecursiveE2E::test_three_file_cycle_default_mode`
- `python -m py_compile pdd/architecture_include_validation.py pdd/code_generator_main.py`
- Direct `agentic_common` prompt contract check: `agentic_common prompt contract errors: 0`

I also attempted full `make test`; it reached 99% with no failures shown and included the prior circular-include tests passing, but pytest/xdist hung during teardown on inherited test-helper pipes. I terminated the stuck process group and reran the bounded acceptance suite above successfully.
