### PR TITLE
fix(cloud-batch): pre-create result file so SIGKILLed tasks report preempted

### DIFF
--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -23,6 +23,31 @@ WORK_DIR="/workspace"
 RESULT_JSON="${RESULTS_DIR}/task_${TASK_INDEX}.json"
 RESULT_LOG="${RESULTS_DIR}/task_${TASK_INDEX}.log"
 
+# ── Pre-create result file so SPOT preemption is visible ──────────────────
+# Cloud Batch SPOT VMs receive SIGTERM then SIGKILL ~30s later when preempted.
+# SIGKILL bypasses traps, so if the test is mid-execution when SIGKILL fires
+# no task_N.json is ever written and the aggregator reports an opaque
+# "ERR / no result file" — indistinguishable from a real crash. Pre-creating
+# the file with status="preempted" means SIGKILL leaves a diagnosable artifact
+# behind: write_result overwrites on normal completion, term_handler
+# overwrites on SIGTERM, and only true preemption leaves the preempted marker.
+# Single heredoc keeps the write to one syscall (the streaming reader in
+# submit.sh skips files <10 bytes, so a partial pre-create won't poison
+# the aggregator if preempted mid-write).
+mkdir -p "${RESULTS_DIR}"
+WROTE_FINAL_RESULT=0
+cat > "${RESULT_JSON}" <<JSON
+{
+    "task_index": ${TASK_INDEX},
+    "suite": "unknown",
+    "detail": "task killed before completion (likely SPOT preemption)",
+    "status": "preempted",
+    "duration_seconds": 0,
+    "setup_seconds": 0,
+    "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+JSON
+
 # Task ranges
 PYTEST_START=0
 PYTEST_END=31
@@ -64,6 +89,10 @@ write_result() {
     "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 JSONEOF
+    # Mark that the real result has been written so trap handlers don't
+    # clobber it. We can't use `[ ! -f "${RESULT_JSON}" ]` as a guard now
+    # that the file is pre-created at startup — the file always exists.
+    WROTE_FINAL_RESULT=1
 }
 
 # ── Extract source code ───────────────────────────────────────────────────
@@ -244,6 +273,13 @@ fi
 START_TIME=$(date +%s)
 
 # ── Trap handler: ensure result file on forced termination ────────────────
+# Guards use WROTE_FINAL_RESULT (set by write_result) instead of `[ ! -f ]`.
+# The result file is pre-created at startup as status="preempted", so a
+# file-existence check would never trigger and the trap would never get
+# to record the real exit info — leaving every task that fell through to
+# the trap looking like a preemption even when it was a normal failure
+# or a SIGTERM. The flag flips the moment write_result runs, so the trap
+# only overwrites the pre-create when no real result was recorded.
 trap_handler() {
     local rc=$?
     local end_time=$(date +%s)
@@ -251,14 +287,14 @@ trap_handler() {
     if [ "${rc}" -eq 124 ]; then
         return 0
     fi
-    if [ ! -f "${RESULT_JSON}" ]; then
+    if [ "${WROTE_FINAL_RESULT}" -eq 0 ]; then
         write_result "error" "${duration}" "unknown" "exit_code_${rc}"
     fi
 }
 term_handler() {
     local end_time=$(date +%s)
     local duration=$((end_time - START_TIME))
-    if [ ! -f "${RESULT_JSON}" ]; then
+    if [ "${WROTE_FINAL_RESULT}" -eq 0 ]; then
         write_result "error" "${duration}" "unknown" "terminated"
     fi
     exit 143

--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -95,6 +95,37 @@ JSONEOF
     WROTE_FINAL_RESULT=1
 }
 
+# ── Trap handler: ensure result file on forced termination ────────────────
+# Installed early — BEFORE source extract, pip install, preflight, and JWT
+# setup — so any `set -e` failure in those phases triggers the trap and
+# overwrites the pre-create with the actual exit info. Without early
+# installation a corrupt tarball or transient pip failure would leave the
+# pre-create as status="preempted" and be mis-reported as preemption.
+# Guards use WROTE_FINAL_RESULT (set by write_result) instead of `[ ! -f ]`
+# because the pre-create makes the file always exist.
+trap_handler() {
+    local rc=$?
+    local end_time=$(date +%s)
+    local duration=$((end_time - START_TIME))
+    if [ "${rc}" -eq 124 ]; then
+        return 0
+    fi
+    if [ "${WROTE_FINAL_RESULT}" -eq 0 ]; then
+        write_result "error" "${duration}" "unknown" "exit_code_${rc}"
+    fi
+}
+term_handler() {
+    local end_time=$(date +%s)
+    local duration=$((end_time - START_TIME))
+    if [ "${WROTE_FINAL_RESULT}" -eq 0 ]; then
+        write_result "error" "${duration}" "unknown" "terminated"
+    fi
+    exit 143
+}
+START_TIME=$(date +%s)
+trap term_handler TERM INT
+trap trap_handler EXIT
+
 # ── Extract source code ───────────────────────────────────────────────────
 SETUP_START=$(date +%s)
 echo "=== Task ${TASK_INDEX}: extracting source ==="
@@ -270,37 +301,8 @@ fi
 # failures when non-agentic tests try to use it for direct API calls.
 
 # ── Dispatch by task index ────────────────────────────────────────────────
-START_TIME=$(date +%s)
-
-# ── Trap handler: ensure result file on forced termination ────────────────
-# Guards use WROTE_FINAL_RESULT (set by write_result) instead of `[ ! -f ]`.
-# The result file is pre-created at startup as status="preempted", so a
-# file-existence check would never trigger and the trap would never get
-# to record the real exit info — leaving every task that fell through to
-# the trap looking like a preemption even when it was a normal failure
-# or a SIGTERM. The flag flips the moment write_result runs, so the trap
-# only overwrites the pre-create when no real result was recorded.
-trap_handler() {
-    local rc=$?
-    local end_time=$(date +%s)
-    local duration=$((end_time - START_TIME))
-    if [ "${rc}" -eq 124 ]; then
-        return 0
-    fi
-    if [ "${WROTE_FINAL_RESULT}" -eq 0 ]; then
-        write_result "error" "${duration}" "unknown" "exit_code_${rc}"
-    fi
-}
-term_handler() {
-    local end_time=$(date +%s)
-    local duration=$((end_time - START_TIME))
-    if [ "${WROTE_FINAL_RESULT}" -eq 0 ]; then
-        write_result "error" "${duration}" "unknown" "terminated"
-    fi
-    exit 143
-}
-trap term_handler TERM INT
-trap trap_handler EXIT
+# START_TIME and trap installations moved above (right after write_result
+# definition) so setup failures are captured.
 
 run_with_timeout() {
     local seconds="$1"

--- a/ci/cloud-batch/submit.sh
+++ b/ci/cloud-batch/submit.sh
@@ -182,8 +182,20 @@ while [ "${ELAPSED}" -lt "${POLL_TIMEOUT}" ]; do
 
     # ── Stream completed task results ─────────────────────────────────
     _with_timeout 15 gcloud storage cp --quiet "gs://${BUCKET}/${JOB_RUN_ID}/results/task_*.json" "${STREAMING_DIR}/" 2>/dev/null || true
-    COMPLETED=$(find "${STREAMING_DIR}" -maxdepth 1 -name "task_*.json" | wc -l | tr -d ' ')
-    COMPLETED=${COMPLETED:-0}
+
+    # Count completed tasks. Tasks pre-create task_N.json with
+    # status="preempted" at startup so SIGKILL leaves a diagnosable marker;
+    # those provisional files must NOT count as completed and must NOT trigger
+    # the failure-reporting loop until the job is in a terminal state (because
+    # write_result will overwrite them with the real result on normal exit).
+    COMPLETED=0
+    for json_file in "${STREAMING_DIR}"/task_*.json; do
+        [ -f "${json_file}" ] || continue
+        [ "$(wc -c < "${json_file}")" -lt 10 ] && continue
+        _stream_status=$(python3 -c "import json; d=json.load(open('${json_file}')); print(d.get('status','error'))" 2>/dev/null || echo "unknown")
+        [ "${_stream_status}" = "preempted" ] && continue
+        COMPLETED=$((COMPLETED + 1))
+    done
 
     # Check for new failures
     for json_file in "${STREAMING_DIR}"/task_*.json; do
@@ -193,9 +205,14 @@ while [ "${ELAPSED}" -lt "${POLL_TIMEOUT}" ]; do
         basename_file=$(basename "${json_file}")
         # Skip if already seen
         [ -f "${STREAMING_DIR}/seen_${basename_file}" ] && continue
-        touch "${STREAMING_DIR}/seen_${basename_file}"
 
         TASK_STATUS=$(python3 -c "import json; d=json.load(open('${json_file}')); print(d.get('status','error'))" 2>/dev/null || echo "unknown")
+        # Skip provisional preempted markers — write_result will overwrite
+        # them with the real result if/when the task completes. Don't mark
+        # them seen, so a later pass picks up the real status.
+        [ "${TASK_STATUS}" = "preempted" ] && continue
+        touch "${STREAMING_DIR}/seen_${basename_file}"
+
         if [ "${TASK_STATUS}" != "passed" ]; then
             STREAM_FAILURES=$((STREAM_FAILURES + 1))
             TASK_NUM=$(echo "${basename_file}" | sed 's/task_\([0-9]*\)\.json/\1/')


### PR DESCRIPTION
## Summary
- SIGKILL bypasses traps, so SPOT-preempted Cloud Batch tasks left no `task_N.json`; the aggregator reported them as opaque `ERR / no result file`, conflating preemption with crashes/OOM/init failures.
- Pre-create `task_N.json` with `status: preempted` immediately after `TASK_INDEX` is known. Normal completion overwrites via `write_result`; SIGTERM overwrites via `term_handler`; SIGKILL leaves the pre-create in place (SIGKILL kills the process but not the file).
- Trap handlers' file-existence guard replaced by a `WROTE_FINAL_RESULT` flag — necessary because the pre-create defeats `[ ! -f ]`. Behavior on normal exit + caught SIGTERM is unchanged.

## Test plan
- [x] `bash -n ci/cloud-batch/entrypoint.sh`
- [x] Local SIGKILL simulation: pre-create persists with `status: "preempted"`
- [x] Local normal-exit simulation: `write_result` overwrites to `"passed"`
- [x] Local SIGTERM simulation: `term_handler` overwrites to `"error"/"terminated"`
- [ ] Observe next `make test-pdd-cli-release` run: preemption-induced tasks should now report `preempted` instead of `no result file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)