### PR TITLE
feat: migrate PyPI release flow to GitHub Actions workflow

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -172,8 +172,49 @@ jobs:
             -f "output[title]=auto-heal skipped (fork PR)" \
             -f "output[summary]=Fork PRs are not auto-healed because the heal pushes commits to the PR branch (not possible across forks). [Workflow run]($RUN_URL)."
 
+      # Short-circuit release branches (gltanaka or github-actions[bot], on
+      # `release/vX.Y.Z` branches opened by the release workflow). These PRs
+      # only touch version files (pyproject.toml etc.) — there is nothing for
+      # auto-heal to heal, and running Cloud Build on every release PR would
+      # add 10+ minutes to release latency. We PATCH the check_run to success
+      # so branch protection sees a passing required check.
+      #
+      # Falls through to the normal heal pipeline if the branch name doesn't
+      # match the strict regex (e.g. someone manually names a PR branch
+      # `release/foo` and expects it to be auto-merged).
+      - name: Short-circuit release branches (success conclusion)
+        id: release_short_circuit
+        if: |
+          steps.pf.outputs.skip != 'true'
+          && steps.pf.outputs.fork == 'false'
+          && github.event_name == 'pull_request_target'
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && (github.event.pull_request.user.login == 'gltanaka' || github.event.pull_request.user.login == 'github-actions[bot]')
+          && startsWith(github.head_ref, 'release/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          CHECK_ID: ${{ steps.check_start.outputs.check_id }}
+          HEAD_REF: ${{ github.head_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Tight regex match — protects against malformed release branches
+          # (e.g. `release/v1.2`, `release/vfoo`) by falling through to the
+          # normal heal pipeline.
+          if ! printf '%s' "$HEAD_REF" | grep -Eq '^release/v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "head_ref '$HEAD_REF' does not match release/vX.Y.Z; falling through to normal heal"
+            exit 0
+          fi
+          gh api -X PATCH "repos/$REPO/check-runs/$CHECK_ID" \
+            -f status='completed' \
+            -f conclusion='success' \
+            -f "output[title]=auto-heal skipped (release branch)" \
+            -f "output[summary]=Release branch \`$HEAD_REF\` short-circuits auto-heal. Touches version files only; nothing to heal. [Workflow run]($RUN_URL)."
+          echo "skipped=true" >> "$GITHUB_OUTPUT"
+
       - name: Mint pdd_cloud App token
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.release_short_circuit.outputs.skipped != 'true'
         id: app_token
         # SHA-pinned to v3.1.1 (https://github.com/actions/create-github-app-token/releases/tag/v3.1.1)
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
@@ -184,7 +225,7 @@ jobs:
           repositories: pdd_cloud
 
       - name: Authorize requester (must be pdd_cloud collaborator)
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.release_short_circuit.outputs.skipped != 'true'
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           REQUESTER: ${{ steps.pf.outputs.requester }}
@@ -220,7 +261,7 @@ jobs:
           esac
 
       - name: Authenticate to GCP via Workload Identity Federation
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.release_short_circuit.outputs.skipped != 'true'
         # SHA-pinned to v3.0.0 (https://github.com/google-github-actions/auth/releases/tag/v3.0.0)
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
@@ -228,12 +269,12 @@ jobs:
           service_account: pdd-public-heal-dispatcher@prompt-driven-development-stg.iam.gserviceaccount.com
 
       - name: Set up gcloud
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.release_short_circuit.outputs.skipped != 'true'
         # SHA-pinned to v3.0.1 (https://github.com/google-github-actions/setup-gcloud/releases/tag/v3.0.1)
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
 
       - name: Submit Cloud Build (async)
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.release_short_circuit.outputs.skipped != 'true'
         id: gcb_submit
         env:
           PR_NUMBER: ${{ steps.pf.outputs.pr_number }}
@@ -267,7 +308,7 @@ jobs:
           echo "Cloud Build $build_id submitted; polling for completion."
 
       - name: Wait for Cloud Build to complete
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false' && steps.release_short_circuit.outputs.skipped != 'true'
         env:
           BUILD_ID: ${{ steps.gcb_submit.outputs.build_id }}
         run: |
@@ -296,7 +337,7 @@ jobs:
           done
 
       - name: Finalize check_run
-        if: always() && steps.check_start.outputs.check_id && steps.pf.outputs.fork == 'false'
+        if: always() && steps.check_start.outputs.check_id && steps.pf.outputs.fork == 'false' && steps.release_short_circuit.outputs.skipped != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -196,6 +196,7 @@ jobs:
           REPO: ${{ github.repository }}
           CHECK_ID: ${{ steps.check_start.outputs.check_id }}
           HEAD_REF: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -204,6 +205,42 @@ jobs:
           # normal heal pipeline.
           if ! printf '%s' "$HEAD_REF" | grep -Eq '^release/v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "head_ref '$HEAD_REF' does not match release/vX.Y.Z; falling through to normal heal"
+            exit 0
+          fi
+          # Validate diff is exactly version-stamp files. Each file must be
+          # on the allowlist. Anything outside (test/, pdd/*.py beyond
+          # setup.py, etc.) is a non-version-only change and must go through
+          # normal auto-heal. Without this check, a collaborator with write
+          # access could push arbitrary commits to a `release/v*` branch
+          # after the PR opens; each `synchronize` event would otherwise
+          # re-PATCH the check to success.
+          #
+          # Allowlist source: pyproject.toml's [tool.commitizen] version_files
+          # entries plus CHANGELOG.md (touched by update_changelog_on_bump).
+          # NOTE: continuation lines below MUST stay at this indent (matches
+          # the surrounding code's column). YAML `|` literal strips the
+          # common leading indent uniformly, so each entry renders flush-left
+          # in the resulting shell script — which is what `grep -Fxq` needs.
+          allowlist='pyproject.toml
+          CHANGELOG.md
+          README.md
+          pypi_description.rst
+          pdd/pdd_completion.sh
+          pdd/setup.py'
+          # `gh api --paginate` handles the 30-file-per-page default; releases
+          # touch < 10 files but defense in depth against a runaway PR.
+          changed=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
+            --jq '.[].filename')
+          violation=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            if ! printf '%s\n' "$allowlist" | grep -Fxq "$f"; then
+              echo "::warning::release short-circuit aborted: '$f' is not on the version-stamp allowlist"
+              violation=true
+            fi
+          done <<< "$changed"
+          if [ "$violation" = "true" ]; then
+            echo "Falling through to normal heal pipeline"
             exit 0
           fi
           gh api -X PATCH "repos/$REPO/check-runs/$CHECK_ID" \

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -231,6 +231,12 @@ jobs:
           # touch < 10 files but defense in depth against a runaway PR.
           changed=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
             --jq '.[].filename')
+          # Empty diff is suspicious — fall through rather than auto-pass.
+          if [ -z "$changed" ]; then
+            echo "::warning::release short-circuit aborted: PR has no changed files"
+            echo "Falling through to normal heal pipeline"
+            exit 0
+          fi
           violation=false
           while IFS= read -r f; do
             [ -z "$f" ] && continue

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,404 @@
+name: release
+
+# PyPI release workflow. Replaces the local `make release` flow so that
+# branch-protected `main` is never bypassed and PyPI credentials never live
+# on a developer laptop.
+#
+# Flow (workflow_dispatch only):
+#   guard   — fails fast unless the user invoking AND triggering is gltanaka.
+#   prepare — bumps the version on a `release/vX.Y.Z` branch and opens a PR.
+#   merge   — waits for the PR to go green, then rebase-merges into main.
+#   tag     — tags the new main tip as `vX.Y.Z` and pushes the tag.
+#   publish — builds the wheel, runs the preprocessor, uploads via OIDC.
+#
+# Dry-run path skips merge+tag and publishes the candidate wheel to TestPyPI
+# from the release branch so end-to-end behavior can be verified before a
+# real release ever ships.
+#
+# ---- Security boundaries ----
+# - `workflow_dispatch` cannot be triggered by a PR or comment, only by a
+#   user with `write` (or higher) on the repo. The `guard` job further
+#   restricts to gltanaka by both `actor` and `triggering_actor`, so a rerun
+#   by another collaborator is rejected.
+# - PyPI uploads use OIDC trusted publishing via `pypa/gh-action-pypi-publish`.
+#   No long-lived API tokens live in GitHub Actions secrets.
+# - Both PyPI and TestPyPI uploads are gated behind GitHub `environment`s
+#   that require manual approval from gltanaka.
+# - Every event-derived value (workflow inputs, etc.) is passed through
+#   `env:` and read via shell variables — never interpolated directly into
+#   `run:` blocks. Matches the security pattern in auto-heal.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      dry_run:
+        description: 'Dry run (publish to TestPyPI, skip merge/tag)'
+        type: boolean
+        default: false
+
+# Deny-by-default at the top level. Each job opts in to exactly what it needs.
+permissions: {}
+
+# Serialize releases. `cancel-in-progress: false` so an in-flight release is
+# never interrupted partway through (e.g. between merge and tag).
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    name: Authorize triggering user
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Verify actor + triggering_actor
+        env:
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          set -euo pipefail
+          # Both must be gltanaka. `actor` is the user who created the run;
+          # `triggering_actor` is the user who triggered the latest run
+          # attempt (e.g. on rerun). Requiring both prevents a different
+          # collaborator from rerunning a release.
+          if [ "$ACTOR" != "gltanaka" ] || [ "$TRIGGERING_ACTOR" != "gltanaka" ]; then
+            echo "::error::release workflow is restricted to gltanaka (actor='$ACTOR' triggering_actor='$TRIGGERING_ACTOR')"
+            exit 1
+          fi
+          echo "Authorized: actor=$ACTOR triggering_actor=$TRIGGERING_ACTOR"
+
+  prepare:
+    name: Bump version and open PR
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      branch: ${{ steps.bump.outputs.branch }}
+      pr_number: ${{ steps.open_pr.outputs.pr_number }}
+      pr_head_sha: ${{ steps.open_pr.outputs.pr_head_sha }}
+    steps:
+      - name: Checkout main
+        # TODO: pin to SHA
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          # Use the default GITHUB_TOKEN for the push; required to be able
+          # to push to the release branch.
+          persist-credentials: true
+
+      - name: Set up Python
+        # TODO: pin to SHA
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Configure git identity
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Install commitizen
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install commitizen
+
+      - name: Bump version (files only) and create release branch
+        id: bump
+        env:
+          BUMP_INPUT: ${{ inputs.bump }}
+        run: |
+          set -euo pipefail
+          # Whitelist the bump input. cz expects uppercase MAJOR/MINOR/PATCH.
+          case "$BUMP_INPUT" in
+            patch) increment=PATCH ;;
+            minor) increment=MINOR ;;
+            major) increment=MAJOR ;;
+            *) echo "::error::invalid bump '$BUMP_INPUT'"; exit 1 ;;
+          esac
+          # --files-only updates the version files but does NOT commit or tag.
+          # We do the commit/push ourselves on a release branch so the version
+          # change goes through the normal PR + required-check pipeline rather
+          # than landing directly on protected main.
+          python -m commitizen bump \
+            --files-only \
+            --increment "$increment" \
+            --yes \
+            --check-consistency
+          # Read the new version from pyproject.toml. -m1 picks the first
+          # `version = "..."` line (the [project] block); the [tool.commitizen]
+          # block also has one but cz keeps them in sync.
+          version=$(grep -m1 '^version' pyproject.toml | sed -E 's/version *= *"([^"]+)"/\1/')
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::computed version '$version' is not X.Y.Z"
+            exit 1
+          fi
+          branch="release/v$version"
+          git checkout -b "$branch"
+          # Explicit add: only files cz actually rewrote should land in the
+          # commit. `git add -A` is intentionally avoided.
+          git add pyproject.toml
+          # Some projects also track version in additional files via cz's
+          # version_files config. Pick those up if cz modified them.
+          if ! git diff --quiet; then
+            git add -u
+          fi
+          git commit -m "bump: version → $version"
+          git push origin "$branch"
+          {
+            echo "version=$version"
+            echo "branch=$branch"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open release PR
+        id: open_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.bump.outputs.version }}
+          BRANCH: ${{ steps.bump.outputs.branch }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Body is built from workflow-controlled values only. Never
+          # interpolate event-derived strings into rendered markdown.
+          body_file=$(mktemp)
+          trap 'rm -f "$body_file"' EXIT
+          {
+            echo "Automated version bump to **v$VERSION**."
+            echo
+            echo "This PR was opened by the [release workflow]($RUN_URL)."
+            echo
+            echo "- Bump type: \`$VERSION\`"
+            echo "- Dry run: \`$DRY_RUN\`"
+            echo
+            echo "After this PR merges, the release workflow tags \`v$VERSION\` on \`main\` and uploads the wheel to PyPI."
+          } > "$body_file"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "bump: version → $VERSION" \
+            --body-file "$body_file"
+          # gh pr create prints the URL but not the number reliably; query
+          # both number and head SHA explicitly so downstream jobs don't
+          # have to re-resolve.
+          pr_info=$(gh pr view "$BRANCH" --json number,headRefOid)
+          pr_number=$(printf '%s' "$pr_info" | python -c 'import json,sys; print(json.load(sys.stdin)["number"])')
+          pr_head_sha=$(printf '%s' "$pr_info" | python -c 'import json,sys; print(json.load(sys.stdin)["headRefOid"])')
+          {
+            echo "pr_number=$pr_number"
+            echo "pr_head_sha=$pr_head_sha"
+          } >> "$GITHUB_OUTPUT"
+
+  merge:
+    name: Wait for green and merge
+    needs: prepare
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Poll PR until mergeable, then merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          # Poll PR status. Timeout at 60 minutes (120 iterations × 30s).
+          # CLEAN + MERGEABLE means all required checks passed and the PR
+          # is fast-forward / clean-merge-ready.
+          max_iter=120
+          i=0
+          while : ; do
+            i=$((i + 1))
+            status=$(gh api "repos/$REPO/pulls/$PR_NUMBER" \
+              --jq '[.mergeable_state, .mergeable] | @tsv')
+            state=$(printf '%s' "$status" | cut -f1)
+            mergeable=$(printf '%s' "$status" | cut -f2)
+            echo "iter=$i mergeable_state=$state mergeable=$mergeable"
+            if [ "$state" = "clean" ] && [ "$mergeable" = "true" ]; then
+              break
+            fi
+            # `dirty` means merge conflict; `blocked` past iteration 1 with
+            # mergeable=false typically means a required check failed.
+            # Don't fail early though — auto-heal may still be running.
+            if [ "$i" -ge "$max_iter" ]; then
+              echo "::error::PR $PR_NUMBER did not reach CLEAN+MERGEABLE within 60 minutes (last state='$state' mergeable='$mergeable')"
+              exit 1
+            fi
+            sleep 30
+          done
+          # Capture current head SHA right before merge to detect drift
+          # (e.g. a late auto-heal commit landing between poll and merge).
+          head_sha=$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)
+          echo "Merging PR $PR_NUMBER at head $head_sha"
+          # --match-head-commit aborts the merge if a new commit landed
+          # between the poll and the merge call, so we never accidentally
+          # rebase-merge a SHA we didn't verify was green.
+          gh pr merge "$PR_NUMBER" \
+            --rebase \
+            --delete-branch \
+            --match-head-commit "$head_sha"
+
+  tag:
+    name: Tag main
+    needs: [prepare, merge]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        # TODO: pin to SHA
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Configure git identity
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Tag the rebase-merged commit
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Fetch and tag the fetched ref directly, never a stale local ref.
+          git fetch origin main
+          if git rev-parse --verify --quiet "refs/tags/v$VERSION" >/dev/null; then
+            echo "::error::tag v$VERSION already exists"
+            exit 1
+          fi
+          git tag "v$VERSION" origin/main
+          git push origin "v$VERSION"
+
+  publish-prod:
+    name: Publish to PyPI
+    needs: [prepare, tag]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # `environment` requires manual approval from gltanaka before the job
+    # actually starts. This is the last human checkpoint before the wheel
+    # ships to PyPI.
+    environment:
+      name: pypi-publish
+      url: https://pypi.org/project/pdd-cli/${{ needs.prepare.outputs.version }}/
+    permissions:
+      id-token: write   # required for PyPI trusted publishing (OIDC)
+      contents: read
+    steps:
+      - name: Checkout release tag
+        # TODO: pin to SHA
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.prepare.outputs.version }}
+
+      - name: Set up Python
+        # TODO: pin to SHA
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install build tools and pdd
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+          # `pdd` must be on PATH for scripts/preprocess_wheel.py to call out
+          # to the CLI to preprocess *_LLM.prompt files inside the wheel.
+          python -m pip install -e .
+
+      - name: Build wheel
+        run: |
+          set -euo pipefail
+          python -m build
+          # Match Makefile behavior: only upload the wheel; the preprocessor
+          # only handles wheels. The sdist would ship unprocessed prompts.
+          rm -f dist/*.tar.gz
+
+      - name: Preprocess wheel
+        run: |
+          set -euo pipefail
+          python scripts/preprocess_wheel.py 'dist/*.whl'
+
+      - name: Publish to PyPI (OIDC)
+        # TODO: pin to SHA
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+
+  publish-test:
+    name: Publish to TestPyPI (dry-run)
+    needs: prepare
+    if: ${{ inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: pypi-test-publish
+      url: https://test.pypi.org/project/pdd-cli/${{ needs.prepare.outputs.version }}/
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout release branch
+        # TODO: pin to SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.branch }}
+
+      - name: Set up Python
+        # TODO: pin to SHA
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install build tools and pdd
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+          python -m pip install -e .
+
+      - name: Build wheel
+        run: |
+          set -euo pipefail
+          python -m build
+          rm -f dist/*.tar.gz
+
+      - name: Preprocess wheel
+        run: |
+          set -euo pipefail
+          python scripts/preprocess_wheel.py 'dist/*.whl'
+
+      - name: Publish to TestPyPI (OIDC)
+        # TODO: pin to SHA
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,8 @@ jobs:
       pr_head_sha: ${{ steps.open_pr.outputs.pr_head_sha }}
     steps:
       - name: Checkout main
-        # TODO: pin to SHA
-        uses: actions/checkout@v4
+        # SHA-pinned to v4.3.1 (https://github.com/actions/checkout/releases/tag/v4.3.1)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: main
           fetch-depth: 0
@@ -100,8 +100,8 @@ jobs:
           persist-credentials: true
 
       - name: Set up Python
-        # TODO: pin to SHA
-        uses: actions/setup-python@v5
+        # SHA-pinned to v5.6.0 (https://github.com/actions/setup-python/releases/tag/v5.6.0)
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -214,8 +214,15 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      # SHA of the rebase-merged commit on main. Captured AFTER `gh pr merge`
+      # returns so the `tag` job can tag this exact commit, not a stale
+      # `origin/main` tip that may have advanced from another PR landing
+      # between merge and tag.
+      merge_sha: ${{ steps.merge.outputs.merge_sha }}
     steps:
       - name: Poll PR until mergeable, then merge
+        id: merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -257,6 +264,29 @@ jobs:
             --rebase \
             --delete-branch \
             --match-head-commit "$head_sha"
+          # After a rebase-merge, GitHub populates pull_request.merge_commit_sha
+          # asynchronously with the resulting commit on main. It can briefly
+          # be null right after `gh pr merge` returns; retry a few times.
+          # The rebased commit SHA is NOT the same as head_sha, so we cannot
+          # reuse that value. The `tag` job uses this SHA so the tag points
+          # at the exact merge commit even if another PR lands on main first.
+          merge_sha=""
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            merge_sha=$(gh pr view "$PR_NUMBER" \
+              --json mergeCommit --jq '.mergeCommit.oid // ""')
+            if printf '%s' "$merge_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+              echo "merge_sha=$merge_sha (attempt=$attempt)"
+              break
+            fi
+            echo "mergeCommit.oid not yet populated (attempt=$attempt); retrying"
+            merge_sha=""
+            sleep 3
+          done
+          if [ -z "$merge_sha" ]; then
+            echo "::error::PR $PR_NUMBER merged but mergeCommit.oid never populated"
+            exit 1
+          fi
+          echo "merge_sha=$merge_sha" >> "$GITHUB_OUTPUT"
 
   tag:
     name: Tag main
@@ -268,8 +298,8 @@ jobs:
       contents: write
     steps:
       - name: Checkout main
-        # TODO: pin to SHA
-        uses: actions/checkout@v4
+        # SHA-pinned to v4.3.1 (https://github.com/actions/checkout/releases/tag/v4.3.1)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: main
           fetch-depth: 0
@@ -284,15 +314,33 @@ jobs:
       - name: Tag the rebase-merged commit
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
+          MERGE_SHA: ${{ needs.merge.outputs.merge_sha }}
         run: |
           set -euo pipefail
-          # Fetch and tag the fetched ref directly, never a stale local ref.
+          # Validate the SHA shape before doing anything with it. Defense in
+          # depth against an empty / malformed output bubbling through.
+          if ! printf '%s' "$MERGE_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::MERGE_SHA '$MERGE_SHA' is not a 40-char hex SHA"
+            exit 1
+          fi
+          # Fetch origin/main (for the ancestor check) AND the exact merge
+          # commit. Using the merge SHA — not origin/main — closes the race
+          # where an unrelated PR lands on main between merge and tag, which
+          # would otherwise cause us to tag a commit that isn't the release.
           git fetch origin main
+          git fetch origin "$MERGE_SHA"
+          # Belt-and-suspenders: confirm the merge commit is actually on
+          # origin/main. If it isn't, something is badly wrong (e.g. main
+          # was force-pushed or rewound); refuse to tag.
+          if ! git merge-base --is-ancestor "$MERGE_SHA" origin/main; then
+            echo "::error::MERGE_SHA $MERGE_SHA is not an ancestor of origin/main; refusing to tag"
+            exit 1
+          fi
           if git rev-parse --verify --quiet "refs/tags/v$VERSION" >/dev/null; then
             echo "::error::tag v$VERSION already exists"
             exit 1
           fi
-          git tag "v$VERSION" origin/main
+          git tag "v$VERSION" "$MERGE_SHA"
           git push origin "v$VERSION"
 
   publish-prod:
@@ -312,14 +360,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout release tag
-        # TODO: pin to SHA
-        uses: actions/checkout@v4
+        # SHA-pinned to v4.3.1 (https://github.com/actions/checkout/releases/tag/v4.3.1)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
       - name: Set up Python
-        # TODO: pin to SHA
-        uses: actions/setup-python@v5
+        # SHA-pinned to v5.6.0 (https://github.com/actions/setup-python/releases/tag/v5.6.0)
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -347,8 +395,8 @@ jobs:
           python scripts/preprocess_wheel.py 'dist/*.whl'
 
       - name: Publish to PyPI (OIDC)
-        # TODO: pin to SHA
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # SHA-pinned to v1.14.0 (https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.0)
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           packages-dir: dist
 
@@ -366,14 +414,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout release branch
-        # TODO: pin to SHA
-        uses: actions/checkout@v4
+        # SHA-pinned to v4.3.1 (https://github.com/actions/checkout/releases/tag/v4.3.1)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ needs.prepare.outputs.branch }}
 
       - name: Set up Python
-        # TODO: pin to SHA
-        uses: actions/setup-python@v5
+        # SHA-pinned to v5.6.0 (https://github.com/actions/setup-python/releases/tag/v5.6.0)
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -397,8 +445,8 @@ jobs:
           python scripts/preprocess_wheel.py 'dist/*.whl'
 
       - name: Publish to TestPyPI (OIDC)
-        # TODO: pin to SHA
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # SHA-pinned to v1.14.0 (https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.0)
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           packages-dir: dist
           repository-url: https://test.pypi.org/legacy/

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,8 @@ help:
 	@echo "  make publish                 - Build & upload current version to PyPI"
 	@echo "  make publish-public          - Copy artifacts to public repo only"
 	@echo "  make check-deps              - Check pyproject.toml and requirements.txt are in sync"
-	@echo "  make release                 - Bump version, tag, and upload to PyPI (public origin only)"
+	@echo "  make release [BUMP=patch]    - Trigger GHA release workflow (bump=patch|minor|major)"
+	@echo "  make release-local           - Emergency: local release flow (bypasses GHA, requires direct main push)"
 	@echo "  make staging                 - Copy files to staging"
 	@echo "  make production              - Copy files from staging to pdd"
 	@echo "  make update-extension        - Update VS Code extension"
@@ -107,7 +108,7 @@ TEST_OUTPUTS := $(patsubst $(PDD_DIR)/%.py,$(TESTS_DIR)/test_%.py,$(PY_OUTPUTS))
 # All Example files in context directory (recursive)
 EXAMPLE_FILES := $(shell find $(CONTEXT_DIR) -name "*_example.py" 2>/dev/null)
 
-.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release check-release-remote check-release-branch check-release-clean
+.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release release-local check-release-remote check-release-branch check-release-clean
 
 all: $(PY_OUTPUTS) $(MAKEFILE_OUTPUT) $(CSV_OUTPUTS) $(EXAMPLE_OUTPUTS) $(TEST_OUTPUTS)
 
@@ -690,7 +691,20 @@ check-release-clean:
 		exit 1; \
 	fi
 
-release: check-deps check-suspicious-files check-release-remote check-release-branch check-release-clean
+# Trigger the GitHub Actions release workflow. CI handles the bump, PR,
+# merge, tag, and PyPI upload — see .github/workflows/release.yml. Use
+# `make release BUMP=patch|minor|major` to choose the bump type (default
+# patch). The workflow requires `workflow_dispatch` permission on
+# promptdriven/pdd and is restricted to gltanaka.
+release:
+	@gh workflow run release.yml -f bump=$(or $(BUMP),patch)
+	@echo "release workflow dispatched (bump=$(or $(BUMP),patch)). Watch with: gh run watch"
+
+# Emergency fallback: the original local release flow. Preserved verbatim
+# for the case where the GHA release workflow is broken and a release must
+# go out manually. Requires push access to branch-protected main, a working
+# `conda run -n pdd` environment, and ~/.pypirc with PyPI credentials.
+release-local: check-deps check-suspicious-files check-release-remote check-release-branch check-release-clean
 	@echo "Preparing release"
 	@set -e; \
 	CURRENT_VERSION=$$(sed -n '1,120s/^version[[:space:]]*=[[:space:]]*"\([0-9.]*\)"/\1/p' pyproject.toml | head -n1); \


### PR DESCRIPTION
## Summary

Replaces the local `make release` flow with a `workflow_dispatch`-triggered GitHub Actions workflow so that:

- Releases no longer require pushing directly to branch-protected `main` (the bump goes through a normal PR + required checks).
- PyPI credentials no longer live on a developer laptop — uploads use OIDC trusted publishing via `pypa/gh-action-pypi-publish`.
- A pre-PyPI manual approval gate (GitHub `environment` review) sits between bump and upload.
- A dry-run path publishes to TestPyPI from the release branch for end-to-end verification.

The original local flow is preserved verbatim as `make release-local` for emergencies.

## What's in this PR

- `.github/workflows/release.yml` (new): the dispatch workflow. Jobs: `guard` (restricts to gltanaka), `prepare` (bump + open PR), `merge` (poll for green + rebase-merge with `--match-head-commit` drift protection), `tag` (tag the fresh main tip), `publish-prod` / `publish-test` (OIDC upload, gated by environment approval).
- `.github/workflows/auto-heal.yml` (patch): short-circuits `release/vX.Y.Z` PRs from gltanaka or `github-actions[bot]` with a `success` conclusion. Strict regex falls through to normal heal if the branch name is malformed. All subsequent steps gated on the new `release_short_circuit.outputs.skipped != 'true'`.
- `Makefile`: `release` becomes a thin wrapper around `gh workflow run release.yml -f bump=$(or $(BUMP),patch)`. The original body is preserved verbatim as `release-local` (with its `check-release-*` prerequisites). Help text updated. `.PHONY` updated.

## Required manual setup before first release

These cannot be automated — please complete before the first dispatch:

1. **PyPI trusted publisher** for the `pdd-cli` PyPI project (note: GitHub repo is `promptdriven/pdd`, PyPI project name is `pdd-cli`):
   - Owner: `promptdriven`
   - Repository: `pdd`
   - Workflow filename: `release.yml`
   - Environment: `pypi-publish`
   - URL: https://pypi.org/manage/project/pdd-cli/settings/publishing/
2. **TestPyPI trusted publisher** — same as above but environment `pypi-test-publish`:
   - URL: https://test.pypi.org/manage/project/pdd-cli/settings/publishing/
3. **GitHub environment `pypi-publish`** (Settings → Environments → New environment):
   - Required reviewer: `gltanaka`
   - Deployment branch rule: allow `main` and tags matching `v*`
4. **GitHub environment `pypi-test-publish`**:
   - Required reviewer: `gltanaka`
5. **GitHub repo setting** (Settings → Actions → General → Workflow permissions):
   - Enable **"Allow GitHub Actions to create and approve pull requests"** — the `prepare` job's `gh pr create` will fail without this.
6. **Branch protection on `main`**: verify "Restrict who can push" is either disabled, or if enabled, that `github-actions[bot]` (and the PR rebase-merge from `gh pr merge`) is permitted. The merge happens via the PR API, not a direct push, so this is usually a non-issue — confirm to be safe.

## Testing plan

- [ ] Confirm `make release` resolves to `gh workflow run` (`make -n release BUMP=minor` shows the expected single-line command).
- [ ] Merge this PR. Workflow becomes dispatchable only from default-branch state.
- [ ] Complete the 6 manual setup items above.
- [ ] Dispatch with `dry_run: true` and `bump: patch`. Verify:
  - [ ] `guard` passes for gltanaka.
  - [ ] `prepare` opens a `release/vX.Y.Z` PR.
  - [ ] auto-heal short-circuits the PR with `success`.
  - [ ] `merge`, `tag`, `publish-prod` are all skipped (dry-run path).
  - [ ] `publish-test` requires manual approval, then uploads to https://test.pypi.org/project/pdd-cli/.
  - [ ] Verify the TestPyPI wheel installs cleanly: `pip install -i https://test.pypi.org/simple/ pdd-cli==X.Y.Z` and run `pdd --help`.
  - [ ] Close the dry-run PR without merging; revert the dry-run version bump locally if needed (or just let the next real release bump past it).
- [ ] Dispatch a real release: `dry_run: false`, `bump: patch`. Verify the full pipeline and the resulting PyPI artifact.

## Out of scope / known notes

- All third-party actions (`actions/checkout`, `actions/setup-python`, `pypa/gh-action-pypi-publish`) are pinned to major tags with `# TODO: pin to SHA` comments. Will follow up to SHA-pin in a subsequent PR; using tags here matches `unit-tests.yml` precedent and avoids guessing SHAs.
- `cz bump` keeps both `[project].version` and `[tool.commitizen].version` in `pyproject.toml` in sync via `version_files`. No extra logic needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)