### PR TITLE
bump: version 0.0.240 → 0.0.241

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.0.241 (2026-05-17)
+
+### Fix
+
+- **ci_drift_heal**: symlink filter must run before git check-ignore (#1050)
+- **ci_drift_heal**: skip symlink-traversal paths in git add (#1048)
+
 ## v0.0.240 (2026-05-16)
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDD (Prompt-Driven Development) Command Line Interface
 
-![PDD-CLI Version](https://img.shields.io/badge/pdd--cli-v0.0.240-blue) [![Discord](https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white)](https://discord.gg/Yp4RTh8bG7)
+![PDD-CLI Version](https://img.shields.io/badge/pdd--cli-v0.0.241-blue) [![Discord](https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white)](https://discord.gg/Yp4RTh8bG7)
 
 ## Introduction
 
@@ -362,7 +362,7 @@ For proper model identifiers to use in your custom configuration, refer to the [
 
 ## Version
 
-Current version: 0.0.240
+Current version: 0.0.241
 
 To check your installed version, run:
 ```

--- a/pdd/pdd_completion.sh
+++ b/pdd/pdd_completion.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # PDD CLI Bash Completion Script
-# Version: 0.0.240
+# Version: 0.0.241
 # Supports all PDD commands and options with filename completion
 
 _pdd() {

--- a/pypi_description.rst
+++ b/pypi_description.rst
@@ -1,4 +1,4 @@
-.. image:: https://img.shields.io/badge/pdd--cli-v0.0.240-blue
+.. image:: https://img.shields.io/badge/pdd--cli-v0.0.241-blue
    :alt: PDD-CLI Version
 
 .. image:: https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white&link=https://discord.gg/Yp4RTh8bG7
@@ -75,7 +75,7 @@ After installation, verify:
 
    pdd --version
 
-You'll see the current PDD version (e.g., 0.0.240).
+You'll see the current PDD version (e.g., 0.0.241).
 
 Getting Started with Examples
 -----------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdd-cli"
-version = "0.0.240"
+version = "0.0.241"
 description = "PDD (Prompt-Driven Development) Command Line Interface"
 readme = {file = "pypi_description.rst", content-type = "text/x-rst"}
 authors = [
@@ -132,7 +132,7 @@ filterwarnings = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.0.240"
+version = "0.0.241"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",


### PR DESCRIPTION
## Summary
- Bump version 0.0.240 → 0.0.241 to release the latest commits on main (ci_drift_heal symlink fixes #1048, #1050 and changelog #1049)

## Test plan
- [x] `make bump` ran successfully with commitizen
- [ ] CI checks pass
- [ ] After merge, run `make release` on main to tag v0.0.241 and trigger PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)