### PR TITLE
ci(auto-heal): use own bucket for gcloud staging + logs

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -249,10 +249,15 @@ jobs:
           trap 'rm -rf "$ctx_dir"' EXIT
           gsutil cp gs://pdd-stg-build-contexts/auto-heal-pr-latest.tgz "$ctx_dir/source.tgz"
           tar -xzf "$ctx_dir/source.tgz" -C "$ctx_dir"
+          # Use our own bucket for staging + logs so the dispatcher SA
+          # doesn't need access to the default `<project>_cloudbuild`
+          # bucket (which is restricted by org policy on this project).
           build_id=$(gcloud builds submit \
             gs://pdd-stg-build-contexts/auto-heal-pr-latest.tgz \
             --project=prompt-driven-development-stg \
             --config="$ctx_dir/cloudbuild-pdd-cli-auto-heal-pr.yaml" \
+            --gcs-source-staging-dir=gs://pdd-stg-build-contexts/_staging \
+            --gcs-log-dir=gs://pdd-stg-build-contexts/_logs \
             --substitutions=_PUBLIC_PR_NUMBER="$PR_NUMBER" \
             --async \
             --format='value(id)')


### PR DESCRIPTION
Workaround for gcloud builds submit hitting org policy on the default `<project>_cloudbuild` staging bucket. Use `gs://pdd-stg-build-contexts/_staging` and `/_logs` instead — dispatcher SA already has full access there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)