### PR TITLE
ci(release): publish to real PyPI via OIDC on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
-name: Publish to TestPyPI
+name: Publish to PyPI
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: read
@@ -12,6 +15,7 @@ concurrency:
 
 jobs:
   publish-testpypi:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: pypi-test-publish
     permissions:
@@ -36,5 +40,33 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          attestations: true
+
+  publish-pypi:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: pypi-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+
+      - name: Verify artifacts
+        run: python -m twine check dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
           skip-existing: true
           attestations: true

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ help:
 	@echo "  make publish                 - Build & upload current version to PyPI"
 	@echo "  make publish-public          - Copy artifacts to public repo only"
 	@echo "  make check-deps              - Check pyproject.toml and requirements.txt are in sync"
-	@echo "  make release                 - Bump version, tag, and upload to PyPI (public origin only)"
+	@echo "  make release                 - Bump version, tag, and push (GitHub Actions publishes to PyPI via OIDC after gltanaka approval)"
 	@echo "  make staging                 - Copy files to staging"
 	@echo "  make production              - Copy files from staging to pdd"
 	@echo "  make update-extension        - Update VS Code extension"
@@ -696,16 +696,20 @@ release: check-deps check-suspicious-files check-release-remote check-release-br
 	CURRENT_VERSION=$$(sed -n '1,120s/^version[[:space:]]*=[[:space:]]*"\([0-9.]*\)"/\1/p' pyproject.toml | head -n1); \
 	CURRENT_TAG="v$$CURRENT_VERSION"; \
 	if git tag --points-at HEAD | grep -qx "$$CURRENT_TAG"; then \
-		echo "HEAD already at $$CURRENT_TAG; publishing current version to PyPI."; \
-		$(MAKE) publish; \
+		echo "HEAD already at $$CURRENT_TAG."; \
+		echo "Pushing tag to origin to trigger GitHub Actions publish workflow."; \
+		git push origin "$$CURRENT_TAG"; \
 	else \
 		echo "Bumping version with commitizen"; \
 		python -m commitizen bump --increment PATCH --yes --check-consistency; \
 		echo "Pushing release commit and tags to origin"; \
 		git push origin main --tags; \
-		echo "Publishing new version to PyPI"; \
-		$(MAKE) publish; \
-	fi
+	fi; \
+	NEW_VERSION=$$(sed -n '1,120s/^version[[:space:]]*=[[:space:]]*"\([0-9.]*\)"/\1/p' pyproject.toml | head -n1); \
+	echo ""; \
+	echo "Tag v$$NEW_VERSION pushed. GitHub Actions will publish to PyPI after gltanaka approval."; \
+	echo "  Watch:    gh run watch --workflow release.yml"; \
+	echo "  Fallback: make publish  (uploads locally via twine)"
 	@# Post-release cleanup check (Issue #186)
 	@$(MAKE) check-suspicious-files
 


### PR DESCRIPTION
## Summary

Add a `publish-pypi` job to `release.yml` that triggers on `v*` tag push, uses environment `pypi-publish` (gated by required-reviewer `gltanaka` + main-branch + v* tag rules), and publishes to real PyPI via OIDC Trusted Publisher. Mirrors the existing TestPyPI flow but binds to the production environment and the real PyPI index.

Update `make release` so it pushes the bump commit + tag and exits. The tag push triggers the Actions workflow; gltanaka approves the deployment; OIDC publishes. **No local PyPI credentials needed for routine releases.** `make publish` remains as a manual fallback for local twine upload (used today for v0.0.236 when this flow didn't exist yet).

## Prerequisites — already in place

- ✅ Trusted Publisher on **pypi.org** for `pdd-cli` is already configured: `promptdriven/pdd` / `release.yml` / `pypi-publish` (verified at https://pypi.org/manage/project/pdd-cli/settings/publishing/)
- ✅ GitHub environment `pypi-publish` is configured with the gltanaka required-reviewer and main + v* deployment rules

No further setup needed before merging. The next release after this lands runs end-to-end via OIDC.

## Test plan

- [ ] Merge this PR
- [ ] Next release: `make release` → bump → tag → push → Actions workflow appears, paused at gltanaka approval
- [ ] Approve → OIDC publish to real PyPI succeeds, no twine password prompt
- [ ] Fallback path (`make publish`) still works for emergencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)