### PR TITLE
feat(tests): CLI-binary isolation fixture (#1405 Fix A-prime)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,6 +160,94 @@ def _isolate_provider_env(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_cli_binary_presence(request, monkeypatch):
+    """Default every agentic CLI binary to "not installed" and the OpenCode
+    filesystem credential signals to "absent" before each test.
+
+    Fix A-prime of ``promptdriven/pdd_cloud#1405``: the autonomous-solve PR
+    ``promptdriven/pdd#858`` shipped 4 tests in ``test_agentic_common.py``
+    that silently passed only because the verifier's minimal worker
+    container had no agentic CLIs installed under ``~/.local/bin`` and
+    no OpenCode auth file at ``~/.local/share/opencode/auth.json``. On a
+    developer machine where the user had ``npm install -g opencode-ai``'d
+    the CLI or run ``opencode auth login``, those tests would have leaked
+    real filesystem state — passing for the wrong reason or failing
+    surprisingly. Fix B (``promptdriven/pdd#899``) and Fix C
+    (``promptdriven/pdd#902``) cover the env-var-leak shape; this fixture
+    covers the CLI-binary-presence + auth-file shape.
+
+    Canonical source
+    ----------------
+    The agentic-CLI name set is sourced from
+    ``pdd.cli_detector.CLI_PREFERENCE`` — the same ordered list the
+    production CLI-detection path consults. Using the public constant
+    (not a duplicate hardcoded literal) means a new agentic CLI added
+    to the codebase is automatically isolated and the Fix B static-
+    analysis detector does not flag this fixture as drift.
+
+    What gets isolated
+    -------------------
+    1. ``pdd.agentic_common._find_cli_binary(name)`` returns ``None`` for
+       every name in ``CLI_PREFERENCE``. Non-agentic names (``git``,
+       ``sh``, ...) pass through to the real implementation so legitimate
+       subprocess tests are unaffected.
+    2. ``pdd.agentic_common._opencode_auth_file_has_credentials`` returns
+       ``False`` unconditionally.
+    3. ``pdd.agentic_common._iter_opencode_config_texts`` yields an empty
+       iterable unconditionally.
+
+    Opt-back-in
+    -----------
+    Tests that need a CLI to be "installed" or credentials to be present
+    override these via ``monkeypatch.setattr`` after the autouse fixture
+    runs, or use the existing per-test fixtures in
+    ``test_agentic_common.py`` (``mock_shutil_which`` patches
+    ``_find_cli_binary``; ``mock_env`` patches the credential helpers).
+    Both compose correctly with this autouse fixture — explicit per-test
+    patches replace our defaults and unwind before our teardown.
+
+    Why this fixture imports lazily
+    --------------------------------
+    Importing ``pdd.agentic_common`` and ``pdd.cli_detector`` at conftest
+    collection time would pull in litellm and other heavy modules even
+    for trivial test sessions. The imports are deferred to first-fixture-
+    use, matching the lazy-import pattern of ``_isolate_provider_env``
+    and ``_isolate_claude_oauth_probe``.
+
+    Opt-out via marker
+    ------------------
+    Tests that exercise ``_find_cli_binary`` itself (the production
+    CLI-detection function — see ``TestCliDiscovery`` / ``TestCliDiscoveryBug``)
+    must be able to run the real function with their own mocks underneath.
+    Mark such tests/classes with ``@pytest.mark.uses_real_cli_detector``
+    to skip the autouse isolation. The marker is registered via
+    ``pytest_configure`` below.
+    """
+    if request.node.get_closest_marker("uses_real_cli_detector"):
+        return  # explicit opt-out for tests that exercise the real CLI detector
+    # Lazy imports: avoid pulling agentic_common / cli_detector into
+    # conftest's import graph. See docstring for rationale.
+    import pdd.agentic_common as ac
+    from pdd.cli_detector import CLI_PREFERENCE
+
+    agentic_clis = frozenset(CLI_PREFERENCE)
+    real_find = ac._find_cli_binary
+
+    def _isolated_find(name, *args, **kwargs):
+        if name in agentic_clis:
+            return None
+        return real_find(name, *args, **kwargs)
+
+    monkeypatch.setattr(ac, "_find_cli_binary", _isolated_find, raising=True)
+    monkeypatch.setattr(
+        ac, "_opencode_auth_file_has_credentials", lambda path: False, raising=True
+    )
+    monkeypatch.setattr(
+        ac, "_iter_opencode_config_texts", lambda cwd=None: iter(()), raising=True
+    )
+
+
+@pytest.fixture(autouse=True)
 def _isolate_claude_oauth_probe(monkeypatch):
     """Default the Issue #813 OAuth probe to False so tests are CI-portable.
 
@@ -265,6 +353,16 @@ def pytest_configure(config: pytest.Config) -> None:
         os.environ["PDD_RUN_ALL_TESTS"] = "1"
     else:
         os.environ.setdefault("PDD_RUN_ALL_TESTS", "0")
+
+    # Fix A-prime (promptdriven/pdd_cloud#1405): register the opt-out marker
+    # for tests that exercise the real CLI-detection path with their own
+    # mocks underneath (TestCliDiscovery / TestCliDiscoveryBug). See the
+    # ``_isolate_cli_binary_presence`` fixture docstring for context.
+    config.addinivalue_line(
+        "markers",
+        "uses_real_cli_detector: skip the Fix A-prime autouse CLI-binary "
+        "isolation fixture; for tests that test _find_cli_binary itself.",
+    )
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/tests/test_agentic_common.py
+++ b/tests/test_agentic_common.py
@@ -1686,6 +1686,7 @@ def _prepend_cli_path(monkeypatch, cli_name: str, path_to_prepend) -> None:
     monkeypatch.setitem(_COMMON_CLI_PATHS, cli_name, [path_to_prepend] + original_paths)
 
 
+@pytest.mark.uses_real_cli_detector
 class TestCliDiscoveryBug:
     """
     Tests for CLI binary discovery bug.
@@ -1840,6 +1841,7 @@ class TestCliDiscoveryBug:
         )
 
 
+@pytest.mark.uses_real_cli_detector
 class TestCliDiscovery:
     """
     Tests for the CLI discovery fix implementation.

--- a/tests/test_cli_binary_isolation.py
+++ b/tests/test_cli_binary_isolation.py
@@ -1,0 +1,201 @@
+"""Regression tests for Fix A-prime of ``promptdriven/pdd_cloud#1405``.
+
+These tests demonstrate that the autouse CLI-binary isolation fixture in
+``tests/conftest.py`` actually fires: each test sees ``_find_cli_binary``
+returning ``None`` for every agentic CLI in ``CLI_PREFERENCE`` and the
+OpenCode filesystem credential helpers returning safe "nothing found"
+values, regardless of what the developer or CI machine actually has
+installed under ``~/.local/bin/`` or stashed in
+``~/.local/share/opencode/auth.json``.
+
+Background
+----------
+``promptdriven/pdd#858`` (autonomous solve of ``promptdriven/pdd#798``,
+OpenCode CLI backend) shipped with 7 test-isolation bugs. The 4 in
+``tests/test_agentic_common.py`` had a CLI-binary-presence shape:
+``_has_opencode_credentials`` returned ``False`` because no ``opencode``
+binary was installed on the worker container — but on a developer
+machine where the user had ``npm install -g opencode-ai``'d the CLI,
+those tests would have silently passed for the wrong reason (real
+filesystem state leaking through instead of the test fixture providing
+deterministic input). Fix B (``promptdriven/pdd#899``) and Fix C
+(``promptdriven/pdd#902``) cover the env-var-leak shape; this PR
+(Fix A-prime) covers the CLI-binary-presence shape.
+
+Sibling shipped PRs:
+- ``promptdriven/pdd#899`` (Fix B — list-drift detector, ``6b67021``)
+- ``promptdriven/pdd#900`` (Gemini 3 temperature clamp, ``2d27b55c``)
+- ``promptdriven/pdd#901`` (#900 polish, ``a4b8ddd0``)
+- ``promptdriven/pdd#902`` (Fix C — provider-env isolation, ``dbd890a5``)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import pdd.agentic_common as _ac
+from pdd.cli_detector import CLI_PREFERENCE
+
+
+# ---------------------------------------------------------------------------
+# Module-load-time poisoning.
+#
+# To make the TDD red phase deterministic, simulate a developer machine
+# where every agentic CLI (claude, codex, gemini, opencode) is installed
+# and the OpenCode auth file + config texts return non-empty signals.
+# Without the autouse isolation fixture in ``tests/conftest.py``, the
+# per-test assertions below will see this poisoned state and fail.
+# ---------------------------------------------------------------------------
+
+_FAKE_BIN_PREFIX = "/tmp/fix-a-prime-fake-bin/"
+_FAKE_CONFIG_PATH = Path("/tmp/fix-a-prime-fake-opencode-config")
+_FAKE_CONFIG_TEXT = '{"provider": {"anthropic": {"options": {"apiKey": "fake"}}}}'
+
+
+_ORIGINAL_FIND_CLI_BINARY = None
+_ORIGINAL_OPENCODE_AUTH = None
+_ORIGINAL_OPENCODE_CONFIG = None
+
+
+def setup_module(module):
+    """Replace agentic_common's CLI / credential helpers with stand-ins that
+    report every agentic CLI as installed and the OpenCode config as
+    populated. The conftest autouse fixture should clear this for every
+    test in this module — if it does not, the assertions below fail with
+    the fake path / fake config visible."""
+    global _ORIGINAL_FIND_CLI_BINARY, _ORIGINAL_OPENCODE_AUTH, _ORIGINAL_OPENCODE_CONFIG
+    _ORIGINAL_FIND_CLI_BINARY = _ac._find_cli_binary
+    _ORIGINAL_OPENCODE_AUTH = _ac._opencode_auth_file_has_credentials
+    _ORIGINAL_OPENCODE_CONFIG = _ac._iter_opencode_config_texts
+
+    agentic_clis = frozenset(CLI_PREFERENCE)
+
+    def _fake_find(name, *args, **kwargs):
+        if name in agentic_clis:
+            return _FAKE_BIN_PREFIX + name
+        return _ORIGINAL_FIND_CLI_BINARY(name, *args, **kwargs)
+
+    _ac._find_cli_binary = _fake_find
+    _ac._opencode_auth_file_has_credentials = lambda path: True
+    _ac._iter_opencode_config_texts = lambda cwd=None: iter(
+        [(_FAKE_CONFIG_TEXT, _FAKE_CONFIG_PATH)]
+    )
+
+
+def teardown_module(module):
+    """Restore the real agentic_common helpers so other test modules see
+    the un-poisoned state."""
+    _ac._find_cli_binary = _ORIGINAL_FIND_CLI_BINARY
+    _ac._opencode_auth_file_has_credentials = _ORIGINAL_OPENCODE_AUTH
+    _ac._iter_opencode_config_texts = _ORIGINAL_OPENCODE_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Per-CLI regression tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cli_name", list(CLI_PREFERENCE))
+def test_agentic_cli_binary_isolated_to_not_installed(cli_name):
+    """The autouse fixture must mask every agentic CLI to 'not installed',
+    even when module-load poisoning made ``_find_cli_binary`` return a
+    fake path."""
+    result = _ac._find_cli_binary(cli_name)
+    assert result is None, (
+        f"CLI-binary isolation fixture failed to mask {cli_name!r}; "
+        f"got {result!r}. This is the bug shape that broke 4 tests in "
+        f"promptdriven/pdd#858 (autonomous solve of #798): test_agentic_common.py "
+        f"tests silently passed only because the worker container had no "
+        f"agentic CLIs installed."
+    )
+
+
+def test_non_agentic_binary_passes_through():
+    """Binaries that are NOT in CLI_PREFERENCE (e.g., ``git``, ``ls``)
+    must NOT be masked — the fixture only isolates agentic CLI presence,
+    not real test-infrastructure tooling like git."""
+    # ``sh`` is essentially guaranteed to exist on macOS/Linux; ``git``
+    # might not be in PATH during minimal CI but is in practice.
+    # Use a name that is in CLI_PREFERENCE neighborhood but not the list.
+    real_find = _ORIGINAL_FIND_CLI_BINARY
+    assert real_find is not None, "setup_module did not run"
+    # The poison wrapper passes through for non-CLI_PREFERENCE names;
+    # so does the autouse isolation fixture.
+    # Probe with a name we know is not in CLI_PREFERENCE.
+    assert "git" not in CLI_PREFERENCE
+    result = _ac._find_cli_binary("git")
+    # Result should be whatever the real impl returns (None or a path).
+    # If it returns _FAKE_BIN_PREFIX + "git", the fixture is over-eager.
+    assert not (isinstance(result, str) and result.startswith(_FAKE_BIN_PREFIX)), (
+        f"Isolation fixture over-masked non-agentic binary; got {result!r}. "
+        "The fixture must only mask CLIs in CLI_PREFERENCE."
+    )
+
+
+def test_opencode_auth_file_isolated_to_absent():
+    """The autouse fixture must default ``_opencode_auth_file_has_credentials``
+    to ``False`` even when module-load poisoning made it return ``True``.
+    Otherwise tests silently pass on developer machines that have run
+    ``opencode auth login`` and stashed credentials under
+    ``~/.local/share/opencode/auth.json``."""
+    result = _ac._opencode_auth_file_has_credentials(_FAKE_CONFIG_PATH)
+    assert result is False, (
+        f"OpenCode auth-file isolation fixture failed; got {result!r}. "
+        "Tests that rely on _has_opencode_credentials returning False must "
+        "see this helper return False by default, not by accident of "
+        "developer machine state."
+    )
+
+
+def test_opencode_config_iter_isolated_to_empty():
+    """The autouse fixture must default ``_iter_opencode_config_texts``
+    to yielding nothing, even when module-load poisoning had it yielding
+    a fake config text. Tests that rely on 'no opencode config' must not
+    silently depend on developer-machine state."""
+    results = list(_ac._iter_opencode_config_texts(cwd=Path(".")))
+    assert results == [], (
+        f"OpenCode config-iter isolation fixture failed; got {results!r}. "
+        "The autouse fixture must yield an empty iterable so tests cannot "
+        "leak developer-machine config text."
+    )
+
+
+def test_opt_in_override_works(monkeypatch):
+    """Tests that need a CLI to 'be installed' or credentials to 'be
+    present' should be able to opt back in via ``monkeypatch.setattr``.
+    This validates the documented opt-out contract."""
+    monkeypatch.setattr(
+        _ac,
+        "_find_cli_binary",
+        lambda name, *args, **kwargs: "/usr/bin/" + name if name == "opencode" else None,
+    )
+    monkeypatch.setattr(
+        _ac, "_opencode_auth_file_has_credentials", lambda path: True
+    )
+    # Opt-in overrides take precedence over the autouse fixture's safe defaults.
+    assert _ac._find_cli_binary("opencode") == "/usr/bin/opencode"
+    assert _ac._find_cli_binary("claude") is None  # other CLIs still isolated
+    assert _ac._opencode_auth_file_has_credentials(_FAKE_CONFIG_PATH) is True
+
+
+def test_canonical_source_matches_cli_preference():
+    """The autouse fixture must source the CLI list from
+    ``pdd.cli_detector.CLI_PREFERENCE`` (not a duplicate hardcoded list)
+    so Fix B's drift detector (``promptdriven/pdd#899``) won't flag a
+    new literal in conftest.py.
+
+    This is a meta-test: the assertion will hold as long as conftest
+    imports from CLI_PREFERENCE rather than re-declaring the names.
+    A duplicate hardcoded list in conftest would still satisfy this
+    runtime assertion, but Fix B's static-analysis scan in CI would
+    flag it. The pair (this test + Fix B static scan) is the contract.
+    """
+    expected = {"gemini", "claude", "codex", "opencode"}
+    assert set(CLI_PREFERENCE) == expected, (
+        f"CLI_PREFERENCE drifted from the documented agentic-CLI set; "
+        f"got {set(CLI_PREFERENCE)!r}. If a new agentic CLI was added, "
+        "update this test AND ensure the autouse fixture sources from "
+        "CLI_PREFERENCE (not a duplicate literal)."
+    )


### PR DESCRIPTION
## Summary

Adds an autouse pytest fixture `_isolate_cli_binary_presence` in `tests/conftest.py` that defaults every agentic CLI binary (claude/codex/gemini/opencode) to "not installed" and the OpenCode filesystem credential signals to "absent" before each test. Catches the CLI-binary-presence shape that broke 4 tests in `tests/test_agentic_common.py` from `promptdriven/pdd#858`.

This is **Fix A-prime** — a new workstream not in the original `promptdriven/pdd_cloud#1405` issue body. Proposed as a cheaper alternative to Fix A (fat reviewer container in pdd_cloud): catches a meaningful subset of Fix A's value at a fraction of the cost, lets the team decide later whether the fat container is still justified.

## The 4 test_agentic_common.py bugs

PR #858 (autonomous solve of `promptdriven/pdd#798`) shipped 7 test-isolation bugs. The 4 in `test_agentic_common.py` had this shape:

- Tests called `_has_opencode_credentials()` and expected `False`
- The helpers `_opencode_auth_file_has_credentials` and `_iter_opencode_config_texts` were NOT mocked in `mock_env` (originally)
- On the verifier's minimal worker container, the helpers returned False/empty because no auth file existed — tests passed
- On a developer machine where `opencode auth login` had been run, those helpers would have returned real signals — tests would have failed for the wrong reason

Fix B (#899) and Fix C (#902) cover the env-var-leak shape. This PR covers the CLI-binary-presence + auth-file-presence shape.

## What this PR does

1. **Autouse fixture in `tests/conftest.py`** — defaults:
   - `_find_cli_binary(name)` returns `None` for every name in `CLI_PREFERENCE` (passes through for non-agentic names like `git`)
   - `_opencode_auth_file_has_credentials` returns `False`
   - `_iter_opencode_config_texts` yields empty
2. **Opt-out marker** `@pytest.mark.uses_real_cli_detector` for tests that exercise the real `_find_cli_binary` (applied to `TestCliDiscovery` and `TestCliDiscoveryBug` in `test_agentic_common.py`).
3. **Regression tests** in `tests/test_cli_binary_isolation.py` — 9 tests covering the 4 CLIs + non-agentic passthrough + opt-in override + canonical-source meta-test. TDD red phase verified: 6/9 fail before the fixture lands.

## Canonical source

`pdd.cli_detector.CLI_PREFERENCE = ["gemini", "claude", "codex", "opencode"]` — the same ordered list the production CLI-detection path consults. **No new hardcoded literal**: Fix B's drift detector on the changed files reports 0 new findings (1 pre-existing finding on `pdd/cli_detector.py:831` is unrelated to this PR).

## Test results

- `tests/test_cli_binary_isolation.py`: **9/9 pass** after fixture lands (6/9 fail before — TDD red phase)
- `test_agentic_common.py + test_cli_detector.py + test_provider_env_isolation.py + test_opencode_provider.py + test_cli_binary_isolation.py`: **368/368 pass**
- Opt-out marker applied to the 9 CLI-discovery tests that would otherwise have broken
- Fix B detector on changed files: 0 new findings

## What this DOESN'T catch (so reviewer knows the scope-vs-Fix-A delta)

- Other CLI binaries beyond `CLI_PREFERENCE` (e.g., `pip`, `npm`, future agentic CLIs not added to the list)
- Subprocess invocations that don't go through `_find_cli_binary` (direct `subprocess.run(["opencode", ...])` would still see real CLI if it's in PATH)
- Filesystem-state leaks beyond OpenCode credentials (e.g., `~/.aws/credentials`, `~/.docker/config.json` — not currently consulted by PDD's test paths)
- Network state, time-based assumptions, locale, PATH ordering — out of scope for "CLI binary presence" class

Fix A (fat reviewer container in pdd_cloud) would catch *unknown* env-dependence beyond named patterns. This PR catches the **known** CLI-binary-presence pattern at a fraction of the cost. The team can decide whether Fix A is still justified after seeing what this catches.

## Sibling shipped PRs

- `promptdriven/pdd#899` — Fix B (list-drift detector, `6b67021`)
- `promptdriven/pdd#900` — Gemini 3 temperature clamp (`2d27b55c`)
- `promptdriven/pdd#901` — #900 polish (`a4b8ddd0`)
- `promptdriven/pdd#902` — Fix C (provider-env isolation, `dbd890a5`)

## Test plan

- [x] Failing-test phase (`14e761036`) — 6/9 fail without fixture
- [x] Implementation phase (`d564d2f15`) — fixture + opt-out marker applied
- [x] Regression: 368/368 in related test files
- [x] Fix B detector: 0 new findings (1 pre-existing unrelated)
- [x] Composes with existing `mock_env` / `mock_shutil_which` per-test fixtures
- [ ] CI green on PR (will run on push)
- [ ] `/gcbrun` triggers Cloud Build verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)