### PR TITLE
chore: auto-heal auto-deps drift in agentic_split_orchestrator

### DIFF
--- a/pdd/prompts/agentic_split_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_split_orchestrator_python.prompt
@@ -261,7 +261,7 @@ Import from `split_validation`: `validate_extraction`, `get_test_command`, `get_
 <pdd.preprocess><include select="def:preprocess">pdd/preprocess.py</include></pdd.preprocess>
 <pdd.architecture_sync><include select="def:sync_all_prompts_to_architecture">pdd/architecture_sync.py</include></pdd.architecture_sync>
 <pdd.agentic_test_orchestrator>
-    <include query="pattern for 11-step pipeline, state resumption, and hard stop markers">context/agentic_test_orchestrator_example.py</include>
+    <include select="def:main,def:example_happy_path,def:example_state_resumption,def:example_hard_stop_duplicate,def:example_hard_stop_needs_info,def:example_step_timeouts,def:example_file_parsing">context/agentic_test_orchestrator_example.py</include>
 </pdd.agentic_test_orchestrator>
 
 % Deliverables


### PR DESCRIPTION
## Summary
Auto-deps drift cleanup detected by the PR #858 auto-heal Cloud Build run
([574b1dd7](https://console.cloud.google.com/cloud-build/builds/574b1dd7-653f-441f-8198-ad2d26e8462a?project=590888610376)).
The Cloud Build run flagged 3 modules but declined to commit because it intentionally skipped the
4 modules currently under PR #858 review (`agentic_common`, `agentic_update`, `cli_detector`, `setup_tool`).

Local re-run results (`pdd auto-deps --strength 0.5 --force`):
- `agentic_split_orchestrator`: drift found, healed (1 line, `query` -> `select` for `agentic_test_orchestrator_example.py` include)
- `agentic_change_orchestrator`: already in sync, no diff
- `one_session_sync`: already in sync, no diff

The 2 already-in-sync prompts must have been healed in `main` between original detection
and this run; this PR carries only the residual drift.

Local cost: $0.117 across all 3 auto-deps invocations.

## Test plan
- [x] `pdd auto-deps` regenerated each prompt with `--strength 0.5 --force`
- [ ] CI: standard pdd repo checks