### PR TITLE
ci(cloud-batch): bump SPOT maxRetryCount 2 → 3

### DIFF
--- a/ci/cloud-batch/job-template.json
+++ b/ci/cloud-batch/job-template.json
@@ -42,7 +42,7 @@
                         "mountPath": "/mnt/disks/source"
                     }
                 ],
-                "maxRetryCount": 2,
+                "maxRetryCount": 3,
                 "maxRunDuration": "5400s",
                 "lifecyclePolicies": [
                     {


### PR DESCRIPTION
## Summary
- Cloud Batch SPOT job retry budget was 2. A task preempted twice (one initial run + one retry) exhausts the budget and is reported as `ERR` / "no result file" — observed in a recent run where pytest chunk_24 hit double preemption and the full suite was marked failed despite the underlying tests being healthy.
- Bump to 3 so a doubly-preempted task gets one more attempt before being marked failed. Same exit-code conditions (`50001`/`50002`/`50003`/`50006`); same parallelism; same VM type.
- `job-template-standard.json` (non-preemptible STANDARD VM for `sync_regression case_1`) left at 2 — retries there mask real bugs rather than absorb preemption.

## Test plan
- [ ] Single line config change; static JSON validated locally
- [ ] Observe next `make test-pdd-cli-release` run to confirm preemption-induced ERRs drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)