### PR TITLE
bump: version 0.0.238 → 0.0.239

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## v0.0.239 (2026-05-15)
+
+### Feat
+
+- reduce no-argument global sync dry-run noise for non-Tier-1 states (#1016)
+
+### Fix
+
+- **checkup**: sync original_reviewer to context example + agentic_checkup prompt
+- **checkup**: preserve original_reviewer and enforce fixer_fallback exclusion
+- **checkup**: defang failed-fixer summaries before rendering audit rows
+- **checkup**: record failed fallback fixer attempts in state.fixes
+- **checkup**: sync fixer_fallback semantics to prompt/architecture/example contracts
+- **checkup**: surface --fixer-fallback in README/completions/architecture + drop unused primary_fix param
+- **checkup**: exclude active_fixer/active_reviewer from cross-fallback promotion
+- **checkup**: move active_fixer to end of ReviewLoopState field list
+- **checkup**: use canonical fallback role for _run_fix and active_fixer promotion
+- **checkup**: make fixer_fallback one-shot with active_fixer takeover + reset to pre-fix SHA
+- **checkup**: reset worktree before fixer fallback to prevent partial primary edits leaking (codex iter-04)
+- **checkup**: document credential-limit stable token in agentic_common prompt (codex iter-03)
+- **checkup**: align fixer_fallback prompt with alias-normalized equality (codex iter-02)
+- **checkup**: move fixer_fallback to end of ReviewLoopConfig (codex iter-01)
+- **checkup**: address code-reviewer findings on fixer-fallback + credential-limit regex
+- **checkup**: add fixer_fallback so credential-exhausted fixer no longer dead-stops loop
+- **agentic**: classify Claude Code subscription weekly-limit as credential-limit
+- address codex review-loop findings
+- address codex review-loop findings
+- address codex review-loop findings
+- address codex review-loop findings
+- address codex review-loop findings
+- address codex review-loop findings
+- address codex review-loop findings
+- **checkup**: raise review loop cost budget
+- **ci-heal**: scope auto-heal staging (fixes #1021)
+- address codex review-loop findings
+- address codex review-loop findings
+- address codex review-loop findings
+
 ## v0.0.238 (2026-05-14)
 
 ### Feat

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDD (Prompt-Driven Development) Command Line Interface
 
-![PDD-CLI Version](https://img.shields.io/badge/pdd--cli-v0.0.238-blue) [![Discord](https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white)](https://discord.gg/Yp4RTh8bG7)
+![PDD-CLI Version](https://img.shields.io/badge/pdd--cli-v0.0.239-blue) [![Discord](https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white)](https://discord.gg/Yp4RTh8bG7)
 
 ## Introduction
 
@@ -362,7 +362,7 @@ For proper model identifiers to use in your custom configuration, refer to the [
 
 ## Version
 
-Current version: 0.0.238
+Current version: 0.0.239
 
 To check your installed version, run:
 ```

--- a/pdd/pdd_completion.sh
+++ b/pdd/pdd_completion.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # PDD CLI Bash Completion Script
-# Version: 0.0.238
+# Version: 0.0.239
 # Supports all PDD commands and options with filename completion
 
 _pdd() {

--- a/pypi_description.rst
+++ b/pypi_description.rst
@@ -1,4 +1,4 @@
-.. image:: https://img.shields.io/badge/pdd--cli-v0.0.238-blue
+.. image:: https://img.shields.io/badge/pdd--cli-v0.0.239-blue
    :alt: PDD-CLI Version
 
 .. image:: https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white&link=https://discord.gg/Yp4RTh8bG7
@@ -75,7 +75,7 @@ After installation, verify:
 
    pdd --version
 
-You'll see the current PDD version (e.g., 0.0.238).
+You'll see the current PDD version (e.g., 0.0.239).
 
 Getting Started with Examples
 -----------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdd-cli"
-version = "0.0.238"
+version = "0.0.239"
 description = "PDD (Prompt-Driven Development) Command Line Interface"
 readme = {file = "pypi_description.rst", content-type = "text/x-rst"}
 authors = [
@@ -131,7 +131,7 @@ filterwarnings = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.0.238"
+version = "0.0.239"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",


### PR DESCRIPTION
## Summary
- Bumps version from 0.0.238 → 0.0.239 via `make bump` (commitizen, PATCH increment)
- Updates pyproject.toml, README, completion script, pypi_description, and CHANGELOG

## Test plan
- [ ] CI passes
- [ ] Merge, then run `make release` on main to tag and publish v0.0.239

🤖 Generated with [Claude Code](https://claude.com/claude-code)