### PR TITLE
ci(auto-heal): skip auto-trigger for bot-authored PRs

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -56,13 +56,25 @@ concurrency:
 
 jobs:
   heal:
-    # Non-draft PR events, or a /heal comment on a PR (issue-comment events
-    # for issues that aren't PRs are filtered out). `startsWith('/heal')`
+    # Non-draft, non-bot PR events, or a /heal comment on a PR (issue-comment
+    # events for issues that aren't PRs are filtered out). `startsWith('/heal')`
     # also matches /healthcheck — the pre-flight step rejects false positives
     # before any privileged work runs.
+    #
+    # Bot-authored PRs (`user.type == 'Bot'`, e.g. `prompt-driven-github[bot]`)
+    # are intentionally excluded from the `pull_request_target` trigger. They
+    # would otherwise hit the `Authorize requester` step and exit 1 because
+    # the bot is not a pdd_cloud collaborator, leaving a permanent failing
+    # `heal` check-run on the PR head that no subsequent `/heal` comment can
+    # overwrite (the auto-posted check-run is per-workflow-run). This matches
+    # the security model: bot PRs require an explicit human `/heal` to
+    # authorize, so skipping the auto-trigger removes only redundant fail
+    # signal — every legitimate run still goes through the same auth gate
+    # via the issue-comment branch.
     if: |
       (github.event_name == 'pull_request_target'
-        && github.event.pull_request.draft == false) ||
+        && github.event.pull_request.draft == false
+        && github.event.pull_request.user.type != 'Bot') ||
       (github.event_name == 'issue_comment'
         && github.event.action == 'created'
         && github.event.issue.pull_request != null


### PR DESCRIPTION
## Summary

Adds `github.event.pull_request.user.type != 'Bot'` to the `heal` job's `pull_request_target` `if:` clause so bot-authored PRs do not auto-trigger the workflow. The security model is preserved — bot PRs still require an explicit `/heal` comment to authorize auto-heal.

## Why this needs its own PR

`pull_request_target` workflows execute from `main`, not from the PR head (see the file's own line 23–25 security comment). That means a workflow fix shipped inside a bot-authored PR (e.g. PR #920) cannot self-apply for its own checks — every push of that PR still loads the pre-fix workflow from `main`, hits the auth gate at the bot author, and posts a failing `heal` check-run that no `/heal` retry can overwrite (auto-posted check-runs are per-workflow-run and owned by the GitHub Actions app).

Splitting the fix out means we can land it on `main` first, then re-trigger PR #920's checks (and every future bot PR) against the corrected workflow.

## Test plan

- [ ] Workflow YAML is valid (`python -c "import yaml; yaml.safe_load(open('.github/workflows/auto-heal.yml'))"` — verified locally before push).
- [ ] After merge: push a no-op commit to PR #920 (`change/issue-871`). The new `pull_request_target` run loads the patched workflow from `main`, sees `user.type == 'Bot'`, and skips the `heal` job → no failing `heal` check-run on the PR head.
- [ ] `/heal` comment path on bot PRs still works (the `issue_comment` branch of the same `if:` is untouched).
- [ ] Human-authored PRs are unaffected — `user.type != 'Bot'` is True for normal users, so `pull_request_target` keeps triggering the job for them.

## Scope

One file, two edits to a single `if:` block plus a deprecation/rationale comment. No behavior change for human-authored PRs, fork PRs, or `/heal` comment flows.