### PR TITLE
fix(llm): clamp temperature to 1.0 for Gemini 3 models (litellm warning)

### DIFF
--- a/pdd/llm_invoke.py
+++ b/pdd/llm_invoke.py
@@ -1637,6 +1637,78 @@ def _model_disallows_temperature(model_name: Any) -> bool:
     return "claude-opus-4-7" in model_lower or "claude-opus-4.7" in model_lower
 
 
+# Regex anchored to the Gemini 3 family identifier so that:
+#   - matches: gemini-3, gemini-3-flash, gemini-3-pro, gemini-3.1-..., gemini-3.5-...
+#   - does NOT match: gemini-2.5-*, gemini-1.5-*, gemini-30-* (hypothetical
+#     unrelated families), claude-3, etc.
+# The lookahead requires a separator (-, _, /, ., end-of-string, or whitespace)
+# after the version number so that "gemini-30-something" cannot be mistaken for
+# a Gemini 3 variant.
+_GEMINI_3_RE = re.compile(r"gemini-3(?:\.\d+)?(?=$|[-_./\s])", re.IGNORECASE)
+
+
+def _is_gemini_3_model(model_name: Any) -> bool:
+    """Return True when *model_name* belongs to the Gemini 3 family.
+
+    See ``_GEMINI_3_RE`` for the matching contract. This intentionally covers
+    every routing prefix (``gemini/``, ``vertex_ai/``, ``gmi/google/``,
+    ``github_copilot/``, bare Vertex AI names like ``gemini-3.1-pro-preview``)
+    by anchoring on the model family identifier itself rather than the prefix.
+    """
+    if model_name is None:
+        return False
+    return bool(_GEMINI_3_RE.search(str(model_name)))
+
+
+def _maybe_clamp_gemini_3_temperature(
+    litellm_kwargs: Dict[str, Any], model_name: Any, verbose: bool
+) -> bool:
+    """Force ``temperature=1`` in *litellm_kwargs* when the model is Gemini 3.
+
+    WHY this override exists (do NOT remove without checking the litellm
+    upstream behavior):
+
+      litellm prints the following warning for Gemini 3 models invoked with
+      temperature < 1.0::
+
+          Warning: Setting temperature < 1.0 for Gemini 3 models
+          (gemini-3-flash-preview) can cause infinite loops, degraded
+          reasoning performance, and failure on complex tasks. Strongly
+          recommended to use temperature = 1.0 (default).
+
+      PDD's defaults pass ``temperature=0.1`` and many callers pass 0.0
+      explicitly, which would trip this warning on every Gemini 3 call and
+      expose us to the documented production failure modes (infinite loops,
+      degraded reasoning). The fix is a narrow, model-family-scoped clamp
+      that only fires for Gemini 3; every other model keeps the
+      caller-supplied temperature unchanged.
+
+    Returns True iff the clamp fired (used to keep ``current_temperature``
+    in sync at the call site).
+    """
+    if "temperature" not in litellm_kwargs:
+        # Caller already removed temperature (e.g. provider rejects it) —
+        # nothing to clamp.
+        return False
+    if not _is_gemini_3_model(model_name):
+        return False
+    current = litellm_kwargs.get("temperature")
+    try:
+        if current is not None and float(current) >= 1.0:
+            return False
+    except (TypeError, ValueError):
+        return False
+    if verbose:
+        logger.info(
+            "[INFO] Gemini 3 model detected: forcing temperature=1 (was %s). "
+            "See litellm warning re infinite loops / degraded reasoning at "
+            "temperature < 1.0.",
+            current,
+        )
+    litellm_kwargs["temperature"] = 1
+    return True
+
+
 def _response_usage_summary(response: Any) -> Dict[str, Any]:
     """Return token and finish metadata from a LiteLLM response."""
     responses = response if isinstance(response, list) else [response]
@@ -3108,6 +3180,14 @@ def llm_invoke(
                 # Use a local adjustable temperature to allow provider-specific fallbacks.
                 litellm_kwargs["temperature"] = current_temperature
 
+            # Gemini 3 family clamp: temperature < 1.0 is documented by litellm
+            # to cause infinite loops and degraded reasoning. Apply BEFORE the
+            # batch/single split so both litellm.completion and
+            # litellm.batch_completion paths are protected. See
+            # _maybe_clamp_gemini_3_temperature for the rationale.
+            if _maybe_clamp_gemini_3_temperature(litellm_kwargs, model_name_litellm, verbose):
+                current_temperature = 1
+
             # --- Resolve API key / credentials ---
             # The CSV api_key field may be:
             #   - Single env var (e.g. "ANTHROPIC_API_KEY") → pass as api_key=
@@ -3676,16 +3756,11 @@ def llm_invoke(
                                 current_temperature = 1
                     except Exception:
                         pass
-                    # Gemini 3 requirement: temperature < 1.0 causes infinite loops and
-                    # degraded reasoning. Force temperature=1 for all Gemini 3+ models.
-                    try:
-                        if 'gemini-3' in model_name_litellm.lower() and litellm_kwargs.get('temperature', 0) < 1:
-                            if verbose:
-                                logger.info(f"[INFO] Gemini 3 model detected: forcing temperature=1 (was {litellm_kwargs.get('temperature')}).")
-                            litellm_kwargs['temperature'] = 1
-                            current_temperature = 1
-                    except Exception:
-                        pass
+                    # Gemini 3 temperature clamp now happens once, early —
+                    # see _maybe_clamp_gemini_3_temperature in section 5 above.
+                    # Both litellm.completion and litellm.batch_completion
+                    # paths are protected by the early clamp, so no per-call
+                    # override is needed here.
                     if verbose:
                         logger.info(f"[INFO] Calling litellm.completion for {model_name_litellm}...")
                     response = litellm.completion(**litellm_kwargs, timeout=LLM_CALL_TIMEOUT)

--- a/pdd/prompts/llm_invoke_python.prompt
+++ b/pdd/prompts/llm_invoke_python.prompt
@@ -140,6 +140,7 @@
     - Pass CSV `location` column as `vertex_location` kwarg (e.g., "global" for Vertex AI models).
     - Pass CSV `base_url` column as both `base_url` and `api_base` kwargs for custom API endpoints.
     - Anthropic with thinking enabled: Force temperature=1.
+    - Gemini 3 family: Force temperature=1 regardless of caller-supplied temperature whenever the resolved model is in the Gemini 3 family (matches `gemini-3`, `gemini-3.x` with any routing prefix such as `gemini/`, `vertex_ai/`, `gmi/google/`, `github_copilot/`, or the bare Vertex AI name like `gemini-3.1-pro-preview`; does NOT match `gemini-2.x`, `gemini-1.5`, etc.). litellm warns that temperature < 1.0 for Gemini 3 models can cause infinite loops and degraded reasoning, so apply the clamp BEFORE the batch/single completion split to protect both `litellm.completion` and `litellm.batch_completion` paths. Only fire when temperature is actually present in kwargs (skip when `_model_disallows_temperature` already removed it).
     - Claude models: Add `extra_headers={"anthropic-beta": "context-1m-2025-08-07"}` to enable 1M context window. Safe for all prompt lengths — API only charges premium rates when exceeding 200K tokens.
     - Vertex AI: Pass `vertex_location` from the CSV's `location` column when present.
     - LM Studio: Set base_url from LM_STUDIO_API_BASE env (default http://localhost:1234/v1) and api_key placeholder "lm-studio".

--- a/tests/test_llm_invoke.py
+++ b/tests/test_llm_invoke.py
@@ -5924,3 +5924,389 @@ class TestIssue796TypeScriptPythonValidation:
             "_has_invalid_python_code() should return True for a CodeFix containing "
             "TypeScript code, because TypeScript looks like Python but fails ast.parse()"
         )
+
+
+# ============================================================================
+# TESTS: Gemini 3 temperature clamp (litellm warning prevention)
+# ============================================================================
+#
+# litellm emits the following warning when a Gemini 3 model is invoked with
+# temperature < 1.0:
+#
+#   Warning: Setting temperature < 1.0 for Gemini 3 models
+#   (gemini-3-flash-preview) can cause infinite loops, degraded reasoning
+#   performance, and failure on complex tasks. Strongly recommended to use
+#   temperature = 1.0 (default).
+#
+# PDD passes temperature=0.1 by default (see llm_invoke signature) and many
+# call sites pass temperature=0.0. These default flows triggered the warning
+# during Path C validation of PR #899 / issue #1405. The documented failure
+# modes (infinite loops, degraded reasoning) are real production risks, so
+# PDD clamps the temperature to 1.0 before handing it to litellm whenever
+# the resolved model is in the Gemini 3 family.
+#
+# The override is intentionally narrow: only Gemini 3 (gemini-3 / gemini-3.x)
+# is affected, never Gemini 2.x / Gemini 1.5 / non-Gemini models.
+
+class TestGemini3TemperatureClamp:
+    """Pre-flight clamp: Gemini 3 models receive temperature=1.0 regardless of
+    the user-supplied temperature, because temperature < 1.0 is documented to
+    cause infinite loops and degraded reasoning."""
+
+    def _make_csv(self, tmp_path, provider, model_name, reasoning_type='none'):
+        content = (
+            "provider,model,input,output,coding_arena_elo,api_key,"
+            "structured_output,reasoning_type,max_tokens,max_completion_tokens,"
+            "max_reasoning_tokens\n"
+            f"{provider},{model_name},1,2,1437,TEST_KEY,True,{reasoning_type},"
+            f"4096,4096,0\n"
+        )
+        csv_path = tmp_path / "models.csv"
+        csv_path.write_text(content)
+        return csv_path
+
+    def _make_mock_response(self):
+        mock_message = MagicMock()
+        mock_message.content = "result"
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_choice.finish_reason = "stop"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response._hidden_params = {}
+        return mock_response
+
+    # ------------------------------------------------------------------
+    # Helper: _is_gemini_3_model classifier
+    # ------------------------------------------------------------------
+    def test_is_gemini_3_model_classifier(self, llm_mod):
+        """The helper should match the Gemini 3 family and ONLY the Gemini 3
+        family. This test pins the regex contract."""
+        is_g3 = llm_mod._is_gemini_3_model
+
+        # Positive cases — Gemini 3.x family
+        assert is_g3("gemini-3-flash-preview") is True
+        assert is_g3("gemini-3-pro-preview") is True
+        assert is_g3("gemini/gemini-3-flash-preview") is True
+        assert is_g3("gemini/gemini-3-pro-preview") is True
+        assert is_g3("vertex_ai/gemini-3-flash-preview") is True
+        assert is_g3("vertex_ai/gemini-3-pro-preview") is True
+        # Bare Vertex AI form (no provider prefix) — see llm_model.csv
+        assert is_g3("gemini-3.1-pro-preview") is True
+        assert is_g3("gemini-3.1-pro-preview-customtools") is True
+        assert is_g3("gemini/gemini-3.1-pro-preview") is True
+        # GMI / GitHub Copilot routes
+        assert is_g3("gmi/google/gemini-3-pro-preview") is True
+        assert is_g3("gmi/google/gemini-3-flash-preview") is True
+        assert is_g3("github_copilot/gemini-3-pro-preview") is True
+        # Hypothetical Gemini 3.5 / 3.x — match too
+        assert is_g3("gemini-3.5-flash") is True
+        # Case-insensitive
+        assert is_g3("GEMINI-3-FLASH-PREVIEW") is True
+
+        # Negative cases — non-Gemini-3 models must NOT match
+        assert is_g3("gemini-2.5-flash") is False
+        assert is_g3("gemini/gemini-2.5-flash") is False
+        assert is_g3("gemini-1.5-pro") is False
+        assert is_g3("gemini-pro") is False
+        assert is_g3("claude-3") is False  # "3" is in claude-3 but not gemini-3
+        assert is_g3("vertex_ai/claude-opus-4-7") is False
+        assert is_g3("gpt-5") is False
+        assert is_g3("o1-preview") is False
+        # Edge case: "gemini-30-..." (hypothetical, not a real family) must NOT
+        # match — boundary-aware regex
+        assert is_g3("gemini-30-something") is False
+        # Defensive: None / empty
+        assert is_g3("") is False
+        assert is_g3(None) is False
+
+    # ------------------------------------------------------------------
+    # Pre-flight: Gemini 3 Flash with low temperature
+    # ------------------------------------------------------------------
+    def test_gemini_3_flash_low_temperature_clamped_to_1(
+        self, llm_mod, tmp_path, monkeypatch
+    ):
+        """gemini/gemini-3-flash-preview with temperature=0.1 must be clamped
+        to temperature=1.0 before reaching litellm."""
+        csv_path = self._make_csv(
+            tmp_path, "Google Gemini", "gemini/gemini-3-flash-preview"
+        )
+        monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+        monkeypatch.setenv("TEST_KEY", "sk-test1234567890123456")
+        monkeypatch.setattr(llm_mod, "LLM_MODEL_CSV_PATH", csv_path)
+        monkeypatch.setattr(
+            llm_mod, "DEFAULT_BASE_MODEL", "gemini/gemini-3-flash-preview"
+        )
+
+        captured_kwargs = {}
+
+        def capture_completion(**kwargs):
+            captured_kwargs.update(kwargs)
+            return self._make_mock_response()
+
+        with patch.object(
+            llm_mod.litellm, "completion", side_effect=capture_completion
+        ):
+            llm_mod.llm_invoke(
+                prompt="Question about {topic}",
+                input_json={"topic": "physics"},
+                strength=0.5,
+                temperature=0.1,
+                time=0.0,
+                use_cloud=False,
+            )
+
+        assert captured_kwargs.get("temperature") == 1, (
+            "Gemini 3 Flash with temperature=0.1 must be clamped to "
+            f"temperature=1, got {captured_kwargs.get('temperature')}"
+        )
+
+    # ------------------------------------------------------------------
+    # Pre-flight: Vertex AI Gemini 3 Flash with temperature=0
+    # ------------------------------------------------------------------
+    def test_vertex_ai_gemini_3_flash_zero_temperature_clamped_to_1(
+        self, llm_mod, tmp_path, monkeypatch
+    ):
+        """vertex_ai/gemini-3-flash-preview with temperature=0.0 must be
+        clamped to temperature=1.0. This reproduces the Path C validation
+        scenario for issue #1405 Fix B."""
+        csv_path = self._make_csv(
+            tmp_path, "Google Vertex AI", "vertex_ai/gemini-3-flash-preview"
+        )
+        monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+        monkeypatch.setenv("TEST_KEY", "sk-test1234567890123456")
+        monkeypatch.setattr(llm_mod, "LLM_MODEL_CSV_PATH", csv_path)
+        monkeypatch.setattr(
+            llm_mod, "DEFAULT_BASE_MODEL", "vertex_ai/gemini-3-flash-preview"
+        )
+
+        captured_kwargs = {}
+
+        def capture_completion(**kwargs):
+            captured_kwargs.update(kwargs)
+            return self._make_mock_response()
+
+        with patch.object(
+            llm_mod.litellm, "completion", side_effect=capture_completion
+        ):
+            llm_mod.llm_invoke(
+                prompt="Question about {topic}",
+                input_json={"topic": "physics"},
+                strength=0.5,
+                temperature=0.0,
+                time=0.0,
+                use_cloud=False,
+            )
+
+        assert captured_kwargs.get("temperature") == 1, (
+            "Vertex AI Gemini 3 Flash with temperature=0.0 must be clamped "
+            f"to 1, got {captured_kwargs.get('temperature')}"
+        )
+
+    # ------------------------------------------------------------------
+    # Pre-flight: Bare gemini-3.1-pro-preview
+    # ------------------------------------------------------------------
+    def test_gemini_3_1_pro_bare_name_temperature_clamped(
+        self, llm_mod, tmp_path, monkeypatch
+    ):
+        """gemini-3.1-pro-preview (bare Vertex AI name in CSV) with
+        temperature=0.7 must be clamped to 1.0."""
+        csv_path = self._make_csv(
+            tmp_path, "Google Vertex AI", "gemini-3.1-pro-preview"
+        )
+        monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+        monkeypatch.setenv("TEST_KEY", "sk-test1234567890123456")
+        monkeypatch.setattr(llm_mod, "LLM_MODEL_CSV_PATH", csv_path)
+        monkeypatch.setattr(
+            llm_mod, "DEFAULT_BASE_MODEL", "gemini-3.1-pro-preview"
+        )
+
+        captured_kwargs = {}
+
+        def capture_completion(**kwargs):
+            captured_kwargs.update(kwargs)
+            return self._make_mock_response()
+
+        with patch.object(
+            llm_mod.litellm, "completion", side_effect=capture_completion
+        ):
+            llm_mod.llm_invoke(
+                prompt="Question about {topic}",
+                input_json={"topic": "physics"},
+                strength=0.5,
+                temperature=0.7,
+                time=0.0,
+                use_cloud=False,
+            )
+
+        assert captured_kwargs.get("temperature") == 1, (
+            f"Bare gemini-3.1-pro-preview must be clamped to 1, "
+            f"got {captured_kwargs.get('temperature')}"
+        )
+
+    # ------------------------------------------------------------------
+    # Pre-flight: explicit temperature=1.0 is a no-op
+    # ------------------------------------------------------------------
+    def test_gemini_3_explicit_temperature_1_is_no_op(
+        self, llm_mod, tmp_path, monkeypatch
+    ):
+        """When the caller already passes temperature=1.0, the clamp is a
+        no-op — the value stays 1.0."""
+        csv_path = self._make_csv(
+            tmp_path, "Google Gemini", "gemini/gemini-3-pro-preview"
+        )
+        monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+        monkeypatch.setenv("TEST_KEY", "sk-test1234567890123456")
+        monkeypatch.setattr(llm_mod, "LLM_MODEL_CSV_PATH", csv_path)
+        monkeypatch.setattr(
+            llm_mod, "DEFAULT_BASE_MODEL", "gemini/gemini-3-pro-preview"
+        )
+
+        captured_kwargs = {}
+
+        def capture_completion(**kwargs):
+            captured_kwargs.update(kwargs)
+            return self._make_mock_response()
+
+        with patch.object(
+            llm_mod.litellm, "completion", side_effect=capture_completion
+        ):
+            llm_mod.llm_invoke(
+                prompt="Question about {topic}",
+                input_json={"topic": "physics"},
+                strength=0.5,
+                temperature=1.0,
+                time=0.0,
+                use_cloud=False,
+            )
+
+        assert captured_kwargs.get("temperature") == 1
+        # And specifically: it didn't drift below 1 in some weird way
+        assert captured_kwargs.get("temperature") >= 1
+
+    # ------------------------------------------------------------------
+    # Negative: Gemini 2.5 must NOT be clamped
+    # ------------------------------------------------------------------
+    def test_gemini_2_5_temperature_NOT_clamped(
+        self, llm_mod, tmp_path, monkeypatch
+    ):
+        """gemini/gemini-2.5-flash must KEEP the user-supplied temperature.
+        Only Gemini 3 has the documented infinite-loop failure mode."""
+        csv_path = self._make_csv(
+            tmp_path, "Google Gemini", "gemini/gemini-2.5-flash"
+        )
+        monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+        monkeypatch.setenv("TEST_KEY", "sk-test1234567890123456")
+        monkeypatch.setattr(llm_mod, "LLM_MODEL_CSV_PATH", csv_path)
+        monkeypatch.setattr(
+            llm_mod, "DEFAULT_BASE_MODEL", "gemini/gemini-2.5-flash"
+        )
+
+        captured_kwargs = {}
+
+        def capture_completion(**kwargs):
+            captured_kwargs.update(kwargs)
+            return self._make_mock_response()
+
+        with patch.object(
+            llm_mod.litellm, "completion", side_effect=capture_completion
+        ):
+            llm_mod.llm_invoke(
+                prompt="Question about {topic}",
+                input_json={"topic": "physics"},
+                strength=0.5,
+                temperature=0.1,
+                time=0.0,
+                use_cloud=False,
+            )
+
+        assert captured_kwargs.get("temperature") == 0.1, (
+            f"Gemini 2.5 must NOT be clamped (only Gemini 3 has the "
+            f"infinite-loop failure mode), got "
+            f"{captured_kwargs.get('temperature')}"
+        )
+
+    # ------------------------------------------------------------------
+    # Negative: non-Gemini model must NOT be clamped
+    # ------------------------------------------------------------------
+    def test_non_gemini_model_temperature_NOT_clamped(
+        self, llm_mod, tmp_path, monkeypatch
+    ):
+        """A non-Gemini model with the same low temperature must keep its
+        temperature — this rule is Gemini-3-specific."""
+        csv_path = self._make_csv(
+            tmp_path, "OpenAI", "gpt-4o-mini"
+        )
+        monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+        monkeypatch.setenv("TEST_KEY", "sk-test1234567890123456")
+        monkeypatch.setattr(llm_mod, "LLM_MODEL_CSV_PATH", csv_path)
+        monkeypatch.setattr(llm_mod, "DEFAULT_BASE_MODEL", "gpt-4o-mini")
+
+        captured_kwargs = {}
+
+        def capture_completion(**kwargs):
+            captured_kwargs.update(kwargs)
+            return self._make_mock_response()
+
+        with patch.object(
+            llm_mod.litellm, "completion", side_effect=capture_completion
+        ):
+            llm_mod.llm_invoke(
+                prompt="Question about {topic}",
+                input_json={"topic": "physics"},
+                strength=0.5,
+                temperature=0.1,
+                time=0.0,
+                use_cloud=False,
+            )
+
+        assert captured_kwargs.get("temperature") == 0.1, (
+            f"Non-Gemini-3 model must NOT be clamped, got "
+            f"{captured_kwargs.get('temperature')}"
+        )
+
+    # ------------------------------------------------------------------
+    # Batch mode: Gemini 3 must also be clamped in batch_completion path
+    # ------------------------------------------------------------------
+    def test_gemini_3_batch_mode_temperature_clamped(
+        self, llm_mod, tmp_path, monkeypatch
+    ):
+        """The batch_completion path (use_batch_mode=True) must also clamp
+        the temperature. Without this, callers that use batch mode bypass
+        the protection."""
+        csv_path = self._make_csv(
+            tmp_path, "Google Vertex AI", "vertex_ai/gemini-3-flash-preview"
+        )
+        monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+        monkeypatch.setenv("TEST_KEY", "sk-test1234567890123456")
+        monkeypatch.setattr(llm_mod, "LLM_MODEL_CSV_PATH", csv_path)
+        monkeypatch.setattr(
+            llm_mod, "DEFAULT_BASE_MODEL", "vertex_ai/gemini-3-flash-preview"
+        )
+
+        captured_kwargs = {}
+
+        def capture_batch_completion(**kwargs):
+            captured_kwargs.update(kwargs)
+            # batch_completion returns a list of response items
+            return [self._make_mock_response()]
+
+        with patch.object(
+            llm_mod.litellm,
+            "batch_completion",
+            side_effect=capture_batch_completion,
+        ):
+            llm_mod.llm_invoke(
+                prompt="Question about {topic}",
+                input_json=[{"topic": "physics"}],
+                strength=0.5,
+                temperature=0.0,
+                time=0.0,
+                use_batch_mode=True,
+                use_cloud=False,
+            )
+
+        assert captured_kwargs.get("temperature") == 1, (
+            "Gemini 3 in batch mode must also be clamped to temperature=1, "
+            f"got {captured_kwargs.get('temperature')}"
+        )


### PR DESCRIPTION
## Summary

litellm prints the following warning whenever a Gemini 3 model is invoked with `temperature < 1.0`:

> Warning: Setting temperature < 1.0 for Gemini 3 models (gemini-3-flash-preview) can cause infinite loops, degraded reasoning performance, and failure on complex tasks. Strongly recommended to use temperature = 1.0 (default).

PDD's default temperature is `0.1` (`llm_invoke(... temperature: float = 0.1, ...)`) and several call sites pass `temperature=0.0`. Path C validation of #1405 / #899 surfaced the warning with `vertex_ai/gemini-3-flash-preview`, exposing PDD to the documented production failure modes (infinite loops, degraded reasoning).

This PR adds a narrow, model-family-scoped clamp: whenever the resolved model is in the Gemini 3 family (`gemini-3`, `gemini-3.x` with any routing prefix — `gemini/`, `vertex_ai/`, `gmi/google/`, `github_copilot/`, or the bare Vertex AI name), PDD forces `temperature=1.0` before handing kwargs to litellm.

### What's intentionally NOT in this PR

- Other model families' temperature defaults are unchanged.
- The litellm warning itself is not silenced — that's litellm's concern; we just stop triggering it.
- No litellm version bump, no broader LLM/temperature refactor.

## Why the change is structured this way

An inline `'gemini-3' in model_name.lower()` override already existed at the `litellm.completion` call site, but it had two gaps:

1. **Batch path bypass.** `litellm.batch_completion` was called earlier in the same `if/else`, before the override, so callers using `use_batch_mode=True` got no protection.
2. **Substring matching is too loose** — `'gemini-3' in name` would also match a hypothetical `gemini-30-something`. A boundary-anchored regex (`gemini-3(?:\.\d+)?(?=$|[-_./\s])`) matches the documented Gemini 3 family identifiers and only those.

The fix extracts the logic into two helpers (`_is_gemini_3_model`, `_maybe_clamp_gemini_3_temperature`) and invokes the clamp once, BEFORE the batch/single split, so both `litellm.completion` and `litellm.batch_completion` are covered. The redundant late-stage inline override is replaced with a pointer comment so future readers know where the single source of truth lives.

## Where the override lives

- Helpers: [`pdd/llm_invoke.py:1640-1708`](https://github.com/promptdriven/pdd/blob/fix/gemini-3-temperature-clamp/pdd/llm_invoke.py#L1640-L1708)
- Call site (early, BEFORE batch/single split): [`pdd/llm_invoke.py:3183-3189`](https://github.com/promptdriven/pdd/blob/fix/gemini-3-temperature-clamp/pdd/llm_invoke.py#L3183-L3189)
- Tests: [`tests/test_llm_invoke.py::TestGemini3TemperatureClamp`](https://github.com/promptdriven/pdd/blob/fix/gemini-3-temperature-clamp/tests/test_llm_invoke.py) (8 cases, including helper unit test, batch path coverage, and negative cases for Gemini 2.x / Gemini 1.5 / non-Gemini)
- Prompt-as-source-of-truth updated: [`pdd/prompts/llm_invoke_python.prompt:143`](https://github.com/promptdriven/pdd/blob/fix/gemini-3-temperature-clamp/pdd/prompts/llm_invoke_python.prompt#L143)

## Empirical evidence

Ad-hoc verification script (`/tmp/verify_gemini3_clamp.py`) calls `llm_invoke` with multiple model-name shapes and captures the `temperature` kwarg that reaches litellm:

```
MODEL                                               INPUT  BATCH    GOT  EXPECT  OK?
------------------------------------------------------------------------------------------
gemini/gemini-3-flash-preview                         0.1  False      1       1  YES
gemini/gemini-3-pro-preview                           0.0  False      1       1  YES
vertex_ai/gemini-3-flash-preview                      0.0  False      1       1  YES
gemini-3.1-pro-preview                                0.7  False      1       1  YES
gmi/google/gemini-3-pro-preview                       0.5  False      1       1  YES
vertex_ai/gemini-3-flash-preview                      0.0   True      1       1  YES
gemini/gemini-2.5-flash                               0.1  False    0.1     0.1  YES
gemini-1.5-pro                                        0.2  False    0.2     0.2  YES
gpt-4o-mini                                           0.1  False    0.1     0.1  YES

OVERALL: PASS
```

Every Gemini 3 shape receives `temperature=1`; every non-Gemini-3 model keeps its caller-supplied temperature.

## TDD evidence

- `7d59bd7f1` — `test(llm): add failing tests for Gemini 3 temperature clamp`. Two tests fail: the helper classifier (helper didn't exist) and the batch-mode clamp (existing late override didn't cover batch). Six already passed thanks to the existing late inline override — kept as regression coverage.
- `5546f6ae1` — `fix(llm): clamp temperature to 1.0 for Gemini 3 models (litellm warning)`. Adds helpers, moves the clamp earlier, removes the redundant late inline override.

## Test plan

- [x] `pytest tests/test_llm_invoke.py::TestGemini3TemperatureClamp` — 8 passing
- [x] `pytest tests/test_llm_invoke.py tests/test_llm_invoke_csv_model_registration.py tests/test_llm_invoke_integration.py tests/test_llm_invoke_nested_schema.py tests/test_llm_invoke_retry_cost.py tests/test_llm_invoke_vertex_retry.py` — 307 passed, 3 skipped (pre-existing skips)
- [x] `pylint pdd/llm_invoke.py` — no new warnings (score 6.79/10 before, 6.79/10 after; pre-existing import-order issues only)
- [x] `pylint --disable=all --enable=E,F tests/test_llm_invoke.py` — 10.00/10
- [x] Ad-hoc verification script confirms actual temperature kwarg reaching litellm
- [ ] `/gcbrun` (Cloud Batch full suite — posting below)