### PR TITLE
fix(#964): orchestrator owns visible step comments (start with pdd bug)

### DIFF
--- a/.pdd/meta/agentic_bug_orchestrator_python.json
+++ b/.pdd/meta/agentic_bug_orchestrator_python.json
@@ -1,19 +1,20 @@
 {
-  "pdd_version": "0.0.228",
-  "timestamp": "2026-05-06T03:28:20.550217+00:00",
-  "command": "regenerate-public",
-  "prompt_hash": "c8e7ed9712d1bc53f57577aa35c2dedbf357cf6039551157e0783606874f9fb9",
-  "code_hash": "1be27569e653774011e94e7ecb376320ede83f538cb62ae1fc85555b4c0b2cc5",
-  "example_hash": "83804a5a51020c2a5c55d821570ac0c15d69599bc22dadca115418faa232e1c6",
-  "test_hash": "9f189b915ae2da9f03eec1fd6cc7b782e95eff7581226dbed66db6be85f51c94",
+  "pdd_version": "0.0.235",
+  "timestamp": "2026-05-12T23:11:43.060753+00:00",
+  "command": "example",
+  "prompt_hash": "e7087b2f9b0eacc6f6ba9f4240ba13b52fed574fe8135fdbeb854de3e254d1fc",
+  "code_hash": "fcfe94890d755eb2f704a75c0fcc569160b02c1262300f05d3f43612ec9fb869",
+  "example_hash": "19c38f6a8459082cdfc525c540a53b79353b0ee46d6a857e6ed2bc71368b6541",
+  "test_hash": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
   "test_files": {
-    "test_agentic_bug_orchestrator.py": "9f189b915ae2da9f03eec1fd6cc7b782e95eff7581226dbed66db6be85f51c94",
-    "test_agentic_bug_orchestrator_1.py": "2f8ba8ce40f8f1fcba01c98eadc57e77f34e517358e9a26c655aa9cb654103f4"
+    "test_agentic_bug_orchestrator.py": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
+    "test_agentic_bug_orchestrator_1.py": "8085e2041355e53aef1709eeba3591fa0f7c512a637038b8c48d633e4cd07aa2",
+    "test_agentic_bug_orchestrator_step_comments.py": "5436e993efa78d2bbc812dccf72f26e088dfc7110c51bedb76103ec5a7cca051"
   },
   "include_deps": {
     "context/agentic_bug_example.py": "96e35df4e8425a9173ff6a30281892c2bd8b81361cff72b732e488172ddf52f5",
     "context/agentic_common_example.py": "113b5829cae3a9e38c362b74d5115ba09cab06c7be5831527d9829f97f7b3b7d",
     "context/load_prompt_template_example.py": "a1cd6619182c6c951f5856dda4070e202875a5884bbfab9cc191d24de2f4951f",
-    "context/python_preamble.prompt": "57a3e51f529024ec0cb9658cd6ac61a7c8051ba0c8e887b31cf00b2e78a07d83"
+    "context/python_preamble.prompt": "0388ed131bf986f8752e1bc4c81e4da0460cfe2908ec8c60b1314edbab768254"
   }
 }

--- a/.pdd/meta/agentic_bug_orchestrator_python.json
+++ b/.pdd/meta/agentic_bug_orchestrator_python.json
@@ -1,15 +1,15 @@
 {
   "pdd_version": "0.0.235",
-  "timestamp": "2026-05-12T23:11:43.060753+00:00",
-  "command": "example",
-  "prompt_hash": "e7087b2f9b0eacc6f6ba9f4240ba13b52fed574fe8135fdbeb854de3e254d1fc",
-  "code_hash": "fcfe94890d755eb2f704a75c0fcc569160b02c1262300f05d3f43612ec9fb869",
-  "example_hash": "19c38f6a8459082cdfc525c540a53b79353b0ee46d6a857e6ed2bc71368b6541",
+  "timestamp": "2026-05-12T23:54:39.399055+00:00",
+  "command": "checkup",
+  "prompt_hash": "75526c28a966e9ed1ca930b034fcaf1d157ec19bb1649c796d008d0895489b3e",
+  "code_hash": "1fe0c355afebf23999bf27ae1d3987695280d5fbd388d13543f6fe853521fe71",
+  "example_hash": "11b5996d5b450abe2a6e8c399b563d454ec4c3f797122cf94ec581e1dd01b502",
   "test_hash": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
   "test_files": {
     "test_agentic_bug_orchestrator.py": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
     "test_agentic_bug_orchestrator_1.py": "8085e2041355e53aef1709eeba3591fa0f7c512a637038b8c48d633e4cd07aa2",
-    "test_agentic_bug_orchestrator_step_comments.py": "5436e993efa78d2bbc812dccf72f26e088dfc7110c51bedb76103ec5a7cca051"
+    "test_agentic_bug_orchestrator_step_comments.py": "bf3d36d45e4d303eb647e07ae6ae62276618244fa4ccd582c7549f39405b7a81"
   },
   "include_deps": {
     "context/agentic_bug_example.py": "96e35df4e8425a9173ff6a30281892c2bd8b81361cff72b732e488172ddf52f5",

--- a/.pdd/meta/agentic_bug_orchestrator_python.json
+++ b/.pdd/meta/agentic_bug_orchestrator_python.json
@@ -1,15 +1,15 @@
 {
   "pdd_version": "0.0.235",
-  "timestamp": "2026-05-12T23:54:39.399055+00:00",
+  "timestamp": "2026-05-13T02:42:58+00:00",
   "command": "checkup",
-  "prompt_hash": "467e2d1dd0fbf11fb464405cac8bfac38148d8e3e21ef162895680351ab682c4",
-  "code_hash": "58edfe90bc32da35bb3c832ae9dbe050512e72f510cdfedb9d530be482a855d0",
+  "prompt_hash": "5f7228362cd6808a5b26e447fb589bcedde66cd8e93132a5804eff32958bb5e4",
+  "code_hash": "cc18b5366afc3e9a9f6d094c5f324207812036ceb6c88b898e21fc63810c3d46",
   "example_hash": "97b2da07e76fb037bf663387f5647e89cd469ce6f2fdb152c089efe81259753c",
   "test_hash": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
   "test_files": {
     "test_agentic_bug_orchestrator.py": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
     "test_agentic_bug_orchestrator_1.py": "8085e2041355e53aef1709eeba3591fa0f7c512a637038b8c48d633e4cd07aa2",
-    "test_agentic_bug_orchestrator_step_comments.py": "da6cc07e7ed2f6b5e92a63d0eb8ecd0e548c5a288481984cb0c698c3abe21c6d"
+    "test_agentic_bug_orchestrator_step_comments.py": "693e1c1b571a1daee1013fb48bc8390f263a6544c163e3f55bcb60dafa1bb679"
   },
   "include_deps": {
     "context/agentic_bug_example.py": "96e35df4e8425a9173ff6a30281892c2bd8b81361cff72b732e488172ddf52f5",

--- a/.pdd/meta/agentic_bug_orchestrator_python.json
+++ b/.pdd/meta/agentic_bug_orchestrator_python.json
@@ -1,13 +1,13 @@
 {
-  "pdd_version": "0.0.235",
-  "timestamp": "2026-05-13T03:03:58+00:00",
-  "command": "checkup",
-  "prompt_hash": "5f7228362cd6808a5b26e447fb589bcedde66cd8e93132a5804eff32958bb5e4",
+  "pdd_version": "0.0.236",
+  "timestamp": "2026-05-13T17:57:04.410287+00:00",
+  "command": "fix",
+  "prompt_hash": "b095fd58d27f15190fd9e60d6bb8cb7a436a4c98fcd9a05264f08f459dcef190",
   "code_hash": "cc18b5366afc3e9a9f6d094c5f324207812036ceb6c88b898e21fc63810c3d46",
   "example_hash": "23b545fc0f892e14ee9660902d3f7e04893f0b793246c1ea9d559656fd39ffe6",
-  "test_hash": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
+  "test_hash": "25e54feff561d62baa1682707a0059c51ffbba687e3f5225c805c6ef6ad3aa00",
   "test_files": {
-    "test_agentic_bug_orchestrator.py": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
+    "test_agentic_bug_orchestrator.py": "25e54feff561d62baa1682707a0059c51ffbba687e3f5225c805c6ef6ad3aa00",
     "test_agentic_bug_orchestrator_1.py": "8085e2041355e53aef1709eeba3591fa0f7c512a637038b8c48d633e4cd07aa2",
     "test_agentic_bug_orchestrator_step_comments.py": "693e1c1b571a1daee1013fb48bc8390f263a6544c163e3f55bcb60dafa1bb679"
   },

--- a/.pdd/meta/agentic_bug_orchestrator_python.json
+++ b/.pdd/meta/agentic_bug_orchestrator_python.json
@@ -3,13 +3,13 @@
   "timestamp": "2026-05-12T23:54:39.399055+00:00",
   "command": "checkup",
   "prompt_hash": "6eeededa17fafb00396c11f7d6ea1fd4eb759ea796ed42ffc3b074f56b9f58a8",
-  "code_hash": "5bc45b060d560c961bbc97916a41cd0709de9f7b4e6a8821aa7b88c228ad63c9",
+  "code_hash": "2af07f762f9a0b55bf46cd1b519151048ff49577830d056855d038d21c2155f1",
   "example_hash": "97b2da07e76fb037bf663387f5647e89cd469ce6f2fdb152c089efe81259753c",
   "test_hash": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
   "test_files": {
     "test_agentic_bug_orchestrator.py": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
     "test_agentic_bug_orchestrator_1.py": "8085e2041355e53aef1709eeba3591fa0f7c512a637038b8c48d633e4cd07aa2",
-    "test_agentic_bug_orchestrator_step_comments.py": "bf3d36d45e4d303eb647e07ae6ae62276618244fa4ccd582c7549f39405b7a81"
+    "test_agentic_bug_orchestrator_step_comments.py": "da6cc07e7ed2f6b5e92a63d0eb8ecd0e548c5a288481984cb0c698c3abe21c6d"
   },
   "include_deps": {
     "context/agentic_bug_example.py": "96e35df4e8425a9173ff6a30281892c2bd8b81361cff72b732e488172ddf52f5",

--- a/.pdd/meta/agentic_bug_orchestrator_python.json
+++ b/.pdd/meta/agentic_bug_orchestrator_python.json
@@ -4,7 +4,7 @@
   "command": "checkup",
   "prompt_hash": "6eeededa17fafb00396c11f7d6ea1fd4eb759ea796ed42ffc3b074f56b9f58a8",
   "code_hash": "5bc45b060d560c961bbc97916a41cd0709de9f7b4e6a8821aa7b88c228ad63c9",
-  "example_hash": "b1c7dda7f989fc6b2b54994c5fd26eb0361a2db72961ece77356548e23b01e73",
+  "example_hash": "97b2da07e76fb037bf663387f5647e89cd469ce6f2fdb152c089efe81259753c",
   "test_hash": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
   "test_files": {
     "test_agentic_bug_orchestrator.py": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",

--- a/.pdd/meta/agentic_bug_orchestrator_python.json
+++ b/.pdd/meta/agentic_bug_orchestrator_python.json
@@ -1,10 +1,10 @@
 {
   "pdd_version": "0.0.235",
-  "timestamp": "2026-05-13T02:42:58+00:00",
+  "timestamp": "2026-05-13T03:03:58+00:00",
   "command": "checkup",
   "prompt_hash": "5f7228362cd6808a5b26e447fb589bcedde66cd8e93132a5804eff32958bb5e4",
   "code_hash": "cc18b5366afc3e9a9f6d094c5f324207812036ceb6c88b898e21fc63810c3d46",
-  "example_hash": "97b2da07e76fb037bf663387f5647e89cd469ce6f2fdb152c089efe81259753c",
+  "example_hash": "23b545fc0f892e14ee9660902d3f7e04893f0b793246c1ea9d559656fd39ffe6",
   "test_hash": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
   "test_files": {
     "test_agentic_bug_orchestrator.py": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",

--- a/.pdd/meta/agentic_bug_orchestrator_python.json
+++ b/.pdd/meta/agentic_bug_orchestrator_python.json
@@ -2,9 +2,9 @@
   "pdd_version": "0.0.235",
   "timestamp": "2026-05-12T23:54:39.399055+00:00",
   "command": "checkup",
-  "prompt_hash": "75526c28a966e9ed1ca930b034fcaf1d157ec19bb1649c796d008d0895489b3e",
-  "code_hash": "1fe0c355afebf23999bf27ae1d3987695280d5fbd388d13543f6fe853521fe71",
-  "example_hash": "11b5996d5b450abe2a6e8c399b563d454ec4c3f797122cf94ec581e1dd01b502",
+  "prompt_hash": "6eeededa17fafb00396c11f7d6ea1fd4eb759ea796ed42ffc3b074f56b9f58a8",
+  "code_hash": "5bc45b060d560c961bbc97916a41cd0709de9f7b4e6a8821aa7b88c228ad63c9",
+  "example_hash": "b1c7dda7f989fc6b2b54994c5fd26eb0361a2db72961ece77356548e23b01e73",
   "test_hash": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
   "test_files": {
     "test_agentic_bug_orchestrator.py": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",

--- a/.pdd/meta/agentic_bug_orchestrator_python.json
+++ b/.pdd/meta/agentic_bug_orchestrator_python.json
@@ -2,8 +2,8 @@
   "pdd_version": "0.0.235",
   "timestamp": "2026-05-12T23:54:39.399055+00:00",
   "command": "checkup",
-  "prompt_hash": "6eeededa17fafb00396c11f7d6ea1fd4eb759ea796ed42ffc3b074f56b9f58a8",
-  "code_hash": "2af07f762f9a0b55bf46cd1b519151048ff49577830d056855d038d21c2155f1",
+  "prompt_hash": "467e2d1dd0fbf11fb464405cac8bfac38148d8e3e21ef162895680351ab682c4",
+  "code_hash": "58edfe90bc32da35bb3c832ae9dbe050512e72f510cdfedb9d530be482a855d0",
   "example_hash": "97b2da07e76fb037bf663387f5647e89cd469ce6f2fdb152c089efe81259753c",
   "test_hash": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
   "test_files": {

--- a/.pdd/meta/agentic_bug_orchestrator_python_run.json
+++ b/.pdd/meta/agentic_bug_orchestrator_python_run.json
@@ -1,0 +1,13 @@
+{
+  "timestamp": "2026-05-13T17:57:04.446190+00:00",
+  "exit_code": 0,
+  "tests_passed": 3,
+  "tests_failed": 0,
+  "coverage": 100.0,
+  "test_hash": "25e54feff561d62baa1682707a0059c51ffbba687e3f5225c805c6ef6ad3aa00",
+  "test_files": {
+    "test_agentic_bug_orchestrator.py": "25e54feff561d62baa1682707a0059c51ffbba687e3f5225c805c6ef6ad3aa00",
+    "test_agentic_bug_orchestrator_1.py": "8085e2041355e53aef1709eeba3591fa0f7c512a637038b8c48d633e4cd07aa2",
+    "test_agentic_bug_orchestrator_step_comments.py": "693e1c1b571a1daee1013fb48bc8390f263a6544c163e3f55bcb60dafa1bb679"
+  }
+}

--- a/.pdd/meta/agentic_bug_python.json
+++ b/.pdd/meta/agentic_bug_python.json
@@ -1,21 +1,21 @@
 {
   "pdd_version": "0.0.228",
-  "timestamp": "2026-05-06T03:28:20.609035+00:00",
+  "timestamp": "2026-05-13T03:03:58+00:00",
   "command": "regenerate-public",
-  "prompt_hash": "d1a77f330389d59db598e1cfc37daefcc358a845bad29ccf60d0249dc1656c01",
+  "prompt_hash": "f74527dd61981e4663f4d6767b38b158ec8ead1bed4eef331f8bd93a2b475cd8",
   "code_hash": "5d9e16efe88528a9eaaec4fcfc8df314fe8eb7d0693c565c49d1e63212900b34",
   "example_hash": null,
   "test_hash": "37a6cd9557683fd852c44a5f267ae6f18773379f8ca0ffbe9c40ba0397d7c230",
   "test_files": {
     "test_agentic_bug.py": "37a6cd9557683fd852c44a5f267ae6f18773379f8ca0ffbe9c40ba0397d7c230",
-    "test_agentic_bug_orchestrator.py": "9f189b915ae2da9f03eec1fd6cc7b782e95eff7581226dbed66db6be85f51c94",
-    "test_agentic_bug_orchestrator_1.py": "2f8ba8ce40f8f1fcba01c98eadc57e77f34e517358e9a26c655aa9cb654103f4",
+    "test_agentic_bug_orchestrator.py": "75ed5d42c484cd8f03cc52fb9f3aeb11ac602315098d0d3bf90b86a81f9aceb5",
+    "test_agentic_bug_orchestrator_1.py": "8085e2041355e53aef1709eeba3591fa0f7c512a637038b8c48d633e4cd07aa2",
     "test_agentic_bug_step10_prompt.py": "cca4e817639dabd0afd5f805eb894b78decc1858472d114debf885ffacbdf3d2",
     "test_agentic_bug_step11_prompt.py": "8b41000be193c0024d999dd6cf1bd9f2f4615692e1c6bc52d0c46a83b560427b",
     "test_agentic_bug_step7_prompt.py": "60c139b52632113013e2e1ac5c77f13257d0d370fc2be61d2420522bf44c830a"
   },
   "include_deps": {
-    "context/agentic_bug_orchestrator_example.py": "00db52821223449eeb381e3d57e0fff538628415ac57aacc3266d8cf83f46121",
-    "context/python_preamble.prompt": "57a3e51f529024ec0cb9658cd6ac61a7c8051ba0c8e887b31cf00b2e78a07d83"
+    "context/agentic_bug_orchestrator_example.py": "23b545fc0f892e14ee9660902d3f7e04893f0b793246c1ea9d559656fd39ffe6",
+    "context/python_preamble.prompt": "0388ed131bf986f8752e1bc4c81e4da0460cfe2908ec8c60b1314edbab768254"
   }
 }

--- a/.pdd/meta/agentic_change_orchestrator_python.json
+++ b/.pdd/meta/agentic_change_orchestrator_python.json
@@ -1,13 +1,13 @@
 {
-  "pdd_version": "0.0.234",
-  "timestamp": "2026-05-12T02:53:56.045714+00:00",
+  "pdd_version": "0.0.236",
+  "timestamp": "2026-05-13T18:00:49.544816+00:00",
   "command": "fix",
   "prompt_hash": "aacd8a9c94d808fd49acaa5739ba7b2ff072afb8b374777d434e7350610e217f",
-  "code_hash": "1ca4de7652414d14e3ab83938a529217898b7d3a9b5ce9502515845b0bdfe639",
+  "code_hash": "e3a6ba1bb3d1b3588777f0beb267e4b737af0293179932e3a66b1e9c477ada0e",
   "example_hash": "64214eeba81aac7ed6747e3f0278db17c406068d7e83deddaf7592e538c7794e",
-  "test_hash": "68227d429442ac109b1cb1c47e796d470a4617165c2d8eb379d4ead19f6280ae",
+  "test_hash": "fb122add0a99d5453e165f5b60603cc82e6f815fb27b53217c015520149320c3",
   "test_files": {
-    "test_agentic_change_orchestrator.py": "68227d429442ac109b1cb1c47e796d470a4617165c2d8eb379d4ead19f6280ae"
+    "test_agentic_change_orchestrator.py": "fb122add0a99d5453e165f5b60603cc82e6f815fb27b53217c015520149320c3"
   },
   "include_deps": {
     "context/construct_paths_example.py": "9fb88745a2a0e2834f9da30c2128a122fef4d5a74212ceacc5f9c3d9ddb9a8ca",

--- a/.pdd/meta/agentic_change_orchestrator_python_run.json
+++ b/.pdd/meta/agentic_change_orchestrator_python_run.json
@@ -1,11 +1,11 @@
 {
-  "timestamp": "2026-05-12T02:53:56.046606+00:00",
+  "timestamp": "2026-05-13T18:00:49.578747+00:00",
   "exit_code": 0,
-  "tests_passed": 1,
+  "tests_passed": 148,
   "tests_failed": 0,
   "coverage": 100.0,
-  "test_hash": "68227d429442ac109b1cb1c47e796d470a4617165c2d8eb379d4ead19f6280ae",
+  "test_hash": "fb122add0a99d5453e165f5b60603cc82e6f815fb27b53217c015520149320c3",
   "test_files": {
-    "test_agentic_change_orchestrator.py": "68227d429442ac109b1cb1c47e796d470a4617165c2d8eb379d4ead19f6280ae"
+    "test_agentic_change_orchestrator.py": "fb122add0a99d5453e165f5b60603cc82e6f815fb27b53217c015520149320c3"
   }
 }

--- a/.pdd/meta/agentic_common_python.json
+++ b/.pdd/meta/agentic_common_python.json
@@ -2,9 +2,9 @@
   "pdd_version": "0.0.235",
   "timestamp": "2026-05-12T23:28:06.985576+00:00",
   "command": "example",
-  "prompt_hash": "d19e4f146e7d11e667205e3b3dcd3beb3ad17c8b34b9442b6a99b9921825c018",
+  "prompt_hash": "1460cd0a87039a4b2668357db8557bd0d589404f84e88b553af8b696e7327f36",
   "code_hash": "00cb7d2c24343e7c6fc4316920cfb619a49f1886ec19b61eb1eb70b90c44b6e5",
-  "example_hash": "0e58edd3bdb9bad707a036074a7a8059b16e6b3cd7bdd4839232f83de269c922",
+  "example_hash": "113b5829cae3a9e38c362b74d5115ba09cab06c7be5831527d9829f97f7b3b7d",
   "test_hash": "f1b15bf3b511a7ed4e394bf4197578e982d679a11767f5f4b7d3daff5b361df8",
   "test_files": {
     "test_agentic_common.py": "f1b15bf3b511a7ed4e394bf4197578e982d679a11767f5f4b7d3daff5b361df8",

--- a/.pdd/meta/agentic_common_python.json
+++ b/.pdd/meta/agentic_common_python.json
@@ -1,20 +1,20 @@
 {
-  "pdd_version": "0.0.233",
-  "timestamp": "2026-05-11T21:05:00+00:00",
-  "command": "fix",
-  "prompt_hash": "890d20086edec6426f7ad83f8b11bfe8dcdf73b3ed47658fd312af8ba2f54389",
-  "code_hash": "d02d2fa6031d0757203fa245b080ded3ea7026eefb898d7e489366f902266be5",
-  "example_hash": "113b5829cae3a9e38c362b74d5115ba09cab06c7be5831527d9829f97f7b3b7d",
-  "test_hash": "8b03df5f78d11958ceb77a1218619a895a1eb9ec5495f19ef0dced642b7d2a76",
+  "pdd_version": "0.0.235",
+  "timestamp": "2026-05-12T23:28:06.985576+00:00",
+  "command": "example",
+  "prompt_hash": "d19e4f146e7d11e667205e3b3dcd3beb3ad17c8b34b9442b6a99b9921825c018",
+  "code_hash": "00cb7d2c24343e7c6fc4316920cfb619a49f1886ec19b61eb1eb70b90c44b6e5",
+  "example_hash": "0e58edd3bdb9bad707a036074a7a8059b16e6b3cd7bdd4839232f83de269c922",
+  "test_hash": "f1b15bf3b511a7ed4e394bf4197578e982d679a11767f5f4b7d3daff5b361df8",
   "test_files": {
-    "test_agentic_common.py": "8b03df5f78d11958ceb77a1218619a895a1eb9ec5495f19ef0dced642b7d2a76",
+    "test_agentic_common.py": "f1b15bf3b511a7ed4e394bf4197578e982d679a11767f5f4b7d3daff5b361df8",
     "test_agentic_common_issue_813_anthropic_api_key_oauth_shadow.py": "1988f9b022bd4071f95aef13ba6a6a6681279711ad6f718744195b8e0b9dac9e",
     "test_agentic_common_worktree.py": "b726b24513865a7e3c23700b192bac001ab09190d7371b6d6714f0cf076c58e2"
   },
   "include_deps": {
     "context/_keyring_timeout_example.py": "41f83d5ef117caba86b788f69b519f7e88f3d7dc2a641a017d74a7cee9be6ed1",
     "context/api_key_scanner_example.py": "4b9f880a30445f25edffc394857ae0c218097726c41ab996a03fcbc4350b5482",
-    "context/python_preamble.prompt": "57a3e51f529024ec0cb9658cd6ac61a7c8051ba0c8e887b31cf00b2e78a07d83",
-    "pdd/agentic_common.py": "d02d2fa6031d0757203fa245b080ded3ea7026eefb898d7e489366f902266be5"
+    "context/python_preamble.prompt": "0388ed131bf986f8752e1bc4c81e4da0460cfe2908ec8c60b1314edbab768254",
+    "pdd/agentic_common.py": "00cb7d2c24343e7c6fc4316920cfb619a49f1886ec19b61eb1eb70b90c44b6e5"
   }
 }

--- a/.pdd/meta/agentic_common_python.json
+++ b/.pdd/meta/agentic_common_python.json
@@ -1,13 +1,13 @@
 {
-  "pdd_version": "0.0.235",
-  "timestamp": "2026-05-13T02:42:58+00:00",
-  "command": "example",
-  "prompt_hash": "a6fc0ca959a445a446ad7407ef9ec9205566ba1e335cede76544ac18445b7790",
+  "pdd_version": "0.0.236",
+  "timestamp": "2026-05-13T17:57:04.484331+00:00",
+  "command": "fix",
+  "prompt_hash": "44aa17e0ecb427acead7f8489b448b3b0fc41c1158968fb55d49affd5aecbfcc",
   "code_hash": "8da0d7f52dae9412a36624a3c2bf25539b17cc48a8561d9b8b767b96076a5051",
   "example_hash": "113b5829cae3a9e38c362b74d5115ba09cab06c7be5831527d9829f97f7b3b7d",
-  "test_hash": "8b03df5f78d11958ceb77a1218619a895a1eb9ec5495f19ef0dced642b7d2a76",
+  "test_hash": "446b6703b07764753c25a51b35b320061f1ecb54320509e1f3cf2cc99c61e3c5",
   "test_files": {
-    "test_agentic_common.py": "8b03df5f78d11958ceb77a1218619a895a1eb9ec5495f19ef0dced642b7d2a76",
+    "test_agentic_common.py": "446b6703b07764753c25a51b35b320061f1ecb54320509e1f3cf2cc99c61e3c5",
     "test_agentic_common_issue_813_anthropic_api_key_oauth_shadow.py": "1988f9b022bd4071f95aef13ba6a6a6681279711ad6f718744195b8e0b9dac9e",
     "test_agentic_common_worktree.py": "b726b24513865a7e3c23700b192bac001ab09190d7371b6d6714f0cf076c58e2"
   },

--- a/.pdd/meta/agentic_common_python.json
+++ b/.pdd/meta/agentic_common_python.json
@@ -1,13 +1,13 @@
 {
   "pdd_version": "0.0.235",
-  "timestamp": "2026-05-12T23:28:06.985576+00:00",
+  "timestamp": "2026-05-13T02:42:58+00:00",
   "command": "example",
-  "prompt_hash": "1460cd0a87039a4b2668357db8557bd0d589404f84e88b553af8b696e7327f36",
-  "code_hash": "00cb7d2c24343e7c6fc4316920cfb619a49f1886ec19b61eb1eb70b90c44b6e5",
+  "prompt_hash": "a6fc0ca959a445a446ad7407ef9ec9205566ba1e335cede76544ac18445b7790",
+  "code_hash": "8da0d7f52dae9412a36624a3c2bf25539b17cc48a8561d9b8b767b96076a5051",
   "example_hash": "113b5829cae3a9e38c362b74d5115ba09cab06c7be5831527d9829f97f7b3b7d",
-  "test_hash": "f1b15bf3b511a7ed4e394bf4197578e982d679a11767f5f4b7d3daff5b361df8",
+  "test_hash": "8b03df5f78d11958ceb77a1218619a895a1eb9ec5495f19ef0dced642b7d2a76",
   "test_files": {
-    "test_agentic_common.py": "f1b15bf3b511a7ed4e394bf4197578e982d679a11767f5f4b7d3daff5b361df8",
+    "test_agentic_common.py": "8b03df5f78d11958ceb77a1218619a895a1eb9ec5495f19ef0dced642b7d2a76",
     "test_agentic_common_issue_813_anthropic_api_key_oauth_shadow.py": "1988f9b022bd4071f95aef13ba6a6a6681279711ad6f718744195b8e0b9dac9e",
     "test_agentic_common_worktree.py": "b726b24513865a7e3c23700b192bac001ab09190d7371b6d6714f0cf076c58e2"
   },
@@ -15,6 +15,6 @@
     "context/_keyring_timeout_example.py": "41f83d5ef117caba86b788f69b519f7e88f3d7dc2a641a017d74a7cee9be6ed1",
     "context/api_key_scanner_example.py": "4b9f880a30445f25edffc394857ae0c218097726c41ab996a03fcbc4350b5482",
     "context/python_preamble.prompt": "0388ed131bf986f8752e1bc4c81e4da0460cfe2908ec8c60b1314edbab768254",
-    "pdd/agentic_common.py": "00cb7d2c24343e7c6fc4316920cfb619a49f1886ec19b61eb1eb70b90c44b6e5"
+    "pdd/agentic_common.py": "8da0d7f52dae9412a36624a3c2bf25539b17cc48a8561d9b8b767b96076a5051"
   }
 }

--- a/.pdd/meta/agentic_common_python_run.json
+++ b/.pdd/meta/agentic_common_python_run.json
@@ -1,12 +1,12 @@
 {
-  "timestamp": "2026-05-12T06:00:00+00:00",
+  "timestamp": "2026-05-13T17:57:04.517965+00:00",
   "exit_code": 0,
-  "tests_passed": 384,
+  "tests_passed": 3,
   "tests_failed": 0,
-  "coverage": 90.0,
-  "test_hash": "8b03df5f78d11958ceb77a1218619a895a1eb9ec5495f19ef0dced642b7d2a76",
+  "coverage": 100.0,
+  "test_hash": "446b6703b07764753c25a51b35b320061f1ecb54320509e1f3cf2cc99c61e3c5",
   "test_files": {
-    "test_agentic_common.py": "8b03df5f78d11958ceb77a1218619a895a1eb9ec5495f19ef0dced642b7d2a76",
+    "test_agentic_common.py": "446b6703b07764753c25a51b35b320061f1ecb54320509e1f3cf2cc99c61e3c5",
     "test_agentic_common_issue_813_anthropic_api_key_oauth_shadow.py": "1988f9b022bd4071f95aef13ba6a6a6681279711ad6f718744195b8e0b9dac9e",
     "test_agentic_common_worktree.py": "b726b24513865a7e3c23700b192bac001ab09190d7371b6d6714f0cf076c58e2"
   }

--- a/README.md
+++ b/README.md
@@ -2575,21 +2575,23 @@ pdd [GLOBAL OPTIONS] bug --manual PROMPT_FILE CODE_FILE PROGRAM_FILE CURRENT_OUT
 
 3. **Triage** - Assess if enough information is provided to proceed. If the issue already contains a detailed root cause analysis with file paths, line numbers, and causal explanation, fast-tracks to root cause analysis (skipping API research and reproduction). Posts comment requesting more info if needed.
 
-4. **Reproduce** - Attempt to reproduce the issue locally. Posts comment confirming reproduction (or failure to reproduce). Skipped when Step 3 fast-tracks.
+4. **API research** - Research external APIs, provider behavior, protocol constraints, and dependency contracts that could affect reproduction or the expected fix. Posts comment with relevant constraints. Skipped when Step 3 fast-tracks.
 
-5. **Root cause analysis** - Run experiments to identify the root cause. Assesses whether the fix is localized or cross-cutting. Performs a variable reference audit to find sibling bugs in parallel code paths and a state symmetry check to detect save/restore asymmetries. Posts comment explaining the root cause.
+5. **Reproduce** - Attempt to reproduce the issue locally. Posts comment confirming reproduction (or failure to reproduce). Skipped when Step 3 fast-tracks.
 
-5.5. **Prompt classification** - Determine if the bug is in the code implementation or in the prompt specification itself. If the prompt is defective, auto-fix the prompt file. Posts comment with classification and any prompt changes. Defaults to "code bug" when uncertain.
+6. **Root cause analysis** - Run experiments to identify the root cause. Assesses whether the fix is localized or cross-cutting. Performs a variable reference audit to find sibling bugs in parallel code paths and a state symmetry check to detect save/restore asymmetries. Posts comment explaining the root cause.
 
-6. **Test plan** - Design a plan for creating tests to detect the problem. Enumerates all affected output channels and all distinct code paths (first-run, resume, retry, error recovery) to ensure complete coverage. Prefers appending tests to existing test files over creating new ones. Posts comment with the test plan.
+7. **Prompt classification** - Determine if the bug is in the code implementation or in the prompt specification itself. If the prompt is defective, auto-fix the prompt file. Posts comment with classification and any prompt changes. Defaults to "code bug" when uncertain.
 
-7. **Generate test** - Create the failing unit test. Posts comment with the generated test code.
+8. **Test plan** - Design a plan for creating tests to detect the problem. Enumerates all affected output channels and all distinct code paths (first-run, resume, retry, error recovery) to ensure complete coverage. Prefers appending tests to existing test files over creating new ones. Posts comment with the test plan.
 
-8. **Verify detection** - Confirm the unit test successfully detects the bug. Classifies whether an E2E test is needed (`E2E_NEEDED: yes|no`) based on bug scope. Posts comment confirming verification.
+9. **Generate test** - Create the failing unit test. Posts comment with the generated test code.
 
-9. **E2E test** - Generate and run end-to-end tests to verify the bug at integration level. Skipped deterministically when Step 8 outputs `E2E_NEEDED: no`, avoiding unnecessary LLM calls for purely internal bugs. Posts comment with E2E test results or skip reason.
+10. **Verify detection** - Confirm the unit test successfully detects the bug. Classifies whether an E2E test is needed (`E2E_NEEDED: yes|no`) based on bug scope. Posts comment confirming verification.
 
-10. **Create draft PR** - Create a draft pull request with the failing tests and link it to the issue. Posts comment with PR link.
+11. **E2E test** - Generate and run end-to-end tests to verify the bug at integration level. Skipped deterministically when Step 10 outputs `E2E_NEEDED: no`, avoiding unnecessary LLM calls for purely internal bugs. Posts comment with E2E test results when run; skipped Step 11 is recorded in workflow state without an extra visible comment.
+
+12. **Create draft PR** - Create a draft pull request with the failing tests and link it to the issue. Posts comment with PR link.
 
 Arguments:
 - `ISSUE_URL`: GitHub issue URL (e.g., https://github.com/owner/repo/issues/123)

--- a/architecture.json
+++ b/architecture.json
@@ -71,8 +71,18 @@
           },
           {
             "name": "post_step_comment",
-            "signature": "(repo_owner, repo_name, issue_number, step_num, total_steps, description, output, cwd) -> bool",
+            "signature": "(repo_owner, repo_name, issue_number, step_num, total_steps, description, output, cwd, body=None) -> bool",
             "returns": "bool"
+          },
+          {
+            "name": "_extract_step_report",
+            "signature": "(text: Optional[str]) -> Optional[str]",
+            "returns": "Optional[str]"
+          },
+          {
+            "name": "_sanitize_comment_body",
+            "signature": "(body: Optional[str], max_chars: int = 25000) -> str",
+            "returns": "str"
           },
           {
             "name": "post_pr_comment",

--- a/architecture.json
+++ b/architecture.json
@@ -1470,8 +1470,8 @@
     }
   },
   {
-    "reason": "Orchestrates the 11-step agentic bug workflow with E2E gate and state persistence.",
-    "description": "Coordinates duplicate checking, documentation review, triage, reproduction, root cause analysis, prompt classification, test planning, test generation, verification, E2E testing (gated by E2E_NEEDED classification), and PR creation.",
+    "reason": "Orchestrates the 12-step agentic bug workflow with E2E gate, persistent state, and orchestrator-owned GitHub step comments.",
+    "description": "Coordinates duplicate checking, documentation review, triage, API research, reproduction, root cause analysis, prompt classification, test planning, test generation, verification, E2E testing (gated by E2E_NEEDED classification), and PR creation. Posts per-step progress comments to the issue and persists workflow state for crash-safe resumes.",
     "dependencies": [],
     "priority": 42,
     "filename": "agentic_bug_orchestrator_python.prompt",
@@ -1487,10 +1487,13 @@
         "functions": [
           {
             "name": "run_agentic_bug_orchestrator",
-            "signature": "(issue_url: str, issue_content: str, repo_owner: str, repo_name: str, issue_number: int, issue_author: str, issue_title: str) -> Tuple[bool, str, float, str, List[str]]",
+            "signature": "(issue_url: str, issue_content: str, repo_owner: str, repo_name: str, issue_number: int, issue_author: str, issue_title: str, *, cwd: Path, verbose: bool = False, quiet: bool = False, timeout_adder: float = 0.0, use_github_state: bool = True, reasoning_time: Optional[float] = None) -> Tuple[bool, str, float, str, List[str]]",
             "returns": "Tuple[bool, str, float, str, List[str]]",
             "sideEffects": [
-              "None"
+              "Posts GitHub issue comments via post_step_comment",
+              "Persists workflow state via save_workflow_state (local + optional GitHub state comment)",
+              "Creates/removes git worktrees and branches under .pdd/worktrees/fix-issue-{N}/",
+              "Spawns external agentic CLI subprocesses (claude/gemini/codex/opencode)"
             ]
           }
         ]

--- a/context/agentic_bug_orchestrator_example.py
+++ b/context/agentic_bug_orchestrator_example.py
@@ -1,119 +1,75 @@
+import os
 import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
-import subprocess
-import shutil
 
-# Ensure the project root is in sys.path so we can import the module
-# Adjust this path based on your actual project structure relative to this script
-project_root = Path(__file__).resolve().parent.parent
-sys.path.append(str(project_root))
+# Ensure output directory exists
+output_dir = Path("./output/test_repo")
+output_dir.mkdir(parents=True, exist_ok=True)
 
-try:
-    # Import the module to be tested
-    # Note: We assume the file is at pdd/agentic_bug_orchestrator.py
-    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
-except ImportError:
-    print("Error: Could not import 'pdd.agentic_bug_orchestrator'.")
-    print("Ensure your PYTHONPATH is set correctly or the file structure matches.")
-    sys.exit(1)
-
-
-def mock_load_prompt_template(template_name: str) -> str:
-    """
-    Mock implementation of load_prompt_template.
-    Returns a dummy prompt string based on the requested template name.
-    """
-    return f"MOCK PROMPT FOR: {template_name}\nContext: {{issue_content}}"
-
-
-def mock_run_agentic_task(instruction: str, cwd: Path, verbose: bool, quiet: bool, label: str, **kwargs):
-    """
-    Mock implementation of run_agentic_task.
-    Simulates the output of an LLM agent for each step of the 11-step workflow.
-    """
-    # Convert step label to identifier (step5_5 -> "5_5", step7 -> "7")
-    step_id = label.replace("step", "")
-
-    # Default return values
-    success = True
-    cost = 0.15  # Simulated cost per step
-    provider = "gpt-4-mock"
-    output = ""
-
-    if step_id == "1":
-        output = "No duplicate issues found. Proceeding."
-    elif step_id == "2":
-        output = "Checked documentation. This behavior is not documented, likely a bug."
-    elif step_id == "3":
-        output = "Sufficient information provided in the issue description."
-    elif step_id == "4":
-        output = "Successfully reproduced the ZeroDivisionError with input (10, 0)."
-    elif step_id == "5":
-        output = "Root cause identified: 'divide' function lacks check for denominator == 0."
-    elif step_id == "5_5":
-        output = "DEFECT_TYPE: code\nThis is a code bug - the prompt specifies division by zero should raise ValueError."
-    elif step_id == "6":
-        output = "Plan: Create a test case 'test_divide_zero' asserting ValueError is raised."
-    elif step_id == "7":
-        output = "Generated file 'tests/test_calculator_bug.py'.\nFILES_CREATED: tests/test_calculator_bug.py"
-    elif step_id == "8":
-        output = "Verification successful: The new test fails as expected against current code."
-    elif step_id == "9":
-        output = "E2E test created and verified.\nE2E_FILES_CREATED: tests/e2e/test_calculator_e2e.py"
-    elif step_id == "10":
-        output = "Created draft PR #101 linking to issue #42."
-    else:
-        output = "Unknown step executed."
-
-    return success, output, cost, provider
-
+# Import the target function from the module
+from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
 
 def main():
-    """Main function to run the agentic bug orchestrator simulation."""
-    # Define dummy issue data
-    issue_data = {
-        "issue_url": "https://github.com/example/calculator/issues/42",
-        "issue_content": "When I divide by zero, the app crashes instead of raising a clean error.",
-        "repo_owner": "example",
-        "repo_name": "calculator",
-        "issue_number": 42,
-        "issue_author": "bug_hunter_99",
-        "issue_title": "Crash on division by zero",
-        "cwd": Path("./temp_workspace"),
-        "verbose": True,
-        "quiet": False
-    }
+    """
+    Example showing how to use `run_agentic_bug_orchestrator`.
+    
+    This function orchestrates a 12-step agentic bug investigation workflow.
+    It relies on a Git repository and LLM providers. In this example, we mock
+    the LLM tasks and state/git helpers so it can run standalone without API keys.
+    """
+    print("Starting mock run of run_agentic_bug_orchestrator...")
+    
+    # Dummy issue details
+    issue_url = "https://github.com/example/repo/issues/123"
+    issue_content = "Bug: The calculator adds numbers incorrectly when using floats."
+    repo_owner = "example"
+    repo_name = "repo"
+    issue_number = 123
+    issue_author = "user1"
+    issue_title = "Float addition bug"
+    cwd = output_dir.resolve()
 
-    # Fix: Create the temp_workspace directory and initialize a git repo to avoid FileNotFoundError and downstream git failures
-    temp_dir = issue_data["cwd"]
-    if temp_dir.exists():
-        shutil.rmtree(temp_dir)
-    temp_dir.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=temp_dir, capture_output=True)
-    subprocess.run(["git", "commit", "--allow-empty", "-m", "Initial commit"], cwd=temp_dir, capture_output=True)
+    # We mock out LLM tasks and Git/GitHub interactions to allow the orchestrator 
+    # to run fully through its steps in this non-interactive example.
+    with patch("pdd.agentic_bug_orchestrator.run_agentic_task") as mock_run_task, \
+         patch("pdd.agentic_bug_orchestrator.load_workflow_state") as mock_load_state, \
+         patch("pdd.agentic_bug_orchestrator.save_workflow_state") as mock_save_state, \
+         patch("pdd.agentic_bug_orchestrator._setup_worktree") as mock_setup_worktree, \
+         patch("pdd.agentic_bug_orchestrator._maybe_post_step_comment") as mock_post_comment:
+         
+        # Mock LLM calls to always return success with some dummy output
+        mock_run_task.return_value = (True, "Mocked task output", 0.05, "mock_model")
+        
+        # Mock state to start fresh
+        mock_load_state.return_value = (None, None)
+        mock_save_state.return_value = "mock_comment_id"
+        mock_post_comment.return_value = "mock_comment_id"
+        
+        # Mock git worktree creation to just use the current directory
+        mock_setup_worktree.return_value = (cwd, None)
 
-    print("Starting Agentic Bug Orchestrator Simulation...")
-    print("-" * 60)
-
-    # Patch the internal dependencies
-    # We patch where they are imported IN the orchestrator module, not where they are defined
-    with patch("pdd.agentic_bug_orchestrator.load_prompt_template", side_effect=mock_load_prompt_template), \
-         patch("pdd.agentic_bug_orchestrator.run_agentic_task", side_effect=mock_run_agentic_task):
-
-        # Run the orchestrator
-        success, final_msg, total_cost, model, changed_files = run_agentic_bug_orchestrator(
-            **issue_data
+        # Execute the orchestrator
+        success, final_message, total_cost, model_used, changed_files = run_agentic_bug_orchestrator(
+            issue_url=issue_url,
+            issue_content=issue_content,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            issue_number=issue_number,
+            issue_author=issue_author,
+            issue_title=issue_title,
+            cwd=cwd,
+            verbose=False,
+            quiet=True,         # Set to True to reduce console spam
+            use_github_state=False # Don't try to fetch remote GH state
         )
 
-    print("-" * 60)
-    print("Simulation Complete.")
-    print(f"Success: {success}")
-    print(f"Final Message: {final_msg}")
-    print(f"Total Cost: ${total_cost:.2f}")
-    print(f"Model Used: {model}")
-    print(f"Changed Files: {changed_files}")
-
+    print("\n--- Investigation Results ---")
+    print(f"Success        : {success}")
+    print(f"Total Cost     : ${total_cost:.4f}")
+    print(f"Model Used     : {model_used}")
+    print(f"Changed Files  : {changed_files}")
+    print(f"Final Message  : {final_message}")
 
 if __name__ == "__main__":
     main()

--- a/context/agentic_bug_orchestrator_example.py
+++ b/context/agentic_bug_orchestrator_example.py
@@ -1,75 +1,132 @@
-import os
 import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+import subprocess
+import shutil
 
-# Ensure output directory exists
-output_dir = Path("./output/test_repo")
-output_dir.mkdir(parents=True, exist_ok=True)
+# Ensure the project root is in sys.path so we can import the module
+# Adjust this path based on your actual project structure relative to this script
+project_root = Path(__file__).resolve().parent.parent
+sys.path.append(str(project_root))
 
-# Import the target function from the module
-from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+try:
+    # Import the module to be tested
+    # Note: We assume the file is at pdd/agentic_bug_orchestrator.py
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+except ImportError:
+    print("Error: Could not import 'pdd.agentic_bug_orchestrator'.")
+    print("Ensure your PYTHONPATH is set correctly or the file structure matches.")
+    sys.exit(1)
+
+
+def mock_load_prompt_template(template_name: str) -> str:
+    """
+    Mock implementation of load_prompt_template.
+    Returns a dummy prompt string based on the requested template name.
+    """
+    return f"MOCK PROMPT FOR: {template_name}\nContext: {{issue_content}}"
+
+
+def mock_run_agentic_task(instruction: str, cwd: Path, verbose: bool, quiet: bool, label: str, **kwargs):
+    """
+    Mock implementation of run_agentic_task.
+    Simulates the output of an LLM agent for each step of the workflow.
+
+    Each step output wraps its visible findings in a
+    `<step_report>...</step_report>` block. The orchestrator extracts that
+    block and posts it via `post_step_comment(body=...)` using trusted
+    credentials (issue #964). Markers like FILES_CREATED stay outside the
+    `<step_report>` block so the orchestrator's downstream parsing still sees
+    them.
+    """
+    step_id = label.replace("step", "")
+
+    success = True
+    cost = 0.15
+    provider = "gpt-4-mock"
+    body = ""
+    trailer = ""
+
+    if step_id == "1":
+        body = "## Step 1: Duplicate Check\n\nNo duplicate issues found. Proceeding."
+    elif step_id == "2":
+        body = "## Step 2: Docs Check\n\nThis behavior is not documented, likely a bug."
+    elif step_id == "3":
+        body = "## Step 3: Triage\n\nSufficient information provided in the issue description."
+    elif step_id == "4":
+        body = "## Step 4: Reproduce\n\nReproduced ZeroDivisionError with input (10, 0)."
+    elif step_id == "5":
+        body = "## Step 5: Root Cause\n\n'divide' function lacks check for denominator == 0."
+    elif step_id == "5_5":
+        body = "## Step 5.5: Prompt Classification\n\nDEFECT_TYPE: code — code bug, not prompt defect."
+    elif step_id == "6":
+        body = "## Step 6: Test Plan\n\nCreate `test_divide_zero` asserting ValueError is raised."
+    elif step_id == "7":
+        body = "## Step 7: Generate\n\nGenerated tests/test_calculator_bug.py."
+        trailer = "\nFILES_CREATED: tests/test_calculator_bug.py"
+    elif step_id == "8":
+        body = "## Step 8: Verify\n\nNew test fails as expected against current code."
+    elif step_id == "9":
+        body = "## Step 9: E2E\n\nE2E test created and verified."
+        trailer = "\nE2E_FILES_CREATED: tests/e2e/test_calculator_e2e.py"
+    elif step_id == "10":
+        body = "## Step 10: PR\n\nCreated draft PR #101 linking to issue #42."
+    else:
+        body = f"## {label}\n\nUnknown step executed."
+
+    output = f"<step_report>{body}</step_report>{trailer}"
+    return success, output, cost, provider
+
 
 def main():
-    """
-    Example showing how to use `run_agentic_bug_orchestrator`.
-    
-    This function orchestrates a 12-step agentic bug investigation workflow.
-    It relies on a Git repository and LLM providers. In this example, we mock
-    the LLM tasks and state/git helpers so it can run standalone without API keys.
-    """
-    print("Starting mock run of run_agentic_bug_orchestrator...")
-    
-    # Dummy issue details
-    issue_url = "https://github.com/example/repo/issues/123"
-    issue_content = "Bug: The calculator adds numbers incorrectly when using floats."
-    repo_owner = "example"
-    repo_name = "repo"
-    issue_number = 123
-    issue_author = "user1"
-    issue_title = "Float addition bug"
-    cwd = output_dir.resolve()
+    """Main function to run the agentic bug orchestrator simulation."""
+    # Define dummy issue data
+    issue_data = {
+        "issue_url": "https://github.com/example/calculator/issues/42",
+        "issue_content": "When I divide by zero, the app crashes instead of raising a clean error.",
+        "repo_owner": "example",
+        "repo_name": "calculator",
+        "issue_number": 42,
+        "issue_author": "bug_hunter_99",
+        "issue_title": "Crash on division by zero",
+        "cwd": Path("./temp_workspace"),
+        "verbose": True,
+        "quiet": False
+    }
 
-    # We mock out LLM tasks and Git/GitHub interactions to allow the orchestrator 
-    # to run fully through its steps in this non-interactive example.
-    with patch("pdd.agentic_bug_orchestrator.run_agentic_task") as mock_run_task, \
-         patch("pdd.agentic_bug_orchestrator.load_workflow_state") as mock_load_state, \
-         patch("pdd.agentic_bug_orchestrator.save_workflow_state") as mock_save_state, \
-         patch("pdd.agentic_bug_orchestrator._setup_worktree") as mock_setup_worktree, \
-         patch("pdd.agentic_bug_orchestrator._maybe_post_step_comment") as mock_post_comment:
-         
-        # Mock LLM calls to always return success with some dummy output
-        mock_run_task.return_value = (True, "Mocked task output", 0.05, "mock_model")
-        
-        # Mock state to start fresh
-        mock_load_state.return_value = (None, None)
-        mock_save_state.return_value = "mock_comment_id"
-        mock_post_comment.return_value = "mock_comment_id"
-        
-        # Mock git worktree creation to just use the current directory
-        mock_setup_worktree.return_value = (cwd, None)
+    # Fix: Create the temp_workspace directory and initialize a git repo to avoid FileNotFoundError and downstream git failures
+    temp_dir = issue_data["cwd"]
+    if temp_dir.exists():
+        shutil.rmtree(temp_dir)
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=temp_dir, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "Initial commit"], cwd=temp_dir, capture_output=True)
 
-        # Execute the orchestrator
-        success, final_message, total_cost, model_used, changed_files = run_agentic_bug_orchestrator(
-            issue_url=issue_url,
-            issue_content=issue_content,
-            repo_owner=repo_owner,
-            repo_name=repo_name,
-            issue_number=issue_number,
-            issue_author=issue_author,
-            issue_title=issue_title,
-            cwd=cwd,
-            verbose=False,
-            quiet=True,         # Set to True to reduce console spam
-            use_github_state=False # Don't try to fetch remote GH state
+    print("Starting Agentic Bug Orchestrator Simulation...")
+    print("-" * 60)
+
+    # Patch the internal dependencies
+    # We patch where they are imported IN the orchestrator module, not where they are defined.
+    # `post_step_comment` is patched so the example stays side-effect-free —
+    # without this the orchestrator would shell out to `gh issue comment`
+    # against the real GitHub API on each successful step (issue #964).
+    with patch("pdd.agentic_bug_orchestrator.load_prompt_template", side_effect=mock_load_prompt_template), \
+         patch("pdd.agentic_bug_orchestrator.run_agentic_task", side_effect=mock_run_agentic_task), \
+         patch("pdd.agentic_bug_orchestrator.post_step_comment", return_value=True):
+
+        # Run the orchestrator
+        success, final_msg, total_cost, model, changed_files = run_agentic_bug_orchestrator(
+            **issue_data
         )
 
-    print("\n--- Investigation Results ---")
-    print(f"Success        : {success}")
-    print(f"Total Cost     : ${total_cost:.4f}")
-    print(f"Model Used     : {model_used}")
-    print(f"Changed Files  : {changed_files}")
-    print(f"Final Message  : {final_message}")
+    print("-" * 60)
+    print("Simulation Complete.")
+    print(f"Success: {success}")
+    print(f"Final Message: {final_msg}")
+    print(f"Total Cost: ${total_cost:.2f}")
+    print(f"Model Used: {model}")
+    print(f"Changed Files: {changed_files}")
+
 
 if __name__ == "__main__":
     main()

--- a/context/agentic_bug_orchestrator_example.py
+++ b/context/agentic_bug_orchestrator_example.py
@@ -1,126 +1,146 @@
+"""Runnable example for the agentic bug orchestrator (issue #964).
+
+Mirrors the pattern used by `context/agentic_common_example.py`:
+    * Insert the repo root at the FRONT of `sys.path` so the local worktree
+      shadows any installed `pdd` package (the installed package may pre-date
+      the PR symbols this example patches).
+    * Mock every external side effect — worktree creation, state load/save,
+      preprocess, subprocess (git/gh), `post_step_comment`, and the per-step
+      LLM call — so the example can run hermetically with no network, no
+      GitHub, and no git operations on a real working tree.
+    * Use the current 12-step flow labels (`step1` .. `step12`) and emit a
+      `<step_report>` block on every step so the orchestrator's
+      `_maybe_post_step_comment` extracts a body to post via the (mocked)
+      trusted-credentials helper.
+"""
+
+from __future__ import annotations
+
+import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
-import subprocess
-import shutil
+from unittest.mock import patch
 
-# Ensure the project root is in sys.path so we can import the module
-# Adjust this path based on your actual project structure relative to this script
-project_root = Path(__file__).resolve().parent.parent
-sys.path.append(str(project_root))
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 try:
-    # Import the module to be tested
-    # Note: We assume the file is at pdd/agentic_bug_orchestrator.py
     from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
-except ImportError:
-    print("Error: Could not import 'pdd.agentic_bug_orchestrator'.")
-    print("Ensure your PYTHONPATH is set correctly or the file structure matches.")
+except ImportError as exc:  # pragma: no cover - guidance only
+    print(f"Error: Could not import 'pdd.agentic_bug_orchestrator': {exc}")
+    print("Run this example from the repository root with PDD installed in editable mode.")
     sys.exit(1)
 
 
+_STEP_BODIES = {
+    1: "Step 1: Duplicate Check — no duplicate issues found.",
+    2: "Step 2: Docs Check — behavior is not documented; treat as bug.",
+    3: "Step 3: Triage — sufficient info to proceed.",
+    4: "Step 4: API Research — no external API constraints.",
+    5: "Step 5: Reproduce — ZeroDivisionError reproduced with input (10, 0).",
+    6: "Step 6: Root Cause — `divide` lacks denominator==0 guard.",
+    7: "Step 7: Prompt Classification — DEFECT_TYPE: code (code bug, not prompt defect).",
+    8: "Step 8: Test Plan — add `test_divide_zero` asserting ValueError.",
+    9: "Step 9: Generate — created tests/test_calculator_bug.py.",
+    10: "Step 10: Verify — new test fails against current code as expected.",
+    11: "Step 11: E2E — created tests/e2e/test_calculator_e2e.py.",
+    12: "Step 12: PR — opened draft PR #101 linked to issue #42.",
+}
+
+_STEP_TRAILERS = {
+    9: "\nFILES_CREATED: tests/test_calculator_bug.py",
+    11: "\nE2E_FILES_CREATED: tests/e2e/test_calculator_e2e.py",
+}
+
+
 def mock_load_prompt_template(template_name: str) -> str:
-    """
-    Mock implementation of load_prompt_template.
-    Returns a dummy prompt string based on the requested template name.
-    """
     return f"MOCK PROMPT FOR: {template_name}\nContext: {{issue_content}}"
 
 
-def mock_run_agentic_task(instruction: str, cwd: Path, verbose: bool, quiet: bool, label: str, **kwargs):
+def mock_preprocess(prompt_text: str, *args, **kwargs) -> str:
+    return prompt_text
+
+
+def mock_run_agentic_task(*args, **kwargs):
+    """Simulate one step of the orchestrator's LLM call.
+
+    The orchestrator wraps the visible body in `<step_report>...</step_report>`;
+    markers like `FILES_CREATED` stay outside that block so the orchestrator's
+    downstream parsing still sees them.
     """
-    Mock implementation of run_agentic_task.
-    Simulates the output of an LLM agent for each step of the workflow.
-
-    Each step output wraps its visible findings in a
-    `<step_report>...</step_report>` block. The orchestrator extracts that
-    block and posts it via `post_step_comment(body=...)` using trusted
-    credentials (issue #964). Markers like FILES_CREATED stay outside the
-    `<step_report>` block so the orchestrator's downstream parsing still sees
-    them.
-    """
-    step_id = label.replace("step", "")
-
-    success = True
-    cost = 0.15
-    provider = "gpt-4-mock"
-    body = ""
-    trailer = ""
-
-    if step_id == "1":
-        body = "## Step 1: Duplicate Check\n\nNo duplicate issues found. Proceeding."
-    elif step_id == "2":
-        body = "## Step 2: Docs Check\n\nThis behavior is not documented, likely a bug."
-    elif step_id == "3":
-        body = "## Step 3: Triage\n\nSufficient information provided in the issue description."
-    elif step_id == "4":
-        body = "## Step 4: Reproduce\n\nReproduced ZeroDivisionError with input (10, 0)."
-    elif step_id == "5":
-        body = "## Step 5: Root Cause\n\n'divide' function lacks check for denominator == 0."
-    elif step_id == "5_5":
-        body = "## Step 5.5: Prompt Classification\n\nDEFECT_TYPE: code — code bug, not prompt defect."
-    elif step_id == "6":
-        body = "## Step 6: Test Plan\n\nCreate `test_divide_zero` asserting ValueError is raised."
-    elif step_id == "7":
-        body = "## Step 7: Generate\n\nGenerated tests/test_calculator_bug.py."
-        trailer = "\nFILES_CREATED: tests/test_calculator_bug.py"
-    elif step_id == "8":
-        body = "## Step 8: Verify\n\nNew test fails as expected against current code."
-    elif step_id == "9":
-        body = "## Step 9: E2E\n\nE2E test created and verified."
-        trailer = "\nE2E_FILES_CREATED: tests/e2e/test_calculator_e2e.py"
-    elif step_id == "10":
-        body = "## Step 10: PR\n\nCreated draft PR #101 linking to issue #42."
-    else:
-        body = f"## {label}\n\nUnknown step executed."
-
+    label = kwargs.get("label", "")
+    try:
+        step_num = int(label.replace("step", ""))
+    except ValueError:
+        step_num = 0
+    body = _STEP_BODIES.get(step_num, f"{label}: mock body")
+    trailer = _STEP_TRAILERS.get(step_num, "")
     output = f"<step_report>{body}</step_report>{trailer}"
-    return success, output, cost, provider
+    return True, output, 0.05, "gpt-4-mock"
 
 
-def main():
-    """Main function to run the agentic bug orchestrator simulation."""
-    # Define dummy issue data
-    issue_data = {
-        "issue_url": "https://github.com/example/calculator/issues/42",
-        "issue_content": "When I divide by zero, the app crashes instead of raising a clean error.",
-        "repo_owner": "example",
-        "repo_name": "calculator",
-        "issue_number": 42,
-        "issue_author": "bug_hunter_99",
-        "issue_title": "Crash on division by zero",
-        "cwd": Path("./temp_workspace"),
-        "verbose": True,
-        "quiet": False
-    }
+def mock_subprocess_run(*args, **kwargs):
+    """Stub out all `git`/`gh`/`pytest` calls inside the orchestrator."""
+    return subprocess.CompletedProcess(
+        args=args[0] if args else [],
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
 
-    # Fix: Create the temp_workspace directory and initialize a git repo to avoid FileNotFoundError and downstream git failures
-    temp_dir = issue_data["cwd"]
-    if temp_dir.exists():
-        shutil.rmtree(temp_dir)
-    temp_dir.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=temp_dir, capture_output=True)
-    subprocess.run(["git", "commit", "--allow-empty", "-m", "Initial commit"], cwd=temp_dir, capture_output=True)
 
-    print("Starting Agentic Bug Orchestrator Simulation...")
+def main() -> None:
+    cwd = Path("/tmp/agentic_bug_orchestrator_example_cwd")
+    worktree = Path("/tmp/agentic_bug_orchestrator_example_worktree")
+
+    issue = dict(
+        issue_url="https://github.com/example/calculator/issues/42",
+        issue_content="Dividing by zero crashes instead of raising a clean error.",
+        repo_owner="example",
+        repo_name="calculator",
+        issue_number=42,
+        issue_author="bug_hunter_99",
+        issue_title="Crash on division by zero",
+        cwd=cwd,
+        verbose=False,
+        quiet=True,
+    )
+
+    print("Starting Agentic Bug Orchestrator simulation (fully mocked)…")
     print("-" * 60)
 
-    # Patch the internal dependencies
-    # We patch where they are imported IN the orchestrator module, not where they are defined.
-    # `post_step_comment` is patched so the example stays side-effect-free —
-    # without this the orchestrator would shell out to `gh issue comment`
-    # against the real GitHub API on each successful step (issue #964).
-    with patch("pdd.agentic_bug_orchestrator.load_prompt_template", side_effect=mock_load_prompt_template), \
-         patch("pdd.agentic_bug_orchestrator.run_agentic_task", side_effect=mock_run_agentic_task), \
-         patch("pdd.agentic_bug_orchestrator.post_step_comment", return_value=True):
+    # All side-effecting helpers the orchestrator calls in
+    # `pdd.agentic_bug_orchestrator` are patched at the import site (where the
+    # names are bound inside the module). `subprocess.run` is patched at the
+    # module level too so the orchestrator's many internal git/gh calls become
+    # no-ops.
+    patches = [
+        patch("pdd.agentic_bug_orchestrator.load_prompt_template", side_effect=mock_load_prompt_template),
+        patch("pdd.agentic_bug_orchestrator.preprocess", side_effect=mock_preprocess),
+        patch("pdd.agentic_bug_orchestrator.run_agentic_task", side_effect=mock_run_agentic_task),
+        patch("pdd.agentic_bug_orchestrator.post_step_comment", return_value=True),
+        patch("pdd.agentic_bug_orchestrator.load_workflow_state", return_value=(None, None)),
+        patch("pdd.agentic_bug_orchestrator.save_workflow_state", return_value=None),
+        patch("pdd.agentic_bug_orchestrator.clear_workflow_state", return_value=None),
+        patch("pdd.agentic_bug_orchestrator._setup_worktree", return_value=(worktree, None)),
+        patch("pdd.agentic_bug_orchestrator.clear_agentic_progress", return_value=None),
+        patch("pdd.agentic_bug_orchestrator.set_agentic_progress", return_value=None),
+        patch("pdd.agentic_bug_orchestrator.subprocess.run", side_effect=mock_subprocess_run),
+    ]
 
-        # Run the orchestrator
-        success, final_msg, total_cost, model, changed_files = run_agentic_bug_orchestrator(
-            **issue_data
-        )
+    try:
+        for p in patches:
+            p.start()
+        result = run_agentic_bug_orchestrator(**issue)
+    finally:
+        for p in patches:
+            p.stop()
+
+    success, final_msg, total_cost, model, changed_files = result
 
     print("-" * 60)
-    print("Simulation Complete.")
+    print("Simulation complete.")
     print(f"Success: {success}")
     print(f"Final Message: {final_msg}")
     print(f"Total Cost: ${total_cost:.2f}")

--- a/context/agentic_bug_orchestrator_example.py
+++ b/context/agentic_bug_orchestrator_example.py
@@ -49,8 +49,16 @@ _STEP_BODIES = {
 }
 
 _STEP_TRAILERS = {
+    5: "\nREPRO_FILES_CREATED: tests/test_calculator_repro.py",
+    6: (
+        "\nFIX_LOCATIONS: pdd/calculator.py"
+        "\nEXPANSION_ITEMS: none"
+    ),
+    7: "\nDEFECT_TYPE: code",
+    8: "\nPLANNED_TEST_COUNT: 1",
     9: "\nFILES_CREATED: tests/test_calculator_bug.py",
-    11: "\nE2E_FILES_CREATED: tests/e2e/test_calculator_e2e.py",
+    10: "\nE2E_NEEDED: no",
+    11: "\nE2E_SKIP: not required (E2E_NEEDED: no)",
 }
 
 
@@ -126,6 +134,13 @@ def main() -> None:
         patch("pdd.agentic_bug_orchestrator._setup_worktree", return_value=(worktree, None)),
         patch("pdd.agentic_bug_orchestrator.clear_agentic_progress", return_value=None),
         patch("pdd.agentic_bug_orchestrator.set_agentic_progress", return_value=None),
+        # `_verify_e2e_tests` ultimately invokes pytest on real files in the
+        # worktree. Replace it with a no-op success so the hermetic example
+        # does not error on missing test files for steps 9/11.
+        patch(
+            "pdd.agentic_bug_orchestrator._verify_e2e_tests",
+            return_value=(True, "mocked: all tests passed"),
+        ),
         patch("pdd.agentic_bug_orchestrator.subprocess.run", side_effect=mock_subprocess_run),
     ]
 

--- a/context/agentic_bug_orchestrator_example.py
+++ b/context/agentic_bug_orchestrator_example.py
@@ -57,8 +57,8 @@ _STEP_TRAILERS = {
     7: "\nDEFECT_TYPE: code",
     8: "\nPLANNED_TEST_COUNT: 1",
     9: "\nFILES_CREATED: tests/test_calculator_bug.py",
-    10: "\nE2E_NEEDED: no",
-    11: "\nE2E_SKIP: not required (E2E_NEEDED: no)",
+    10: "\nE2E_NEEDED: yes - integration path should be covered",
+    11: "\nE2E_FILES_CREATED: tests/e2e/test_calculator_e2e.py",
 }
 
 

--- a/context/agentic_common_example.py
+++ b/context/agentic_common_example.py
@@ -1,185 +1,121 @@
-from __future__ import annotations
-
-import json
 import os
-import subprocess
 import sys
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from unittest.mock import patch
-
-from rich.console import Console
-
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
 
 from pdd.agentic_common import (
-    get_agent_provider_preference,
-    github_load_state,
-    github_save_state,
-    post_pr_comment,
-    post_step_comment,
+    get_available_agents,
     run_agentic_task,
-    validate_cached_state,
+    detect_control_token,
+    save_workflow_state,
+    load_workflow_state,
+    clear_workflow_state
 )
 
-console = Console()
-
-
-def example_provider_preference() -> None:
-    """Show the default provider order and an env override."""
-    console.print("[bold blue]Provider Preference[/bold blue]")
-    console.print(f"Default: {get_agent_provider_preference()}")
-
-    with patch.dict(os.environ, {"PDD_AGENTIC_PROVIDER": "google,anthropic"}, clear=False):
-        console.print(f"Override: {get_agent_provider_preference()}")
-
-
-def example_run_agentic_task(cwd: Path) -> None:
-    """Run a fully mocked agentic task through the public entry point."""
-    console.print("\n[bold blue]run_agentic_task()[/bold blue]")
-    mocked_json = {
-        "response": "Applied the fix, ran verification, and everything passed.",
-        "total_cost_usd": 0.12,
-    }
-
-    with patch("pdd.agentic_common._find_cli_binary", return_value="/usr/local/bin/claude"), \
-         patch("pdd.agentic_common._subprocess_run") as mock_run:
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=["claude"],
-            returncode=0,
-            stdout=json.dumps(mocked_json),
-            stderr="",
-        )
-        success, output, cost, provider = run_agentic_task(
-            "Fix the failing workflow.",
-            cwd,
-            verbose=False,
-            max_retries=1,
-        )
-
-    console.print(f"Success: {success}")
-    console.print(f"Provider: {provider}")
-    console.print(f"Cost: ${cost:.2f}")
-    console.print(f"Output: {output}")
-
-
-def example_validate_cached_state() -> None:
-    """Demonstrate cache correction when a stored step failed."""
-    console.print("\n[bold blue]validate_cached_state()[/bold blue]")
-    corrected = validate_cached_state(
-        last_completed_step=4,
-        step_outputs={
-            "1": "Collected context",
-            "2": "Generated fix",
-            "3": "FAILED: verification failed",
-            "4": "Should not be trusted",
-        },
-        step_order=[1, 2, 3, 4],
+def main():
+    """
+    Example demonstrating how to use the agentic_common utilities.
+    
+    This includes:
+    1. Discovering available agent providers
+    2. Running an agentic task via the orchestrator
+    3. Detecting control tokens in text outputs
+    4. Saving, loading, and clearing local workflow state
+    """
+    # Setup an output directory for operations
+    output_dir = Path("./output")
+    output_dir.mkdir(exist_ok=True, parents=True)
+    
+    # 1. Discover available agent providers (checks CLIs and credentials)
+    print("--- Agent Discovery ---")
+    agents = get_available_agents()
+    print(f"Available agents: {agents}")
+    
+    if not agents:
+        print("\nNo agent providers available (API keys or CLIs missing).")
+        print("Set ANTHROPIC_API_KEY, GEMINI_API_KEY, or OPENAI_API_KEY to test task execution.")
+        sys.exit(0)
+        
+    # 2. Run a simple agentic task
+    print("\n--- Agentic Task Execution ---")
+    instruction = "Write a one-line python script that prints 'Hello World'"
+    print(f"Instruction: {instruction}")
+    
+    # We use quiet=True to avoid excessive console output in this example
+    success, output, cost, provider = run_agentic_task(
+        instruction=instruction,
+        cwd=output_dir,
+        label="example_hello_world",
+        verbose=False,
         quiet=True,
+        timeout=30.0,
+        max_retries=1
     )
-    console.print(f"Corrected last completed step: {corrected}")
-
-
-def example_post_step_comment(cwd: Path) -> None:
-    """Show the issue comment helper with a mocked gh CLI."""
-    console.print("\n[bold blue]post_step_comment()[/bold blue]")
-    with patch("pdd.agentic_common.shutil.which", return_value="/usr/bin/gh"), \
-         patch("pdd.agentic_common.subprocess.run") as mock_run:
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=["gh"],
-            returncode=0,
-            stdout="",
-            stderr="",
-        )
-        posted = post_step_comment(
-            repo_owner="example-owner",
-            repo_name="example-repo",
-            issue_number=822,
-            step_num=3,
-            total_steps=5,
-            description="Verify generated fix",
-            output="pytest failed with one assertion error",
-            cwd=cwd,
-        )
-    console.print(f"Issue comment posted: {posted}")
-
-
-def _example_post_pr_comment(cwd: Path) -> None:
-    """Show the PR comment helper used by CI validation."""
-    console.print("\n[bold blue]post_pr_comment()[/bold blue]")
-    with patch("pdd.agentic_common.shutil.which", return_value="/usr/bin/gh"), \
-         patch("pdd.agentic_common.subprocess.run") as mock_run:
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=["gh"],
-            returncode=0,
-            stdout="",
-            stderr="",
-        )
-        posted = post_pr_comment(
-            repo_owner="example-owner",
-            repo_name="example-repo",
-            pr_number=42,
-            body="CI validation exhausted retries; lint is still failing.",
-            cwd=cwd,
-        )
-    console.print(f"PR comment posted: {posted}")
-
-
-def example_post_pr_comment():
-    """Compatibility wrapper retained for prompt-level example assertions."""
-    _example_post_pr_comment(Path.cwd())
-
-
-def example_github_state_helpers(cwd: Path) -> None:
-    """Show state save/load helpers without talking to GitHub."""
-    console.print("\n[bold blue]GitHub State Helpers[/bold blue]")
-
-    def mock_gh_api(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        cmd = args[0]
-        if isinstance(cmd, list) and "POST" in cmd:
-            return subprocess.CompletedProcess(cmd, 0, json.dumps({"id": 321}), "")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
-
-    with patch("pdd.agentic_common.shutil.which", return_value="/usr/bin/gh"), \
-         patch("pdd.agentic_common.subprocess.run", side_effect=mock_gh_api), \
-         patch(
-             "pdd.agentic_common._find_state_comment",
-             return_value=(321, {"last_completed_step": 2, "step_outputs": {"1": "ok", "2": "ok"}}),
-         ):
-        comment_id = github_save_state(
-            repo_owner="example-owner",
-            repo_name="example-repo",
-            issue_number=822,
-            workflow_type="agentic_sync",
-            state={"last_completed_step": 2, "step_outputs": {"1": "ok", "2": "ok"}},
-            cwd=cwd,
-        )
-        loaded_state, loaded_comment_id = github_load_state(
-            repo_owner="example-owner",
-            repo_name="example-repo",
-            issue_number=822,
-            workflow_type="agentic_sync",
-            cwd=cwd,
-        )
-
-    console.print(f"Saved comment id: {comment_id}")
-    console.print(f"Loaded state: {loaded_state}")
-    console.print(f"Loaded comment id: {loaded_comment_id}")
-
-
-def main() -> None:
-    """Run the example in a temporary working directory."""
-    with TemporaryDirectory() as temp_dir:
-        cwd = Path(temp_dir)
-        example_provider_preference()
-        example_run_agentic_task(cwd)
-        example_validate_cached_state()
-        example_post_step_comment(cwd)
-        _example_post_pr_comment(cwd)
-        example_github_state_helpers(cwd)
-
+    
+    print(f"Task success: {success}")
+    print(f"Provider used: {provider}")
+    print(f"Cost: ${cost:.6f}")
+    print(f"Output preview: {output[:150]}...\n")
+    
+    # 3. Detect control tokens in LLM output
+    # This is used to understand status changes triggered by an LLM response.
+    print("--- Control Token Detection ---")
+    dummy_output = "The issue has been resolved. ALL_TESTS_PASS"
+    print(f"Scanning output: {dummy_output}")
+    
+    match = detect_control_token(dummy_output, "ALL_TESTS_PASS")
+    if match:
+        print(f"Token 'ALL_TESTS_PASS' found via {match.tier} match.\n")
+        
+    # 4. State management (Local state serialization)
+    print("--- State Management ---")
+    state_dir = output_dir / ".state"
+    issue_number = 9999
+    workflow = "example"
+    repo_owner = "dummy-owner"
+    repo_name = "dummy-repo"
+    
+    dummy_state = {
+        "step": 1,
+        "status": "in_progress",
+        "info": "Starting tests"
+    }
+    
+    # Save the state locally (disabling GitHub sync for the example)
+    print(f"Saving workflow state locally for issue {issue_number}...")
+    save_workflow_state(
+        cwd=output_dir,
+        issue_number=issue_number,
+        workflow_type=workflow,
+        state=dummy_state,
+        state_dir=state_dir,
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        use_github_state=False
+    )
+    
+    # Load the state back
+    loaded_state, gh_id = load_workflow_state(
+        cwd=output_dir,
+        issue_number=issue_number,
+        workflow_type=workflow,
+        state_dir=state_dir,
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        use_github_state=False
+    )
+    print(f"Loaded state: {loaded_state}")
+    
+    # Clean up state
+    clear_workflow_state(
+        cwd=output_dir,
+        issue_number=issue_number,
+        workflow_type=workflow,
+        state_dir=state_dir,
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        use_github_state=False
+    )
+    print("Workflow state cleared.")
 
 if __name__ == "__main__":
     main()

--- a/context/agentic_common_example.py
+++ b/context/agentic_common_example.py
@@ -1,121 +1,185 @@
+from __future__ import annotations
+
+import json
 import os
+import subprocess
 import sys
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from rich.console import Console
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from pdd.agentic_common import (
-    get_available_agents,
+    get_agent_provider_preference,
+    github_load_state,
+    github_save_state,
+    post_pr_comment,
+    post_step_comment,
     run_agentic_task,
-    detect_control_token,
-    save_workflow_state,
-    load_workflow_state,
-    clear_workflow_state
+    validate_cached_state,
 )
 
-def main():
-    """
-    Example demonstrating how to use the agentic_common utilities.
-    
-    This includes:
-    1. Discovering available agent providers
-    2. Running an agentic task via the orchestrator
-    3. Detecting control tokens in text outputs
-    4. Saving, loading, and clearing local workflow state
-    """
-    # Setup an output directory for operations
-    output_dir = Path("./output")
-    output_dir.mkdir(exist_ok=True, parents=True)
-    
-    # 1. Discover available agent providers (checks CLIs and credentials)
-    print("--- Agent Discovery ---")
-    agents = get_available_agents()
-    print(f"Available agents: {agents}")
-    
-    if not agents:
-        print("\nNo agent providers available (API keys or CLIs missing).")
-        print("Set ANTHROPIC_API_KEY, GEMINI_API_KEY, or OPENAI_API_KEY to test task execution.")
-        sys.exit(0)
-        
-    # 2. Run a simple agentic task
-    print("\n--- Agentic Task Execution ---")
-    instruction = "Write a one-line python script that prints 'Hello World'"
-    print(f"Instruction: {instruction}")
-    
-    # We use quiet=True to avoid excessive console output in this example
-    success, output, cost, provider = run_agentic_task(
-        instruction=instruction,
-        cwd=output_dir,
-        label="example_hello_world",
-        verbose=False,
-        quiet=True,
-        timeout=30.0,
-        max_retries=1
-    )
-    
-    print(f"Task success: {success}")
-    print(f"Provider used: {provider}")
-    print(f"Cost: ${cost:.6f}")
-    print(f"Output preview: {output[:150]}...\n")
-    
-    # 3. Detect control tokens in LLM output
-    # This is used to understand status changes triggered by an LLM response.
-    print("--- Control Token Detection ---")
-    dummy_output = "The issue has been resolved. ALL_TESTS_PASS"
-    print(f"Scanning output: {dummy_output}")
-    
-    match = detect_control_token(dummy_output, "ALL_TESTS_PASS")
-    if match:
-        print(f"Token 'ALL_TESTS_PASS' found via {match.tier} match.\n")
-        
-    # 4. State management (Local state serialization)
-    print("--- State Management ---")
-    state_dir = output_dir / ".state"
-    issue_number = 9999
-    workflow = "example"
-    repo_owner = "dummy-owner"
-    repo_name = "dummy-repo"
-    
-    dummy_state = {
-        "step": 1,
-        "status": "in_progress",
-        "info": "Starting tests"
+console = Console()
+
+
+def example_provider_preference() -> None:
+    """Show the default provider order and an env override."""
+    console.print("[bold blue]Provider Preference[/bold blue]")
+    console.print(f"Default: {get_agent_provider_preference()}")
+
+    with patch.dict(os.environ, {"PDD_AGENTIC_PROVIDER": "google,anthropic"}, clear=False):
+        console.print(f"Override: {get_agent_provider_preference()}")
+
+
+def example_run_agentic_task(cwd: Path) -> None:
+    """Run a fully mocked agentic task through the public entry point."""
+    console.print("\n[bold blue]run_agentic_task()[/bold blue]")
+    mocked_json = {
+        "response": "Applied the fix, ran verification, and everything passed.",
+        "total_cost_usd": 0.12,
     }
-    
-    # Save the state locally (disabling GitHub sync for the example)
-    print(f"Saving workflow state locally for issue {issue_number}...")
-    save_workflow_state(
-        cwd=output_dir,
-        issue_number=issue_number,
-        workflow_type=workflow,
-        state=dummy_state,
-        state_dir=state_dir,
-        repo_owner=repo_owner,
-        repo_name=repo_name,
-        use_github_state=False
+
+    with patch("pdd.agentic_common._find_cli_binary", return_value="/usr/local/bin/claude"), \
+         patch("pdd.agentic_common._subprocess_run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["claude"],
+            returncode=0,
+            stdout=json.dumps(mocked_json),
+            stderr="",
+        )
+        success, output, cost, provider = run_agentic_task(
+            "Fix the failing workflow.",
+            cwd,
+            verbose=False,
+            max_retries=1,
+        )
+
+    console.print(f"Success: {success}")
+    console.print(f"Provider: {provider}")
+    console.print(f"Cost: ${cost:.2f}")
+    console.print(f"Output: {output}")
+
+
+def example_validate_cached_state() -> None:
+    """Demonstrate cache correction when a stored step failed."""
+    console.print("\n[bold blue]validate_cached_state()[/bold blue]")
+    corrected = validate_cached_state(
+        last_completed_step=4,
+        step_outputs={
+            "1": "Collected context",
+            "2": "Generated fix",
+            "3": "FAILED: verification failed",
+            "4": "Should not be trusted",
+        },
+        step_order=[1, 2, 3, 4],
+        quiet=True,
     )
-    
-    # Load the state back
-    loaded_state, gh_id = load_workflow_state(
-        cwd=output_dir,
-        issue_number=issue_number,
-        workflow_type=workflow,
-        state_dir=state_dir,
-        repo_owner=repo_owner,
-        repo_name=repo_name,
-        use_github_state=False
-    )
-    print(f"Loaded state: {loaded_state}")
-    
-    # Clean up state
-    clear_workflow_state(
-        cwd=output_dir,
-        issue_number=issue_number,
-        workflow_type=workflow,
-        state_dir=state_dir,
-        repo_owner=repo_owner,
-        repo_name=repo_name,
-        use_github_state=False
-    )
-    print("Workflow state cleared.")
+    console.print(f"Corrected last completed step: {corrected}")
+
+
+def example_post_step_comment(cwd: Path) -> None:
+    """Show the issue comment helper with a mocked gh CLI."""
+    console.print("\n[bold blue]post_step_comment()[/bold blue]")
+    with patch("pdd.agentic_common.shutil.which", return_value="/usr/bin/gh"), \
+         patch("pdd.agentic_common.subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+        posted = post_step_comment(
+            repo_owner="example-owner",
+            repo_name="example-repo",
+            issue_number=822,
+            step_num=3,
+            total_steps=5,
+            description="Verify generated fix",
+            output="pytest failed with one assertion error",
+            cwd=cwd,
+        )
+    console.print(f"Issue comment posted: {posted}")
+
+
+def _example_post_pr_comment(cwd: Path) -> None:
+    """Show the PR comment helper used by CI validation."""
+    console.print("\n[bold blue]post_pr_comment()[/bold blue]")
+    with patch("pdd.agentic_common.shutil.which", return_value="/usr/bin/gh"), \
+         patch("pdd.agentic_common.subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+        posted = post_pr_comment(
+            repo_owner="example-owner",
+            repo_name="example-repo",
+            pr_number=42,
+            body="CI validation exhausted retries; lint is still failing.",
+            cwd=cwd,
+        )
+    console.print(f"PR comment posted: {posted}")
+
+
+def example_post_pr_comment():
+    """Compatibility wrapper retained for prompt-level example assertions."""
+    _example_post_pr_comment(Path.cwd())
+
+
+def example_github_state_helpers(cwd: Path) -> None:
+    """Show state save/load helpers without talking to GitHub."""
+    console.print("\n[bold blue]GitHub State Helpers[/bold blue]")
+
+    def mock_gh_api(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        cmd = args[0]
+        if isinstance(cmd, list) and "POST" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, json.dumps({"id": 321}), "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    with patch("pdd.agentic_common.shutil.which", return_value="/usr/bin/gh"), \
+         patch("pdd.agentic_common.subprocess.run", side_effect=mock_gh_api), \
+         patch(
+             "pdd.agentic_common._find_state_comment",
+             return_value=(321, {"last_completed_step": 2, "step_outputs": {"1": "ok", "2": "ok"}}),
+         ):
+        comment_id = github_save_state(
+            repo_owner="example-owner",
+            repo_name="example-repo",
+            issue_number=822,
+            workflow_type="agentic_sync",
+            state={"last_completed_step": 2, "step_outputs": {"1": "ok", "2": "ok"}},
+            cwd=cwd,
+        )
+        loaded_state, loaded_comment_id = github_load_state(
+            repo_owner="example-owner",
+            repo_name="example-repo",
+            issue_number=822,
+            workflow_type="agentic_sync",
+            cwd=cwd,
+        )
+
+    console.print(f"Saved comment id: {comment_id}")
+    console.print(f"Loaded state: {loaded_state}")
+    console.print(f"Loaded comment id: {loaded_comment_id}")
+
+
+def main() -> None:
+    """Run the example in a temporary working directory."""
+    with TemporaryDirectory() as temp_dir:
+        cwd = Path(temp_dir)
+        example_provider_preference()
+        example_run_agentic_task(cwd)
+        example_validate_cached_state()
+        example_post_step_comment(cwd)
+        _example_post_pr_comment(cwd)
+        example_github_state_helpers(cwd)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/agentic_bug_orchestrator_example.py
+++ b/examples/agentic_bug_orchestrator_example.py
@@ -94,7 +94,7 @@ def example_happy_path() -> None:
                 return (
                     True,
                     "<step_report>## Step 10\n\nUnit tests verified.</step_report>\n"
-                    "E2E_NEEDED: no",
+                    "E2E_NEEDED: yes - integration path should be covered",
                     0.10,
                     "anthropic",
                 )

--- a/examples/agentic_bug_orchestrator_example.py
+++ b/examples/agentic_bug_orchestrator_example.py
@@ -42,15 +42,43 @@ def example_happy_path() -> None:
         cwd = Path(tmpdir)
 
         def mock_run(*args, **kwargs):
-            """Return step-specific outputs for realistic behavior."""
+            """Return step-specific outputs for realistic behavior.
+
+            Each output wraps a `<step_report>` block — the orchestrator
+            extracts that and posts it via `post_step_comment(body=...)`
+            using trusted credentials (issue #964).
+            """
             label = kwargs.get("label", "")
             if label == "step9":
-                return (True, "Generated unit test\nFILES_CREATED: tests/test_fix.py", 0.10, "anthropic")
+                return (
+                    True,
+                    "<step_report>## Step 9\n\nGenerated failing test.</step_report>\n"
+                    "FILES_CREATED: tests/test_fix.py",
+                    0.10,
+                    "anthropic",
+                )
             if label == "step11":
-                return (True, "E2E test\nE2E_FILES_CREATED: tests/e2e/test_e2e.py", 0.15, "anthropic")
+                return (
+                    True,
+                    "<step_report>## Step 11\n\nE2E test passes against the fix.</step_report>\n"
+                    "E2E_FILES_CREATED: tests/e2e/test_e2e.py",
+                    0.15,
+                    "anthropic",
+                )
             if label == "step12":
-                return (True, "PR created: https://github.com/owner/repo/pull/99", 0.05, "anthropic")
-            return (True, f"Output for {label}", 0.10, "anthropic")
+                return (
+                    True,
+                    "<step_report>## Step 12\n\nDraft PR created: "
+                    "https://github.com/owner/repo/pull/99</step_report>",
+                    0.05,
+                    "anthropic",
+                )
+            return (
+                True,
+                f"<step_report>## {label}\n\nMocked output for {label}.</step_report>",
+                0.10,
+                "anthropic",
+            )
 
         mock_worktree = cwd / ".pdd" / "worktrees" / "fix-issue-42"
         mock_worktree.mkdir(parents=True, exist_ok=True)
@@ -65,7 +93,8 @@ def example_happy_path() -> None:
              patch("pdd.agentic_bug_orchestrator._verify_e2e_tests", return_value=(True, "all passed")), \
              patch("pdd.agentic_bug_orchestrator.subprocess") as _mock_sub, \
              patch("pdd.agentic_bug_orchestrator.set_agentic_progress"), \
-             patch("pdd.agentic_bug_orchestrator.clear_agentic_progress"):
+             patch("pdd.agentic_bug_orchestrator.clear_agentic_progress"), \
+             patch("pdd.agentic_bug_orchestrator.post_step_comment", return_value=True):
 
             import subprocess as _real_subprocess
             _mock_sub.run.return_value = _real_subprocess.CompletedProcess(
@@ -105,10 +134,13 @@ def example_hard_stop_duplicate() -> None:
     with TemporaryDirectory() as tmpdir:
         cwd = Path(tmpdir)
 
-        # Step 1 output triggers the hard stop condition
+        # Step 1 output triggers the hard stop condition. The `<step_report>`
+        # block is what the orchestrator extracts and posts via the trusted
+        # `post_step_comment(body=...)` path (issue #964).
         mock_run = MagicMock(return_value=(
             True,
-            "This looks like a Duplicate of #17",
+            "<step_report>## Step 1: Duplicate Check\n\n"
+            "This looks like a Duplicate of #17.</step_report>",
             0.05,
             "anthropic",
         ))
@@ -120,7 +152,8 @@ def example_hard_stop_duplicate() -> None:
              patch("pdd.agentic_bug_orchestrator.load_workflow_state", return_value=(None, None)), \
              patch("pdd.agentic_bug_orchestrator._get_git_root", return_value=cwd), \
              patch("pdd.agentic_bug_orchestrator.set_agentic_progress"), \
-             patch("pdd.agentic_bug_orchestrator.clear_agentic_progress"):
+             patch("pdd.agentic_bug_orchestrator.clear_agentic_progress"), \
+             patch("pdd.agentic_bug_orchestrator.post_step_comment", return_value=True):
 
             success, message, cost, model, changed_files = run_agentic_bug_orchestrator(
                 issue_url="https://github.com/owner/repo/issues/50",

--- a/examples/agentic_bug_orchestrator_example.py
+++ b/examples/agentic_bug_orchestrator_example.py
@@ -49,11 +49,52 @@ def example_happy_path() -> None:
             using trusted credentials (issue #964).
             """
             label = kwargs.get("label", "")
+            if label == "step5":
+                return (
+                    True,
+                    "<step_report>## Step 5\n\nReproduced the crash.</step_report>\n"
+                    "REPRO_FILES_CREATED: tests/test_repro.py",
+                    0.10,
+                    "anthropic",
+                )
+            if label == "step6":
+                return (
+                    True,
+                    "<step_report>## Step 6\n\nRoot cause located.</step_report>\n"
+                    "FIX_LOCATIONS: pdd/module.py\n"
+                    "EXPANSION_ITEMS: none",
+                    0.10,
+                    "anthropic",
+                )
+            if label == "step7":
+                return (
+                    True,
+                    "<step_report>## Step 7\n\nDefect classified.</step_report>\n"
+                    "DEFECT_TYPE: code",
+                    0.10,
+                    "anthropic",
+                )
+            if label == "step8":
+                return (
+                    True,
+                    "<step_report>## Step 8\n\nTest plan drafted.</step_report>\n"
+                    "PLANNED_TEST_COUNT: 1",
+                    0.10,
+                    "anthropic",
+                )
             if label == "step9":
                 return (
                     True,
                     "<step_report>## Step 9\n\nGenerated failing test.</step_report>\n"
                     "FILES_CREATED: tests/test_fix.py",
+                    0.10,
+                    "anthropic",
+                )
+            if label == "step10":
+                return (
+                    True,
+                    "<step_report>## Step 10\n\nUnit tests verified.</step_report>\n"
+                    "E2E_NEEDED: no",
                     0.10,
                     "anthropic",
                 )
@@ -91,6 +132,7 @@ def example_happy_path() -> None:
              patch("pdd.agentic_bug_orchestrator._get_git_root", return_value=cwd), \
              patch("pdd.agentic_bug_orchestrator._setup_worktree", return_value=(mock_worktree, None)), \
              patch("pdd.agentic_bug_orchestrator._verify_e2e_tests", return_value=(True, "all passed")), \
+             patch("pdd.agentic_bug_orchestrator._count_generated_tests", return_value=(1, 0)), \
              patch("pdd.agentic_bug_orchestrator.subprocess") as _mock_sub, \
              patch("pdd.agentic_bug_orchestrator.set_agentic_progress"), \
              patch("pdd.agentic_bug_orchestrator.clear_agentic_progress"), \

--- a/pdd/__init__.py
+++ b/pdd/__init__.py
@@ -59,7 +59,7 @@ def _setup_cloud_defaults() -> None:
 
 # Initialize cloud defaults on package import
 _setup_cloud_defaults()
-from .agentic_common import get_agent_provider_preference, get_job_deadline, Pricing, get_available_agents, run_agentic_task, github_save_state, github_load_state, github_clear_state, validate_cached_state, load_workflow_state, save_workflow_state, clear_workflow_state, post_step_comment, substitute_template_variables, post_pr_comment, post_final_comment
+from .agentic_common import get_agent_provider_preference, get_job_deadline, Pricing, get_available_agents, run_agentic_task, github_save_state, github_load_state, github_clear_state, validate_cached_state, load_workflow_state, save_workflow_state, clear_workflow_state, post_step_comment, substitute_template_variables, post_pr_comment, post_final_comment, _extract_step_report, _sanitize_comment_body
 from .agentic_test_orchestrator import run_agentic_test_orchestrator
 from .architecture_sync_helper import filepath_to_prompt_filename
 from .agentic_e2e_fix_orchestrator import run_agentic_e2e_fix_orchestrator

--- a/pdd/agentic_bug_orchestrator.py
+++ b/pdd/agentic_bug_orchestrator.py
@@ -22,6 +22,7 @@ from .agentic_common import (
     clear_agentic_progress,
     post_step_comment,
     _extract_step_report,
+    _sanitize_comment_body,
     DEFAULT_MAX_RETRIES,
 )
 from .get_test_command import get_test_command_for_file
@@ -924,6 +925,30 @@ def _check_hard_stop(step_num: Union[int, float], output: str, files_extracted: 
     return None
 
 
+def _state_safe_step_output(output: str) -> str:
+    """Redact secrets before persisting step output to resumable/GitHub state."""
+    if not isinstance(output, str):
+        return output
+    return _sanitize_comment_body(output, max_chars=max(len(output) + 1024, 25_000))
+
+
+def _parse_e2e_needed_marker(output: str) -> Optional[str]:
+    """Return the last E2E_NEEDED yes/no marker outside any step_report block."""
+    if not output:
+        return None
+    outside_report = re.sub(
+        r"<step_report>.*?</step_report>",
+        "",
+        output,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    matches = re.findall(
+        r"(?im)^\s*E2E_NEEDED:\s*(yes|no)\b",
+        outside_report,
+    )
+    return matches[-1].lower() if matches else None
+
+
 def _maybe_post_step_comment(
     *,
     step_success: bool,
@@ -950,8 +975,6 @@ def _maybe_post_step_comment(
     terminate ``_extract_step_report`` early. Acceptable for v1 — models do
     not normally emit the closing tag inside their own report body.
     """
-    if not step_success:
-        return github_comment_id
     # Defensive normalization: stale/corrupted persisted state (e.g. a list, or
     # a per-step entry that isn't a dict) would otherwise crash on `.get()`.
     # Only a literal `True` for `posted` counts — truthy strings/ints don't.
@@ -960,6 +983,31 @@ def _maybe_post_step_comment(
         raw_sc = {}
     state["step_comments"] = raw_sc
     entry = raw_sc.get(str(step_num))
+    if not step_success:
+        if isinstance(entry, dict) and entry.get("failed_posted") is True:
+            return github_comment_id
+        step_num_int = step_num if isinstance(step_num, int) else int(step_num)
+        posted = post_step_comment(
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            issue_number=issue_number,
+            step_num=step_num_int,
+            total_steps=12,
+            description=description,
+            output=step_output,
+            cwd=cwd,
+        )
+        state["step_comments"][str(step_num)] = {
+            "failed_posted": bool(posted),
+            "failed_pending": not bool(posted),
+        }
+        save_result = save_workflow_state(
+            cwd, issue_number, "bug", state, state_dir,
+            repo_owner, repo_name, use_github_state, github_comment_id,
+        )
+        if save_result:
+            github_comment_id = save_result
+        return github_comment_id
     if isinstance(entry, dict) and entry.get("posted") is True:
         return github_comment_id
     extracted = _extract_step_report(step_output)
@@ -1421,7 +1469,7 @@ def run_agentic_bug_orchestrator(
     reasoning_time: Optional[float] = None,
 ) -> Tuple[bool, str, float, str, List[str]]:
     """
-    Orchestrates the 11-step agentic bug investigation workflow.
+    Orchestrates the 12-step agentic bug investigation workflow.
     
     Returns:
         (success, final_message, total_cost, model_used, changed_files)
@@ -1481,7 +1529,7 @@ def run_agentic_bug_orchestrator(
     for s_key, s_out in step_outputs.items():
         context[f"step{s_key}_output"] = s_out
 
-    # Re-extract files from step 5.5/7/9 outputs if available
+    # Re-extract files from step 5/7/9/11 outputs if available
     changed_files: List[str] = []
     
     # Step 5
@@ -1491,7 +1539,7 @@ def run_agentic_bug_orchestrator(
         repro_files = _parse_changed_files(s5_out, "REPRO_FILES_CREATED")
         changed_files.extend(repro_files)
 
-    # Step 5.5
+    # Legacy fractional prompt-classification state from older resumed runs.
     if "step5.5_output" in context:
         s55_out = context["step5.5_output"]
         prompt_fixed = _parse_changed_files(s55_out, "PROMPT_FIXED")
@@ -1542,7 +1590,7 @@ def run_agentic_bug_orchestrator(
     if (
         "11" not in step_outputs
         and isinstance(s10_out_pre, str)
-        and "E2E_NEEDED: no" in s10_out_pre
+        and _parse_e2e_needed_marker(s10_out_pre) == "no"
         and isinstance(s12_out_pre, str)
         and not s12_out_pre.startswith("FAILED:")
     ):
@@ -1667,6 +1715,7 @@ def run_agentic_bug_orchestrator(
 
     current_work_dir = cwd
     consecutive_failures = 0
+    terminal_step_failed: Optional[str] = None
     skip_e2e = False
 
     # Codex review #5 of PR #966: rehydrate skip_e2e from cached Step 10
@@ -1674,7 +1723,7 @@ def run_agentic_bug_orchestrator(
     # Steps 10 and 11) still honors the E2E_NEEDED:no classification instead
     # of unconditionally rerunning E2E generation.
     cached_step10 = step_outputs.get("10")
-    if isinstance(cached_step10, str) and "E2E_NEEDED: no" in cached_step10:
+    if isinstance(cached_step10, str) and _parse_e2e_needed_marker(cached_step10) == "no":
         skip_e2e = True
 
     # Worktree restoration for resume
@@ -1901,8 +1950,24 @@ def run_agentic_bug_orchestrator(
             consecutive_failures += 1
             if consecutive_failures >= 3:
                 state["last_completed_step"] = last_completed_step
-                state["step_outputs"][str(step_num)] = f"FAILED: {step_output}"
-                save_workflow_state(cwd, issue_number, "bug", state, state_dir, repo_owner, repo_name, use_github_state, github_comment_id)
+                state["step_outputs"][str(step_num)] = f"FAILED: {_state_safe_step_output(step_output)}"
+                save_result = save_workflow_state(cwd, issue_number, "bug", state, state_dir, repo_owner, repo_name, use_github_state, github_comment_id)
+                if save_result:
+                    github_comment_id = save_result
+                _maybe_post_step_comment(
+                    step_success=False,
+                    step_num=step_num,
+                    description=description,
+                    step_output=step_output,
+                    state=state,
+                    state_dir=state_dir,
+                    cwd=cwd,
+                    issue_number=issue_number,
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                    use_github_state=use_github_state,
+                    github_comment_id=github_comment_id,
+                )
                 return False, "Aborting: 3 consecutive steps failed — agent providers unavailable", total_cost, model_used, changed_files
         else:
             consecutive_failures = 0
@@ -1921,9 +1986,9 @@ def run_agentic_bug_orchestrator(
             # at lines 1495-1507 walks ordered_steps, finds the gap at "3", and
             # downgrades last_completed_step to 0 — forcing a re-run of triage
             # even though step 3's comment was already posted.
-            state["step_outputs"]["3"] = step_output
-            state["step_outputs"]["4"] = context["step4_output"]
-            state["step_outputs"]["5"] = context["step5_output"]
+            state["step_outputs"]["3"] = _state_safe_step_output(step_output)
+            state["step_outputs"]["4"] = _state_safe_step_output(context["step4_output"])
+            state["step_outputs"]["5"] = _state_safe_step_output(context["step5_output"])
             state["last_completed_step"] = 5
             last_completed_step = 5
             # Recalculate start_step so the loop skips 4 and 5
@@ -2511,7 +2576,7 @@ def run_agentic_bug_orchestrator(
         if step_num == 10:
             # Check for E2E classification marker in step output.
             # Safe default: if marker is missing, E2E runs (backward compatible).
-            if "E2E_NEEDED: no" in step_output:
+            if _parse_e2e_needed_marker(step_output) == "no":
                 skip_e2e = True
                 if not quiet:
                     console.print("   (E2E skipped: E2E_NEEDED: no)")
@@ -2543,7 +2608,7 @@ def run_agentic_bug_orchestrator(
             if not quiet:
                 console.print(f"[yellow]⏹️  Investigation stopped at Step {step_num}: {stop_reason}[/yellow]")
             state["last_completed_step"] = step_num
-            state["step_outputs"][str(step_num)] = step_output
+            state["step_outputs"][str(step_num)] = _state_safe_step_output(step_output)
             save_result = save_workflow_state(cwd, issue_number, "bug", state, state_dir, repo_owner, repo_name, use_github_state, github_comment_id)
             if save_result:
                 github_comment_id = save_result
@@ -2574,11 +2639,13 @@ def run_agentic_bug_orchestrator(
 
         # Update state
         if step_success:
-            state["step_outputs"][str(step_num)] = step_output
+            state["step_outputs"][str(step_num)] = _state_safe_step_output(step_output)
             state["last_completed_step"] = step_num
             last_completed_step = step_num
         else:
-            state["step_outputs"][str(step_num)] = f"FAILED: {step_output}"
+            state["step_outputs"][str(step_num)] = f"FAILED: {_state_safe_step_output(step_output)}"
+            if step_num == 12:
+                terminal_step_failed = step_output
 
         save_result = save_workflow_state(cwd, issue_number, "bug", state, state_dir, repo_owner, repo_name, use_github_state, github_comment_id)
         if save_result:
@@ -2614,6 +2681,17 @@ def run_agentic_bug_orchestrator(
         url_match = re.search(r"https://github.com/\S+/pull/\d+", s10_out)
         if url_match:
             pr_url = url_match.group(0)
+
+    if terminal_step_failed is not None:
+        if not quiet:
+            console.print("\n[red]❌ Investigation failed[/red]")
+            console.print(f"   Total cost: ${total_cost:.4f}")
+            console.print(f"   Files changed: {', '.join(changed_files) if changed_files else 'none'}")
+            if worktree_path:
+                console.print(f"   Worktree: {worktree_path}")
+            console.print("   PR created: none")
+        detail = terminal_step_failed.strip().splitlines()[0] if terminal_step_failed.strip() else "unknown error"
+        return False, f"Investigation failed at step 12: {detail}", total_cost, model_used, changed_files
 
     if not quiet:
         console.print("\n[green]✅ Investigation complete[/green]")

--- a/pdd/agentic_bug_orchestrator.py
+++ b/pdd/agentic_bug_orchestrator.py
@@ -1795,6 +1795,12 @@ def run_agentic_bug_orchestrator(
             fast_track_summary = fast_track_match.group(1).strip() if fast_track_match else "Pre-diagnosed by issue author"
             context["step4_output"] = f"Step 4 skipped (fast-track): Issue was pre-diagnosed by the author. Root cause: {fast_track_summary}"
             context["step5_output"] = f"Step 5 skipped (fast-track): Issue was pre-diagnosed by the author. Root cause: {fast_track_summary}"
+            # Persist step 3's actual output BEFORE the synthetic 4/5 entries
+            # (codex review of PR #966 #3). Without this, the resume validator
+            # at lines 1495-1507 walks ordered_steps, finds the gap at "3", and
+            # downgrades last_completed_step to 0 — forcing a re-run of triage
+            # even though step 3's comment was already posted.
+            state["step_outputs"]["3"] = step_output
             state["step_outputs"]["4"] = context["step4_output"]
             state["step_outputs"]["5"] = context["step5_output"]
             state["last_completed_step"] = 5

--- a/pdd/agentic_bug_orchestrator.py
+++ b/pdd/agentic_bug_orchestrator.py
@@ -1530,6 +1530,27 @@ def run_agentic_bug_orchestrator(
 
     # State validation: find actual last successful step
     ordered_steps: List[Union[int, float]] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    # Codex review #5 of PR #966: legacy E2E-skip states (before we persisted
+    # a synthetic Step 11 entry) can have step_outputs with keys 1..10 + 12
+    # but no 11. The contiguous walk below would stop at 10, downgrade a
+    # completed last_completed_step from 12 → 10, miss Step 12's backfill,
+    # and rerun the side-effectful PR creation step. Heal those states by
+    # synthesizing the missing Step 11 entry in-memory when Step 10's cached
+    # output indicates E2E_NEEDED:no AND Step 12 is also cached.
+    s10_out_pre = step_outputs.get("10")
+    s12_out_pre = step_outputs.get("12")
+    if (
+        "11" not in step_outputs
+        and isinstance(s10_out_pre, str)
+        and "E2E_NEEDED: no" in s10_out_pre
+        and isinstance(s12_out_pre, str)
+        and not s12_out_pre.startswith("FAILED:")
+    ):
+        step_outputs["11"] = (
+            "Step 11 skipped: E2E_NEEDED:no from Step 10 — unit tests "
+            "provide sufficient coverage."
+        )
+        state.setdefault("step_outputs", {})["11"] = step_outputs["11"]
     actual_last: Union[int, float] = 0
     for s in ordered_steps:
         key = str(s)
@@ -1648,6 +1669,14 @@ def run_agentic_bug_orchestrator(
     consecutive_failures = 0
     skip_e2e = False
 
+    # Codex review #5 of PR #966: rehydrate skip_e2e from cached Step 10
+    # output so a resume that lands on Step 11 (e.g. after a crash between
+    # Steps 10 and 11) still honors the E2E_NEEDED:no classification instead
+    # of unconditionally rerunning E2E generation.
+    cached_step10 = step_outputs.get("10")
+    if isinstance(cached_step10, str) and "E2E_NEEDED: no" in cached_step10:
+        skip_e2e = True
+
     # Worktree restoration for resume
     if start_step >= 5 and start_step <= 12:
         if worktree_path and worktree_path.exists():
@@ -1724,6 +1753,28 @@ def run_agentic_bug_orchestrator(
         if step_num == 11 and skip_e2e:
             if not quiet:
                 console.print("Skipping Step 11 (E2E): unit tests provide sufficient coverage")
+            # Codex review #5 of PR #966: persist a synthetic Step 11 skip
+            # entry. Without it, step_outputs has a gap at "11" so the resume
+            # validator (lines 1531-1543) walks contiguously, stops at 10,
+            # and silently downgrades a completed last_completed_step=12 to
+            # 10 — causing Step 12's cached body to miss backfill AND the
+            # side-effectful PR creation step to rerun on resume. The
+            # synthetic body intentionally omits <step_report> so the
+            # backfill sweep (lines 1622-1623) correctly skips posting any
+            # bogus "step 11 done" comment.
+            synthetic = (
+                "Step 11 skipped: E2E_NEEDED:no from Step 10 — unit tests "
+                "provide sufficient coverage."
+            )
+            state["step_outputs"]["11"] = synthetic
+            state["last_completed_step"] = 11
+            last_completed_step = 11
+            save_result = save_workflow_state(
+                cwd, issue_number, "bug", state, state_dir,
+                repo_owner, repo_name, use_github_state, github_comment_id,
+            )
+            if save_result:
+                github_comment_id = save_result
             continue
 
         # Record progress so KeyboardInterrupt can report how far we got.

--- a/pdd/agentic_bug_orchestrator.py
+++ b/pdd/agentic_bug_orchestrator.py
@@ -1540,6 +1540,40 @@ def run_agentic_bug_orchestrator(
 
     total_steps = len(steps_config)  # 12
 
+    # Issue #964: backfill any visible step comments missed by a prior crash
+    # or transient `gh issue comment` failure. Only retries steps whose
+    # outputs we already trust (not "FAILED:" sentinels). The helper is
+    # idempotent — successful resumes are gated by step_comments[n].posted.
+    if state.get("step_outputs"):
+        state.setdefault("step_comments", {})
+        for s_key, s_out in list(state["step_outputs"].items()):
+            if not isinstance(s_out, str) or s_out.startswith("FAILED:"):
+                continue
+            if state["step_comments"].get(s_key, {}).get("posted"):
+                continue
+            try:
+                s_num = int(float(s_key))
+            except (TypeError, ValueError):
+                continue
+            desc = next(
+                (d for (n, _name, d) in steps_config if n == s_num),
+                str(s_key),
+            )
+            github_comment_id = _maybe_post_step_comment(
+                step_success=True,
+                step_num=s_num,
+                description=desc,
+                step_output=s_out,
+                state=state,
+                state_dir=state_dir,
+                cwd=cwd,
+                issue_number=issue_number,
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                use_github_state=use_github_state,
+                github_comment_id=github_comment_id,
+            )
+
     current_work_dir = cwd
     consecutive_failures = 0
     skip_e2e = False
@@ -1767,7 +1801,9 @@ def run_agentic_bug_orchestrator(
             last_completed_step = 5
             # Recalculate start_step so the loop skips 4 and 5
             start_step = 6
-            save_workflow_state(cwd, issue_number, "bug", state, state_dir, repo_owner, repo_name, use_github_state, github_comment_id)
+            save_result = save_workflow_state(cwd, issue_number, "bug", state, state_dir, repo_owner, repo_name, use_github_state, github_comment_id)
+            if save_result:
+                github_comment_id = save_result
             # Issue #964: post the step-3 triage comment before short-circuiting,
             # otherwise the user sees no visible signal that triage succeeded.
             github_comment_id = _maybe_post_step_comment(
@@ -2381,7 +2417,9 @@ def run_agentic_bug_orchestrator(
                 console.print(f"[yellow]⏹️  Investigation stopped at Step {step_num}: {stop_reason}[/yellow]")
             state["last_completed_step"] = step_num
             state["step_outputs"][str(step_num)] = step_output
-            save_workflow_state(cwd, issue_number, "bug", state, state_dir, repo_owner, repo_name, use_github_state, github_comment_id)
+            save_result = save_workflow_state(cwd, issue_number, "bug", state, state_dir, repo_owner, repo_name, use_github_state, github_comment_id)
+            if save_result:
+                github_comment_id = save_result
             # Issue #964: post the model's report even on hard stop. The step's
             # WORK succeeded (e.g. detected duplicate, classified user error);
             # the orchestrator just decided not to continue. Without this the

--- a/pdd/agentic_bug_orchestrator.py
+++ b/pdd/agentic_bug_orchestrator.py
@@ -963,7 +963,8 @@ def _maybe_post_step_comment(
     if isinstance(entry, dict) and entry.get("posted") is True:
         return github_comment_id
     extracted = _extract_step_report(step_output)
-    if extracted is None:
+    is_fallback = extracted is None
+    if is_fallback:
         body_to_post = (
             f"_Step {step_num} completed; no `<step_report>` block "
             f"returned by agent. Raw output retained in workflow state._"
@@ -982,8 +983,31 @@ def _maybe_post_step_comment(
         cwd=cwd,
         body=body_to_post,
     )
+    # Persist outcome regardless of success so the resume backfill can
+    # distinguish PR-era no-report fallback attempts (retryable) from legacy
+    # pre-PR outputs (where the agent posted comments itself and we must NOT
+    # repost). For no-report outputs the saved state is the only signal —
+    # `_extract_step_report` will return None on resume too.
     if posted:
-        state["step_comments"][str(step_num)] = {"posted": True}
+        entry: Dict[str, object] = {"posted": True}
+        if is_fallback:
+            entry["fallback"] = True
+        state["step_comments"][str(step_num)] = entry
+        save_result = save_workflow_state(
+            cwd, issue_number, "bug", state, state_dir,
+            repo_owner, repo_name, use_github_state, github_comment_id,
+        )
+        if save_result:
+            github_comment_id = save_result
+    elif is_fallback:
+        # Transient GitHub posting failure on a no-report step: mark it so
+        # the resume backfill knows to retry. Without this marker the backfill
+        # at the top of the orchestrator would skip the saved output (no
+        # `<step_report>` to extract) and the comment would be lost forever.
+        state["step_comments"][str(step_num)] = {
+            "posted": False,
+            "fallback_pending": True,
+        }
         save_result = save_workflow_state(
             cwd, issue_number, "bug", state, state_dir,
             repo_owner, repo_name, use_github_state, github_comment_id,
@@ -1558,11 +1582,15 @@ def run_agentic_bug_orchestrator(
     # idempotent — successful resumes are gated by step_comments[n].posted.
     #
     # Gating (codex review #4 of PR #966):
-    # - Require the saved output to contain a `<step_report>` block.
-    #   Legacy pre-PR states (where models posted comments themselves) and the
-    #   synthetic skipped-step outputs from FAST_TRACK (lines 1796-1797 below)
-    #   both lack this marker, so they're skipped — preventing duplicate or
-    #   bogus comments on resume.
+    # - Require the saved output to contain a `<step_report>` block, OR a
+    #   prior fallback attempt that failed (`fallback_pending`). Legacy pre-PR
+    #   states (where models posted comments themselves) and the synthetic
+    #   skipped-step outputs from FAST_TRACK (lines 1796-1797 below) both
+    #   lack this marker AND have no `step_comments` entry, so they're skipped
+    #   — preventing duplicate or bogus comments on resume.
+    # - Codex review #5 of PR #966: persist `fallback_pending` for no-report
+    #   outputs whose initial post failed, so we can safely retry them here
+    #   without confusing them with legacy outputs.
     # - Normalize `step_comments` shape: a stale list / non-dict entry / non-
     #   boolean `posted` would otherwise crash with AttributeError here.
     if state.get("step_outputs"):
@@ -1576,7 +1604,10 @@ def run_agentic_bug_orchestrator(
             entry = raw_sc.get(s_key)
             if isinstance(entry, dict) and entry.get("posted") is True:
                 continue
-            if _extract_step_report(s_out) is None:
+            fallback_pending = (
+                isinstance(entry, dict) and entry.get("fallback_pending") is True
+            )
+            if _extract_step_report(s_out) is None and not fallback_pending:
                 continue
             try:
                 s_num = int(float(s_key))

--- a/pdd/agentic_bug_orchestrator.py
+++ b/pdd/agentic_bug_orchestrator.py
@@ -20,6 +20,8 @@ from .agentic_common import (
     clear_workflow_state,
     set_agentic_progress,
     clear_agentic_progress,
+    post_step_comment,
+    _extract_step_report,
     DEFAULT_MAX_RETRIES,
 )
 from .get_test_command import get_test_command_for_file
@@ -2319,6 +2321,45 @@ def run_agentic_bug_orchestrator(
         save_result = save_workflow_state(cwd, issue_number, "bug", state, state_dir, repo_owner, repo_name, use_github_state, github_comment_id)
         if save_result:
             github_comment_id = save_result
+
+        # Issue #964: orchestrator (not the model) owns visible step comments.
+        # Posting through trusted credentials means Gemini's sandboxed shell no
+        # longer needs GH_TOKEN passthrough. The posted-state is tracked in
+        # workflow state so a resume after an interruption does not double-post.
+        if step_success:
+            state.setdefault("step_comments", {})
+            already_posted = (
+                state["step_comments"].get(str(step_num), {}).get("posted", False)
+            )
+            if not already_posted:
+                extracted = _extract_step_report(step_output)
+                if extracted is None:
+                    body_to_post = (
+                        f"_Step {step_num} completed; no `<step_report>` block "
+                        f"returned by agent. Raw output retained in workflow state._"
+                    )
+                else:
+                    body_to_post = extracted
+                step_num_int = step_num if isinstance(step_num, int) else int(step_num)
+                posted = post_step_comment(
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                    issue_number=issue_number,
+                    step_num=step_num_int,
+                    total_steps=12,
+                    description=description,
+                    output=step_output,
+                    cwd=cwd,
+                    body=body_to_post,
+                )
+                if posted:
+                    state["step_comments"][str(step_num)] = {"posted": True}
+                    save_result = save_workflow_state(
+                        cwd, issue_number, "bug", state, state_dir,
+                        repo_owner, repo_name, use_github_state, github_comment_id,
+                    )
+                    if save_result:
+                        github_comment_id = save_result
 
         # Print step completion marker (required for credential waterfall detection)
         if not quiet:

--- a/pdd/agentic_bug_orchestrator.py
+++ b/pdd/agentic_bug_orchestrator.py
@@ -1593,12 +1593,24 @@ def run_agentic_bug_orchestrator(
     #   without confusing them with legacy outputs.
     # - Normalize `step_comments` shape: a stale list / non-dict entry / non-
     #   boolean `posted` would otherwise crash with AttributeError here.
-    if state.get("step_outputs"):
+    # - Codex review #6 of PR #966: gate the sweep to the contiguous trusted
+    #   range. The validator above corrects `last_completed_step` down when
+    #   `step_outputs` has gaps (e.g. cached 1 and 3 but no 2). Iterating
+    #   every saved key would then publish a visible comment for stale
+    #   downstream step 3 before step 2 is rerun — leaking progress the
+    #   orchestrator has already decided is not valid. Walk `ordered_steps`
+    #   only up to `last_completed_step` (post-validation) instead.
+    if state.get("step_outputs") and last_completed_step > 0:
         raw_sc = state.get("step_comments")
         if not isinstance(raw_sc, dict):
             raw_sc = {}
         state["step_comments"] = raw_sc
-        for s_key, s_out in list(state["step_outputs"].items()):
+        step_outputs_map = state["step_outputs"]
+        for s_num in ordered_steps:
+            if s_num > last_completed_step:
+                break
+            s_key = str(s_num)
+            s_out = step_outputs_map.get(s_key)
             if not isinstance(s_out, str) or s_out.startswith("FAILED:"):
                 continue
             entry = raw_sc.get(s_key)
@@ -1610,16 +1622,16 @@ def run_agentic_bug_orchestrator(
             if _extract_step_report(s_out) is None and not fallback_pending:
                 continue
             try:
-                s_num = int(float(s_key))
+                s_num_int = int(float(s_key))
             except (TypeError, ValueError):
                 continue
             desc = next(
-                (d for (n, _name, d) in steps_config if n == s_num),
+                (d for (n, _name, d) in steps_config if n == s_num_int),
                 str(s_key),
             )
             github_comment_id = _maybe_post_step_comment(
                 step_success=True,
-                step_num=s_num,
+                step_num=s_num_int,
                 description=desc,
                 step_output=s_out,
                 state=state,

--- a/pdd/agentic_bug_orchestrator.py
+++ b/pdd/agentic_bug_orchestrator.py
@@ -952,8 +952,15 @@ def _maybe_post_step_comment(
     """
     if not step_success:
         return github_comment_id
-    state.setdefault("step_comments", {})
-    if state["step_comments"].get(str(step_num), {}).get("posted"):
+    # Defensive normalization: stale/corrupted persisted state (e.g. a list, or
+    # a per-step entry that isn't a dict) would otherwise crash on `.get()`.
+    # Only a literal `True` for `posted` counts — truthy strings/ints don't.
+    raw_sc = state.get("step_comments")
+    if not isinstance(raw_sc, dict):
+        raw_sc = {}
+    state["step_comments"] = raw_sc
+    entry = raw_sc.get(str(step_num))
+    if isinstance(entry, dict) and entry.get("posted") is True:
         return github_comment_id
     extracted = _extract_step_report(step_output)
     if extracted is None:
@@ -1418,6 +1425,11 @@ def run_agentic_bug_orchestrator(
         github_comment_id = loaded_gh_id
         worktree_path_str = state.get("worktree_path")
         worktree_path = Path(worktree_path_str) if worktree_path_str else None
+        # Normalize the persisted `step_comments` shape early so any code path
+        # touching it (backfill sweep, `_maybe_post_step_comment`) sees a dict
+        # rather than crashing on a corrupted/legacy value (e.g. a list).
+        if not isinstance(state.get("step_comments"), dict):
+            state["step_comments"] = {}
     else:
         state = {"step_outputs": {}}
         last_completed_step = 0
@@ -1544,12 +1556,27 @@ def run_agentic_bug_orchestrator(
     # or transient `gh issue comment` failure. Only retries steps whose
     # outputs we already trust (not "FAILED:" sentinels). The helper is
     # idempotent — successful resumes are gated by step_comments[n].posted.
+    #
+    # Gating (codex review #4 of PR #966):
+    # - Require the saved output to contain a `<step_report>` block.
+    #   Legacy pre-PR states (where models posted comments themselves) and the
+    #   synthetic skipped-step outputs from FAST_TRACK (lines 1796-1797 below)
+    #   both lack this marker, so they're skipped — preventing duplicate or
+    #   bogus comments on resume.
+    # - Normalize `step_comments` shape: a stale list / non-dict entry / non-
+    #   boolean `posted` would otherwise crash with AttributeError here.
     if state.get("step_outputs"):
-        state.setdefault("step_comments", {})
+        raw_sc = state.get("step_comments")
+        if not isinstance(raw_sc, dict):
+            raw_sc = {}
+        state["step_comments"] = raw_sc
         for s_key, s_out in list(state["step_outputs"].items()):
             if not isinstance(s_out, str) or s_out.startswith("FAILED:"):
                 continue
-            if state["step_comments"].get(s_key, {}).get("posted"):
+            entry = raw_sc.get(s_key)
+            if isinstance(entry, dict) and entry.get("posted") is True:
+                continue
+            if _extract_step_report(s_out) is None:
                 continue
             try:
                 s_num = int(float(s_key))

--- a/pdd/agentic_bug_orchestrator.py
+++ b/pdd/agentic_bug_orchestrator.py
@@ -924,6 +924,68 @@ def _check_hard_stop(step_num: Union[int, float], output: str, files_extracted: 
     return None
 
 
+def _maybe_post_step_comment(
+    *,
+    step_success: bool,
+    step_num: Union[int, float],
+    description: str,
+    step_output: str,
+    state: Dict,
+    state_dir: Path,
+    cwd: Path,
+    issue_number: int,
+    repo_owner: str,
+    repo_name: str,
+    use_github_state: bool,
+    github_comment_id: Optional[str],
+) -> Optional[str]:
+    """Post a per-step visible comment via trusted credentials (issue #964).
+
+    Used by the bug orchestrator's three step-exit paths (success-continue,
+    FAST_TRACK-continue at step 3, and hard-stop early return). Resume-safe:
+    ``state["step_comments"][n]["posted"]`` gates reposts. Returns the
+    (possibly refreshed) ``github_comment_id`` so the caller can thread it.
+
+    NOTE: a literal ``</step_report>`` substring inside the model body would
+    terminate ``_extract_step_report`` early. Acceptable for v1 — models do
+    not normally emit the closing tag inside their own report body.
+    """
+    if not step_success:
+        return github_comment_id
+    state.setdefault("step_comments", {})
+    if state["step_comments"].get(str(step_num), {}).get("posted"):
+        return github_comment_id
+    extracted = _extract_step_report(step_output)
+    if extracted is None:
+        body_to_post = (
+            f"_Step {step_num} completed; no `<step_report>` block "
+            f"returned by agent. Raw output retained in workflow state._"
+        )
+    else:
+        body_to_post = extracted
+    step_num_int = step_num if isinstance(step_num, int) else int(step_num)
+    posted = post_step_comment(
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        issue_number=issue_number,
+        step_num=step_num_int,
+        total_steps=12,
+        description=description,
+        output=step_output,
+        cwd=cwd,
+        body=body_to_post,
+    )
+    if posted:
+        state["step_comments"][str(step_num)] = {"posted": True}
+        save_result = save_workflow_state(
+            cwd, issue_number, "bug", state, state_dir,
+            repo_owner, repo_name, use_github_state, github_comment_id,
+        )
+        if save_result:
+            github_comment_id = save_result
+    return github_comment_id
+
+
 def _get_state_dir(cwd: Path) -> Path:
     """Get the state directory relative to git root."""
     root = _get_git_root(cwd) or cwd
@@ -1706,6 +1768,22 @@ def run_agentic_bug_orchestrator(
             # Recalculate start_step so the loop skips 4 and 5
             start_step = 6
             save_workflow_state(cwd, issue_number, "bug", state, state_dir, repo_owner, repo_name, use_github_state, github_comment_id)
+            # Issue #964: post the step-3 triage comment before short-circuiting,
+            # otherwise the user sees no visible signal that triage succeeded.
+            github_comment_id = _maybe_post_step_comment(
+                step_success=True,
+                step_num=step_num,
+                description=description,
+                step_output=step_output,
+                state=state,
+                state_dir=state_dir,
+                cwd=cwd,
+                issue_number=issue_number,
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                use_github_state=use_github_state,
+                github_comment_id=github_comment_id,
+            )
             if not quiet:
                 console.print(f"[cyan]  → Fast-track: skipping Steps 4-5 (issue pre-diagnosed)[/cyan]")
             continue
@@ -2304,6 +2382,25 @@ def run_agentic_bug_orchestrator(
             state["last_completed_step"] = step_num
             state["step_outputs"][str(step_num)] = step_output
             save_workflow_state(cwd, issue_number, "bug", state, state_dir, repo_owner, repo_name, use_github_state, github_comment_id)
+            # Issue #964: post the model's report even on hard stop. The step's
+            # WORK succeeded (e.g. detected duplicate, classified user error);
+            # the orchestrator just decided not to continue. Without this the
+            # final visible signal (Duplicate-of-X, Needs-More-Info, etc.) is
+            # lost to the user.
+            github_comment_id = _maybe_post_step_comment(
+                step_success=True,
+                step_num=step_num,
+                description=description,
+                step_output=step_output,
+                state=state,
+                state_dir=state_dir,
+                cwd=cwd,
+                issue_number=issue_number,
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                use_github_state=use_github_state,
+                github_comment_id=github_comment_id,
+            )
             return False, f"Stopped at step {step_num}: {stop_reason}", total_cost, model_used, changed_files
 
         if not step_success:
@@ -2326,40 +2423,20 @@ def run_agentic_bug_orchestrator(
         # Posting through trusted credentials means Gemini's sandboxed shell no
         # longer needs GH_TOKEN passthrough. The posted-state is tracked in
         # workflow state so a resume after an interruption does not double-post.
-        if step_success:
-            state.setdefault("step_comments", {})
-            already_posted = (
-                state["step_comments"].get(str(step_num), {}).get("posted", False)
-            )
-            if not already_posted:
-                extracted = _extract_step_report(step_output)
-                if extracted is None:
-                    body_to_post = (
-                        f"_Step {step_num} completed; no `<step_report>` block "
-                        f"returned by agent. Raw output retained in workflow state._"
-                    )
-                else:
-                    body_to_post = extracted
-                step_num_int = step_num if isinstance(step_num, int) else int(step_num)
-                posted = post_step_comment(
-                    repo_owner=repo_owner,
-                    repo_name=repo_name,
-                    issue_number=issue_number,
-                    step_num=step_num_int,
-                    total_steps=12,
-                    description=description,
-                    output=step_output,
-                    cwd=cwd,
-                    body=body_to_post,
-                )
-                if posted:
-                    state["step_comments"][str(step_num)] = {"posted": True}
-                    save_result = save_workflow_state(
-                        cwd, issue_number, "bug", state, state_dir,
-                        repo_owner, repo_name, use_github_state, github_comment_id,
-                    )
-                    if save_result:
-                        github_comment_id = save_result
+        github_comment_id = _maybe_post_step_comment(
+            step_success=step_success,
+            step_num=step_num,
+            description=description,
+            step_output=step_output,
+            state=state,
+            state_dir=state_dir,
+            cwd=cwd,
+            issue_number=issue_number,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            use_github_state=use_github_state,
+            github_comment_id=github_comment_id,
+        )
 
         # Print step completion marker (required for credential waterfall detection)
         if not quiet:

--- a/pdd/agentic_change_orchestrator.py
+++ b/pdd/agentic_change_orchestrator.py
@@ -1212,8 +1212,12 @@ def _load_pddrc_context(cwd: Path) -> Dict[str, str]:
         test_dir = ctx_defaults.get("test_output_path", defaults["test_dir"])
         example_dir = ctx_defaults.get("example_output_path", defaults["example_dir"])
 
-        # Derive ext from language
-        ext = get_extension(language) if language else defaults["ext"]
+        # Derive ext from language; preserve .pddrc dirs even if package data
+        # resolution is unavailable in a minimal test/runtime environment.
+        try:
+            ext = get_extension(language) if language else defaults["ext"]
+        except Exception:
+            ext = defaults["ext"]
         if ext.startswith("."):
             ext = ext[1:]  # Remove leading dot if present
 

--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -3382,6 +3382,76 @@ def clear_workflow_state(
         github_clear_state(repo_owner, repo_name, issue_number, workflow_type, cwd)
 
 
+# ---------------------------------------------------------------------------
+# Step-comment helpers (issue #964)
+#
+# Models used to post per-step GitHub issue comments themselves via shell
+# commands embedded in their prompts. This is unreliable across providers (in
+# particular Gemini's sandboxed shell cannot read GH_TOKEN). The orchestrator
+# now owns these writes: providers emit a delimited `<step_report>…
+# </step_report>` block that the orchestrator extracts, sanitizes, truncates,
+# and posts via `post_step_comment(body=…)` using trusted credentials.
+# ---------------------------------------------------------------------------
+
+_STEP_REPORT_RE = re.compile(
+    r"<step_report>(.*?)</step_report>",
+    re.DOTALL | re.IGNORECASE,
+)
+
+_SECRET_PATTERNS: Tuple[Tuple["re.Pattern[str]", str], ...] = (
+    (re.compile(r"\bghp_[A-Za-z0-9]{20,}"),                "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}"),        "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"\b(?:gho_|ghu_|ghs_|ghr_)[A-Za-z0-9]{20,}"), "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"\bAIza[A-Za-z0-9_\-]{20,}"),             "[REDACTED_GOOGLE_API_KEY]"),
+    (re.compile(r"\bxai-[A-Za-z0-9]{20,}"),                "[REDACTED_XAI_KEY]"),
+    (re.compile(r"\bsk-[A-Za-z0-9_\-]{20,}"),              "[REDACTED_OPENAI_KEY]"),
+    (re.compile(r"\bgsk_[A-Za-z0-9]{20,}"),                "[REDACTED_GROQ_KEY]"),
+)
+
+_ENV_TOKEN_RE    = re.compile(r"\b(GH_TOKEN|GITHUB_TOKEN)\s*=\s*\S+")
+_BEARER_TOKEN_RE = re.compile(r"(Authorization:\s*Bearer\s+)\S+", re.IGNORECASE)
+
+_COMMENT_MAX_CHARS = 25_000
+
+
+def _extract_step_report(text: Optional[str]) -> Optional[str]:
+    """Extract the LAST ``<step_report>…</step_report>`` block from text.
+
+    Returns ``None`` if the input is empty or no tagged block is present. The
+    extracted body has surrounding whitespace stripped so callers can rely on a
+    clean payload. The regex is DOTALL + case-insensitive so the body can span
+    multiple lines and providers can emit ``<STEP_REPORT>`` if they choose.
+    """
+    if not text:
+        return None
+    matches = _STEP_REPORT_RE.findall(text)
+    if not matches:
+        return None
+    return matches[-1].strip()
+
+
+def _sanitize_comment_body(
+    body: Optional[str],
+    max_chars: int = _COMMENT_MAX_CHARS,
+) -> str:
+    """Redact known secret formats and truncate the body.
+
+    Idempotent and conservative: only patterns that look like credentials are
+    rewritten, and the function never raises. Truncation happens AFTER redaction
+    so a secret near the end of an oversized payload still gets scrubbed.
+    """
+    if not body:
+        return body or ""
+    redacted = body
+    for pat, repl in _SECRET_PATTERNS:
+        redacted = pat.sub(repl, redacted)
+    redacted = _ENV_TOKEN_RE.sub(lambda m: f"{m.group(1)}=[REDACTED]", redacted)
+    redacted = _BEARER_TOKEN_RE.sub(lambda m: f"{m.group(1)}[REDACTED]", redacted)
+    if len(redacted) > max_chars:
+        redacted = redacted[:max_chars] + "\n\n…[truncated]"
+    return redacted
+
+
 def post_step_comment(
     repo_owner: str,
     repo_name: str,
@@ -3391,59 +3461,87 @@ def post_step_comment(
     description: str,
     output: str,
     cwd: Path,
+    body: Optional[str] = None,
 ) -> bool:
-    """
-    Post a fallback comment on a GitHub issue when a step fails.
+    """Post a per-step GitHub issue comment.
 
-    When the LLM agent fails (e.g., all providers unavailable), the agent never
-    runs and therefore never posts its own step comment. This function posts a
-    fallback comment so users can see which steps failed and why.
+    Two modes:
+
+    1. ``body is None`` (legacy / fallback path): used by orchestrators when
+       the LLM agent itself failed and therefore could not produce a report.
+       The body is the historical FAILED template, kept verbatim for backwards
+       compatibility with existing callers (e.g. ``agentic_change_orchestrator``
+       hard-stop paths).
+    2. ``body is not None``: the orchestrator extracted a ``<step_report>``
+       block from a successful run. The body is sanitized + truncated by the
+       orchestrator's pipeline; here we additionally strip any leading
+       duplicate ``## Step N`` header the model emitted and prepend our own
+       canonical header so framing is consistent regardless of provider.
 
     Args:
-        repo_owner: GitHub repository owner
-        repo_name: GitHub repository name
-        issue_number: Issue number to comment on
-        step_num: Current step number
-        total_steps: Total number of steps in the workflow
-        description: Human-readable step description
-        output: Error output / failure details
-        cwd: Working directory for subprocess
+        repo_owner: GitHub repository owner.
+        repo_name: GitHub repository name.
+        issue_number: Issue number to comment on.
+        step_num: Current step number.
+        total_steps: Total number of steps in the workflow.
+        description: Human-readable step description (used in the header).
+        output: Raw provider output (still used for the FAILED fallback path).
+        cwd: Working directory for the ``gh`` subprocess.
+        body: Optional pre-extracted, model-supplied report body. When set,
+            takes precedence over the FAILED template.
 
     Returns:
-        True if comment was posted successfully, False otherwise
+        True if the comment posted successfully, False otherwise (including
+        when ``gh`` is not on PATH).
     """
     if not _find_cli_binary("gh"):
         return False
 
-    # Truncate output to avoid exceeding GitHub comment size limits
-    error_detail = output[:1000] if len(output) > 1000 else output
-
-    body = (
-        f"## Step {step_num}/{total_steps}: {description}\n\n"
-        f"**Status:** FAILED\n\n"
-        f"### Error Details\n"
-        f"```\n{error_detail}\n```\n\n"
-        f"---\n"
-        f"*Automated fallback comment — agent did not execute for this step.*"
-    )
+    if body is None:
+        # Backwards-compatible fallback for agent-execution failures.
+        error_detail = output[:1000] if output and len(output) > 1000 else (output or "")
+        final_body = (
+            f"## Step {step_num}/{total_steps}: {description}\n\n"
+            f"**Status:** FAILED\n\n"
+            f"### Error Details\n"
+            f"```\n{error_detail}\n```\n\n"
+            f"---\n"
+            f"*Automated fallback comment — agent did not execute for this step.*"
+        )
+    else:
+        # Strip a single leading duplicate "## Step <N>..." line so the
+        # orchestrator's canonical header isn't shadowed. Only the FIRST
+        # occurrence is removed — interior headers (e.g. inside a fenced
+        # block summarising another step) are preserved.
+        leading_dup_re = re.compile(
+            rf"^\s*##\s+Step\s+{re.escape(str(step_num))}\b[^\n]*\n+",
+        )
+        stripped = leading_dup_re.sub("", body, count=1)
+        sanitized = _sanitize_comment_body(stripped)
+        final_body = (
+            f"## Step {step_num}/{total_steps}: {description}\n\n"
+            f"{sanitized}\n\n"
+            f"---\n"
+            f"*Posted by PDD orchestrator (trusted credentials).*"
+        )
 
     try:
         result = subprocess.run(
             [
                 "gh", "issue", "comment", str(issue_number),
                 "--repo", f"{repo_owner}/{repo_name}",
-                "--body", body,
+                "--body", final_body,
             ],
             cwd=cwd,
             capture_output=True,
             text=True,
         )
         if result.returncode != 0:
-            console.print(f"[yellow]Warning: Failed to post fallback comment for step {step_num}: {result.stderr}[/yellow]")
+            console.print(f"[yellow]Warning: Failed to post comment for step {step_num}: {result.stderr}[/yellow]")
             return False
         return True
     except Exception as e:
-        console.print(f"[yellow]Warning: Failed to post fallback comment for step {step_num}: {e}[/yellow]")
+        console.print(f"[yellow]Warning: Failed to post comment for step {step_num}: {e}[/yellow]")
         return False
 
 

--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -3505,7 +3505,7 @@ def post_step_comment(
 
     if body is None:
         # Backwards-compatible fallback for agent-execution failures.
-        error_detail = output[:1000] if output and len(output) > 1000 else (output or "")
+        error_detail = _sanitize_comment_body(output or "", max_chars=1000)
         final_body = (
             f"## Step {step_num}/{total_steps}: {description}\n\n"
             f"**Status:** FAILED\n\n"

--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -3412,6 +3412,7 @@ _ENV_TOKEN_RE    = re.compile(r"\b(GH_TOKEN|GITHUB_TOKEN)\s*=\s*\S+")
 _BEARER_TOKEN_RE = re.compile(r"(Authorization:\s*Bearer\s+)\S+", re.IGNORECASE)
 
 _COMMENT_MAX_CHARS = 25_000
+_TRUNCATED_MARKER = "\n\n…[truncated]"
 
 
 def _extract_step_report(text: Optional[str]) -> Optional[str]:
@@ -3448,7 +3449,10 @@ def _sanitize_comment_body(
     redacted = _ENV_TOKEN_RE.sub(lambda m: f"{m.group(1)}=[REDACTED]", redacted)
     redacted = _BEARER_TOKEN_RE.sub(lambda m: f"{m.group(1)}[REDACTED]", redacted)
     if len(redacted) > max_chars:
-        redacted = redacted[:max_chars] + "\n\n…[truncated]"
+        # Reserve room for the marker so the returned length never exceeds the
+        # caller-supplied cap (codex review of PR #966).
+        keep = max(0, max_chars - len(_TRUNCATED_MARKER))
+        redacted = redacted[:keep] + _TRUNCATED_MARKER
     return redacted
 
 

--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -3450,9 +3450,11 @@ def _sanitize_comment_body(
     redacted = _BEARER_TOKEN_RE.sub(lambda m: f"{m.group(1)}[REDACTED]", redacted)
     if len(redacted) > max_chars:
         # Reserve room for the marker so the returned length never exceeds the
-        # caller-supplied cap (codex review of PR #966).
+        # caller-supplied cap (codex review of PR #966). When max_chars is
+        # smaller than the marker itself, the marker won't fit either — the
+        # final slice enforces the cap unconditionally.
         keep = max(0, max_chars - len(_TRUNCATED_MARKER))
-        redacted = redacted[:keep] + _TRUNCATED_MARKER
+        redacted = (redacted[:keep] + _TRUNCATED_MARKER)[:max_chars]
     return redacted
 
 

--- a/pdd/prompts/agentic_bug_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_bug_orchestrator_python.prompt
@@ -57,7 +57,7 @@ BUG_STEP_TIMEOUTS: Dict[int, float] = {
 7. For Step 11: Parse agent output for `E2E_FILES_CREATED: path1, path2` lines to extract E2E test files, extend changed_files list
 8. Pass extracted files to Step 11 (E2E) and Step 12 (PR) via `files_to_stage` context variable for explicit git staging
 9. Persist workflow state between steps via `save_workflow_state` / `load_workflow_state` so a crash can resume; honor `use_github_state` to mirror state into a hidden GitHub state comment
-10. After every successfully completed step (including hard-stop reports, which are treated as successful posts before early return), post a visible step comment to the issue via `post_step_comment(..., body=...)` using the model's `<step_report>` block (issue #964 — orchestrator-owned posting). Soft failures (`step_success=False` without a hard-stop trigger) are skipped — the workflow logs the warning and continues without posting. Persist `state["step_comments"][str(step_num)] = {"posted": True}` so resumes never duplicate comments, and backfill any completed step that has a `<step_report>` block but no posted flag on resume entry.
+10. After every successfully completed step (including hard-stop reports, which are treated as successful posts before early return), post a visible step comment to the issue via `post_step_comment(..., body=...)` using the model's `<step_report>` block (issue #964 — orchestrator-owned posting). For soft failures (`step_success=False` without a hard-stop trigger), post the legacy FAILED fallback comment through the orchestrator and continue, but do not set the normal `posted: True` flag so a later successful retry can still post its report. Persist `state["step_comments"][str(step_num)] = {"posted": True}` only for successful reports so resumes never duplicate comments, and backfill any completed step that has a `<step_report>` block but no posted flag on resume entry. If Step 12 fails, return failure instead of reporting a completed investigation. Redact secrets before storing any raw step output in workflow state because state may sync to GitHub.
 
 % Step Execution
 For each step (1-12):
@@ -134,7 +134,15 @@ The orchestrator must parse step output to detect stop conditions:
 **Soft failures (continue):**
 - If `run_agentic_task()` returns `(False, ...)` but does NOT match a hard stop condition: log warning and continue
 - This applies to all steps - only the specific hard stop patterns above terminate the workflow
-- The orchestrator still attempts to post the model's `<step_report>` block on success; the legacy FAILED template path (`body=None`) is retained for hard-stop callers in `agentic_change_orchestrator` only.
+- The orchestrator posts the legacy FAILED template (`body=None`) for the failed step, tracking it with `failed_posted` instead of `posted` so a future successful retry is not suppressed.
+- The third consecutive `All agent providers failed` abort still posts the failed-step fallback before returning failure.
+- If Step 12 fails, the workflow returns `(False, "Investigation failed at step 12: ...", ...)` after posting the fallback comment; there is no later step that can recover PR creation.
+
+% E2E Gate
+
+- Parse `E2E_NEEDED:` only from raw output outside any `<step_report>...</step_report>` block.
+- Use the last outside marker line matching `E2E_NEEDED: yes|no`.
+- Skip Step 11 only when that parsed marker is `no`; if missing or `yes`, run Step 11.
 
 % Git Worktree Isolation
 

--- a/pdd/prompts/agentic_bug_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_bug_orchestrator_python.prompt
@@ -57,7 +57,7 @@ BUG_STEP_TIMEOUTS: Dict[int, float] = {
 7. For Step 11: Parse agent output for `E2E_FILES_CREATED: path1, path2` lines to extract E2E test files, extend changed_files list
 8. Pass extracted files to Step 11 (E2E) and Step 12 (PR) via `files_to_stage` context variable for explicit git staging
 9. Persist workflow state between steps via `save_workflow_state` / `load_workflow_state` so a crash can resume; honor `use_github_state` to mirror state into a hidden GitHub state comment
-10. After every step (success, hard stop, or soft failure), post a visible step comment to the issue via `post_step_comment(..., body=...)` using the model's `<step_report>` block (issue #964 — orchestrator-owned posting). Persist `state["step_comments"][str(step_num)] = {"posted": True}` so resumes never duplicate comments, and backfill any completed step that has a `<step_report>` block but no posted flag on resume entry.
+10. After every successfully completed step (including hard-stop reports, which are treated as successful posts before early return), post a visible step comment to the issue via `post_step_comment(..., body=...)` using the model's `<step_report>` block (issue #964 — orchestrator-owned posting). Soft failures (`step_success=False` without a hard-stop trigger) are skipped — the workflow logs the warning and continues without posting. Persist `state["step_comments"][str(step_num)] = {"posted": True}` so resumes never duplicate comments, and backfill any completed step that has a `<step_report>` block but no posted flag on resume entry.
 
 % Step Execution
 For each step (1-12):

--- a/pdd/prompts/agentic_bug_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_bug_orchestrator_python.prompt
@@ -1,4 +1,4 @@
-<pdd-reason>Orchestrates the 11-step agentic bug workflow with E2E gate and state persistence.</pdd-reason>
+<pdd-reason>Orchestrates the 12-step agentic bug workflow with E2E gate, persistent state, and orchestrator-owned GitHub step comments.</pdd-reason>
 <pdd-interface>
 {
   "type": "module",
@@ -6,10 +6,13 @@
     "functions": [
       {
         "name": "run_agentic_bug_orchestrator",
-        "signature": "(issue_url: str, issue_content: str, repo_owner: str, repo_name: str, issue_number: int, issue_author: str, issue_title: str) -> Tuple[bool, str, float, str, List[str]]",
+        "signature": "(issue_url: str, issue_content: str, repo_owner: str, repo_name: str, issue_number: int, issue_author: str, issue_title: str, *, cwd: Path, verbose: bool = False, quiet: bool = False, timeout_adder: float = 0.0, use_github_state: bool = True, reasoning_time: Optional[float] = None) -> Tuple[bool, str, float, str, List[str]]",
         "returns": "Tuple[bool, str, float, str, List[str]]",
         "sideEffects": [
-          "None"
+          "Posts GitHub issue comments via post_step_comment",
+          "Persists workflow state via save_workflow_state (local + optional GitHub state comment)",
+          "Creates/removes git worktrees and branches under .pdd/worktrees/fix-issue-{N}/",
+          "Spawns external agentic CLI subprocesses (claude/gemini/codex/opencode)"
         ]
       }
     ]
@@ -45,17 +48,19 @@ BUG_STEP_TIMEOUTS: Dict[int, float] = {
 ```
 
 % Requirements
-1. Function: `run_agentic_bug_orchestrator(issue_url: str, issue_content: str, repo_owner: str, repo_name: str, issue_number: int, issue_author: str, issue_title: str, *, cwd: Path, verbose: bool = False, quiet: bool = False) -> Tuple[bool, str, float, str, List[str]]`
+1. Function: `run_agentic_bug_orchestrator(issue_url: str, issue_content: str, repo_owner: str, repo_name: str, issue_number: int, issue_author: str, issue_title: str, *, cwd: Path, verbose: bool = False, quiet: bool = False, timeout_adder: float = 0.0, use_github_state: bool = True, reasoning_time: Optional[float] = None) -> Tuple[bool, str, float, str, List[str]]`
 2. Return 5-tuple: (success, final_message, total_cost, model_used, changed_files)
-3. Run 10 steps sequentially, each as a separate `run_agentic_task()` call
+3. Run 12 steps sequentially, each as a separate `run_agentic_task()` call
 4. Accumulate step outputs to pass as context to subsequent steps
 5. Track total cost across all steps
-6. For Step 7: Parse agent output for `FILES_CREATED: path1, path2` or `FILES_MODIFIED: path1, path2` lines to extract changed files (used for hard stop check and final summary)
-7. For Step 9: Parse agent output for `E2E_FILES_CREATED: path1, path2` lines to extract E2E test files, extend changed_files list
-8. Pass extracted files to Step 9 (E2E) and Step 10 (PR) via `files_to_stage` context variable for explicit git staging
+6. For Step 9: Parse agent output for `FILES_CREATED: path1, path2` or `FILES_MODIFIED: path1, path2` lines to extract changed files (used for hard stop check and final summary)
+7. For Step 11: Parse agent output for `E2E_FILES_CREATED: path1, path2` lines to extract E2E test files, extend changed_files list
+8. Pass extracted files to Step 11 (E2E) and Step 12 (PR) via `files_to_stage` context variable for explicit git staging
+9. Persist workflow state between steps via `save_workflow_state` / `load_workflow_state` so a crash can resume; honor `use_github_state` to mirror state into a hidden GitHub state comment
+10. After every step (success, hard stop, or soft failure), post a visible step comment to the issue via `post_step_comment(..., body=...)` using the model's `<step_report>` block (issue #964 — orchestrator-owned posting). Persist `state["step_comments"][str(step_num)] = {"posted": True}` so resumes never duplicate comments, and backfill any completed step that has a `<step_report>` block but no posted flag on resume entry.
 
 % Step Execution
-For each step (1-10):
+For each step (1-12):
 1. Load the step prompt template via `load_prompt_template(f"agentic_bug_step{n}_{name}_LLM")`
 2. Format template with: issue_url, repo_owner, repo_name, issue_number, issue_content, issue_author, step1_output, step2_output, etc.
 3. Call `run_agentic_task(formatted_prompt, cwd, ..., timeout=STEP_TIMEOUTS.get(step_num))`
@@ -70,30 +75,29 @@ For each step (1-10):
 | 1 | agentic_bug_step1_duplicate_LLM | Search for duplicate issues |
 | 2 | agentic_bug_step2_docs_LLM | Check documentation for user error |
 | 3 | agentic_bug_step3_triage_LLM | Assess if enough info to proceed |
-| 4 | agentic_bug_step4_reproduce_LLM | Attempt to reproduce the bug |
-| 5 | agentic_bug_step5_root_cause_LLM | Analyze root cause |
-| 6 | agentic_bug_step6_test_plan_LLM | Design test strategy |
-| 7 | agentic_bug_step7_generate_LLM | Generate failing unit test |
-| 8 | agentic_bug_step8_verify_LLM | Verify test catches the bug |
-| 9 | agentic_bug_step9_e2e_test_LLM | Generate and run E2E tests |
-| 10 | agentic_bug_step10_pr_LLM | Create draft PR and link to issue |
+| 4 | agentic_bug_step4_api_research_LLM | Research external API dependencies and constraints |
+| 5 | agentic_bug_step5_reproduce_LLM | Attempt to reproduce the bug |
+| 6 | agentic_bug_step6_root_cause_LLM | Analyze root cause |
+| 7 | agentic_bug_step7_prompt_classification_LLM | Classify defect: code bug vs prompt defect (may auto-fix prompts) |
+| 8 | agentic_bug_step8_test_plan_LLM | Design test strategy |
+| 9 | agentic_bug_step9_generate_LLM | Generate failing unit test |
+| 10 | agentic_bug_step10_verify_LLM | Verify test catches the bug |
+| 11 | agentic_bug_step11_e2e_test_LLM | Generate and run E2E tests |
+| 12 | agentic_bug_step12_pr_LLM | Create draft PR and link to issue |
 
 % Context Accumulation
 - Step 1 receives: issue_content
 - Step 2 receives: issue_content, step1_output
 - Step 3 receives: issue_content, step1_output, step2_output
-- Step 4 receives: issue_content, step1_output through step3_output
-- ... and so on
-- Step 8 receives: issue_content, step1_output through step7_output
-- Step 9 receives: issue_content, step1_output through step8_output, worktree_path, files_to_stage
-- Step 10 receives: issue_content, step1_output through step9_output, worktree_path, files_to_stage
+- Step N receives: issue_content plus step1_output through step(N-1)_output
+- Steps 11 and 12 additionally receive: worktree_path, files_to_stage
 
 % Files to Stage
-After Step 7 parses FILES_CREATED/FILES_MODIFIED, pass the extracted file list to Steps 9 and 10:
+After Step 9 parses FILES_CREATED/FILES_MODIFIED, pass the extracted file list to Steps 11 and 12:
 - `context["files_to_stage"] = ", ".join(changed_files)`
-- After Step 9 parses E2E_FILES_CREATED, extend changed_files and update files_to_stage
-- This ensures Step 9 (E2E) and Step 10 (PR) know exactly which files to include
-- Step 10 prompt uses `{files_to_stage}` to display the explicit list of files to stage
+- After Step 11 parses E2E_FILES_CREATED, extend changed_files and update files_to_stage
+- This ensures Step 11 (E2E) and Step 12 (PR) know exactly which files to include
+- Step 12 prompt uses `{files_to_stage}` to display the explicit list of files to stage
 
 % Early Exit Conditions (Hard Stops)
 
@@ -104,9 +108,10 @@ The orchestrator must parse step output to detect stop conditions:
 | 1 | Issue is a duplicate | Output contains "Duplicate of #" |
 | 2 | "Feature Request" or "User Error" | Output contains "Feature Request (Not a Bug)" or "User Error (Not a Bug)" |
 | 3 | Needs more info from author | Output contains "Needs More Info" |
-| 7 | No test file generated | No FILES_CREATED or FILES_MODIFIED line in output, or empty file list |
-| 8 | Test doesn't fail correctly | Output contains "FAIL: Test does not work as expected" |
-| 9 | E2E test doesn't catch bug | Output contains "E2E_FAIL: Test does not catch bug correctly" |
+| 7 | Prompt defect detected (auto-fixed) | Output contains "PROMPT_REVIEW:" |
+| 9 | No test file generated | No FILES_CREATED or FILES_MODIFIED line in output, or empty file list |
+| 10 | Test doesn't fail correctly | Output contains "FAIL: Test does not work as expected" |
+| 11 | E2E test doesn't catch bug | Output contains "E2E_FAIL: Test does not catch bug correctly" |
 
 **Hard stop behavior (issue #964 — orchestrator-owned posting):**
 - Steps do NOT shell out to `gh issue comment` themselves. Instead, each step's
@@ -144,11 +149,11 @@ Before Step 7, create an isolated git worktree for test generation and PR creati
    - Create worktree: `git worktree add -b {branch} {path} HEAD`
    - Return (worktree_path, None) on success, (None, error_msg) on failure
 
-2. In orchestrator loop, before Step 7:
+2. In orchestrator loop, before Step 9 (the first step that writes test files):
    - Call `_setup_worktree(cwd, issue_number, quiet)`
    - If worktree creation fails, return early with error: `(False, "Failed to create worktree: {error}", ...)`
-   - Switch working directory to worktree path for Steps 7-10
-   - Add `worktree_path` to context dict (for Step 10 prompt formatting)
+   - Switch working directory to worktree path for Steps 9-12
+   - Add `worktree_path` to context dict (for Step 12 prompt formatting)
    - Print: `"[blue]Working in worktree: {worktree_path}[/blue]"` (unless quiet)
 
 3. Additional helper functions:
@@ -169,7 +174,7 @@ The orchestrator must provide real-time feedback to the user via rich console ou
 
 2. **Step progress** (before each step):
    ```
-   [Step N/10] {step_description}...
+   [Step N/12] {step_description}...
    ```
 
 3. **Agentic output** (during each step):
@@ -199,7 +204,9 @@ The orchestrator must provide real-time feedback to the user via rich console ou
 Use `quiet` flag to suppress all output except errors. Use `verbose` flag to show full agentic task output.
 
 % Dependencies
-Import from `agentic_common`: `run_agentic_task`, `STEP_TIMEOUTS`
+Import from `agentic_common`: `run_agentic_task`, `STEP_TIMEOUTS`,
+`post_step_comment`, `save_workflow_state`, `load_workflow_state`,
+`clear_workflow_state`.
 <pdd.agentic_common><include>context/agentic_common_example.py</include></pdd.agentic_common>
 <pdd.load_prompt_template><include>context/load_prompt_template_example.py</include></pdd.load_prompt_template>
 <pdd.agentic_bug><include>context/agentic_bug_example.py</include></pdd.agentic_bug>

--- a/pdd/prompts/agentic_bug_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_bug_orchestrator_python.prompt
@@ -108,15 +108,28 @@ The orchestrator must parse step output to detect stop conditions:
 | 8 | Test doesn't fail correctly | Output contains "FAIL: Test does not work as expected" |
 | 9 | E2E test doesn't catch bug | Output contains "E2E_FAIL: Test does not catch bug correctly" |
 
-**Hard stop behavior:**
-- Return `(False, "Stopped at step N: {reason}", total_cost, model_used, changed_files)`
-- The step has already posted its findings to GitHub before returning
+**Hard stop behavior (issue #964 — orchestrator-owned posting):**
+- Steps do NOT shell out to `gh issue comment` themselves. Instead, each step's
+  prompt instructs the model to wrap its visible findings in a
+  `<step_report>...</step_report>` block. The orchestrator extracts that block
+  via `_extract_step_report`, sanitizes it via `_sanitize_comment_body`, and
+  posts via `post_step_comment(..., body=...)` using the cloud worker's trusted
+  GitHub credentials. This avoids the Gemini sandbox failure mode where
+  `GH_TOKEN` is not visible to the agent subprocess.
+- Persist a per-step `state["step_comments"][str(step_num)] = {"posted": True}`
+  entry on every successful post so resumes never duplicate comments. On entry,
+  the orchestrator backfills any completed step whose output contains a
+  `<step_report>` block but lacks a matching `posted: True` flag — that gate
+  skips legacy pre-PR outputs and FAST_TRACK synthetic skipped-step entries,
+  both of which lack the tag.
+- After posting (or skipping if already posted), return
+  `(False, "Stopped at step N: {reason}", total_cost, model_used, changed_files)`
 - Do NOT continue to subsequent steps
 
 **Soft failures (continue):**
 - If `run_agentic_task()` returns `(False, ...)` but does NOT match a hard stop condition: log warning and continue
 - This applies to all steps - only the specific hard stop patterns above terminate the workflow
-- Steps should post their findings to GitHub even on partial failure
+- The orchestrator still attempts to post the model's `<step_report>` block on success; the legacy FAILED template path (`body=None`) is retained for hard-stop callers in `agentic_change_orchestrator` only.
 
 % Git Worktree Isolation
 

--- a/pdd/prompts/agentic_bug_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_bug_orchestrator_python.prompt
@@ -149,10 +149,10 @@ Before Step 7, create an isolated git worktree for test generation and PR creati
    - Create worktree: `git worktree add -b {branch} {path} HEAD`
    - Return (worktree_path, None) on success, (None, error_msg) on failure
 
-2. In orchestrator loop, before Step 9 (the first step that writes test files):
+2. In orchestrator loop, before Step 7 (the first step that can write files — Step 7 may auto-fix prompt specifications and emits `PROMPT_FIXED`):
    - Call `_setup_worktree(cwd, issue_number, quiet)`
    - If worktree creation fails, return early with error: `(False, "Failed to create worktree: {error}", ...)`
-   - Switch working directory to worktree path for Steps 9-12
+   - Switch working directory to worktree path for Steps 7-12
    - Add `worktree_path` to context dict (for Step 12 prompt formatting)
    - Print: `"[blue]Working in worktree: {worktree_path}[/blue]"` (unless quiet)
 

--- a/pdd/prompts/agentic_bug_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_bug_orchestrator_python.prompt
@@ -1,3 +1,22 @@
+<pdd-reason>Orchestrates the 11-step agentic bug workflow with E2E gate and state persistence.</pdd-reason>
+<pdd-interface>
+{
+  "type": "module",
+  "module": {
+    "functions": [
+      {
+        "name": "run_agentic_bug_orchestrator",
+        "signature": "(issue_url: str, issue_content: str, repo_owner: str, repo_name: str, issue_number: int, issue_author: str, issue_title: str) -> Tuple[bool, str, float, str, List[str]]",
+        "returns": "Tuple[bool, str, float, str, List[str]]",
+        "sideEffects": [
+          "None"
+        ]
+      }
+    ]
+  }
+}
+</pdd-interface>
+
 <include>context/python_preamble.prompt</include>
 
 % Goal

--- a/pdd/prompts/agentic_bug_step10_verify_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step10_verify_LLM.prompt
@@ -143,12 +143,15 @@ Return your findings between `<step_report>` and `</step_report>` tags. The PDD 
 4. Submit PR with fix and test
 
 ---
-*{{If E2E_NEEDED: yes → "Proceeding to Step 11: E2E Tests" | If E2E_NEEDED: no → "E2E skipped — proceeding to Step 12: Create Draft PR"}}*
+*Proceeding to {{Step 11: E2E Tests | Step 12: Create Draft PR}} based on E2E classification (emitted after this report).*
 </step_report>
 
-After the closing `</step_report>` tag, emit the E2E classification marker on its own line (parsed from raw output — MUST live OUTSIDE the report block):
+After the closing `</step_report>` tag, emit the E2E classification marker on its own line (parsed from raw output — MUST live OUTSIDE the report block). The marker literal `E2E_NEEDED:` must never appear inside the report body because the orchestrator parses raw `step_output` for it.
+
+Choose one of:
 ```
-E2E_NEEDED: [yes|no] — [one-line justification]
+E2E_NEEDED: yes — [one-line justification why a user-facing E2E test is needed]
+E2E_NEEDED: no  — [one-line justification why the unit test covers it end-to-end]
 ```
 
 % Important — MANDATORY

--- a/pdd/prompts/agentic_bug_step10_verify_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step10_verify_LLM.prompt
@@ -103,15 +103,9 @@ You are working on step 10 of 12 in an agentic bug investigation workflow. Previ
 
 % Output
 
-After completing verification, use `gh issue comment` to post your final report to issue #{issue_number}:
+Return your findings between `<step_report>` and `</step_report>` tags. The PDD orchestrator will sanitize, truncate, and post the contents as a GitHub comment using trusted credentials. **Do NOT run `gh issue comment` yourself** — model subprocesses cannot reliably authenticate.
 
-```
-gh issue comment {issue_number} --repo {repo_owner}/{repo_name} --body "..."
-```
-
-Your comment should follow this format:
-
-```markdown
+<step_report>
 ## Step 10: Verification Complete
 
 ### Test Execution
@@ -142,9 +136,6 @@ Your comment should follow this format:
 - **Root Cause:** {{one_line_summary}}
 - **Test File:** `{{test_file_path}}`
 
-### E2E Classification
-E2E_NEEDED: [yes|no] — [one-line justification]
-
 ### Next Steps
 1. Fix the bug at the identified location
 2. Run the test to confirm the fix
@@ -153,17 +144,21 @@ E2E_NEEDED: [yes|no] — [one-line justification]
 
 ---
 *{{If E2E_NEEDED: yes → "Proceeding to Step 11: E2E Tests" | If E2E_NEEDED: no → "E2E skipped — proceeding to Step 12: Create Draft PR"}}*
+</step_report>
+
+After the closing `</step_report>` tag, emit the E2E classification marker on its own line (parsed from raw output — MUST live OUTSIDE the report block):
+```
+E2E_NEEDED: [yes|no] — [one-line justification]
 ```
 
 % Important — MANDATORY
 
-- Provide a complete summary of the investigation so far
-- The test must actually fail when run (verify this)
-- If the test doesn't fail, go back and fix the test
-- The comment should serve as documentation for anyone fixing the bug
-- Always post your findings as a GitHub comment before completing
-- **MANDATORY E2E CLASSIFICATION:** Your GitHub comment MUST include the "### E2E Classification" section with exactly one of:
+- Provide a complete summary of the investigation so far inside the `<step_report>` block.
+- The test must actually fail when run (verify this).
+- If the test doesn't fail, go back and fix the test.
+- The report should serve as documentation for anyone fixing the bug.
+- Place your findings inside the `<step_report>` block — the orchestrator will post it to GitHub for you.
+- **MANDATORY E2E CLASSIFICATION (OUTSIDE THE REPORT BLOCK):** After the `</step_report>` tag, your very last output line MUST be exactly one of:
   - `E2E_NEEDED: yes — [justification]` — if the bug has user-facing symptoms that the unit test cannot verify because it mocks the integration boundary
   - `E2E_NEEDED: no — [justification]` — if the unit test already covers the behavioral fix end-to-end, or if the bug is purely internal with no distinct integration path
-  The orchestrator parses this marker to decide whether to run Step 11. If you omit it, Step 11 runs unconditionally (wasting time and cost). This line MUST appear exactly as shown — on its own line, starting with `E2E_NEEDED:`.
-- **CRITICAL — ECHO MARKER IN FINAL OUTPUT:** After posting the GitHub comment, your very last output line MUST repeat the `E2E_NEEDED:` marker verbatim (e.g., `E2E_NEEDED: no — unit test covers full path`). The orchestrator parses YOUR OUTPUT, not the GitHub comment. If you only include the marker in the GitHub comment but not in your final output, the gate will not work and Step 11 will run unnecessarily.
+  The orchestrator parses this marker from raw output to decide whether to run Step 11. If you omit it, Step 11 runs unconditionally (wasting time and cost).

--- a/pdd/prompts/agentic_bug_step11_e2e_test_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step11_e2e_test_LLM.prompt
@@ -311,15 +311,9 @@ dev server not running, emulators not available):
 
 % Output
 
-After generating and running the test, use `gh issue comment` to post your findings to issue #{issue_number}:
+Return your findings between `<step_report>` and `</step_report>` tags. The PDD orchestrator will sanitize, truncate, and post the contents as a GitHub comment using trusted credentials. **Do NOT run `gh issue comment` yourself** — model subprocesses cannot reliably authenticate.
 
-```
-gh issue comment {issue_number} --repo {repo_owner}/{repo_name} --body "..."
-```
-
-Your comment should follow this format:
-
-```markdown
+<step_report>
 ## Step 11: E2E Test
 
 ### Environment Discovery
@@ -355,11 +349,13 @@ Your comment should follow this format:
 
 ---
 *Proceeding to Step 12: Create Draft PR*
-```
+</step_report>
 
 % Machine-Readable Output
 
-After writing files, output this line exactly (for automated tracking):
+After the closing `</step_report>` tag, emit the relevant markers on their own lines. The orchestrator parses raw output for these — they MUST live OUTSIDE the report block.
+
+If you created E2E test files:
 ```
 E2E_FILES_CREATED: <comma-separated list of file paths you created>
 ```
@@ -380,8 +376,8 @@ E2E_FILES_MODIFIED: <comma-separated list of file paths you modified>
 - The E2E test MUST fail on the current (buggy) code
 - The test should pass once the bug is fixed
 - Focus on the user-facing behavior, not internal implementation
-- Run the test and include the actual output in your comment
-- Always post your findings as a GitHub comment before completing
-- If the test cannot be made to work, output `E2E_FAIL: Test does not catch bug correctly`
-- If no E2E test is applicable (purely internal bug with no integration path), output `E2E_SKIP: No E2E test applicable` and explain why
-- If you wrote a test but cannot verify it (missing browsers, dev server, emulators), output BOTH `E2E_FILES_CREATED: <path>` AND `E2E_SKIP: <reason>` — the file will still be included in the PR
+- Run the test and include the actual output inside the `<step_report>` block
+- Place your findings inside the `<step_report>` block — the orchestrator will post it to GitHub for you. Keep `E2E_FILES_CREATED:`, `E2E_FILES_MODIFIED:`, `E2E_SKIP:`, and `E2E_FAIL:` markers OUTSIDE the tags so the orchestrator can parse them.
+- If the test cannot be made to work, emit `E2E_FAIL: Test does not catch bug correctly` after the closing tag
+- If no E2E test is applicable (purely internal bug with no integration path), emit `E2E_SKIP: No E2E test applicable` after the closing tag and explain why
+- If you wrote a test but cannot verify it (missing browsers, dev server, emulators), emit BOTH `E2E_FILES_CREATED: <path>` AND `E2E_SKIP: <reason>` after the closing tag — the file will still be included in the PR

--- a/pdd/prompts/agentic_bug_step12_pr_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step12_pr_LLM.prompt
@@ -150,15 +150,9 @@ EOF
 
 % Output
 
-After creating the PR, use `gh issue comment` to post your final report to issue #{issue_number}:
+After creating the draft PR, return your final report between `<step_report>` and `</step_report>` tags. The PDD orchestrator will sanitize, truncate, and post the contents as a GitHub comment using trusted credentials. **Do NOT run `gh issue comment` yourself** — model subprocesses cannot reliably authenticate. (`gh pr create` is still required and works fine; only the issue comment is now orchestrator-owned.)
 
-```
-gh issue comment {issue_number} --repo {repo_owner}/{repo_name} --body "..."
-```
-
-Your comment should follow this format:
-
-```markdown
+<step_report>
 ## Step 12: Draft PR Created
 
 ### Pull Request
@@ -192,7 +186,9 @@ pdd fix {issue_url}
 
 ---
 *Investigation complete. A draft PR with failing tests has been created and linked to this issue.*
-```
+</step_report>
+
+The PR URL must also appear verbatim in your final output (the orchestrator scans raw output for `https://github.com/.../pull/<n>` to capture the PR link).
 
 % Important
 
@@ -201,4 +197,4 @@ pdd fix {issue_url}
 - Use "Fixes #{issue_number}" to auto-link the PR to the issue
 - Do NOT create a new branch - you are already on the correct branch in the worktree
 - Include both unit test files (Step 9) and E2E test files (Step 11) if both exist
-- Always post your findings as a GitHub comment before completing
+- Place your findings inside the `<step_report>` block — the orchestrator will post it to GitHub for you.

--- a/pdd/prompts/agentic_bug_step1_duplicate_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step1_duplicate_LLM.prompt
@@ -2,7 +2,7 @@
 
 % Context
 
-You are working on step 1 of 11 in an agentic bug investigation workflow. The PDD orchestrator will post your `<step_report>` findings as a comment on the GitHub issue (you must not call `gh issue comment` yourself).
+You are working on step 1 of 12 in an agentic bug investigation workflow. The PDD orchestrator will post your `<step_report>` findings as a comment on the GitHub issue (you must not call `gh issue comment` yourself).
 
 % Inputs
 

--- a/pdd/prompts/agentic_bug_step1_duplicate_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step1_duplicate_LLM.prompt
@@ -2,7 +2,7 @@
 
 % Context
 
-You are working on step 1 of 11 in an agentic bug investigation workflow. Your findings will be posted as a comment on the GitHub issue.
+You are working on step 1 of 11 in an agentic bug investigation workflow. The PDD orchestrator will post your `<step_report>` findings as a comment on the GitHub issue (you must not call `gh issue comment` yourself).
 
 % Inputs
 
@@ -58,15 +58,9 @@ You are working on step 1 of 11 in an agentic bug investigation workflow. Your f
 
 % Output
 
-After completing your analysis, use `gh issue comment` to post your findings to issue #{issue_number}:
+Return your findings between `<step_report>` and `</step_report>` tags. The PDD orchestrator will sanitize, truncate, and post the contents as a GitHub comment using trusted credentials. **Do NOT run `gh issue comment` yourself** — model subprocesses cannot reliably authenticate.
 
-```
-gh issue comment {issue_number} --repo {repo_owner}/{repo_name} --body "..."
-```
-
-Your comment should follow this format:
-
-```markdown
+<step_report>
 ## Step 1: Duplicate Check
 
 **Status:** [No duplicates found | Duplicate of #XXX]
@@ -81,10 +75,10 @@ Your comment should follow this format:
 
 ---
 *Proceeding to Step 2: Documentation Check*
-```
+</step_report>
 
 % Important
 
-- Always post your findings as a GitHub comment before completing
-- If this is a duplicate, still post a comment explaining the closure
-- Be thorough but efficient in your search
+- Place your findings inside the `<step_report>` block above — the orchestrator will post it to GitHub for you.
+- If this is a duplicate, still emit a `<step_report>` explaining the closure.
+- Be thorough but efficient in your search.

--- a/pdd/prompts/agentic_bug_step2_docs_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step2_docs_LLM.prompt
@@ -2,7 +2,7 @@
 
 % Context
 
-You are working on step 2 of 11 in an agentic bug investigation workflow. Previous step checked for duplicate issues.
+You are working on step 2 of 12 in an agentic bug investigation workflow. Previous step checked for duplicate issues.
 
 **This step may terminate the workflow** if the reported behavior matches documentation (not a bug).
 

--- a/pdd/prompts/agentic_bug_step2_docs_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step2_docs_LLM.prompt
@@ -45,16 +45,12 @@ You are working on step 2 of 11 in an agentic bug investigation workflow. Previo
 
 % Output
 
-After completing your analysis, use `gh issue comment` to post your findings to issue #{issue_number}:
+Return your findings between `<step_report>` and `</step_report>` tags. The PDD orchestrator will sanitize, truncate, and post the contents as a GitHub comment using trusted credentials. **Do NOT run `gh issue comment` yourself** — model subprocesses cannot reliably authenticate.
 
-```
-gh issue comment {issue_number} --repo {repo_owner}/{repo_name} --body "..."
-```
+Pick exactly ONE of the three templates below and place it inside the tags. Status text (e.g. `Feature Request (Not a Bug)`, `User Error (Not a Bug)`) is what the orchestrator parses for hard-stop detection, so keep the wording exact.
 
-Your comment should follow this format:
-
-**If Confirmed Bug or Needs Investigation:**
-```markdown
+**If Confirmed Bug, Documentation Gap, or Needs Investigation:**
+<step_report>
 ## Step 2: Documentation Check
 
 **Status:** [Confirmed Bug | Documentation Gap | Needs Investigation]
@@ -67,10 +63,10 @@ Your comment should follow this format:
 
 ---
 *Proceeding to Step 3: Triage*
-```
+</step_report>
 
 **If Feature Request (STOP workflow):**
-```markdown
+<step_report>
 ## Step 2: Documentation Check
 
 **Status:** Feature Request (Not a Bug)
@@ -92,10 +88,10 @@ If you'd like to change this behavior, consider using `pdd change` to create a f
 
 ---
 *Investigation paused - this appears to be a feature request, not a bug.*
-```
+</step_report>
 
 **If User Error (STOP workflow):**
-```markdown
+<step_report>
 ## Step 2: Documentation Check
 
 **Status:** User Error (Not a Bug)
@@ -117,13 +113,13 @@ Please try the correct usage above. If you still experience issues after followi
 
 ---
 *Investigation paused - this appears to be a usage error, not a bug.*
-```
+</step_report>
 
 % Important
 
-- **STOP the workflow** if status is "Feature Request" or "User Error"
-- **CONTINUE the workflow** if status is "Confirmed Bug", "Documentation Gap", or "Needs Investigation"
-- Tag the issue author when asking for clarification
-- Mention `pdd change` as an alternative for feature requests
-- Be helpful and non-judgmental in your assessment
-- Always post your findings as a GitHub comment before completing
+- **STOP the workflow** if status is "Feature Request" or "User Error" — the orchestrator detects this from the report body.
+- **CONTINUE the workflow** if status is "Confirmed Bug", "Documentation Gap", or "Needs Investigation".
+- Tag the issue author when asking for clarification.
+- Mention `pdd change` as an alternative for feature requests.
+- Be helpful and non-judgmental in your assessment.
+- Place your findings inside the `<step_report>` block above — the orchestrator will post it to GitHub for you.

--- a/pdd/prompts/agentic_bug_step3_triage_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step3_triage_LLM.prompt
@@ -3,7 +3,7 @@ Your task is to assess if there's sufficient information to attempt reproduction
 
 % Context
 
-You are working on step 3 of 11 in an agentic bug investigation workflow.
+You are working on step 3 of 12 in an agentic bug investigation workflow.
 Previous steps checked for duplicates and reviewed documentation.
 
 **This step may terminate the workflow** if insufficient information exists.
@@ -94,7 +94,7 @@ This line is required for the orchestrator to skip diagnosis steps. Omit it when
 [What we understand about the issue and why we can attempt reproduction]
 
 ---
-*Proceeding to Step 4: Reproduction*
+*Proceeding to Step 4: API Research*
 </step_report>
 
 **If Needs More Info (STOP workflow):**

--- a/pdd/prompts/agentic_bug_step3_triage_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step3_triage_LLM.prompt
@@ -50,16 +50,12 @@ Previous steps checked for duplicates and reviewed documentation.
 
 % Output
 
-After completing your analysis, use `gh issue comment` to post your findings to issue #{issue_number}:
+Return your findings between `<step_report>` and `</step_report>` tags. The PDD orchestrator will sanitize, truncate, and post the contents as a GitHub comment using trusted credentials. **Do NOT run `gh issue comment` yourself** — model subprocesses cannot reliably authenticate.
 
-```
-gh issue comment {issue_number} --repo {repo_owner}/{repo_name} --body "..."
-```
-
-Your comment should follow this format:
+Pick exactly ONE of the three templates below and place it inside the tags.
 
 **If Fast-Track (issue already contains root cause analysis):**
-```markdown
+<step_report>
 ## Step 3: Triage
 
 **Status:** Fast-Track
@@ -80,16 +76,16 @@ The issue author has provided a detailed root cause analysis:
 
 ---
 *Fast-tracking to Step 6: Root Cause Analysis (skipping Steps 4-5)*
-```
+</step_report>
 
-**IMPORTANT:** When the status is "Fast-Track", you MUST also include the following line on its own line in your final output (outside the GitHub comment):
+**IMPORTANT:** When the status is "Fast-Track", you MUST also include the following line on its own line in your final output AFTER the `</step_report>` closing tag (the orchestrator parses raw output for this marker — it must live OUTSIDE the report block):
 ```
 FAST_TRACK: [One-paragraph summary of the provided root cause analysis, including the specific file paths, line numbers, and causal explanation from the issue]
 ```
 This line is required for the orchestrator to skip diagnosis steps. Omit it when status is "Proceed" or "Needs More Info".
 
 **If Proceed:**
-```markdown
+<step_report>
 ## Step 3: Triage
 
 **Status:** Proceed
@@ -99,10 +95,10 @@ This line is required for the orchestrator to skip diagnosis steps. Omit it when
 
 ---
 *Proceeding to Step 4: Reproduction*
-```
+</step_report>
 
 **If Needs More Info (STOP workflow):**
-```markdown
+<step_report>
 ## Step 3: Triage
 
 **Status:** Needs More Info
@@ -121,9 +117,9 @@ To investigate this issue further, we need clarification on:
 
 ---
 *Investigation paused - awaiting additional information from issue author.*
-```
+</step_report>
 
-**IMPORTANT:** When the status is "Needs More Info", you MUST also include the following line on its own line in your final output (outside the GitHub comment):
+**IMPORTANT:** When the status is "Needs More Info", you MUST also include the following line on its own line in your final output AFTER the `</step_report>` closing tag (the orchestrator parses raw output for this marker — it must live OUTSIDE the report block):
 ```
 STOP_CONDITION: Needs more info
 ```
@@ -135,4 +131,4 @@ This line is required for the orchestrator to detect the stop. Omit it when stat
 - Tag the issue author (@username) when requesting info
 - Be specific about what information is missing
 - Only request info that's truly necessary to attempt reproduction
-- Always post your findings as a GitHub comment before completing
+- Place your findings inside the `<step_report>` block above — the orchestrator will post it to GitHub for you. Keep `FAST_TRACK:`/`STOP_CONDITION:` markers OUTSIDE the tags so the orchestrator can parse them.

--- a/pdd/prompts/agentic_bug_step4_api_research_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step4_api_research_LLM.prompt
@@ -70,15 +70,9 @@ You are working on step 4 of 12 in an agentic bug investigation workflow. Previo
 
 % Output
 
-After completing your research, use `gh issue comment` to post your findings to issue #{issue_number}:
+Return your findings between `<step_report>` and `</step_report>` tags. The PDD orchestrator will sanitize, truncate, and post the contents as a GitHub comment using trusted credentials. **Do NOT run `gh issue comment` yourself** — model subprocesses cannot reliably authenticate.
 
-```
-gh issue comment {issue_number} --repo {repo_owner}/{repo_name} --body "..."
-```
-
-Your comment should follow this format:
-
-```markdown
+<step_report>
 ## Step 4: External API Research
 
 ### External API Dependencies Found
@@ -103,7 +97,7 @@ Your comment should follow this format:
 
 ---
 *Proceeding to Step 5: Reproduction*
-```
+</step_report>
 
 % Important
 
@@ -111,4 +105,4 @@ Your comment should follow this format:
 - Even if no external API issues are found, document that finding (it helps downstream steps rule out API causes)
 - Focus on the specific auth type used in THIS codebase, not general API docs
 - If the bug report mentions permission errors, 403s, or "not found" responses, prioritize researching auth-type limitations
-- Always post your findings as a GitHub comment before completing
+- Place your findings inside the `<step_report>` block above — the orchestrator will post it to GitHub for you.

--- a/pdd/prompts/agentic_bug_step5_reproduce_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step5_reproduce_LLM.prompt
@@ -70,15 +70,9 @@ You are working on step 5 of 12 in an agentic bug investigation workflow. Previo
 
 % Output
 
-After completing your analysis, use `gh issue comment` to post your findings to issue #{issue_number}:
+Return your findings between `<step_report>` and `</step_report>` tags. The PDD orchestrator will sanitize, truncate, and post the contents as a GitHub comment using trusted credentials. **Do NOT run `gh issue comment` yourself** — model subprocesses cannot reliably authenticate.
 
-```
-gh issue comment {issue_number} --repo {repo_owner}/{repo_name} --body "..."
-```
-
-Your comment should follow this format:
-
-```markdown
+<step_report>
 ## Step 5: Reproduction
 
 **Status:** [Reproduced | Partially Reproduced | Could Not Reproduce]
@@ -104,19 +98,19 @@ Your comment should follow this format:
 
 ---
 *Proceeding to Step 6: Root Cause Analysis*
-```
+</step_report>
 
 % Important
 
 - If you cannot reproduce, still proceed - the analysis may reveal the issue
 - Document your environment carefully for comparison with the reporter's
 - Capture actual error output, not paraphrased descriptions
-- Always post your findings as a GitHub comment before completing
-- Always write reproduction tests to disk before posting the comment
+- Place your findings inside the `<step_report>` block above — the orchestrator will post it to GitHub for you.
+- Always write reproduction tests to disk before emitting the report.
 
 % CRITICAL: Machine-Readable Output (REQUIRED)
 
-If you created a reproduction test file, output this line at the very end of your response:
+If you created a reproduction test file, output this line on its own line AFTER the closing `</step_report>` tag (the orchestrator parses raw output for this marker — it MUST live OUTSIDE the report block):
 ```
 REPRO_FILES_CREATED: <path-to-your-reproduction-test-file>
 ```

--- a/pdd/prompts/agentic_bug_step6_root_cause_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step6_root_cause_LLM.prompt
@@ -122,15 +122,9 @@ You are working on step 6 of 12 in an agentic bug investigation workflow. Previo
 
 % Output
 
-After completing your analysis, use `gh issue comment` to post your findings to issue #{issue_number}:
+Return your findings between `<step_report>` and `</step_report>` tags. The PDD orchestrator will sanitize, truncate, and post the contents as a GitHub comment using trusted credentials. **Do NOT run `gh issue comment` yourself** — model subprocesses cannot reliably authenticate.
 
-```
-gh issue comment {issue_number} --repo {repo_owner}/{repo_name} --body "..."
-```
-
-Your comment should follow this format:
-
-```markdown
+<step_report>
 ## Step 6: Root Cause Analysis
 
 **Root Cause Identified:** [Yes | Partially | No]
@@ -187,9 +181,9 @@ problematic_code_snippet()
 
 ---
 *Proceeding to Step 7: Prompt Classification*
-```
+</step_report>
 
-After posting your comment, output two machine-readable markers. Both are parsed by the orchestrator and injected into downstream steps as structured variables:
+After the closing `</step_report>` tag, emit two machine-readable markers on their own lines (the orchestrator parses raw output for these — they MUST live OUTSIDE the report block):
 
 ```
 FIX_LOCATIONS: path/to/file1.py, path/to/file2.py
@@ -223,4 +217,4 @@ Examples:
 - The fix location you recommend here directly determines which component pdd bug will create tests for — getting this wrong means tests will target the wrong code
 - If root cause is unclear, document what you learned and hypotheses
 - **Cross-cutting check**: Count how many call sites would need the same change. If 5+, stop and think about a centralized solution. A fix that patches 10 functions with the same `if not flag:` guard is a code smell — the right fix is usually one mechanism at a higher level.
-- Always post your findings as a GitHub comment before completing
+- Place your findings inside the `<step_report>` block — the orchestrator will post it to GitHub for you. Keep `FIX_LOCATIONS:`, `EXPANSION_ITEMS:`, and `PATTERN_SEARCH:` markers OUTSIDE the tags so the orchestrator can parse them.

--- a/pdd/prompts/agentic_bug_step7_prompt_classification_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step7_prompt_classification_LLM.prompt
@@ -79,21 +79,15 @@ This project uses Prompt-Driven Development (PDD). In PDD:
 
 % Output
 
-After completing your analysis, use `gh issue comment` to post your findings to issue #{issue_number}:
+Return your findings between `<step_report>` and `</step_report>` tags. The PDD orchestrator will sanitize, truncate, and post the contents as a GitHub comment using trusted credentials. **Do NOT run `gh issue comment` yourself** — model subprocesses cannot reliably authenticate.
 
-```
-gh issue comment {issue_number} --repo {repo_owner}/{repo_name} --body "..."
-```
-
-Your comment should follow this format:
+Pick exactly ONE of the three templates below and place it inside the tags.
 
 **For Code Bug (most common):**
-```markdown
+<step_report>
 ## Step 7: Prompt Classification
 
 **Classification:** Code Bug
-
-DEFECT_TYPE: code
 
 ### Analysis
 [Brief explanation of why this is a code bug - the code doesn't match the prompt]
@@ -108,16 +102,18 @@ The code does not correctly implement the prompt specification. Proceeding with 
 
 ---
 *Proceeding to Step 8: Test Plan*
+</step_report>
+
+After the `</step_report>` closing tag, emit the orchestrator marker on its own line (parsed from raw output — MUST live OUTSIDE the report block):
+```
+DEFECT_TYPE: code
 ```
 
 **For Prompt Defect:**
-```markdown
+<step_report>
 ## Step 7: Prompt Classification
 
 **Classification:** Prompt Defect
-
-DEFECT_TYPE: prompt
-PROMPT_FIXED: prompts/module_name_python.prompt
 
 ### Analysis
 [Brief explanation of why the prompt itself is defective]
@@ -145,15 +141,19 @@ The prompt specification was incorrect. The prompt has been fixed. Proceeding wi
 
 ---
 *Proceeding to Step 8: Test Plan*
+</step_report>
+
+After the `</step_report>` closing tag, emit BOTH orchestrator markers on their own lines (parsed from raw output — MUST live OUTSIDE the report block):
+```
+DEFECT_TYPE: prompt
+PROMPT_FIXED: prompts/module_name_python.prompt
 ```
 
 **For Ambiguous Cases (hard stop):**
-```markdown
+<step_report>
 ## Step 7: Prompt Classification
 
 **Classification:** Needs Human Review
-
-PROMPT_REVIEW: [reason for uncertainty]
 
 ### Analysis
 [Explanation of the ambiguity]
@@ -173,6 +173,11 @@ Please clarify in the issue:
 
 ---
 *Investigation paused - awaiting clarification on whether this is a prompt defect or code bug.*
+</step_report>
+
+After the `</step_report>` closing tag, emit the orchestrator marker on its own line (parsed from raw output — MUST live OUTSIDE the report block):
+```
+PROMPT_REVIEW: [reason for uncertainty]
 ```
 
 % Important
@@ -180,6 +185,6 @@ Please clarify in the issue:
 - Default to "Code Bug" when uncertain - this preserves backward compatibility
 - Only modify prompt files, never code files
 - When fixing a prompt, make minimal changes to address the specific defect
-- Always include the `DEFECT_TYPE:` marker in your output (either `code` or `prompt`)
-- If you fix a prompt, include the `PROMPT_FIXED:` marker with the file path
-- Always post your findings as a GitHub comment before completing
+- Always include the `DEFECT_TYPE:` marker AFTER the `</step_report>` tag (either `code` or `prompt`) so the orchestrator can parse it
+- If you fix a prompt, include the `PROMPT_FIXED:` marker (also outside the report block) with the file path
+- Place your narrative findings inside the `<step_report>` block — the orchestrator will post it to GitHub for you.

--- a/pdd/prompts/agentic_bug_step8_test_plan_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step8_test_plan_LLM.prompt
@@ -90,15 +90,9 @@ You are working on step 8 of 12 in an agentic bug investigation workflow. Previo
 
 % Output
 
-After completing your analysis, use `gh issue comment` to post your findings to issue #{issue_number}:
+Return your findings between `<step_report>` and `</step_report>` tags. The PDD orchestrator will sanitize, truncate, and post the contents as a GitHub comment using trusted credentials. **Do NOT run `gh issue comment` yourself** — model subprocesses cannot reliably authenticate.
 
-```
-gh issue comment {issue_number} --repo {repo_owner}/{repo_name} --body "..."
-```
-
-Your comment should follow this format:
-
-```markdown
+<step_report>
 ## Step 8: Test Plan
 
 ### Existing Test Coverage
@@ -126,7 +120,7 @@ Your comment should follow this format:
 
 ---
 *Proceeding to Step 9: Generate Test*
-```
+</step_report>
 
 % Scope Expansion Items
 
@@ -170,11 +164,11 @@ Your test plan must verify **observable behavior**, not code structure.
 - **Channel check**: For each symptom, ask "through which channel does this manifest?" (stdout, stderr, logging, Rich, click.echo, warnings, return value, side effect, state change). If a symptom can leak through multiple channels, test each one. The fix is only complete when ALL channels are covered — a fix that suppresses Rich output but leaves Python logging untouched is a partial fix, and the tests should catch that.
 - **Code path check**: For each root cause, ask "through which code paths can this be reached?" (first-run execution, resume from checkpoint, retry after failure, error recovery, different entry points). If the same data is processed in multiple paths, test each one. A fix that corrects the first-run path but leaves the resume path broken is incomplete — the tests should catch that. Cross-reference Step 6's sibling bugs to ensure every independently-discovered bug has test coverage.
 - **Call-boundary coverage check**: The fix locations are: `{fix_locations}`. If there are multiple files, the test plan MUST include tests for BOTH sides of the call boundary — mock the callee and verify the caller passes the right arguments, AND test the callee directly.
-- Always post your findings as a GitHub comment before completing
+- Place your test plan inside the `<step_report>` block — the orchestrator will post it to GitHub for you. Keep the `PLANNED_TEST_COUNT:` marker OUTSIDE the tags so the orchestrator can parse it.
 
 % CRITICAL: Machine-Readable Output (REQUIRED)
 
-After your GitHub comment, you MUST output this line with the total number of tests you planned:
+After the closing `</step_report>` tag, you MUST output this line on its own line with the total number of tests you planned (the orchestrator parses raw output for this marker — it MUST live OUTSIDE the report block):
 
 ```
 PLANNED_TEST_COUNT: <number>

--- a/pdd/prompts/agentic_bug_step9_generate_LLM.prompt
+++ b/pdd/prompts/agentic_bug_step9_generate_LLM.prompt
@@ -223,15 +223,9 @@ Step 8 planned {planned_test_count} tests. You MUST generate exactly that many `
 
 % Output
 
-After generating the test, use `gh issue comment` to post your findings to issue #{issue_number}:
+Return your findings between `<step_report>` and `</step_report>` tags. The PDD orchestrator will sanitize, truncate, and post the contents as a GitHub comment using trusted credentials. **Do NOT run `gh issue comment` yourself** — model subprocesses cannot reliably authenticate.
 
-```
-gh issue comment {issue_number} --repo {repo_owner}/{repo_name} --body "..."
-```
-
-Your comment should follow this format:
-
-```markdown
+<step_report>
 ## Step 9: Generated Test
 
 ### Test File
@@ -252,20 +246,19 @@ Your comment should follow this format:
 
 ---
 *Proceeding to Step 10: Verification*
-```
+</step_report>
 
 % Important
 
 - The test MUST fail on the current (buggy) code
 - The test should pass once the bug is fixed
 - Focus on testing behavior, not implementation details — do NOT use reflection, introspection, or source scanning to verify code structure
-- Write the test file to disk before posting the comment
-- Always post your findings as a GitHub comment before completing
+- Write the test file to disk before emitting the report
+- Place your findings inside the `<step_report>` block — the orchestrator will post it to GitHub for you. Keep the `FILES_CREATED:`/`FILES_MODIFIED:` marker OUTSIDE the tags so the orchestrator can parse it.
 
 % CRITICAL: Machine-Readable Output (REQUIRED)
 
-**You MUST output exactly one of these lines at the very end of your response.**
-This is required for the automation to continue. Without this line, the workflow will fail.
+**You MUST output exactly one of these lines on its own line AFTER the closing `</step_report>` tag.** The orchestrator parses raw output for this marker — it MUST live OUTSIDE the report block. Without this line, the workflow will fail.
 
 If you created a new test file:
 ```

--- a/pdd/prompts/agentic_common_python.prompt
+++ b/pdd/prompts/agentic_common_python.prompt
@@ -15,7 +15,9 @@
       {"name": "clear_agentic_progress", "signature": "() -> None", "returns": "None"},
       {"name": "get_and_clear_agentic_interrupt_context", "signature": "() -> Optional[Dict]", "returns": "Optional[Dict]"},
       {"name": "get_job_deadline", "signature": "() -> Optional[float]", "returns": "Optional[float]"},
-      {"name": "post_step_comment", "signature": "(repo_owner, repo_name, issue_number, step_num, total_steps, description, output, cwd) -> bool", "returns": "bool"},
+      {"name": "post_step_comment", "signature": "(repo_owner, repo_name, issue_number, step_num, total_steps, description, output, cwd, body=None) -> bool", "returns": "bool"},
+      {"name": "_extract_step_report", "signature": "(text: Optional[str]) -> Optional[str]", "returns": "Optional[str]"},
+      {"name": "_sanitize_comment_body", "signature": "(body: Optional[str], max_chars: int = 25_000) -> str", "returns": "str"},
       {"name": "post_pr_comment", "signature": "(repo_owner, repo_name, pr_number, body, cwd) -> bool", "returns": "bool"},
       {"name": "post_final_comment", "signature": "(repo_owner, repo_name, issue_number, reason, total_cost, steps_completed, total_steps, cwd) -> bool", "returns": "bool"},
       {"name": "validate_cached_state", "signature": "(last_completed_step, step_outputs, step_order=None, quiet=False) -> Union[int, float]", "returns": "Union[int, float]"},
@@ -122,7 +124,9 @@ Shared infrastructure for agentic CLI invocations (Claude Code, Gemini, Codex, O
 `clear_agentic_progress() -> None`
 `get_and_clear_agentic_interrupt_context() -> Optional[Dict]`
 `get_job_deadline() -> Optional[float]`
-`post_step_comment(repo_owner, repo_name, issue_number, step_num, total_steps, description, output, cwd) -> bool`
+`post_step_comment(repo_owner, repo_name, issue_number, step_num, total_steps, description, output, cwd, body=None) -> bool` — Issue #964: when `body` is provided (orchestrator extracted a `<step_report>` block from a successful run), strip any leading duplicate `## Step <N>` header from the model body, sanitize via `_sanitize_comment_body`, and wrap in the orchestrator's canonical header. When `body=None`, retain the legacy FAILED fallback template using `output` (used by hard-stop callers in `agentic_change_orchestrator`).
+`_extract_step_report(text: Optional[str]) -> Optional[str]` — Extracts the LAST `<step_report>...</step_report>` block (DOTALL + case-insensitive). Returns `None` when text is empty or no tagged block is present; otherwise the body is whitespace-stripped. Used by orchestrators to gate orchestrator-owned posting AND to gate the resume-time backfill sweep (legacy pre-PR outputs and synthetic FAST_TRACK skipped-step outputs both lack the tag and must NOT be reposted).
+`_sanitize_comment_body(body: Optional[str], max_chars: int = 25_000) -> str` — Redacts known secret formats (GitHub tokens, Google API keys, OpenAI/xAI/Groq keys, `GH_TOKEN=` / `GITHUB_TOKEN=` env, Bearer headers) then truncates to `max_chars`. Truncation reserves room for the `…[truncated]` marker so the returned length never exceeds `max_chars`. Idempotent.
 `post_pr_comment(repo_owner, repo_name, pr_number, body, cwd) -> bool`
 `post_final_comment(repo_owner, repo_name, issue_number, reason, total_cost, steps_completed, total_steps, cwd) -> bool`
 `validate_cached_state(last_completed_step, step_outputs, step_order=None, quiet=False) -> Union[int, float]`

--- a/tests/test_agentic_bug_orchestrator.py
+++ b/tests/test_agentic_bug_orchestrator.py
@@ -77,7 +77,8 @@ def mock_dependencies(tmp_path):
          patch("pdd.agentic_bug_orchestrator.load_workflow_state", return_value=(None, None)) as mock_load_state, \
          patch("pdd.agentic_bug_orchestrator._get_git_root", return_value=tmp_path) as mock_git_root, \
          patch("pdd.agentic_bug_orchestrator.set_agentic_progress") as mock_set_progress, \
-         patch("pdd.agentic_bug_orchestrator.clear_agentic_progress") as mock_clear_progress:
+         patch("pdd.agentic_bug_orchestrator.clear_agentic_progress") as mock_clear_progress, \
+         patch("pdd.agentic_bug_orchestrator.post_step_comment", return_value=True):
 
         # Default behavior: successful run, generic output
         # Note: run_agentic_task returns 4 values: (success, output, cost, provider)

--- a/tests/test_agentic_bug_orchestrator_1.py
+++ b/tests/test_agentic_bug_orchestrator_1.py
@@ -52,6 +52,7 @@ def mock_dependencies():
          patch("pdd.agentic_bug_orchestrator._get_git_root") as mock_git_root, \
          patch("pdd.agentic_bug_orchestrator.set_agentic_progress") as mock_progress, \
          patch("pdd.agentic_bug_orchestrator.clear_agentic_progress") as mock_clear_progress, \
+         patch("pdd.agentic_bug_orchestrator.post_step_comment", return_value=True), \
          patch("pdd.agentic_bug_orchestrator.subprocess") as mock_subprocess:
 
         # Default behavior: return a template string that can be formatted

--- a/tests/test_agentic_bug_orchestrator_step_comments.py
+++ b/tests/test_agentic_bug_orchestrator_step_comments.py
@@ -1,0 +1,480 @@
+"""
+Tests for issue #964: orchestrator-owned visible step comments.
+
+The bug orchestrator now extracts a `<step_report>...</step_report>` block from
+provider output and posts it as a GitHub comment using trusted credentials.
+This removes the dependency on the model subprocess being able to authenticate
+`gh issue comment` (which fails for Gemini due to GH_TOKEN sandboxing).
+
+These tests cover:
+  - `_extract_step_report`: deterministic extraction with edge cases.
+  - `_sanitize_comment_body`: secret redaction + length truncation.
+  - `post_step_comment(body=...)`: new optional path that wraps a model-supplied
+    body in the orchestrator's step header, preserving the original FAILED
+    fallback template when `body=None`.
+  - Bug orchestrator wiring: posts on success, does not repost on resume, and
+    falls back gracefully when the agent omits the `<step_report>` block.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure local source wins over any installed copy of pdd.
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root))
+
+
+# ---------------------------------------------------------------------------
+# _extract_step_report
+# ---------------------------------------------------------------------------
+
+
+def test_extract_step_report_basic():
+    from pdd.agentic_common import _extract_step_report
+
+    assert _extract_step_report("x <step_report>BODY</step_report> y") == "BODY"
+
+
+def test_extract_step_report_strips_whitespace():
+    from pdd.agentic_common import _extract_step_report
+
+    raw = "<step_report>\n  BODY  \n</step_report>"
+    assert _extract_step_report(raw) == "BODY"
+
+
+def test_extract_step_report_prefers_last_block():
+    from pdd.agentic_common import _extract_step_report
+
+    raw = (
+        "<step_report>FIRST</step_report>\n"
+        "<step_report>SECOND</step_report>\n"
+        "<step_report>LAST</step_report>"
+    )
+    assert _extract_step_report(raw) == "LAST"
+
+
+def test_extract_step_report_missing_returns_none():
+    from pdd.agentic_common import _extract_step_report
+
+    assert _extract_step_report("no tags here") is None
+    assert _extract_step_report("") is None
+    assert _extract_step_report(None) is None  # type: ignore[arg-type]
+
+
+def test_extract_step_report_empty_tags():
+    from pdd.agentic_common import _extract_step_report
+
+    assert _extract_step_report("<step_report></step_report>") == ""
+
+
+def test_extract_step_report_inside_fenced_block():
+    from pdd.agentic_common import _extract_step_report
+
+    raw = "```xml\n<step_report>BODY</step_report>\n```"
+    assert _extract_step_report(raw) == "BODY"
+
+
+def test_extract_step_report_multiline_body():
+    from pdd.agentic_common import _extract_step_report
+
+    raw = "<step_report>line1\nline2\nline3</step_report>"
+    assert _extract_step_report(raw) == "line1\nline2\nline3"
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_comment_body
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_redacts_ghp_token():
+    from pdd.agentic_common import _sanitize_comment_body
+
+    body = "secret: ghp_" + "A" * 36 + " trailing"
+    out = _sanitize_comment_body(body)
+    assert "ghp_" + "A" * 36 not in out
+    assert "[REDACTED_GITHUB_TOKEN]" in out
+
+
+def test_sanitize_redacts_github_pat():
+    from pdd.agentic_common import _sanitize_comment_body
+
+    body = "token=github_pat_" + "B" * 40
+    out = _sanitize_comment_body(body)
+    assert "github_pat_" + "B" * 40 not in out
+    assert "[REDACTED_GITHUB_TOKEN]" in out
+
+
+@pytest.mark.parametrize("prefix", ["gho_", "ghu_", "ghs_", "ghr_"])
+def test_sanitize_redacts_other_gh_token_prefixes(prefix):
+    from pdd.agentic_common import _sanitize_comment_body
+
+    body = f"oauth={prefix}{'C' * 30}"
+    out = _sanitize_comment_body(body)
+    assert prefix + "C" * 30 not in out
+    assert "[REDACTED_GITHUB_TOKEN]" in out
+
+
+def test_sanitize_redacts_google_key():
+    from pdd.agentic_common import _sanitize_comment_body
+
+    body = "key=AIzaSy" + "D" * 33
+    out = _sanitize_comment_body(body)
+    assert "AIzaSy" + "D" * 33 not in out
+    assert "[REDACTED_GOOGLE_API_KEY]" in out
+
+
+def test_sanitize_redacts_xai_key():
+    from pdd.agentic_common import _sanitize_comment_body
+
+    body = "xai-" + "E" * 40
+    out = _sanitize_comment_body(body)
+    assert "xai-" + "E" * 40 not in out
+    assert "[REDACTED_XAI_KEY]" in out
+
+
+def test_sanitize_redacts_openai_key():
+    from pdd.agentic_common import _sanitize_comment_body
+
+    body = "OPENAI=sk-" + "F" * 40
+    out = _sanitize_comment_body(body)
+    assert "sk-" + "F" * 40 not in out
+    assert "[REDACTED_OPENAI_KEY]" in out
+
+
+def test_sanitize_redacts_groq_key():
+    from pdd.agentic_common import _sanitize_comment_body
+
+    body = "GROQ=gsk_" + "G" * 40
+    out = _sanitize_comment_body(body)
+    assert "gsk_" + "G" * 40 not in out
+    assert "[REDACTED_GROQ_KEY]" in out
+
+
+def test_sanitize_redacts_env_var_assignments():
+    from pdd.agentic_common import _sanitize_comment_body
+
+    body = "Running with GH_TOKEN=secret123 and GITHUB_TOKEN=othersecret"
+    out = _sanitize_comment_body(body)
+    assert "secret123" not in out
+    assert "othersecret" not in out
+    assert "GH_TOKEN=[REDACTED]" in out
+    assert "GITHUB_TOKEN=[REDACTED]" in out
+
+
+def test_sanitize_redacts_bearer_token():
+    from pdd.agentic_common import _sanitize_comment_body
+
+    body = "Authorization: Bearer eyJabc.def.ghi"
+    out = _sanitize_comment_body(body)
+    assert "eyJabc.def.ghi" not in out
+    assert "Authorization: Bearer [REDACTED]" in out
+
+
+def test_sanitize_truncates_long_body():
+    from pdd.agentic_common import _sanitize_comment_body
+
+    body = "x" * 30_000
+    out = _sanitize_comment_body(body)
+    assert len(out) <= 30_000  # truncated + tag suffix is shorter than 30k
+    assert out.endswith("…[truncated]")
+    assert out.startswith("x" * 1000)
+
+
+def test_sanitize_short_body_passes_through():
+    from pdd.agentic_common import _sanitize_comment_body
+
+    body = "Hello world."
+    assert _sanitize_comment_body(body) == "Hello world."
+
+
+def test_sanitize_empty_body():
+    from pdd.agentic_common import _sanitize_comment_body
+
+    assert _sanitize_comment_body("") == ""
+    assert _sanitize_comment_body(None) == ""  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# post_step_comment(body=...)
+# ---------------------------------------------------------------------------
+
+
+def test_post_step_comment_with_body_kwarg_uses_supplied_body(tmp_path):
+    from pdd.agentic_common import post_step_comment
+
+    with patch("pdd.agentic_common._find_cli_binary", return_value="/usr/bin/gh"), \
+         patch("pdd.agentic_common.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        result = post_step_comment(
+            repo_owner="owner",
+            repo_name="repo",
+            issue_number=42,
+            step_num=3,
+            total_steps=12,
+            description="Reproduce",
+            output="raw provider trail",
+            cwd=tmp_path,
+            body="hello world",
+        )
+
+    assert result is True
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args[0][0]
+    assert cmd[:3] == ["gh", "issue", "comment"]
+    body_index = cmd.index("--body") + 1
+    final_body = cmd[body_index]
+    assert "hello world" in final_body
+    assert "## Step 3/12: Reproduce" in final_body
+    assert "FAILED" not in final_body
+    assert "Error Details" not in final_body
+
+
+def test_post_step_comment_strips_duplicate_step_header(tmp_path):
+    from pdd.agentic_common import post_step_comment
+
+    body_from_model = (
+        "## Step 3: Reproduce (model header)\n\n"
+        "**Status:** Reproduced\n\n"
+        "Body content here."
+    )
+    with patch("pdd.agentic_common._find_cli_binary", return_value="/usr/bin/gh"), \
+         patch("pdd.agentic_common.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        post_step_comment(
+            repo_owner="owner",
+            repo_name="repo",
+            issue_number=42,
+            step_num=3,
+            total_steps=12,
+            description="Reproduce",
+            output="raw provider trail",
+            cwd=tmp_path,
+            body=body_from_model,
+        )
+
+    cmd = mock_run.call_args[0][0]
+    body_index = cmd.index("--body") + 1
+    final_body = cmd[body_index]
+    # Exactly one "## Step 3" header (the orchestrator-supplied one).
+    assert final_body.count("## Step 3") == 1
+    # Orchestrator header is kept (with the /12 suffix).
+    assert "## Step 3/12: Reproduce" in final_body
+    # Body content survives.
+    assert "Body content here." in final_body
+
+
+def test_post_step_comment_without_body_kwarg_preserves_failed_template(tmp_path):
+    """Backwards compatibility: body=None ⇒ old FAILED fallback template."""
+    from pdd.agentic_common import post_step_comment
+
+    with patch("pdd.agentic_common._find_cli_binary", return_value="/usr/bin/gh"), \
+         patch("pdd.agentic_common.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        result = post_step_comment(
+            repo_owner="owner",
+            repo_name="repo",
+            issue_number=42,
+            step_num=3,
+            total_steps=12,
+            description="Reproduce",
+            output="All agent providers failed: exit 1",
+            cwd=tmp_path,
+        )
+
+    assert result is True
+    cmd = mock_run.call_args[0][0]
+    body_index = cmd.index("--body") + 1
+    final_body = cmd[body_index]
+    assert "**Status:** FAILED" in final_body
+    assert "### Error Details" in final_body
+    assert "Automated fallback comment" in final_body
+
+
+def test_post_step_comment_no_gh_returns_false_with_body(tmp_path):
+    from pdd.agentic_common import post_step_comment
+
+    with patch("pdd.agentic_common._find_cli_binary", return_value=None):
+        result = post_step_comment(
+            repo_owner="owner",
+            repo_name="repo",
+            issue_number=42,
+            step_num=3,
+            total_steps=12,
+            description="Reproduce",
+            output="raw provider trail",
+            cwd=tmp_path,
+            body="hello world",
+        )
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Bug orchestrator integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bug_orchestrator_mocks(tmp_path):
+    """
+    Mocks the heavy dependencies of run_agentic_bug_orchestrator so that
+    we can drive the step loop end-to-end while observing post_step_comment.
+    """
+    mock_worktree_path = tmp_path / ".pdd" / "worktrees" / "fix-issue-964"
+    mock_worktree_path.mkdir(parents=True, exist_ok=True)
+
+    with patch("pdd.agentic_bug_orchestrator.run_agentic_task") as mock_run, \
+         patch("pdd.agentic_bug_orchestrator.load_prompt_template") as mock_load, \
+         patch("pdd.agentic_bug_orchestrator.console"), \
+         patch("pdd.agentic_bug_orchestrator._setup_worktree") as mock_worktree, \
+         patch("pdd.agentic_bug_orchestrator.preprocess", side_effect=lambda t, **kw: t), \
+         patch("pdd.agentic_bug_orchestrator.save_workflow_state", return_value=None), \
+         patch("pdd.agentic_bug_orchestrator.load_workflow_state", return_value=(None, None)) as mock_load_state, \
+         patch("pdd.agentic_bug_orchestrator._get_git_root", return_value=tmp_path), \
+         patch("pdd.agentic_bug_orchestrator.set_agentic_progress"), \
+         patch("pdd.agentic_bug_orchestrator.clear_agentic_progress"), \
+         patch("pdd.agentic_bug_orchestrator.post_step_comment") as mock_post_comment:
+
+        mock_run.return_value = (True, "Step output", 0.1, "claude")
+        mock_load.return_value = "Prompt for {issue_number}"
+        mock_worktree.return_value = (mock_worktree_path, None)
+        mock_post_comment.return_value = True
+
+        yield {
+            "run_agentic_task": mock_run,
+            "load_prompt_template": mock_load,
+            "load_state": mock_load_state,
+            "post_step_comment": mock_post_comment,
+            "worktree_path": mock_worktree_path,
+        }
+
+
+@pytest.fixture
+def bug_default_args(tmp_path):
+    return {
+        "issue_url": "http://github.com/owner/repo/issues/964",
+        "issue_content": "Bug description",
+        "repo_owner": "owner",
+        "repo_name": "repo",
+        "issue_number": 964,
+        "issue_author": "alice",
+        "issue_title": "Gemini step comments",
+        "cwd": tmp_path,
+        "verbose": False,
+        "quiet": True,
+    }
+
+
+def test_bug_orchestrator_posts_step_comment_on_success(bug_orchestrator_mocks, bug_default_args):
+    """End-to-end: each successful step's <step_report> is posted via post_step_comment."""
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step1":
+            return (
+                True,
+                "preamble\n<step_report>\n## Step 1: Duplicate Check\n\nNo duplicates found.\n</step_report>\nORCHESTRATOR_TRAIL",
+                0.1,
+                "claude",
+            )
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: test_x.py",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, msg, _cost, _model, _files = run_agentic_bug_orchestrator(**bug_default_args)
+
+    assert success is True, msg
+    post_calls = bug_orchestrator_mocks["post_step_comment"].call_args_list
+    assert post_calls, "post_step_comment should have been invoked for each successful step"
+
+    step1_calls = [c for c in post_calls if c.kwargs.get("step_num") == 1]
+    assert step1_calls, f"No post for step 1 found. Calls: {post_calls!r}"
+    step1_body = step1_calls[0].kwargs.get("body")
+    assert step1_body is not None
+    assert "Duplicate Check" in step1_body
+    assert "No duplicates found" in step1_body
+
+
+def test_bug_orchestrator_does_not_repost_on_resume(bug_orchestrator_mocks, bug_default_args):
+    """Resume after step 1 succeeded previously: step 1 must NOT be reposted."""
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    bug_orchestrator_mocks["load_state"].return_value = (
+        {
+            "step_outputs": {
+                "1": "<step_report>## Step 1: Duplicate Check\n\nNo duplicates.\n</step_report>"
+            },
+            "last_completed_step": 1,
+            "total_cost": 0.1,
+            "model_used": "claude",
+            "step_comments": {"1": {"posted": True}},
+        },
+        None,
+    )
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: t.py",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, _msg, _cost, _model, _files = run_agentic_bug_orchestrator(**bug_default_args)
+
+    assert success is True
+    posted_steps = [
+        c.kwargs.get("step_num") for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+    ]
+    assert 1 not in posted_steps, f"Step 1 was reposted on resume. Posted steps: {posted_steps}"
+
+
+def test_bug_orchestrator_falls_back_when_no_step_report_tag(bug_orchestrator_mocks, bug_default_args):
+    """Agent omits <step_report> ⇒ orchestrator posts a clear fallback notice."""
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step1":
+            return (True, "raw output without any step report tags", 0.1, "claude")
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: t.py",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, _msg, _cost, _model, _files = run_agentic_bug_orchestrator(**bug_default_args)
+
+    assert success is True
+    step1_calls = [
+        c for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+        if c.kwargs.get("step_num") == 1
+    ]
+    assert step1_calls, "Step 1 should still post a fallback comment"
+    fallback_body = step1_calls[0].kwargs.get("body")
+    assert fallback_body is not None
+    assert "no `<step_report>` block" in fallback_body

--- a/tests/test_agentic_bug_orchestrator_step_comments.py
+++ b/tests/test_agentic_bug_orchestrator_step_comments.py
@@ -925,3 +925,75 @@ def test_bug_orchestrator_backfill_skips_fast_track_skipped_outputs(
     assert 5 not in posted_step_nums
     # Step 3 already posted previously.
     assert 3 not in posted_step_nums
+
+
+def test_bug_orchestrator_backfill_skips_non_contiguous_downstream_steps(
+    bug_orchestrator_mocks, bug_default_args
+):
+    """Non-contiguous cached step outputs must not leak stale downstream comments.
+
+    Regression for codex review #6 of PR #966 — the resume validator corrects
+    `last_completed_step` down when `step_outputs` has gaps (e.g. cached 1 and
+    3 but missing 2). The backfill sweep was previously iterating every saved
+    key and posting visible comments for stale downstream entries the
+    orchestrator had already decided were not valid completed progress.
+
+    Here: cached steps 1 and 3 with no entry for step 2 → validator corrects
+    `last_completed_step` to 1. The sweep must only post step 1 (and skip the
+    stale step 3 entry). Step 2 then runs fresh through the main loop.
+    """
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    bug_orchestrator_mocks["load_state"].return_value = (
+        {
+            "step_outputs": {
+                "1": "<step_report>## Step 1: R1</step_report>",
+                # Gap at "2" — non-contiguous cached progress.
+                "3": "<step_report>## Step 3: STALE R3</step_report>",
+            },
+            # Caller claimed 3, but the validator must correct this to 1.
+            "last_completed_step": 3,
+            "total_cost": 0.1,
+            "model_used": "claude",
+            # Step 1 not yet posted — sweep should retry it.
+            "step_comments": {},
+        },
+        None,
+    )
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: t.py",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, _msg, _cost, _model, _files = run_agentic_bug_orchestrator(**bug_default_args)
+    assert success is True
+
+    post_calls = bug_orchestrator_mocks["post_step_comment"].call_args_list
+    # Identify backfill-sweep calls for step 3: any call posting the STALE
+    # cached body. The main loop reruns step 3 with a fresh "## Step step3"
+    # body, so the stale body is a unique signature for the sweep.
+    stale_step3_calls = [
+        c for c in post_calls
+        if c.kwargs.get("step_num") == 3
+        and "STALE R3" in (c.kwargs.get("body") or "")
+    ]
+    assert not stale_step3_calls, (
+        "Backfill sweep posted a comment for stale downstream step 3 even "
+        "though the validator corrected last_completed_step down to 1. "
+        f"Calls: {post_calls!r}"
+    )
+
+    # Step 1's saved comment must still be backfilled (it's within the
+    # contiguous trusted range).
+    step1_calls = [c for c in post_calls if c.kwargs.get("step_num") == 1]
+    assert step1_calls, "Step 1 should be backfilled — it's within the contiguous range."
+    assert "R1" in (step1_calls[0].kwargs.get("body") or "")

--- a/tests/test_agentic_bug_orchestrator_step_comments.py
+++ b/tests/test_agentic_bug_orchestrator_step_comments.py
@@ -997,3 +997,83 @@ def test_bug_orchestrator_backfill_skips_non_contiguous_downstream_steps(
     step1_calls = [c for c in post_calls if c.kwargs.get("step_num") == 1]
     assert step1_calls, "Step 1 should be backfilled — it's within the contiguous range."
     assert "R1" in (step1_calls[0].kwargs.get("body") or "")
+
+
+def test_bug_orchestrator_resume_with_e2e_skipped_completed_run(
+    bug_orchestrator_mocks, bug_default_args
+):
+    """E2E-skipped completed runs must not lose Step 12 backfill or rerun PR creation.
+
+    Regression for codex review #5 of PR #966 — when Step 10 emits
+    ``E2E_NEEDED: no`` the orchestrator skips Step 11 via ``continue``. The
+    pre-fix code never persisted a synthetic Step 11 entry, so a resume of a
+    completed run had ``step_outputs`` with keys 1..10 plus 12 (missing 11).
+    The contiguous resume validator then downgraded ``last_completed_step``
+    from 12 to 10, miss-skipping Step 12's cached backfill AND rerunning the
+    side-effectful Step 12 PR creation.
+    """
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    cached_step10 = (
+        "<step_report>## Step 10: Verify</step_report>\n"
+        "E2E_NEEDED: no"
+    )
+    cached_step12 = "<step_report>## Step 12: PR created</step_report>"
+
+    bug_orchestrator_mocks["load_state"].return_value = (
+        {
+            "step_outputs": {
+                "1": "<step_report>## Step 1</step_report>",
+                "2": "<step_report>## Step 2</step_report>",
+                "3": "<step_report>## Step 3</step_report>",
+                "4": "<step_report>## Step 4</step_report>",
+                "5": "<step_report>## Step 5</step_report>",
+                "6": "<step_report>## Step 6</step_report>",
+                "7": "<step_report>## Step 7</step_report>",
+                "8": "<step_report>## Step 8</step_report>",
+                "9": (
+                    "<step_report>## Step 9</step_report>\n"
+                    "FILES_CREATED: test_x.py"
+                ),
+                "10": cached_step10,
+                # Step 11 intentionally missing — legacy state from before
+                # the synthetic-Step-11 persistence fix.
+                "12": cached_step12,
+            },
+            "last_completed_step": 12,
+            "total_cost": 0.5,
+            "model_used": "claude",
+            # All step comments already posted EXCEPT Step 12 (the one the
+            # transient post failure dropped).
+            "step_comments": {
+                str(n): {"posted": True} for n in range(1, 12) if n != 11
+            },
+        },
+        None,
+    )
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = AssertionError(
+        "No step should re-run; all 12 steps are cached after the heal."
+    )
+
+    success, _msg, _cost, _model, _files = run_agentic_bug_orchestrator(
+        **bug_default_args
+    )
+    assert success is True
+
+    post_calls = bug_orchestrator_mocks["post_step_comment"].call_args_list
+
+    # Step 12's cached body must be backfilled.
+    step12_calls = [c for c in post_calls if c.kwargs.get("step_num") == 12]
+    assert step12_calls, (
+        "Step 12's cached <step_report> must be backfilled even when Step 11 "
+        "was skipped by E2E_NEEDED:no. Calls: " + repr(post_calls)
+    )
+    assert "PR created" in (step12_calls[0].kwargs.get("body") or "")
+
+    # Step 11 has no <step_report>; the synthetic entry must NOT be posted.
+    step11_calls = [c for c in post_calls if c.kwargs.get("step_num") == 11]
+    assert not step11_calls, (
+        "Synthetic E2E-skip Step 11 entry must never be posted as a visible "
+        "comment. Calls: " + repr(step11_calls)
+    )

--- a/tests/test_agentic_bug_orchestrator_step_comments.py
+++ b/tests/test_agentic_bug_orchestrator_step_comments.py
@@ -195,6 +195,20 @@ def test_sanitize_truncates_respects_custom_max_chars():
     assert out.endswith("…[truncated]")
 
 
+def test_sanitize_cap_smaller_than_marker_still_bounded():
+    """When max_chars is tinier than the marker itself, the cap still holds.
+
+    Regression for codex re-review of PR #966 — the previous fix reserved
+    room for the marker but didn't final-slice, so a 3-char cap with a
+    15-char marker returned 15 chars.
+    """
+    from pdd.agentic_common import _sanitize_comment_body
+
+    body = "x" * 1000
+    out = _sanitize_comment_body(body, max_chars=3)
+    assert len(out) <= 3
+
+
 def test_sanitize_short_body_passes_through():
     from pdd.agentic_common import _sanitize_comment_body
 
@@ -579,3 +593,74 @@ def test_bug_orchestrator_posts_step_comment_on_hard_stop(bug_orchestrator_mocks
     body = step1_calls[0].kwargs.get("body")
     assert body is not None
     assert "Duplicate of #999" in body
+
+
+def test_bug_orchestrator_backfills_missing_comments_on_resume(
+    bug_orchestrator_mocks, bug_default_args
+):
+    """Resume with a step that was completed but never posted: retry on entry.
+
+    Regression for codex re-review of PR #966 — if `post_step_comment`
+    returns False on the success path, the orchestrator advances
+    `last_completed_step` anyway, so the next run's `step_num < start_step`
+    skip would silently swallow the missed comment. The resume-time sweep
+    retries every completed step whose `step_comments[n].posted` is falsy.
+    """
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    # Steps 1 and 2 completed previously; step 1 already had its comment
+    # posted, step 2 did NOT (e.g. transient gh failure). The state validator
+    # walks step_outputs and stops at the first missing/FAILED entry, so we
+    # only need entries for 1 and 2 — last_completed_step will be corrected
+    # down to 2, start_step will become 3, and the main loop will continue
+    # from there. We set step 9 to emit FILES_CREATED so the loop completes.
+    bug_orchestrator_mocks["load_state"].return_value = (
+        {
+            "step_outputs": {
+                "1": "<step_report>R1</step_report>",
+                "2": "<step_report>R2</step_report>",
+            },
+            "last_completed_step": 2,
+            "total_cost": 0.1,
+            "model_used": "claude",
+            "step_comments": {"1": {"posted": True}},
+        },
+        None,
+    )
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: t.py",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, _msg, _cost, _model, _files = run_agentic_bug_orchestrator(**bug_default_args)
+    assert success is True
+
+    posted_steps = [
+        c.kwargs.get("step_num")
+        for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+    ]
+    # The backfill sweep at orchestrator entry must retry step 2 (skipped
+    # by the main loop because step_num < start_step). Step 1 was already
+    # posted previously and must NOT be re-posted by the sweep.
+    assert 2 in posted_steps, f"Step 2 should be backfilled on resume. Posted: {posted_steps}"
+    # Find the FIRST step-2 call — that's the sweep's retry, not anything
+    # else from the main loop (which starts at step 3).
+    step2_calls = [
+        c for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+        if c.kwargs.get("step_num") == 2
+    ]
+    assert step2_calls
+    body = step2_calls[0].kwargs.get("body")
+    assert body is not None
+    assert "R2" in body
+    # And step 1's previously-posted state must be respected.
+    assert 1 not in posted_steps, "Step 1 was already posted; sweep must not repost it."

--- a/tests/test_agentic_bug_orchestrator_step_comments.py
+++ b/tests/test_agentic_bug_orchestrator_step_comments.py
@@ -299,6 +299,7 @@ def test_post_step_comment_without_body_kwarg_preserves_failed_template(tmp_path
     """Backwards compatibility: body=None ⇒ old FAILED fallback template."""
     from pdd.agentic_common import post_step_comment
 
+    secret = "ghp_" + "A" * 36
     with patch("pdd.agentic_common._find_cli_binary", return_value="/usr/bin/gh"), \
          patch("pdd.agentic_common.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
@@ -310,7 +311,7 @@ def test_post_step_comment_without_body_kwarg_preserves_failed_template(tmp_path
             step_num=3,
             total_steps=12,
             description="Reproduce",
-            output="All agent providers failed: exit 1",
+            output=f"All agent providers failed: exit 1 {secret}",
             cwd=tmp_path,
         )
 
@@ -321,6 +322,8 @@ def test_post_step_comment_without_body_kwarg_preserves_failed_template(tmp_path
     assert "**Status:** FAILED" in final_body
     assert "### Error Details" in final_body
     assert "Automated fallback comment" in final_body
+    assert secret not in final_body
+    assert "[REDACTED_GITHUB_TOKEN]" in final_body
 
 
 def test_post_step_comment_no_gh_returns_false_with_body(tmp_path):
@@ -434,6 +437,204 @@ def test_bug_orchestrator_posts_step_comment_on_success(bug_orchestrator_mocks, 
     assert step1_body is not None
     assert "Duplicate Check" in step1_body
     assert "No duplicates found" in step1_body
+
+
+def test_bug_orchestrator_posts_failed_step_fallback(
+    bug_orchestrator_mocks, bug_default_args
+):
+    """Soft failed steps should still get a visible FAILED fallback comment."""
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    captured_states: list = []
+
+    def save_side_effect(cwd, issue_number, workflow_type, state, *args, **kwargs):
+        captured_states.append(copy.deepcopy(state))
+        return None
+
+    bug_orchestrator_mocks["save_state"].side_effect = save_side_effect
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step6":
+            return (False, "Provider timeout during root cause", 0.1, "claude")
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: test_x.py",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, _msg, _cost, _model, _files = run_agentic_bug_orchestrator(
+        **bug_default_args
+    )
+    assert success is True
+
+    step6_calls = [
+        c for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+        if c.kwargs.get("step_num") == 6
+    ]
+    assert step6_calls
+    assert step6_calls[0].kwargs.get("body") is None
+    assert "Provider timeout" in step6_calls[0].kwargs.get("output", "")
+
+    step6_comment_states = [
+        s.get("step_comments", {}).get("6", {}) for s in captured_states
+        if s.get("step_comments", {}).get("6")
+    ]
+    assert step6_comment_states
+    assert step6_comment_states[-1].get("failed_posted") is True
+    assert step6_comment_states[-1].get("posted") is not True
+
+
+def test_bug_orchestrator_posts_fallback_before_provider_failure_abort(
+    bug_orchestrator_mocks, bug_default_args
+):
+    """The third consecutive provider failure abort still needs a visible comment."""
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    bug_orchestrator_mocks["run_agentic_task"].return_value = (
+        False,
+        "All agent providers failed: timed out",
+        0.1,
+        "claude",
+    )
+
+    success, msg, _cost, _model, _files = run_agentic_bug_orchestrator(
+        **bug_default_args
+    )
+
+    assert success is False
+    assert "3 consecutive" in msg
+    posted_steps = [
+        c.kwargs.get("step_num")
+        for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+    ]
+    assert posted_steps == [1, 2, 3]
+
+
+def test_bug_orchestrator_step12_failure_returns_failure(
+    bug_orchestrator_mocks, bug_default_args
+):
+    """A failed final PR step must not report a successful investigation."""
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: test_x.py",
+                0.1,
+                "claude",
+            )
+        if label == "step12":
+            return (False, "All agent providers failed: timed out", 0.1, "claude")
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, msg, _cost, _model, _files = run_agentic_bug_orchestrator(
+        **bug_default_args
+    )
+
+    assert success is False
+    assert "step 12" in msg.lower()
+    assert "timed out" in msg
+
+    step12_calls = [
+        c for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+        if c.kwargs.get("step_num") == 12
+    ]
+    assert step12_calls
+    assert step12_calls[0].kwargs.get("body") is None
+
+
+def test_bug_orchestrator_e2e_gate_ignores_report_body_marker(
+    bug_orchestrator_mocks, bug_default_args
+):
+    """Only the E2E_NEEDED marker outside <step_report> controls Step 11."""
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: test_x.py",
+                0.1,
+                "claude",
+            )
+        if label == "step10":
+            return (
+                True,
+                "<step_report>Report body mentions E2E_NEEDED: no as an example.</step_report>\n"
+                "E2E_NEEDED: yes - integration path still needs coverage",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, _msg, _cost, _model, _files = run_agentic_bug_orchestrator(
+        **bug_default_args
+    )
+
+    assert success is True
+    executed_labels = [
+        c.kwargs.get("label")
+        for c in bug_orchestrator_mocks["run_agentic_task"].call_args_list
+    ]
+    assert "step11" in executed_labels
+
+
+def test_bug_orchestrator_redacts_secrets_before_state_save(
+    bug_orchestrator_mocks, bug_default_args
+):
+    """Step output stored in workflow state may sync to GitHub, so redact it."""
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    secret = "ghp_" + "A" * 36
+    captured_states: list = []
+
+    def save_side_effect(cwd, issue_number, workflow_type, state, *args, **kwargs):
+        captured_states.append(copy.deepcopy(state))
+        return None
+
+    bug_orchestrator_mocks["save_state"].side_effect = save_side_effect
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step1":
+            return (
+                True,
+                f"<step_report>Secret leaked: {secret}</step_report>",
+                0.1,
+                "claude",
+            )
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: test_x.py",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, _msg, _cost, _model, _files = run_agentic_bug_orchestrator(
+        **bug_default_args
+    )
+
+    assert success is True
+    saved = repr(captured_states)
+    assert secret not in saved
+    assert "[REDACTED_GITHUB_TOKEN]" in saved
 
 
 def test_bug_orchestrator_does_not_repost_on_resume(bug_orchestrator_mocks, bug_default_args):

--- a/tests/test_agentic_bug_orchestrator_step_comments.py
+++ b/tests/test_agentic_bug_orchestrator_step_comments.py
@@ -17,6 +17,7 @@ These tests cover:
 """
 from __future__ import annotations
 
+import copy
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -359,7 +360,7 @@ def bug_orchestrator_mocks(tmp_path):
          patch("pdd.agentic_bug_orchestrator.console"), \
          patch("pdd.agentic_bug_orchestrator._setup_worktree") as mock_worktree, \
          patch("pdd.agentic_bug_orchestrator.preprocess", side_effect=lambda t, **kw: t), \
-         patch("pdd.agentic_bug_orchestrator.save_workflow_state", return_value=None), \
+         patch("pdd.agentic_bug_orchestrator.save_workflow_state", return_value=None) as mock_save_state, \
          patch("pdd.agentic_bug_orchestrator.load_workflow_state", return_value=(None, None)) as mock_load_state, \
          patch("pdd.agentic_bug_orchestrator._get_git_root", return_value=tmp_path), \
          patch("pdd.agentic_bug_orchestrator.set_agentic_progress"), \
@@ -375,6 +376,7 @@ def bug_orchestrator_mocks(tmp_path):
             "run_agentic_task": mock_run,
             "load_prompt_template": mock_load,
             "load_state": mock_load_state,
+            "save_state": mock_save_state,
             "post_step_comment": mock_post_comment,
             "worktree_path": mock_worktree_path,
         }
@@ -664,3 +666,68 @@ def test_bug_orchestrator_backfills_missing_comments_on_resume(
     assert "R2" in body
     # And step 1's previously-posted state must be respected.
     assert 1 not in posted_steps, "Step 1 was already posted; sweep must not repost it."
+
+
+def test_bug_orchestrator_fast_track_persists_step3_output(
+    bug_orchestrator_mocks, bug_default_args
+):
+    """FAST_TRACK must persist step 3's output (codex review of PR #966 #3).
+
+    Without this the resume state validator walks ordered_steps, finds the
+    gap at "3" (because the previous FAST_TRACK only wrote 4/5), and
+    downgrades last_completed_step to 0 — forcing a re-run of triage even
+    though step 3's comment was already posted.
+    """
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    captured_states: list = []
+
+    def save_side_effect(cwd, issue_number, workflow_type, state, *args, **kwargs):
+        # State is mutated in-place across the orchestrator. Snapshot via
+        # deepcopy so we observe the value at the moment of each save call.
+        captured_states.append(copy.deepcopy(state))
+        return None
+
+    bug_orchestrator_mocks["save_state"].side_effect = save_side_effect
+
+    fast_track_output = (
+        "FAST_TRACK: pre-diagnosed by author\n"
+        "<step_report>## Step 3: Triage\n\nFast-tracked.</step_report>"
+    )
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step3":
+            return (True, fast_track_output, 0.1, "claude")
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: t.py",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    run_agentic_bug_orchestrator(**bug_default_args)
+
+    # Find the snapshot taken right after FAST_TRACK populated steps 4/5.
+    fast_tracked = [
+        s for s in captured_states
+        if s.get("step_outputs", {}).get("4", "").startswith("Step 4 skipped (fast-track)")
+    ]
+    assert fast_tracked, "Expected at least one save_workflow_state call after FAST_TRACK"
+    snapshot = fast_tracked[0]
+    assert "3" in snapshot["step_outputs"], (
+        "FAST_TRACK must persist step 3 output so resume validator doesn't "
+        "downgrade last_completed_step. Outputs: "
+        f"{list(snapshot['step_outputs'].keys())}"
+    )
+    assert "Triage" in snapshot["step_outputs"]["3"]
+    assert "FAST_TRACK:" in snapshot["step_outputs"]["3"]
+    # Synthetic 4/5 entries still present.
+    assert "4" in snapshot["step_outputs"]
+    assert "5" in snapshot["step_outputs"]
+    # last_completed_step rolls forward to 5 as before.
+    assert snapshot["last_completed_step"] == 5

--- a/tests/test_agentic_bug_orchestrator_step_comments.py
+++ b/tests/test_agentic_bug_orchestrator_step_comments.py
@@ -731,3 +731,197 @@ def test_bug_orchestrator_fast_track_persists_step3_output(
     assert "5" in snapshot["step_outputs"]
     # last_completed_step rolls forward to 5 as before.
     assert snapshot["last_completed_step"] == 5
+
+
+# ---------------------------------------------------------------------------
+# codex review #4 of PR #966: malformed persisted state + backfill gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "malformed_state",
+    [
+        # The whole field is a list (legacy/corrupted payload).
+        {"step_comments": []},
+        # Per-step entry isn't a dict.
+        {"step_comments": {"1": "posted"}},
+        # Per-step entry's `posted` is truthy but not `True` — only the literal
+        # boolean True should suppress reposts.
+        {"step_comments": {"1": {"posted": "yes"}}},
+    ],
+)
+def test_bug_orchestrator_normalizes_malformed_step_comments(
+    bug_orchestrator_mocks, bug_default_args, malformed_state
+):
+    """Corrupted/stale persisted state must not crash `pdd bug` on entry.
+
+    Regression for codex review #4 of PR #966 — `state.setdefault("step_comments", {})`
+    leaves a malformed value (list, non-dict entry, non-bool `posted`) in place
+    and the subsequent `.get()` call raises AttributeError. The fix normalizes
+    the shape after load AND inside the backfill sweep, and treats only
+    `posted is True` as truly posted.
+    """
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    bug_orchestrator_mocks["load_state"].return_value = (
+        {
+            "step_outputs": {
+                "1": "<step_report>## Step 1: previously completed.</step_report>",
+            },
+            "last_completed_step": 1,
+            "total_cost": 0.1,
+            "model_used": "claude",
+            **malformed_state,
+        },
+        None,
+    )
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: t.py",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    # Must complete without raising AttributeError on the malformed state.
+    success, _msg, _cost, _model, _files = run_agentic_bug_orchestrator(**bug_default_args)
+    assert success is True
+
+    # The non-`True` `posted` cases must NOT suppress backfill — step 1's saved
+    # output contains a `<step_report>` block, so it should be reposted.
+    posted_step_nums = [
+        c.kwargs.get("step_num")
+        for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+    ]
+    assert 1 in posted_step_nums
+
+
+def test_bug_orchestrator_backfill_skips_legacy_outputs_without_step_report(
+    bug_orchestrator_mocks, bug_default_args
+):
+    """Legacy pre-PR step outputs (no `<step_report>` tag) must not be reposted.
+
+    Codex review #4 of PR #966: before the fix, the resume sweep would happily
+    repost any non-FAILED `step_outputs` entry whose `step_comments[n].posted`
+    flag was missing. That includes legacy state from runs predating this PR
+    (where models posted their own comments), causing duplicate visible
+    comments on the issue.
+    """
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    bug_orchestrator_mocks["load_state"].return_value = (
+        {
+            "step_outputs": {
+                # Legacy run: model posted its own comment back when the
+                # orchestrator did not own posting. No `<step_report>` block,
+                # no `step_comments` flag.
+                "1": "No duplicates found. Proceeding.",
+                "2": "Not user error. Continuing.",
+            },
+            "last_completed_step": 2,
+            "total_cost": 0.1,
+            "model_used": "claude",
+        },
+        None,
+    )
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: t.py",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, _msg, _cost, _model, _files = run_agentic_bug_orchestrator(**bug_default_args)
+    assert success is True
+
+    posted_step_nums = [
+        c.kwargs.get("step_num")
+        for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+    ]
+    # Steps 1 and 2 are legacy outputs lacking `<step_report>` — the sweep
+    # must skip them to avoid duplicate visible comments.
+    assert 1 not in posted_step_nums
+    assert 2 not in posted_step_nums
+
+
+def test_bug_orchestrator_backfill_skips_fast_track_skipped_outputs(
+    bug_orchestrator_mocks, bug_default_args
+):
+    """FAST_TRACK persists synthetic skipped-step outputs for steps 4 and 5.
+
+    Those synthetic strings ("Step 4 skipped (fast-track)...") lack the
+    `<step_report>` tag because no agent ever ran for them. Codex review #4
+    of PR #966 — the backfill sweep must NOT post them as visible comments;
+    they're internal state used to bridge the gap so the resume validator
+    rolls last_completed_step forward to 5.
+    """
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    bug_orchestrator_mocks["load_state"].return_value = (
+        {
+            "step_outputs": {
+                # Steps 1-2 ran normally in the prior session and were posted.
+                "1": "<step_report>## Step 1: no duplicates.</step_report>",
+                "2": "<step_report>## Step 2: not a docs issue.</step_report>",
+                "3": (
+                    "<step_report>## Step 3: Triage</step_report>\n"
+                    "FAST_TRACK: pre-diagnosed by author"
+                ),
+                # Synthetic skipped-step outputs persisted by FAST_TRACK at
+                # `pdd/agentic_bug_orchestrator.py:1796-1797`. These lack the
+                # `<step_report>` tag because no agent ever ran for them.
+                "4": "Step 4 skipped (fast-track): pre-diagnosed.",
+                "5": "Step 5 skipped (fast-track): pre-diagnosed.",
+            },
+            "last_completed_step": 5,
+            "total_cost": 0.1,
+            "model_used": "claude",
+            # Steps 1-3 were already posted in the prior run.
+            "step_comments": {
+                "1": {"posted": True},
+                "2": {"posted": True},
+                "3": {"posted": True},
+            },
+        },
+        None,
+    )
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: t.py",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, _msg, _cost, _model, _files = run_agentic_bug_orchestrator(**bug_default_args)
+    assert success is True
+
+    posted_step_nums = [
+        c.kwargs.get("step_num")
+        for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+    ]
+    # Steps 4 and 5 were never run; their synthetic outputs lack `<step_report>`
+    # and must not be reposted as visible comments.
+    assert 4 not in posted_step_nums
+    assert 5 not in posted_step_nums
+    # Step 3 already posted previously.
+    assert 3 not in posted_step_nums

--- a/tests/test_agentic_bug_orchestrator_step_comments.py
+++ b/tests/test_agentic_bug_orchestrator_step_comments.py
@@ -175,13 +175,24 @@ def test_sanitize_redacts_bearer_token():
 
 
 def test_sanitize_truncates_long_body():
+    """Truncation reserves room for the marker so the cap is respected (codex review of PR #966)."""
     from pdd.agentic_common import _sanitize_comment_body
 
     body = "x" * 30_000
     out = _sanitize_comment_body(body)
-    assert len(out) <= 30_000  # truncated + tag suffix is shorter than 30k
+    # The cap MUST hold: returned length ≤ max_chars (default 25 000).
+    assert len(out) <= 25_000
     assert out.endswith("…[truncated]")
     assert out.startswith("x" * 1000)
+
+
+def test_sanitize_truncates_respects_custom_max_chars():
+    """An explicit max_chars must also include the marker length in the cap."""
+    from pdd.agentic_common import _sanitize_comment_body
+
+    out = _sanitize_comment_body("y" * 500, max_chars=100)
+    assert len(out) <= 100
+    assert out.endswith("…[truncated]")
 
 
 def test_sanitize_short_body_passes_through():
@@ -478,3 +489,93 @@ def test_bug_orchestrator_falls_back_when_no_step_report_tag(bug_orchestrator_mo
     fallback_body = step1_calls[0].kwargs.get("body")
     assert fallback_body is not None
     assert "no `<step_report>` block" in fallback_body
+
+
+def test_bug_orchestrator_posts_step_comment_on_fast_track(bug_orchestrator_mocks, bug_default_args):
+    """FAST_TRACK at step 3 must still post the triage report before short-circuiting.
+
+    Regression for codex review of PR #966 — the `continue` that skips
+    steps 4 and 5 ran BEFORE the post-comment block, hiding the triage
+    result from the user.
+    """
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step3":
+            return (
+                True,
+                (
+                    "<step_report>\n## Step 3: Triage\n\nFast-tracked: pre-diagnosed.\n</step_report>\n"
+                    "FAST_TRACK: pre-diagnosed by author"
+                ),
+                0.1,
+                "claude",
+            )
+        if label == "step9":
+            return (
+                True,
+                "<step_report>## Step 9 details</step_report>\nFILES_CREATED: t.py",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, _msg, _cost, _model, _files = run_agentic_bug_orchestrator(**bug_default_args)
+    assert success is True
+
+    posted_steps = [
+        c.kwargs.get("step_num")
+        for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+    ]
+    assert 3 in posted_steps, f"Step 3 (FAST_TRACK) must post a comment. Calls: {posted_steps}"
+
+    step3_calls = [
+        c for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+        if c.kwargs.get("step_num") == 3
+    ]
+    body = step3_calls[0].kwargs.get("body")
+    assert body is not None
+    assert "Fast-tracked" in body
+    # Steps 4 and 5 are skipped by FAST_TRACK — they must NOT get comments.
+    assert 4 not in posted_steps
+    assert 5 not in posted_steps
+
+
+def test_bug_orchestrator_posts_step_comment_on_hard_stop(bug_orchestrator_mocks, bug_default_args):
+    """Hard stops (Duplicate/NeedsInfo/etc.) must still post the model's report.
+
+    Regression for codex review of PR #966 — `_check_hard_stop` causes an
+    early return BEFORE the original post-comment block, so users saw no
+    visible signal for stops like Duplicate-of-#999.
+    """
+    from pdd.agentic_bug_orchestrator import run_agentic_bug_orchestrator
+
+    def run_side_effect(*args, **kwargs):
+        label = kwargs.get("label", "")
+        if label == "step1":
+            return (
+                True,
+                "<step_report>\n## Step 1: Duplicate Check\n\nDuplicate of #999.\n</step_report>",
+                0.1,
+                "claude",
+            )
+        return (True, f"<step_report>## Step {label}</step_report>", 0.1, "claude")
+
+    bug_orchestrator_mocks["run_agentic_task"].side_effect = run_side_effect
+
+    success, msg, _cost, _model, _files = run_agentic_bug_orchestrator(**bug_default_args)
+    # Hard stop must short-circuit the workflow.
+    assert success is False
+    assert "Stopped at step 1" in msg
+
+    step1_calls = [
+        c for c in bug_orchestrator_mocks["post_step_comment"].call_args_list
+        if c.kwargs.get("step_num") == 1
+    ]
+    assert step1_calls, "Step 1 must post the visible report even on hard stop"
+    body = step1_calls[0].kwargs.get("body")
+    assert body is not None
+    assert "Duplicate of #999" in body


### PR DESCRIPTION
## Summary
- Move per-step GitHub comment posting from the model subprocess to the PDD orchestrator (start with `pdd bug`); fixes Gemini `401 Bad credentials` because `gh` cannot auth inside the model CLI's sandboxed shell.
- Models now return findings between `<step_report>…</step_report>` tags; the orchestrator extracts, sanitizes (tokens), truncates (25k chars), and posts via `post_step_comment(body=…)`.
- Resume-safe via `state["step_comments"][step]["posted"]` so a retry does not double-post.

## Scope
- `pdd/agentic_common.py`: extends `post_step_comment` (optional `body`), adds `_extract_step_report` and `_sanitize_comment_body`.
- `pdd/agentic_bug_orchestrator.py`: posts a per-step comment after each successful step.
- `prompts/agentic_bug_step{1..12}_*_LLM.prompt`: replace `gh issue comment` instructions with `<step_report>` contract; orchestrator markers (FILES_CREATED, FAST_TRACK, EXPANSION_ITEMS, DEFECT_TYPE, etc.) preserved outside tags.
- `tests/test_agentic_bug_orchestrator_step_comments.py`: extraction, sanitization, orchestrator wiring, resume.
- `tests/test_agentic_bug_orchestrator{,_1}.py`: pin `post_step_comment` mock in existing fixtures so tests don't shell out to real `gh`.

Out of scope (deliberate, per issue #964 step plan): `change`, `test`, `checkup`, `architecture` — follow-up PRs.

## Test plan
- [x] `pytest -vv tests/test_agentic_bug_orchestrator_step_comments.py` (29 passed)
- [x] `pytest -vv tests/test_agentic_common.py -k "post_step_comment or post_pr_comment"` (4 passed)
- [x] `pytest -vv tests/test_agentic_bug_orchestrator.py` (one pre-existing unrelated `PDD_PATH` failure, otherwise green)
- [x] `pytest -vv tests/test_agentic_bug_orchestrator_1.py` (passes)
- [x] `pytest -vv tests/test_e2e_issue_737_step_completion_markers.py` (passes; step-complete printf untouched)
- [ ] Manual: `pdd bug` with `--provider gemini` on a sandbox issue; confirm visible per-step comments with no `gh issue comment` errors in step output.

Fixes #964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)