### PR TITLE
feat(release): migrate to setuptools-scm; one-command make release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -48,10 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi-publish
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -70,3 +74,14 @@ jobs:
         with:
           skip-existing: true
           attestations: true
+
+      - name: Create GitHub Release with auto-notes (idempotent)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ github.ref_name }}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "GitHub Release $tag already exists; skipping."
+          else
+            gh release create "$tag" --generate-notes --verify-tag --target main
+          fi

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -86,6 +88,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -117,6 +121,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.vsix
+
+# setuptools-scm generated version file
+pdd/_version.py
+
 .tmp/
 .agentic_prompt*
 .agentic_output_*.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+> Historical record up to v0.0.241. See [GitHub Releases](https://github.com/promptdriven/pdd/releases) for current release notes.
+
 ## v0.0.241 (2026-05-17)
 
 ### Fix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,23 +148,25 @@ Artifacts appear in `dist/`.
 - Participate in meetups and related community events when possible.
 
 ## Publishing a Release (Maintainers)
-1. Ensure build artifacts are up‑to‑date (see Building the Package).
-2. Install Twine if needed:
-   ```bash
-   pip install twine
-   ```
-3. Upload to PyPI with credentials:
-   ```bash
-   twine upload dist/*
-   ```
+
+The version is derived from `v*` git tags via setuptools-scm — no static version in `pyproject.toml`, no bump commit. To cut a release, on a clean `main`:
+
+```bash
+make release              # patch bump (default)
+make release BUMP=minor   # minor bump
+make release BUMP=major   # major bump
+```
+
+`make release` fetches tags, computes the next `vX.Y.Z`, tags HEAD, and pushes the tag. GitHub Actions then builds the wheel, waits for the `gltanaka` approval on the `pypi-publish` environment, publishes to PyPI via OIDC, and creates a GitHub Release with auto-generated notes.
+
+`make publish` is a local twine fallback that requires HEAD to be at a released tag that exists on origin.
 
 ## Pull Request Process
 1. Remove stray build/install artifacts before committing.
 2. Update `README.md` if you change the interface (env vars, commands, parameters, examples).
-3. Bump the version in `pyproject.toml` (SemVer) when appropriate; reflect changes in `README.md` as needed.
-4. Include tests in `tests/` that demonstrate the issue/feature and verify the behavior.
-5. Aim to include dev‑unit elements (prompt/code/example/tests) when applicable.
-6. **Make sure CI passes (unit tests).** If your change affects modules that have integration/LLM tests, run those locally for the impacted areas before marking your PR ready. You do not need to run the full integration suite -- maintainers will do that before merging.
-7. Seek two maintainer reviews prior to merge, or request a reviewer to merge if you lack permissions.
+3. Include tests in `tests/` that demonstrate the issue/feature and verify the behavior.
+4. Aim to include dev‑unit elements (prompt/code/example/tests) when applicable.
+5. **Make sure CI passes (unit tests).** If your change affects modules that have integration/LLM tests, run those locally for the impacted areas before marking your PR ready. You do not need to run the full integration suite -- maintainers will do that before merging.
+6. Seek two maintainer reviews prior to merge, or request a reviewer to merge if you lack permissions.
 
 Thank you for your contributions!

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ help:
 	@echo "  make publish                 - Build & upload current version to PyPI"
 	@echo "  make publish-public          - Copy artifacts to public repo only"
 	@echo "  make check-deps              - Check pyproject.toml and requirements.txt are in sync"
-	@echo "  make bump                    - Bump version with commitizen on the current feature branch (commit only, no tag, no push)"
-	@echo "  make release                 - On main: tag HEAD with v\$$VERSION and push (Actions publishes to PyPI via OIDC after gltanaka approval)"
+	@echo "  make release                 - On main: tag HEAD with next vN.N.N and push (BUMP=patch|minor|major; default patch)"
+	@echo "                                  Actions publishes to PyPI via OIDC after gltanaka approval"
 	@echo "  make staging                 - Copy files to staging"
 	@echo "  make production              - Copy files from staging to pdd"
 	@echo "  make update-extension        - Update VS Code extension"
@@ -108,7 +108,7 @@ TEST_OUTPUTS := $(patsubst $(PDD_DIR)/%.py,$(TESTS_DIR)/test_%.py,$(PY_OUTPUTS))
 # All Example files in context directory (recursive)
 EXAMPLE_FILES := $(shell find $(CONTEXT_DIR) -name "*_example.py" 2>/dev/null)
 
-.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend bump release check-release-remote check-release-branch check-release-clean
+.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release check-release-remote check-release-branch check-release-clean
 
 all: $(PY_OUTPUTS) $(MAKEFILE_OUTPUT) $(CSV_OUTPUTS) $(EXAMPLE_OUTPUTS) $(TEST_OUTPUTS)
 
@@ -617,7 +617,29 @@ upload-pypi:
 	@conda run -n pdd --no-capture-output twine upload --repository pypi dist/*.whl
 
 publish:
-	@echo "Building and uploading package to PyPI"
+	@set -e; \
+	HEAD_SHA=$$(git rev-parse HEAD); \
+	TAG=$$(git tag --points-at HEAD --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | head -1); \
+	if [ -z "$$TAG" ]; then \
+		echo "Error: HEAD has no release tag (vN.N.N) pointing at it; refusing to publish."; \
+		echo "Run 'make release' to create and push a tag instead."; \
+		exit 1; \
+	fi; \
+	echo "Verifying $$TAG exists on origin at HEAD"; \
+	git fetch --tags --prune origin; \
+	REMOTE_TAG_COMMIT=$$(git ls-remote origin "refs/tags/$$TAG^{}" "refs/tags/$$TAG" 2>/dev/null | awk '/\^\{\}$$/ {peeled=$$1} END {if (peeled) print peeled}'); \
+	if [ -z "$$REMOTE_TAG_COMMIT" ]; then \
+		REMOTE_TAG_COMMIT=$$(git ls-remote origin "refs/tags/$$TAG" 2>/dev/null | awk 'NR==1 {print $$1}'); \
+	fi; \
+	if [ -z "$$REMOTE_TAG_COMMIT" ]; then \
+		echo "Error: tag $$TAG is local-only; push it first ('git push origin $$TAG') or use 'make release'."; \
+		exit 1; \
+	fi; \
+	if [ "$$REMOTE_TAG_COMMIT" != "$$HEAD_SHA" ]; then \
+		echo "Error: origin's $$TAG points at $$REMOTE_TAG_COMMIT, not HEAD ($$HEAD_SHA)."; \
+		exit 1; \
+	fi; \
+	echo "Tag $$TAG verified on origin at HEAD. Building and uploading to PyPI."
 	@$(MAKE) build
 	@$(MAKE) upload-pypi
 
@@ -692,70 +714,53 @@ check-release-clean:
 		exit 1; \
 	fi
 
-bump: check-release-clean
-	@echo "Bumping version with commitizen (commit only — no tag, no push)"
-	@set -e; \
-	BRANCH=$$(git symbolic-ref --quiet --short HEAD || echo ""); \
-	if [ -z "$$BRANCH" ]; then \
-		echo "Error: detached HEAD detected. 'make bump' requires a feature branch."; \
-		echo "Create a branch (e.g. 'git switch -c feat/your-work') and rerun."; \
-		exit 1; \
-	fi; \
-	if [ "$$BRANCH" = "main" ]; then \
-		echo "Error: do not run 'make bump' on main."; \
-		echo "Create a feature branch first; commit the bump there; merge via PR."; \
-		exit 1; \
-	fi; \
-	OLD_VERSION=$$(sed -n '1,120s/^version[[:space:]]*=[[:space:]]*"\([0-9.]*\)"/\1/p' pyproject.toml | head -n1); \
-	python -m commitizen bump --increment PATCH --yes --check-consistency --files-only; \
-	NEW_VERSION=$$(sed -n '1,120s/^version[[:space:]]*=[[:space:]]*"\([0-9.]*\)"/\1/p' pyproject.toml | head -n1); \
-	if [ "$$OLD_VERSION" = "$$NEW_VERSION" ]; then \
-		echo "Error: commitizen did not change the version (current: $$OLD_VERSION)."; \
-		exit 1; \
-	fi; \
-	git add -A; \
-	git commit -m "bump: version $$OLD_VERSION → $$NEW_VERSION"; \
-	echo ""; \
-	echo "Bumped $$OLD_VERSION → $$NEW_VERSION on branch '$$BRANCH'."; \
-	echo "Next: push '$$BRANCH', merge the PR, then run 'make release' on main."
-
 release: check-deps check-suspicious-files check-release-remote check-release-branch check-release-clean
 	@echo "Preparing release"
 	@set -e; \
-	CURRENT_VERSION=$$(sed -n '1,120s/^version[[:space:]]*=[[:space:]]*"\([0-9.]*\)"/\1/p' pyproject.toml | head -n1); \
-	CURRENT_TAG="v$$CURRENT_VERSION"; \
+	echo "Fetching tags from origin"; \
+	git fetch --tags --prune origin; \
 	HEAD_SHA=$$(git rev-parse HEAD); \
-	if git rev-parse --verify --quiet "refs/tags/$$CURRENT_TAG" >/dev/null; then \
-		LOCAL_TAG_COMMIT=$$(git rev-parse "$$CURRENT_TAG^{commit}"); \
-		if [ "$$LOCAL_TAG_COMMIT" != "$$HEAD_SHA" ]; then \
-			echo "Error: tag $$CURRENT_TAG already exists locally but points at commit $$LOCAL_TAG_COMMIT, not HEAD ($$HEAD_SHA)."; \
-			echo "Either delete the stale local tag or move HEAD to the right commit."; \
+	EXISTING_TAG=$$(git tag --points-at HEAD --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | head -1 || true); \
+	if [ -n "$$EXISTING_TAG" ]; then \
+		echo "HEAD is already tagged as $$EXISTING_TAG."; \
+		REMOTE_TAG_COMMIT=$$(git ls-remote origin "refs/tags/$$EXISTING_TAG^{}" "refs/tags/$$EXISTING_TAG" 2>/dev/null | awk '/\^\{\}$$/ {peeled=$$1} END {if (peeled) print peeled}'); \
+		if [ -z "$$REMOTE_TAG_COMMIT" ]; then \
+			REMOTE_TAG_COMMIT=$$(git ls-remote origin "refs/tags/$$EXISTING_TAG" 2>/dev/null | awk 'NR==1 {print $$1}'); \
+		fi; \
+		if [ -z "$$REMOTE_TAG_COMMIT" ]; then \
+			echo "Local tag $$EXISTING_TAG not on origin; pushing."; \
+			git push origin "$$EXISTING_TAG"; \
+			echo "Tag $$EXISTING_TAG pushed. GHA will request gltanaka approval, then publish."; \
+		elif [ "$$REMOTE_TAG_COMMIT" = "$$HEAD_SHA" ]; then \
+			echo "Tag $$EXISTING_TAG already on origin at HEAD; nothing to do."; \
+		else \
+			echo "Error: tag $$EXISTING_TAG on origin points at $$REMOTE_TAG_COMMIT, not HEAD ($$HEAD_SHA)."; \
 			exit 1; \
 		fi; \
-		echo "Tag $$CURRENT_TAG already exists locally at HEAD; reusing."; \
-	else \
-		echo "Tagging HEAD as $$CURRENT_TAG"; \
-		git tag -a "$$CURRENT_TAG" -m "Release $$CURRENT_TAG"; \
+		exit 0; \
 	fi; \
-	REMOTE_TAG_COMMIT=$$(git ls-remote origin "refs/tags/$$CURRENT_TAG^{}" "refs/tags/$$CURRENT_TAG" | awk '/\^\{\}$$/ {peeled=$$1} END {if (peeled) print peeled}'); \
-	if [ -z "$$REMOTE_TAG_COMMIT" ]; then \
-		REMOTE_TAG_COMMIT=$$(git ls-remote origin "refs/tags/$$CURRENT_TAG" | awk 'NR==1 {print $$1}'); \
+	LATEST_TAG=$$(git tag --list --merged HEAD --sort=-v:refname 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | head -1); \
+	if [ -z "$$LATEST_TAG" ]; then LATEST_TAG="v0.0.0"; fi; \
+	CURRENT_VERSION=$${LATEST_TAG#v}; \
+	BUMP=$${BUMP:-patch}; \
+	case "$$BUMP" in \
+		major|minor|patch) ;; \
+		*) echo "Error: BUMP must be one of: major, minor, patch (got: '$$BUMP')"; exit 1 ;; \
+	esac; \
+	NEW_VERSION=$$(python -c "v=[int(x) for x in '$$CURRENT_VERSION'.split('.')]; i={'major':0,'minor':1,'patch':2}['$$BUMP']; v[i]+=1; [v.__setitem__(j,0) for j in range(i+1,3)]; print('.'.join(map(str,v)))"); \
+	NEW_TAG="v$$NEW_VERSION"; \
+	echo "Releasing $$LATEST_TAG → $$NEW_TAG at $$HEAD_SHA"; \
+	if git rev-parse --verify --quiet "refs/tags/$$NEW_TAG" >/dev/null; then \
+		echo "Error: tag $$NEW_TAG exists locally at a different commit than HEAD."; \
+		exit 1; \
 	fi; \
-	if [ -n "$$REMOTE_TAG_COMMIT" ]; then \
-		if [ "$$REMOTE_TAG_COMMIT" != "$$HEAD_SHA" ]; then \
-			echo "Error: tag $$CURRENT_TAG already exists on origin but points at commit $$REMOTE_TAG_COMMIT, not HEAD ($$HEAD_SHA)."; \
-			echo "PyPI version $$CURRENT_VERSION may already be published; bump the version on a feature branch with 'make bump' first."; \
-			exit 1; \
-		fi; \
-		echo "Tag $$CURRENT_TAG already on origin at HEAD; nothing to push."; \
-	else \
-		echo "Pushing tag $$CURRENT_TAG to origin (triggers Actions publish workflow)"; \
-		git push origin "$$CURRENT_TAG"; \
+	if git ls-remote --exit-code --tags origin "$$NEW_TAG" >/dev/null 2>&1; then \
+		echo "Error: tag $$NEW_TAG already exists on origin."; \
+		exit 1; \
 	fi; \
-	echo ""; \
-	echo "Tag $$CURRENT_TAG is on origin. GitHub Actions will publish to PyPI after gltanaka approval."; \
-	echo "  Watch:    gh run watch --workflow release.yml"; \
-	echo "  Fallback: make publish  (uploads locally via twine)"
+	git tag -a "$$NEW_TAG" -m "Release $$NEW_TAG"; \
+	git push origin "$$NEW_TAG"; \
+	echo "Tag $$NEW_TAG is on origin. GHA will request gltanaka approval, then publish."
 	@# Post-release cleanup check (Issue #186)
 	@$(MAKE) check-suspicious-files
 
@@ -823,8 +828,12 @@ publish-public:
 		cd "$(PUBLIC_PDD_REPO_DIR)" && git add . && \
 		if ! git diff --cached --quiet; then \
 			git commit -m "Bump version" && \
-			CURR_VER=$$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9.]*\)"/\1/p' pyproject.toml | head -n1) && \
-			(git tag -a "v$$CURR_VER" -m "Release v$$CURR_VER" 2>/dev/null || true) && \
+			CURR_VER=$$(git describe --tags --abbrev=0 --match='v*' 2>/dev/null | sed 's/^v//') && \
+			if [ -z "$$CURR_VER" ] || ! echo "$$CURR_VER" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+				echo "Skip tagging: no valid release tag found in public repo (got: '$$CURR_VER')"; \
+			else \
+				(git tag -a "v$$CURR_VER" -m "Release v$$CURR_VER" 2>/dev/null || true); \
+			fi && \
 			git push && git push --tags; \
 		else \
 			echo "No changes to commit in public repo — skipping push"; \

--- a/Makefile
+++ b/Makefile
@@ -618,6 +618,13 @@ upload-pypi:
 
 publish:
 	@set -e; \
+	if [ -n "$$(git status --porcelain)" ]; then \
+		echo "Error: working tree is dirty; refusing to publish."; \
+		echo "python -m build reads files from the working tree, not from the commit,"; \
+		echo "so uncommitted edits would be baked into the wheel. Commit or stash first."; \
+		git status --short; \
+		exit 1; \
+	fi; \
 	HEAD_SHA=$$(git rev-parse HEAD); \
 	TAG=$$(git tag --points-at HEAD --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | head -1); \
 	if [ -z "$$TAG" ]; then \
@@ -732,7 +739,26 @@ release: check-deps check-suspicious-files check-release-remote check-release-br
 			git push origin "$$EXISTING_TAG"; \
 			echo "Tag $$EXISTING_TAG pushed. GHA will request gltanaka approval, then publish."; \
 		elif [ "$$REMOTE_TAG_COMMIT" = "$$HEAD_SHA" ]; then \
-			echo "Tag $$EXISTING_TAG already on origin at HEAD; nothing to do."; \
+			echo "Tag $$EXISTING_TAG already on origin at HEAD."; \
+			if command -v gh >/dev/null 2>&1; then \
+				if ! gh release view "$$EXISTING_TAG" >/dev/null 2>&1; then \
+					echo "GitHub Release for $$EXISTING_TAG is missing. Creating it idempotently."; \
+					gh release create "$$EXISTING_TAG" --generate-notes --verify-tag --target main \
+						|| echo "(could not create GitHub Release; check gh auth and permissions)"; \
+				else \
+					echo "GitHub Release for $$EXISTING_TAG exists."; \
+				fi; \
+				LATEST_RUN_STATUS=$$(gh run list --workflow release.yml --event push --limit 1 --json status,conclusion --jq '.[0] | "\(.status):\(.conclusion)"' 2>/dev/null || echo ""); \
+				if [ -n "$$LATEST_RUN_STATUS" ]; then \
+					case "$$LATEST_RUN_STATUS" in \
+						completed:success) echo "Last release.yml run: success.";; \
+						completed:*) echo "Last release.yml run did not succeed ($$LATEST_RUN_STATUS). To re-trigger, delete and re-push the tag, or run 'gh workflow run release.yml'.";; \
+						*) echo "Last release.yml run status: $$LATEST_RUN_STATUS (may still be pending gltanaka approval).";; \
+					esac; \
+				fi; \
+			else \
+				echo "(install 'gh' CLI to auto-check release status)"; \
+			fi; \
 		else \
 			echo "Error: tag $$EXISTING_TAG on origin points at $$REMOTE_TAG_COMMIT, not HEAD ($$HEAD_SHA)."; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -740,25 +740,29 @@ release: check-deps check-suspicious-files check-release-remote check-release-br
 			echo "Tag $$EXISTING_TAG pushed. GHA will request gltanaka approval, then publish."; \
 		elif [ "$$REMOTE_TAG_COMMIT" = "$$HEAD_SHA" ]; then \
 			echo "Tag $$EXISTING_TAG already on origin at HEAD."; \
+			RECOVERY_FAILED=0; \
 			if command -v gh >/dev/null 2>&1; then \
 				if ! gh release view "$$EXISTING_TAG" >/dev/null 2>&1; then \
 					echo "GitHub Release for $$EXISTING_TAG is missing. Creating it idempotently."; \
 					gh release create "$$EXISTING_TAG" --generate-notes --verify-tag --target main \
-						|| echo "(could not create GitHub Release; check gh auth and permissions)"; \
+						|| { echo "(could not create GitHub Release; check gh auth and permissions)"; RECOVERY_FAILED=1; }; \
 				else \
 					echo "GitHub Release for $$EXISTING_TAG exists."; \
 				fi; \
-				LATEST_RUN_STATUS=$$(gh run list --workflow release.yml --event push --limit 1 --json status,conclusion --jq '.[0] | "\(.status):\(.conclusion)"' 2>/dev/null || echo ""); \
-				if [ -n "$$LATEST_RUN_STATUS" ]; then \
+				LATEST_RUN_STATUS=$$(gh run list --workflow release.yml --limit 20 --json status,conclusion,headSha --jq ".[] | select(.headSha==\"$$HEAD_SHA\") | \"\(.status):\(.conclusion)\"" 2>/dev/null | head -1); \
+				if [ -z "$$LATEST_RUN_STATUS" ]; then \
+					echo "No release.yml run found for HEAD ($$HEAD_SHA); the workflow may not have started yet."; \
+				else \
 					case "$$LATEST_RUN_STATUS" in \
-						completed:success) echo "Last release.yml run: success.";; \
-						completed:*) echo "Last release.yml run did not succeed ($$LATEST_RUN_STATUS). To re-trigger, delete and re-push the tag, or run 'gh workflow run release.yml'.";; \
-						*) echo "Last release.yml run status: $$LATEST_RUN_STATUS (may still be pending gltanaka approval).";; \
+						completed:success) echo "release.yml run for this tag: success.";; \
+						completed:*) echo "release.yml run for this tag did not succeed ($$LATEST_RUN_STATUS). To re-trigger, delete and re-push the tag, or run 'gh workflow run release.yml'."; RECOVERY_FAILED=1;; \
+						*) echo "release.yml run for this tag status: $$LATEST_RUN_STATUS (may still be pending gltanaka approval).";; \
 					esac; \
 				fi; \
 			else \
 				echo "(install 'gh' CLI to auto-check release status)"; \
 			fi; \
+			if [ "$$RECOVERY_FAILED" = "1" ]; then exit 1; fi; \
 		else \
 			echo "Error: tag $$EXISTING_TAG on origin points at $$REMOTE_TAG_COMMIT, not HEAD ($$HEAD_SHA)."; \
 			exit 1; \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDD (Prompt-Driven Development) Command Line Interface
 
-![PDD-CLI Version](https://img.shields.io/badge/pdd--cli-v0.0.241-blue) [![Discord](https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white)](https://discord.gg/Yp4RTh8bG7)
+![PyPI version](https://img.shields.io/pypi/v/pdd-cli.svg) [![Discord](https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white)](https://discord.gg/Yp4RTh8bG7)
 
 ## Introduction
 
@@ -361,8 +361,6 @@ For proper model identifiers to use in your custom configuration, refer to the [
    - **Python version conflicts**: If you have multiple Python versions, ensure `python3` points to Python 3.8+: `which python3 && python3 --version`
 
 ## Version
-
-Current version: 0.0.241
 
 To check your installed version, run:
 ```

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -514,8 +514,8 @@ pip install -e ".[dev]"
 - **pytest-mock**: Mocking utilities for unit tests
 - **pytest-asyncio**: Support for async test functions
 - **z3-solver**: Formal verification tools
-- **commitizen**: Conventional commits and versioning
 - **build, twine**: Package building and publishing tools
+- **setuptools-scm**: Derives package version from git tags (no static version in pyproject.toml)
 
 ### 2. Enable Test Caching and Smart Execution
 
@@ -643,7 +643,7 @@ rm -rf .testmondata
 rm -rf .coverage htmlcov/
 ```
 
-### 8. Git Workflow with Commitizen
+### 8. Git Workflow
 
 **Make commits following conventional commits:**
 
@@ -651,24 +651,23 @@ rm -rf .coverage htmlcov/
 # Stage your changes
 git add .
 
-# Use commitizen for structured commits
-cz commit
-
-# Or use git commit with conventional format
+# Use conventional commit format
 git commit -m "feat: add new feature"
 git commit -m "fix: resolve bug in module"
 git commit -m "docs: update documentation"
 ```
 
-**Bump version (maintainers only):**
+**Cut a release (maintainers only):**
+
+The version is derived from git tags via setuptools-scm. To release, on `main`:
 
 ```bash
-# Automatically bump version and update CHANGELOG
-cz bump
-
-# Push with tags
-git push --follow-tags
+make release              # patch bump (default)
+make release BUMP=minor   # minor bump
+make release BUMP=major   # major bump
 ```
+
+`make release` tags `HEAD` with the next `vX.Y.Z` and pushes the tag. GitHub Actions then builds the wheel, waits for the `gltanaka` approval on the `pypi-publish` environment, publishes to PyPI via OIDC, and creates a GitHub Release with auto-generated notes.
 
 ### 9. Troubleshooting Development Setup
 

--- a/pdd/pdd_completion.sh
+++ b/pdd/pdd_completion.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # PDD CLI Bash Completion Script
-# Version: 0.0.241
 # Supports all PDD commands and options with filename completion
 
 _pdd() {

--- a/pypi_description.rst
+++ b/pypi_description.rst
@@ -1,5 +1,5 @@
-.. image:: https://img.shields.io/badge/pdd--cli-v0.0.241-blue
-   :alt: PDD-CLI Version
+.. image:: https://img.shields.io/pypi/v/pdd-cli.svg
+   :alt: PyPI version
 
 .. image:: https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white&link=https://discord.gg/Yp4RTh8bG7
    :alt: Join us on Discord
@@ -75,7 +75,7 @@ After installation, verify:
 
    pdd --version
 
-You'll see the current PDD version (e.g., 0.0.241).
+You'll see the current PDD version.
 
 Getting Started with Examples
 -----------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [build-system]
 requires = [
-    "setuptools>=43.0.0",
+    "setuptools>=64",
+    "setuptools-scm>=8",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdd-cli"
-version = "0.0.241"
+dynamic = ["version"]
 description = "PDD (Prompt-Driven Development) Command Line Interface"
 readme = {file = "pypi_description.rst", content-type = "text/x-rst"}
 authors = [
@@ -95,7 +96,6 @@ packages = ["pdd", "pdd.commands", "pdd.core", "pdd.server", "pdd.server.routes"
 
 [project.optional-dependencies]
 dev = [
-    "commitizen",
     "pytest-cov",
     "pytest-testmon",
     "pytest-xdist",
@@ -130,17 +130,7 @@ filterwarnings = [
     "ignore:Support for class-based.*config.*is deprecated:DeprecationWarning",
 ]
 
-[tool.commitizen]
-name = "cz_conventional_commits"
-version = "0.0.241"
-tag_format = "v$version"
-version_files = [
-    "pyproject.toml:version",
-    "README.md:Current version: (.*?)$",
-    "README.md:https://img.shields.io/badge/pdd--cli-v(.*?)-blue",
-    "pdd/pdd_completion.sh:# Version: (.*?)",
-    "pypi_description.rst:.. image:: https://img.shields.io/badge/pdd--cli-v(.*?)-blue",
-    "pypi_description.rst:You'll see the current PDD version \\(e\\.g\\., (.*?)\\)\\."
-]
-changelog_file = "CHANGELOG.md"
-update_changelog_on_bump = true
+[tool.setuptools_scm]
+version_file = "pdd/_version.py"
+tag_regex = "^v(?P<version>\\d+\\.\\d+\\.\\d+)$"
+local_scheme = "no-local-version"

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ tiktoken>=0.7.0
 
 # Dev dependencies
 build
-commitizen
 httpx==0.28.1
 pytest-asyncio
 pytest-mock

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,30 +1,73 @@
 """Tests for package version reporting."""
 
-from importlib.metadata import version as metadata_version
+import re
+import subprocess
 from pathlib import Path
-import tomllib
+from importlib.metadata import version as metadata_version
 
 from click.testing import CliRunner
 
 import pdd
 from pdd.core.cli import cli as cli_command
 
+_PEP440_VERSION = re.compile(r"^\d+\.\d+\.\d+(?:\.(?:dev|rc|a|b|post)\d+)?$")
+_SCM_FALLBACKS = {"0.0.0", "0.0.0+unknown"}
+_SEMVER_TAG = re.compile(r"^\d+\.\d+\.\d+$")
 
-def test_package_version_matches_distribution_metadata():
-    """pdd.__version__ should report the installed pdd-cli version."""
-    project_root = Path(__file__).resolve().parents[1]
-    pyproject = tomllib.loads((project_root / "pyproject.toml").read_text())
-    expected_version = pyproject["project"]["version"]
 
-    assert metadata_version("pdd-cli") == expected_version
-    assert pdd.__version__ == expected_version
+def test_package_version_is_well_formed_and_not_a_fallback():
+    """__version__ must be a real PEP 440 version, not a setuptools-scm fallback."""
+    v = pdd.__version__
+    assert v, "pdd.__version__ is empty"
+    assert v not in _SCM_FALLBACKS, (
+        f"pdd.__version__ is the setuptools-scm fallback {v!r} — "
+        "git tags likely not visible to the build (check actions/checkout fetch-depth)."
+    )
+    assert _PEP440_VERSION.match(v), f"pdd.__version__ {v!r} is not valid PEP 440."
 
 
 def test_cli_version_reports_distribution_metadata():
-    """`pdd --version` should report the installed pdd-cli version."""
-    expected_version = metadata_version("pdd-cli")
-
+    """`pdd --version` reports the installed pdd-cli version."""
+    expected = metadata_version("pdd-cli")
     result = CliRunner().invoke(cli_command, ["--version"])
-
     assert result.exit_code == 0
-    assert f"version {expected_version}" in result.output
+    assert f"version {expected}" in result.output
+
+
+def test_version_matches_expected_for_current_state():
+    """At a tag: version == tag. Between tags: version starts with next-patch + '.dev'."""
+    repo_root = Path(__file__).resolve().parents[1]
+    if not (repo_root / ".git").exists():
+        return  # installed wheel outside checkout
+
+    result = subprocess.run(
+        ["git", "tag", "--list", "--merged", "HEAD", "--sort=-v:refname", "v*"],
+        cwd=repo_root, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return
+    semver_tags = [
+        t for t in result.stdout.split()
+        if _SEMVER_TAG.match(t.lstrip("v"))
+    ]
+    if not semver_tags:
+        return  # no semver tags yet
+    latest = semver_tags[0].lstrip("v")
+
+    head_tags = subprocess.check_output(
+        ["git", "tag", "--points-at", "HEAD"], cwd=repo_root, text=True,
+    ).split()
+    at_tag = f"v{latest}" in head_tags
+
+    if at_tag:
+        assert pdd.__version__ == latest, (
+            f"At tag v{latest}, expected pdd.__version__ == {latest!r}, got {pdd.__version__!r}"
+        )
+    else:
+        parts = [int(x) for x in latest.split(".")]
+        parts[-1] += 1
+        expected_prefix = ".".join(str(p) for p in parts) + ".dev"
+        assert pdd.__version__.startswith(expected_prefix), (
+            f"Between tags after v{latest}, expected pdd.__version__ to start with "
+            f"{expected_prefix!r}, got {pdd.__version__!r}"
+        )


### PR DESCRIPTION
## Summary

Replace the bump-branch + bump-PR + tag-push release flow with a single `make release` command. Version is derived from the latest `v*` git tag via setuptools-scm — no static version in `pyproject.toml`, no bump commit, no separate bump PR or CI cycle.

After this lands, the entire release flow is:

```
make release    # on main: tag HEAD with next vN.N.N (BUMP=patch|minor|major) and push
```

GHA then builds the wheel, gltanaka approves once on the `pypi-publish` environment, OIDC publishes to PyPI, and a GitHub Release with auto-generated notes is created. Only the gltanaka approval requires a human.

## Key changes

- **`pyproject.toml`**: `dynamic = ["version"]`, `[tool.setuptools_scm]` with `version_file`, strict `tag_regex`, `local_scheme = "no-local-version"`. **No `fallback_version`** — broken setups fail loud. `[tool.commitizen]` removed; `commitizen` dropped from dev deps.
- **`requirements.txt`**: drop `commitizen`.
- **`.github/workflows/release.yml`**: `fetch-depth: 0` on both jobs (setuptools-scm needs tags). `publish-pypi` gets `contents: write` for `gh release create`. Added idempotent "Create GitHub Release with auto-notes" step using `--verify-tag`.
- **`.github/workflows/unit-tests.yml`**: `fetch-depth: 0` on all three checkout steps.
- **`Makefile`**: replace `bump` + `release` split with a single idempotent `release` target. Handles fresh release, rerun-after-success (no-op), retry-after-push-failure (pushes existing local tag), drift detection (error). Validates `BUMP=patch|minor|major`. Uses strict semver tag discovery (`git tag --list --merged HEAD --sort=-v:refname` + grep regex). `make publish` now requires an exact semver tag at HEAD that exists on origin.
- **`tests/test_version.py`**: rewrite to validate PEP 440 form, reject setuptools-scm fallbacks (`0.0.0`, `0.0.0+unknown`), and assert exact-match-at-tag / `next-patch.devN` prefix-match-between-tags.
- **`.gitignore`**: `pdd/_version.py` (build-time artifact).
- **`README.md`, `pypi_description.rst`**: replace static badges with dynamic PyPI shields (`https://img.shields.io/pypi/v/pdd-cli.svg`). Remove hardcoded version strings.
- **`pdd/pdd_completion.sh`**: remove static `# Version:` comment.
- **`CHANGELOG.md`**: header note pointing to GitHub Releases; historical entries preserved.
- **`docs/ONBOARDING.md`**: replace commitizen workflow section with the new `make release` flow.

## Local validation

- `python -m build` produces `pdd_cli-0.0.242.dev1-py3-none-any.whl` with `Version: 0.0.242.dev1` (no `+gHASH`, confirms `local_scheme` applied).
- `twine check` PASSED.
- 3/3 tests in `tests/test_version.py` pass.
- `check-deps` reports deps in sync (commitizen removed from both pyproject.toml and requirements.txt; counts dropped 10→9 dev, 43→42 total).

## Pre-merge action required (one-time)

Before merging — or at the latest, before the first release on the new flow — back-fill `v0.0.241` as a GitHub Release so that `gh release create --generate-notes` for `v0.0.242` walks back to `v0.0.241` instead of the entire repo history:

```bash
gh release create v0.0.241 \
  --verify-tag \
  --title "v0.0.241" \
  --notes "Historical release; GitHub Releases adopted starting with v0.0.242."
```

## Test plan
- [x] `python -m build` succeeds and produces correctly-versioned wheel
- [x] `twine check dist/*.whl` passes
- [x] `pytest tests/test_version.py` all pass
- [x] Wheel installs cleanly in fresh venv; `pdd.__version__` matches METADATA
- [ ] CI: `unit-tests.yml` jobs pass with `fetch-depth: 0`
- [ ] CI: Cloud Build (`gcbrun`) passes
- [ ] First release on new flow (post-merge): `make release` cuts `v0.0.242`, GHA build+publish+release-create work end-to-end after gltanaka approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)