### PR TITLE
fix(ci): drop :latest from AR_IMAGE — hotfix for PR #962 double-tag bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -538,7 +538,7 @@ CLOUD_BATCH_DIR := ci/cloud-batch
 GCP_PROJECT_ID := prompt-driven-development-stg
 GCP_REGION ?= us-central1
 GCS_BUCKET ?= pdd-stg-ci-results
-AR_IMAGE := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/pdd-ci/pdd-test:latest
+AR_IMAGE := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/pdd-ci/pdd-test
 
 # Files baked into the Docker image — changes to these require a rebuild
 CLOUD_IMAGE_DEPS := requirements.txt pyproject.toml $(CLOUD_BATCH_DIR)/entrypoint.sh $(CLOUD_BATCH_DIR)/Dockerfile


### PR DESCRIPTION
## Summary

PR #962 broke the Cloud Build image-rebuild step. Root cause: `Makefile:541` defined `AR_IMAGE` with a trailing `:latest`, which combined with #962's new candidate-tag step (`-t \${_AR_IMAGE}:\$BUILD_ID`) produced `pdd-test:latest:\$BUILD_ID` — invalid docker reference.

Every Cloud Build with an image-deps change is currently failing at step 1 with `invalid reference format`.

## Fix

One line: drop `:latest` from `AR_IMAGE` in the Makefile. `cloudbuild.yaml` is now the sole authority on tagging — it builds to `:\$BUILD_ID`, verifies plugins, then retags + pushes `:latest` only after verify passes.

## Repro

```
make -C pdd/staging/public/pdd cloud-test
```
Currently fails with:
```
Step #1 - "build-image": invalid argument "...pdd-test:latest:a5fff4db-..." for "-t, --tag" flag
ERROR: build step 1 ... failed: step exited with non-zero status: 125
```

## Test plan
- [ ] Re-run `make test-pdd-cli-release` post-merge — image build should reach the verify step.