### PR TITLE
fix(ci): avoid red auto-heal job for generated PRs

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -122,9 +122,17 @@ jobs:
             fork=true
           fi
 
+          manual_heal_required=false
+          if [ "$EVENT_NAME" = "pull_request_target" ] &&
+             [ "$fork" = "false" ] &&
+             [ "$requester" = "prompt-driven-github[bot]" ]; then
+            manual_heal_required=true
+          fi
+
           {
             echo "skip=false"
             echo "fork=$fork"
+            echo "manual_heal_required=$manual_heal_required"
             echo "pr_number=$pr_number"
             echo "pr_head_sha=$pr_head_sha"
             echo "pr_head_repo=$pr_head_repo"
@@ -172,8 +180,27 @@ jobs:
             -f "output[title]=auto-heal skipped (fork PR)" \
             -f "output[summary]=Fork PRs are not auto-healed because the heal pushes commits to the PR branch (not possible across forks). [Workflow run]($RUN_URL)."
 
+      # Generated PRs are authored by prompt-driven-github[bot], which is not
+      # itself a pdd_cloud collaborator. Leave the job green and wait for an
+      # authorized collaborator to comment /heal; the comment path validates
+      # that human requester before dispatching Cloud Build.
+      - name: Wait for collaborator /heal on generated PRs
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          CHECK_ID: ${{ steps.check_start.outputs.check_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh api -X PATCH "repos/$REPO/check-runs/$CHECK_ID" \
+            -f status='completed' \
+            -f conclusion='neutral' \
+            -f "output[title]=auto-heal waiting for /heal" \
+            -f "output[summary]=Generated PRs require a pdd_cloud collaborator to comment /heal before auto-heal can run. [Workflow run]($RUN_URL)."
+
       - name: Mint pdd_cloud App token
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
         id: app_token
         # SHA-pinned to v3.1.1 (https://github.com/actions/create-github-app-token/releases/tag/v3.1.1)
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
@@ -184,7 +211,7 @@ jobs:
           repositories: pdd_cloud
 
       - name: Authorize requester (must be pdd_cloud collaborator)
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           REQUESTER: ${{ steps.pf.outputs.requester }}
@@ -220,7 +247,7 @@ jobs:
           esac
 
       - name: Authenticate to GCP via Workload Identity Federation
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
         # SHA-pinned to v3.0.0 (https://github.com/google-github-actions/auth/releases/tag/v3.0.0)
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
@@ -228,12 +255,12 @@ jobs:
           service_account: pdd-public-heal-dispatcher@prompt-driven-development-stg.iam.gserviceaccount.com
 
       - name: Set up gcloud
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
         # SHA-pinned to v3.0.1 (https://github.com/google-github-actions/setup-gcloud/releases/tag/v3.0.1)
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
 
       - name: Submit Cloud Build (async)
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
         id: gcb_submit
         env:
           PR_NUMBER: ${{ steps.pf.outputs.pr_number }}
@@ -267,7 +294,7 @@ jobs:
           echo "Cloud Build $build_id submitted; polling for completion."
 
       - name: Wait for Cloud Build to complete
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
         env:
           BUILD_ID: ${{ steps.gcb_submit.outputs.build_id }}
         run: |
@@ -296,7 +323,7 @@ jobs:
           done
 
       - name: Finalize check_run
-        if: always() && steps.check_start.outputs.check_id && steps.pf.outputs.fork == 'false'
+        if: always() && steps.check_start.outputs.check_id && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -122,17 +122,17 @@ jobs:
             fork=true
           fi
 
-          manual_heal_required=false
+          trusted_app_requester=false
           if [ "$EVENT_NAME" = "pull_request_target" ] &&
              [ "$fork" = "false" ] &&
              [ "$requester" = "prompt-driven-github[bot]" ]; then
-            manual_heal_required=true
+            trusted_app_requester=true
           fi
 
           {
             echo "skip=false"
             echo "fork=$fork"
-            echo "manual_heal_required=$manual_heal_required"
+            echo "trusted_app_requester=$trusted_app_requester"
             echo "pr_number=$pr_number"
             echo "pr_head_sha=$pr_head_sha"
             echo "pr_head_repo=$pr_head_repo"
@@ -180,27 +180,8 @@ jobs:
             -f "output[title]=auto-heal skipped (fork PR)" \
             -f "output[summary]=Fork PRs are not auto-healed because the heal pushes commits to the PR branch (not possible across forks). [Workflow run]($RUN_URL)."
 
-      # Generated PRs are authored by prompt-driven-github[bot], which is not
-      # itself a pdd_cloud collaborator. Leave the job green and wait for an
-      # authorized collaborator to comment /heal; the comment path validates
-      # that human requester before dispatching Cloud Build.
-      - name: Wait for collaborator /heal on generated PRs
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          CHECK_ID: ${{ steps.check_start.outputs.check_id }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          gh api -X PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-            -f status='completed' \
-            -f conclusion='neutral' \
-            -f "output[title]=auto-heal waiting for /heal" \
-            -f "output[summary]=Generated PRs require a pdd_cloud collaborator to comment /heal before auto-heal can run. [Workflow run]($RUN_URL)."
-
       - name: Mint pdd_cloud App token
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
         id: app_token
         # SHA-pinned to v3.1.1 (https://github.com/actions/create-github-app-token/releases/tag/v3.1.1)
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
@@ -211,15 +192,25 @@ jobs:
           repositories: pdd_cloud
 
       - name: Authorize requester (must be pdd_cloud collaborator)
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           REQUESTER: ${{ steps.pf.outputs.requester }}
+          TRUSTED_APP_REQUESTER: ${{ steps.pf.outputs.trusted_app_requester }}
         run: |
           set -euo pipefail
           if [ -z "$REQUESTER" ]; then
             echo "::error::requester unresolved; refusing to authorize"
             exit 1
+          fi
+          # Generated internal PRs are authored by prompt-driven-github[bot],
+          # a GitHub App identity that cannot be a repository collaborator.
+          # Pre-flight only marks this exact requester as trusted on
+          # non-fork pull_request_target events. Human /heal comments still
+          # go through the pdd_cloud collaborator check below.
+          if [ "$TRUSTED_APP_REQUESTER" = "true" ]; then
+            echo "authorized: $REQUESTER is the trusted generated-PR App identity"
+            exit 0
           fi
           # 204 = is a collaborator. 404 = not a collaborator.
           # Anything else = fail loud (don't silently confuse denial with
@@ -247,7 +238,7 @@ jobs:
           esac
 
       - name: Authenticate to GCP via Workload Identity Federation
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
         # SHA-pinned to v3.0.0 (https://github.com/google-github-actions/auth/releases/tag/v3.0.0)
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
@@ -255,12 +246,12 @@ jobs:
           service_account: pdd-public-heal-dispatcher@prompt-driven-development-stg.iam.gserviceaccount.com
 
       - name: Set up gcloud
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
         # SHA-pinned to v3.0.1 (https://github.com/google-github-actions/setup-gcloud/releases/tag/v3.0.1)
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
 
       - name: Submit Cloud Build (async)
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
         id: gcb_submit
         env:
           PR_NUMBER: ${{ steps.pf.outputs.pr_number }}
@@ -294,7 +285,7 @@ jobs:
           echo "Cloud Build $build_id submitted; polling for completion."
 
       - name: Wait for Cloud Build to complete
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
         env:
           BUILD_ID: ${{ steps.gcb_submit.outputs.build_id }}
         run: |
@@ -323,7 +314,7 @@ jobs:
           done
 
       - name: Finalize check_run
-        if: always() && steps.check_start.outputs.check_id && steps.pf.outputs.fork == 'false' && steps.pf.outputs.manual_heal_required != 'true'
+        if: always() && steps.check_start.outputs.check_id && steps.pf.outputs.fork == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -3561,6 +3561,11 @@ For detailed command examples for each workflow, see the respective command docu
 - `pull_request_target` (opened / synchronize / reopened / ready_for_review): heals only modules changed by the PR and pushes a `chore: auto-heal …` commit back to the PR branch.
 - `issue_comment` with a `/heal` command on a PR by an authorized collaborator: same as above, on demand.
 
+Generated internal PRs authored by `prompt-driven-github[bot]` are trusted as
+the autonomous pdd-issue App identity for the `pull_request_target` heal path.
+Other PR authors and all `/heal` comment requesters must pass the `pdd_cloud`
+collaborator check before Cloud Build is dispatched.
+
 There is no push-to-main trigger. Drift on `main` is healed by the next PR that touches the affected modules.
 
 **Loop prevention**: Auto-heal commits start with `chore: auto-heal …`; the Cloud Build step short-circuits when the triggering commit subject matches that prefix, so the heal cannot retrigger itself.

--- a/tests/test_auto_heal_workflow.py
+++ b/tests/test_auto_heal_workflow.py
@@ -1,0 +1,128 @@
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW_PATH = Path(".github/workflows/auto-heal.yml")
+GENERATED_BOT = "prompt-driven-github[bot]"
+
+
+def _load_workflow():
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def _steps():
+    return _load_workflow()["jobs"]["heal"]["steps"]
+
+
+def _step(name):
+    for step in _steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"Missing workflow step: {name}")
+
+
+def _run_preflight(tmp_path, *, event_name, requester, fork=False, body="/heal"):
+    output_path = tmp_path / "github_output"
+    env = os.environ.copy()
+    env.update(
+        {
+            "GITHUB_OUTPUT": str(output_path),
+            "GH_TOKEN": "unused",
+            "EVENT_NAME": event_name,
+            "BODY": body,
+            "PR_NUMBER_FROM_PR": "123",
+            "PR_HEAD_SHA_FROM_PR": "abc123",
+            "PR_HEAD_REPO_FROM_PR": "someone/other" if fork else "promptdriven/pdd",
+            "REQUESTER_FROM_PR": requester,
+            "ISSUE_NUMBER": "123",
+            "REQUESTER_FROM_COMMENT": requester,
+            "REPO": "promptdriven/pdd",
+        }
+    )
+    result = subprocess.run(
+        ["bash", "-c", _step("Pre-flight (validate trigger + resolve PR)")["run"]],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    outputs = {}
+    if output_path.exists():
+        for line in output_path.read_text().splitlines():
+            key, value = line.split("=", 1)
+            outputs[key] = value
+    return result, outputs
+
+
+def test_generated_bot_pull_request_is_trusted_app_requester(tmp_path):
+    result, outputs = _run_preflight(
+        tmp_path,
+        event_name="pull_request_target",
+        requester=GENERATED_BOT,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert outputs["trusted_app_requester"] == "true"
+    assert outputs["fork"] == "false"
+    assert outputs["requester"] == GENERATED_BOT
+
+
+def test_trusted_app_requester_is_exact_to_internal_generated_prs(tmp_path):
+    human_result, human_outputs = _run_preflight(
+        tmp_path,
+        event_name="pull_request_target",
+        requester="trusted-human",
+    )
+    fork_result, fork_outputs = _run_preflight(
+        tmp_path,
+        event_name="pull_request_target",
+        requester=GENERATED_BOT,
+        fork=True,
+    )
+
+    assert human_result.returncode == 0, human_result.stderr
+    assert fork_result.returncode == 0, fork_result.stderr
+    assert human_outputs["trusted_app_requester"] == "false"
+    assert fork_outputs["trusted_app_requester"] == "false"
+    assert fork_outputs["fork"] == "true"
+
+
+def test_authorize_step_allows_only_preflight_trusted_app_requester():
+    auth_step = _step("Authorize requester (must be pdd_cloud collaborator)")
+    auth_script = auth_step["run"]
+
+    assert "TRUSTED_APP_REQUESTER" in auth_step["env"]
+    assert '[ "$TRUSTED_APP_REQUESTER" = "true" ]' in auth_script
+    assert "trusted generated-PR App identity" in auth_script
+    assert "collaborators/$REQUESTER" in auth_script
+
+
+def test_privileged_heal_steps_run_for_internal_generated_prs():
+    privileged_steps = [
+        "Mint pdd_cloud App token",
+        "Authorize requester (must be pdd_cloud collaborator)",
+        "Authenticate to GCP via Workload Identity Federation",
+        "Set up gcloud",
+        "Submit Cloud Build (async)",
+        "Wait for Cloud Build to complete",
+        "Finalize check_run",
+    ]
+
+    for name in privileged_steps:
+        condition = _step(name)["if"]
+        assert "manual_heal_required" not in condition, name
+        assert "trusted_app_requester" not in condition, name
+
+
+def test_workflow_does_not_allowlist_arbitrary_bot_identities():
+    auth_script = _step("Authorize requester (must be pdd_cloud collaborator)")["run"]
+    workflow_text = WORKFLOW_PATH.read_text()
+
+    assert "*\"[bot]\"" not in auth_script
+    assert '"$REQUESTER" == *"[bot]"' not in auth_script
+    assert "manual_heal_required" not in workflow_text
+    assert "auto-heal waiting for /heal" not in workflow_text
+    assert "-f conclusion='action_required'" not in workflow_text


### PR DESCRIPTION
## Summary

- Trust the exact generated-PR App identity, `prompt-driven-github[bot]`, on internal `pull_request_target` auto-heal runs.
- Keep fork PRs short-circuited before any privileged token is minted.
- Keep the existing `pdd_cloud` collaborator gate for human PR authors and all `/heal` comment requesters.
- Add focused workflow tests for exact bot scope, no broad bot allowlist, and continued Cloud Build dispatch for trusted generated PRs.
- Update README CI Auto-Heal docs with the generated-PR trust rule.

Closes #921.

## Why this shape

Issue #921 is about bot-authored pdd-issue PRs landing with failing auto-heal checks because GitHub App identities cannot be `pdd_cloud` collaborators. The autonomous loop needs these PR-triggered heals to run without a human `/heal` comment, while preserving the collaborator gate for normal users and comment-triggered runs.

This avoids the risky approach from #946: it does not synthesize or overwrite the GitHub Actions `heal` job check-run. The normal workflow still runs, and the explicit `auto-heal` check remains the source of truth.

## Validation

- `conda run -n pdd python -m pytest -q tests/test_auto_heal_workflow.py`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/auto-heal.yml'); puts 'yaml ok'"`
- `git diff --check`
