### PR TITLE
fix(ci): restrict pytest CI to Google Vertex gemini rows (no opus)

### DIFF
--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -315,6 +315,17 @@ if [ "${TASK_INDEX}" -ge "${PYTEST_START}" ] && [ "${TASK_INDEX}" -le "${PYTEST_
     CHUNK_INDEX="${TASK_INDEX}"
     DURATIONS_FILE="${WORK_DIR}/ci/cloud-batch/test-durations.json"
 
+    # CI model cap: restrict real-LLM pytest tests to Google Vertex AI gemini
+    # rows. The selector at strength=1.0 (e.g. test_generate_test_maximum_values)
+    # otherwise escalates to the highest-ELO row in the full CSV (claude-opus-4-7),
+    # which is too slow to be a reliable CI dependency. After this filter the
+    # highest ELO is a Gemini Pro variant — fast, cheap, and stable. PDD prefers
+    # <cwd>/.pdd/llm_model.csv when present (see pdd/llm_invoke.py:778-781).
+    mkdir -p "${WORK_DIR}/.pdd"
+    head -1 "${WORK_DIR}/pdd/data/llm_model.csv" > "${WORK_DIR}/.pdd/llm_model.csv"
+    grep -E '^Google Vertex AI,[^,]*gemini' "${WORK_DIR}/pdd/data/llm_model.csv" >> "${WORK_DIR}/.pdd/llm_model.csv"
+    echo "=== CI-restricted llm_model.csv ($(( $(wc -l < "${WORK_DIR}/.pdd/llm_model.csv") - 1 )) gemini rows) ==="
+
     if [ -f "${DURATIONS_FILE}" ]; then
         # Duration-based bin packing for balanced chunks
         echo "=== Using duration-based chunk balancing ==="


### PR DESCRIPTION
## Summary

Real-LLM pytest tests at strength=1.0 (e.g. `test_generate_test_maximum_values`) were escalating to `claude-opus-4-7` via the model selector in `pdd/llm_invoke.py:2174-2188`, which interpolates target ELO from the `PDD_MODEL_DEFAULT` *base* up to the *highest-ELO available* model. Opus is too slow / rate-limited to be a reliable CI dependency — it timed out at 180s, then at 300s (PRs #962 / #982).

## Fix

Mirror `tests/sync_regression.sh`'s CI-safe-CSV pattern but narrower: in the pytest branch of `ci/cloud-batch/entrypoint.sh`, write a working-dir `.pdd/llm_model.csv` that contains only `Google Vertex AI,...gemini...` rows. PDD's CSV resolution at `pdd/llm_invoke.py:778-781` prefers `<cwd>/.pdd/llm_model.csv` when present.

After the filter the available models are:
- `gemini-3.1-pro-preview` (ELO 1456) — highest, used at strength=1.0
- `gemini-3.1-pro-preview-customtools` (1456)
- `vertex_ai/gemini-3-flash-preview` (1437) — matches the `PDD_MODEL_DEFAULT` base

## Scope

Pytest branch only. `regression.sh` and `sync_regression.sh` keep their own (looser) CI-safe filters; vitest is frontend, no LLM.

## Test plan
- [ ] Re-run `make test-pdd-cli-release`. Expect chunk_7 to pass.