### PR TITLE
fix(ci): entrypoint preflight broken heredoc — all 77 batch tasks were exiting 2

### DIFF
--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -82,13 +82,11 @@ SETUP_SECONDS=$((SETUP_END - SETUP_START))
 # Image plugin contract: confirm pytest plugins required by markers in tests/
 # are actually importable. Catches a stale image, or someone bumping
 # requirements.txt without updating Dockerfile's explicit plugin install.
-python - <<'PY' || {
+python -c "import pytest_timeout, xdist, pytest_mock, pytest_asyncio, pytest_cov, testmon" || {
     echo "FATAL: image missing expected pytest plugins"
     write_result "failed" "${SETUP_SECONDS}" "preflight" "missing pytest plugins"
     exit 1
 }
-import pytest_timeout, xdist, pytest_mock, pytest_asyncio, pytest_cov, testmon
-PY
 
 # Pytest config contract: confirm pyproject.toml [tool.pytest.ini_options]
 # parses cleanly and all markers we use are registered (strict-markers).


### PR DESCRIPTION
## Summary

The per-chunk pytest-plugin preflight we shipped in #962 had a bash quoting bug: a heredoc combined with `|| { ... }` consumed the brace block as heredoc body, leaving the `{` unclosed. Every Cloud Batch task in `make test-pdd-cli-release` was exiting 2 with:

    /entrypoint.sh: line 402: syntax error: unexpected end of file from `{' command on line 85

…before any test ran. Fix: use the simpler `python -c "..."` form (same pattern we already use in `cloudbuild.yaml` after Codex's round-2 feedback on multi-line Python in another quoting context).

`bash -n ci/cloud-batch/entrypoint.sh` now reports clean.

## Follow-up
Adding `bash -n` + `shellcheck` to the preflight verification step is a sensible cheap defense — same family of bug.

## Test plan
- [ ] Re-run `make test-pdd-cli-release` after merge; expect preflight to run cleanly and tests to dispatch.