### PR TITLE
bump: version 0.0.237 → 0.0.238

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## v0.0.238 (2026-05-14)
+
+### Feat
+
+- enforce metadata finalization in CI auto-heal/preflight drift-heal (#1006)
+
+### Fix
+
+- pdd sync bug fixes
+- address codex review-loop findings
+- address codex review-loop findings round 6
+- address codex review-loop findings
+- address codex review-loop findings round 5
+- address codex review-loop findings round 4
+- address codex review-loop findings
+- address codex review-loop findings
+- address codex review-loop findings
+- address codex review-loop findings
+- **update_main**: finalize fingerprint in default single-file mode
+- align update_main prompt contract
+- restore metadata sync state
+- **metadata_sync**: preserve user-facing command on fingerprint finalize
+- hard fail preflight metadata errors
+- harden metadata finalization validation
+- fail finalized empty-index commits
+- skip commits on advisory partial failures
+- restore ci drift heal summaries
+- preserve full metadata fingerprint state
+- hard fail unresolved post-update prompts
+- restore promptless module drift detection
+- enforce metadata finalization in auto-heal
+- **ci**: avoid red auto-heal job for generated PRs
+
 ## v0.0.237 (2026-05-13)
 
 ### CI

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDD (Prompt-Driven Development) Command Line Interface
 
-![PDD-CLI Version](https://img.shields.io/badge/pdd--cli-v0.0.237-blue) [![Discord](https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white)](https://discord.gg/Yp4RTh8bG7)
+![PDD-CLI Version](https://img.shields.io/badge/pdd--cli-v0.0.238-blue) [![Discord](https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white)](https://discord.gg/Yp4RTh8bG7)
 
 ## Introduction
 
@@ -362,7 +362,7 @@ For proper model identifiers to use in your custom configuration, refer to the [
 
 ## Version
 
-Current version: 0.0.237
+Current version: 0.0.238
 
 To check your installed version, run:
 ```

--- a/pdd/pdd_completion.sh
+++ b/pdd/pdd_completion.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # PDD CLI Bash Completion Script
-# Version: 0.0.237
+# Version: 0.0.238
 # Supports all PDD commands and options with filename completion
 
 _pdd() {

--- a/pypi_description.rst
+++ b/pypi_description.rst
@@ -1,4 +1,4 @@
-.. image:: https://img.shields.io/badge/pdd--cli-v0.0.237-blue
+.. image:: https://img.shields.io/badge/pdd--cli-v0.0.238-blue
    :alt: PDD-CLI Version
 
 .. image:: https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white&link=https://discord.gg/Yp4RTh8bG7
@@ -75,7 +75,7 @@ After installation, verify:
 
    pdd --version
 
-You'll see the current PDD version (e.g., 0.0.237).
+You'll see the current PDD version (e.g., 0.0.238).
 
 Getting Started with Examples
 -----------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdd-cli"
-version = "0.0.237"
+version = "0.0.238"
 description = "PDD (Prompt-Driven Development) Command Line Interface"
 readme = {file = "pypi_description.rst", content-type = "text/x-rst"}
 authors = [
@@ -131,7 +131,7 @@ filterwarnings = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.0.237"
+version = "0.0.238"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",


### PR DESCRIPTION
Automated patch-version bump required before running `make release` because `v0.0.237` already exists on origin.