### PR TITLE
fix(ci): relax timeouts on two real-LLM tests flaking post-PR-962

### DIFF
--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -372,7 +372,10 @@ elif [ "${TASK_INDEX}" -ge "${SYNC_REGRESSION_START}" ] && [ "${TASK_INDEX}" -le
     # ── Sync regression test ──────────────────────────────────────────
     SYNC_OFFSET=$((TASK_INDEX - SYNC_REGRESSION_START))
     CASE_NUM="${SYNC_CASE_IDS[$SYNC_OFFSET]}"
-    export PDD_CMD_TIMEOUT="${PDD_CMD_TIMEOUT:-600}"
+    # 10 min was tight for case_7 (complex sync data_processor — strength 0.3,
+    # 1 attempt, $5 budget; legit LLM completion + scaffold can run 8-10 min).
+    # 15 min gives realistic headroom without weakening fail-fast for hangs.
+    export PDD_CMD_TIMEOUT="${PDD_CMD_TIMEOUT:-900}"
     run_test "sync_regression" "case_${CASE_NUM}" \
         bash tests/sync_regression.sh "${CASE_NUM}"
 

--- a/tests/test_generate_test.py
+++ b/tests/test_generate_test.py
@@ -115,7 +115,7 @@ def test_generate_test_minimum_values(valid_inputs):
 
 
 
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(300)
 def test_generate_test_maximum_values(valid_inputs):
     valid_inputs['strength'] = 1.0
     valid_inputs['temperature'] = 1.0


### PR DESCRIPTION
## Summary

First end-to-end `make test-pdd-cli-release` against `origin/main` post-PR-962 surfaced two real-LLM tests timing out:

| Test | Old budget | New budget | Why |
|---|---|---|---|
| `test_generate_test_maximum_values` (chunk_7) | `@pytest.mark.timeout(180)` | `@pytest.mark.timeout(300)` | strength=1.0 → claude-opus-4-7 chained calls legit run >3 min under load |
| `sync_regression case_7` (chunk_62) | `PDD_CMD_TIMEOUT=600s` | `PDD_CMD_TIMEOUT=900s` | complex `pdd sync data_processor` (strength 0.3, --budget 5.0, --max-attempts 1) ran ~9 min |

Both bounds still catch true hangs; just give realistic-but-not-infinite headroom for the slow path.

These flakes were pre-existing — PR #962's lifecycle tuning (exit 124 no longer retried) just made them visible as one fast failure instead of buried in retry spirals.

## Test plan
- [ ] Re-run `make test-pdd-cli-release` against this branch's merged state and confirm green.