### PR TITLE
fix(ci_drift_heal): skip symlink-traversal paths in git add

### DIFF
--- a/pdd/ci_drift_heal.py
+++ b/pdd/ci_drift_heal.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 from rich.console import Console
@@ -918,6 +918,30 @@ def _healed_module_file_relpaths(module: Any, repo_root: Path) -> List[str]:
     return relpaths
 
 
+def _has_symlinked_ancestor(rel: str, repo_root: Path) -> bool:
+    """Return True if any directory ancestor of ``rel`` under ``repo_root`` is a symlink.
+
+    ``git add`` refuses pathspecs whose ancestor directory is a symlink ("pathspec
+    'X' is beyond a symbolic link"). When ``_git_relative_path_candidates`` returns
+    both the symlinked form (e.g. ``prompts/foo.prompt`` via ``prompts -> pdd/prompts``)
+    and the canonical form (``pdd/prompts/foo.prompt``) for the same source path,
+    the symlinked form will fail staging. Dropping it lets the canonical form get
+    staged instead.
+    """
+    parts = PurePosixPath(rel).parts
+    if len(parts) <= 1:
+        return False
+    cur = repo_root
+    for part in parts[:-1]:
+        cur = cur / part
+        try:
+            if cur.is_symlink():
+                return True
+        except OSError:
+            return False
+    return False
+
+
 def _git_add_pathspecs(pathspecs: Sequence[str], cwd: Optional[Path] = None) -> bool:
     """Stage existing pathspecs with an explicit git-add call.
 
@@ -926,7 +950,13 @@ def _git_add_pathspecs(pathspecs: Sequence[str], cwd: Optional[Path] = None) -> 
     an otherwise-successful heal commit. Examples include per-run reports
     under ``.pdd/meta/*_run.json``, which the repo intentionally ignores but
     which appear in the healed module's metadata pathspecs.
+
+    Also drops pathspecs whose ancestor directory is a symlink (e.g. the
+    repo-root ``prompts -> pdd/prompts`` shim). Git refuses such paths with
+    "beyond a symbolic link"; the canonical form is normally also present in
+    the list because ``_git_relative_path_candidates`` returns both shapes.
     """
+    repo_root = (cwd or Path.cwd()).resolve()
     existing = [rel for rel in pathspecs if (cwd or Path.cwd()).joinpath(rel).exists()]
     if not existing:
         return True
@@ -959,7 +989,14 @@ def _git_add_pathspecs(pathspecs: Sequence[str], cwd: Optional[Path] = None) -> 
             f"{sorted(ignored)}[/dim]"
         )
 
-    stageable = [rel for rel in existing if rel not in ignored]
+    symlinked = {rel for rel in existing if _has_symlinked_ancestor(rel, repo_root)}
+    if symlinked:
+        console.print(
+            f"[dim]ci-heal: skipping symlink-traversal paths during stage: "
+            f"{sorted(symlinked)}[/dim]"
+        )
+
+    stageable = [rel for rel in existing if rel not in ignored and rel not in symlinked]
     if not stageable:
         return True
 

--- a/pdd/ci_drift_heal.py
+++ b/pdd/ci_drift_heal.py
@@ -989,6 +989,13 @@ def _git_add_pathspecs(pathspecs: Sequence[str], cwd: Optional[Path] = None) -> 
             f"{sorted(ignored)}[/dim]"
         )
 
+    # Invariant: when `_git_relative_path_candidates` emits a path whose
+    # ancestor is a symlink, it also emits the canonical (resolved) form
+    # for the same source — both for absolute inputs (branches 4 + 5) and
+    # for relative inputs (branches 1 + 2). Dropping the symlinked form
+    # here is therefore safe: the canonical form is in `existing` too and
+    # will get staged. If that invariant ever breaks, this filter would
+    # become a silent miss — adjust the helper, don't drop this filter.
     symlinked = {rel for rel in existing if _has_symlinked_ancestor(rel, repo_root)}
     if symlinked:
         console.print(

--- a/tests/test_ci_drift_heal.py
+++ b/tests/test_ci_drift_heal.py
@@ -14,7 +14,9 @@ from pdd.ci_drift_heal import (
     PromptRevertError,
     _AUTO_HEAL_SUCCESS_TRAILER,
     _capture_rollback_state,
+    _git_add_pathspecs,
     _git_relative_path_candidates,
+    _has_symlinked_ancestor,
     _run_pdd_command,
     _get_git_changed_files,
     detect_drift,
@@ -283,6 +285,95 @@ class TestGetGitChangedFiles:
 
         assert "prompts/auth_python.prompt" in candidates
         assert "pdd/prompts/auth_python.prompt" in candidates
+
+
+# ---------------------------------------------------------------------------
+# _has_symlinked_ancestor / _git_add_pathspecs symlink-staging tests
+# ---------------------------------------------------------------------------
+
+
+class TestSymlinkStaging:
+    """Regression: auto-heal must not pass symlink-traversal pathspecs to git add.
+
+    `_git_relative_path_candidates` returns both the symlinked form
+    (e.g. ``prompts/foo.prompt`` via a tracked ``prompts -> pdd/prompts`` shim)
+    and the canonical form (``pdd/prompts/foo.prompt``) for the same source.
+    Newer Git refuses the symlinked form with
+    ``pathspec 'prompts/foo.prompt' is beyond a symbolic link``, which kills
+    the whole heal commit. The fix drops symlink-traversal paths at the
+    staging boundary so the canonical form (always also in the list) wins.
+    """
+
+    def _make_symlink_repo(self, tmp_path: Path) -> Path:
+        """Set up a fake repo where ``prompts -> pdd/prompts``."""
+        (tmp_path / "pdd" / "prompts").mkdir(parents=True)
+        (tmp_path / "prompts").symlink_to("pdd/prompts")
+        (tmp_path / "pdd" / "prompts" / "foo.prompt").write_text("% prompt", encoding="utf-8")
+        return tmp_path
+
+    def test_has_symlinked_ancestor_detects_symlinked_dir(self, tmp_path):
+        self._make_symlink_repo(tmp_path)
+        assert _has_symlinked_ancestor("prompts/foo.prompt", tmp_path) is True
+        assert _has_symlinked_ancestor("pdd/prompts/foo.prompt", tmp_path) is False
+        # Trivial top-level files have no ancestor to traverse.
+        assert _has_symlinked_ancestor("foo.prompt", tmp_path) is False
+
+    def test_git_add_pathspecs_drops_symlinked_form(self, tmp_path):
+        """When both forms of a symlinked path are passed, only the canonical
+        form reaches `git add`; the symlinked form is dropped."""
+        self._make_symlink_repo(tmp_path)
+
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured.setdefault("calls", []).append(list(cmd))
+            # check-ignore: pretend none are ignored
+            if cmd[:2] == ["git", "check-ignore"]:
+                return MagicMock(returncode=1, stdout="", stderr="")
+            # git add: succeed
+            if cmd[:2] == ["git", "add"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("pdd.ci_drift_heal.subprocess.run", side_effect=fake_run):
+            ok = _git_add_pathspecs(
+                ["prompts/foo.prompt", "pdd/prompts/foo.prompt"],
+                cwd=tmp_path,
+            )
+
+        assert ok is True
+        add_calls = [c for c in captured["calls"] if c[:2] == ["git", "add"]]
+        assert len(add_calls) == 1, f"expected one git add call, got {add_calls}"
+        staged = add_calls[0][add_calls[0].index("--") + 1 :]
+        assert "pdd/prompts/foo.prompt" in staged
+        assert "prompts/foo.prompt" not in staged, (
+            "symlinked-ancestor path must be filtered before git add"
+        )
+
+    def test_git_add_pathspecs_unchanged_without_symlink(self, tmp_path):
+        """No symlinks in the repo → no filtering, behaviour matches the
+        original (gitignore-only) filter path."""
+        (tmp_path / "pdd").mkdir()
+        (tmp_path / "pdd" / "foo.py").write_text("# foo", encoding="utf-8")
+
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured.setdefault("calls", []).append(list(cmd))
+            if cmd[:2] == ["git", "check-ignore"]:
+                return MagicMock(returncode=1, stdout="", stderr="")
+            if cmd[:2] == ["git", "add"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("pdd.ci_drift_heal.subprocess.run", side_effect=fake_run):
+            ok = _git_add_pathspecs(["pdd/foo.py"], cwd=tmp_path)
+
+        assert ok is True
+        add_calls = [c for c in captured["calls"] if c[:2] == ["git", "add"]]
+        assert len(add_calls) == 1
+        staged = add_calls[0][add_calls[0].index("--") + 1 :]
+        assert staged == ["pdd/foo.py"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The auto-heal CI workflow currently fails on every PR that modifies `pdd/*.py` because of a symlink-staging bug. `auto-heal` is a required status check on `promptdriven/pdd:main`, so this blocks all code PRs from merging.

## Root cause
`_git_relative_path_candidates` in `pdd/ci_drift_heal.py` returns **both** path forms for a given source — the symlinked form (e.g. `prompts/foo.prompt` via the tracked `prompts -> pdd/prompts` shim) and the canonical form (`pdd/prompts/foo.prompt`). Both end up in the flat list passed to `_git_add_pathspecs`. Recent Git rejects the symlinked form with:
```
fatal: pathspec 'prompts/foo.prompt' is beyond a symbolic link
```
… which tanks the whole heal commit. Build step `auto-heal-public-pdd-pr` returns `FAILURE`; the GHA `auto-heal` check fails; merge is blocked.

Concrete example from the latest reproducer: build `6e2ac8b1-e7d0-45e1-bfae-51e206e1856b` (auto-heal for PR #1047) — heal generated the prompt cleanly (`✓ prompt: ok (24246 chars)`, `Auto-heal summary: healed=1 failed=0 skipped=0`), then crashed at `git add prompts/llm_invoke_python.prompt`.

## Fix
In `_git_add_pathspecs`, drop pathspecs whose ancestor directory is a symlink before invoking `git add`. The canonical (resolved) form is normally already present in the list (because `_git_relative_path_candidates` emits both), so the entry isn't lost — the canonical form just gets staged instead.

New helper `_has_symlinked_ancestor(rel, repo_root)` walks the path's ancestor chain under `repo_root` and returns True if any directory along the way is a symlink. Used as a filter alongside the existing `.gitignore` check.

## Tests
Added `TestSymlinkStaging` (3 cases) in `tests/test_ci_drift_heal.py`:
- `_has_symlinked_ancestor` correctly detects a symlinked ancestor directory.
- `_git_add_pathspecs` drops the symlinked form when both forms are passed, staging only the canonical form.
- `_git_add_pathspecs` is unchanged when no symlinks are in play.

All 3 new tests pass locally. 151/152 of the existing `tests/test_ci_drift_heal.py` suite pass; the one failure (`TestDetectDrift::test_pr_touched_metadata_modules_are_not_left_in_drift`) is **pre-existing test fragility unrelated to the fix** — that test runs `detect_drift` against the live working tree, which sees this PR's own edit to `pdd/ci_drift_heal.py` as drift (operation: `verify`). The same drift would auto-heal cleanly once this PR's fix is shipped and the published pdd-cli picks it up.

## Rollout
Auto-heal CI installs `pdd-cli` from PyPI (`pip install --quiet pdd-cli` in `scripts/ci/run_pdd_cli_auto_heal_pr.sh:120`), so this fix only takes effect for new PRs *after* a fresh pdd-cli release that includes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)