### PR TITLE
Fix/issue 829

### DIFF
--- a/docs/contract_check.md
+++ b/docs/contract_check.md
@@ -1,0 +1,468 @@
+# Contract check for prompt authoring quality
+
+`pdd contracts check` parses the structured contract sections of a prompt file
+and reports structural authoring defects deterministically — no LLM required,
+safe for CI.
+
+## Quick start
+
+```bash
+# Check one prompt file.
+pdd contracts check prompts/foo_python.prompt
+
+# Check all *.prompt files in a directory (recursive).
+pdd contracts check prompts/
+
+# Emit JSON (stdout only — informational messages go to stderr).
+pdd contracts check --json prompts/
+
+# Treat all warnings as errors (CI hard gate).
+pdd contracts check --strict prompts/foo_python.prompt
+
+# Also validate story ## Covers rule-ID references.
+pdd contracts check --stories user_stories/ prompts/foo_python.prompt
+
+# Run optional LLM ambiguity review on <contract_rules> terms.
+pdd contracts check --llm-ambiguity prompts/foo_python.prompt
+```
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0`  | No issues |
+| `1`  | Warnings present (and `--strict` not set) |
+| `2`  | Errors present, OR any warning when `--strict` is set |
+
+## Sections parsed
+
+The checker reads these XML-delimited sections when present in a prompt file:
+
+| Section | What is checked |
+|---------|-----------------|
+| `<contract_rules>` | Rule IDs, modal verbs, vague terms |
+| `<vocabulary>` | Term definitions that suppress vague-term warnings |
+| `<capabilities>` | Modal verb presence on each capability line |
+| `<coverage>` | Rule ID validity; MUST NOT rule coverage; waiver cross-references |
+| `<waivers>` | Required fields; expiry dates |
+| `<non_responsibilities>` | Parsed but not checked (informational only) |
+
+Prompts that contain **none** of the checked sections (legacy format) produce
+zero issues and are silently marked clean.
+
+## Rule ID formats
+
+Two canonical formats are accepted and may be mixed within a file:
+
+```text
+# Explicit R-prefix IDs (both short and zero-padded forms)
+R1 - Short name
+R-001: Description
+
+# Sequential numeric IDs
+1. Rule text
+2. Rule text
+```
+
+Anything else that looks like an ID prefix but does not match (e.g. `R_001`,
+`RR-01`, `RULE_1`) is flagged as `MALFORMED_ID`.
+
+## Checks reference
+
+### `DUPLICATE_ID` — error
+
+The same rule ID appears more than once in `<contract_rules>`.
+
+```text
+R2 - Merchant check
+The system MUST only accept authorized merchants.
+
+R2 - Payment validation        ← duplicate
+The system MUST reject requests with an invalid payment method.
+```
+
+**Fix:** Assign each rule a unique ID.
+
+---
+
+### `MALFORMED_ID` — error
+
+A line begins with something that resembles an ID prefix but does not match the
+canonical `R<N>`, `R-<N>`, `RULE<N>`, or `<N>.` formats.
+
+```text
+R_001: Rule text          ← underscore separator
+RR-01: Rule text          ← double-letter prefix
+RULE_003: Rule text       ← underscore
+```
+
+**Fix:** Use `R1 -`, `R1:`, `R-001:`, or plain `1.` sequential numbering.
+
+---
+
+### `NON_SEQUENTIAL_ID` — warning
+
+Explicit `R<N>` IDs have a numeric gap, suggesting a rule was deleted or
+misnumbered. This is a warning, not an error, because intentional gaps are
+sometimes used to match external specification numbering.
+
+```text
+R1, R2, R4   ← R3 is missing
+```
+
+**Fix:** Renumber rules sequentially, or add a comment explaining the gap.
+
+---
+
+### `MISSING_MODAL` — warning (error in `--strict`)
+
+A `<contract_rules>` block or `<capabilities>` line contains no recognised
+modal verb.
+
+Required modals: `MUST`, `MUST NOT`, `MAY`, `MAY NOT`, `SHOULD`, `SHOULD NOT`,
+`SHALL`, `SHALL NOT`, `DOES NOT`.
+
+```text
+R4 - Fraud gate
+The system reject suspicious transactions.    ← no modal verb
+```
+
+**Fix:** Add a modal: `"The system MUST NOT process suspicious transactions."`
+
+---
+
+### `VAGUE_TERM` — warning
+
+A line in `<contract_rules>` uses a known vague phrase without a matching
+`<vocabulary>` definition. The same core term list as `pdd prompt lint` is used:
+
+`active`, `authorized`, `complete`, `duplicate`, `graceful`, `inactive`,
+`invalid`, `reasonable`, `recent`, `safe`, `successful`, `trusted`,
+`unauthorized`, `unsafe`, `untrusted`, `valid`
+
+```text
+R6 - Error format
+The system MUST return a reasonable error response within a reasonable time.
+                          ↑ vague, no <vocabulary> entry
+```
+
+**Suppression:** Define the term in `<vocabulary>` to silence the warning:
+
+```text
+<vocabulary>
+- reasonable response time: completes within 500 ms at p99 under standard load
+</vocabulary>
+```
+
+Term matching is generous — defining `valid file` suppresses warnings for both
+`valid file` and the bare word `valid`.
+
+---
+
+### `UNKNOWN_COVERAGE_REF` — error
+
+A `<coverage>` entry cites a rule ID that does not exist in `<contract_rules>`.
+
+```text
+<coverage>
+- R3: test_burst_window (tests/test_rate_limiter.py)   ← R3 not defined
+</coverage>
+```
+
+**Fix:** Add the missing rule to `<contract_rules>`, or remove the stale
+coverage entry.
+
+---
+
+### `UNCHECKED_RULE` — warning
+
+A `<coverage>` entry is marked `TODO`, meaning no test, story, or waiver has
+been assigned yet.
+
+```text
+<coverage>
+- R4: TODO add integration test
+</coverage>
+```
+
+**Fix:** Replace `TODO` with a test name, story filename, or `WAIVED W<N>`.
+
+---
+
+### `UNCOVERED_MUST_NOT` — warning
+
+A `MUST NOT` rule has no entry in `<coverage>`. This check only fires when a
+`<coverage>` section is present at all (so legacy prompts without `<coverage>`
+are unaffected).
+
+`MUST NOT` rules carry the highest risk — a missing or incorrect implementation
+silently violates a prohibition. Requiring coverage evidence surfaces this
+early.
+
+```text
+<contract_rules>
+R5 - Raw card data
+The system MUST NOT store raw card numbers.    ← no coverage entry
+</contract_rules>
+
+<coverage>
+- R1: …
+- R3: …
+# R5 absent
+</coverage>
+```
+
+**Fix:** Add a coverage entry: `R5: test_no_raw_card_stored (tests/test_payment.py)`,
+a story reference, or `WAIVED W<N>`.
+
+---
+
+### `WAIVER_REF_MISSING` — error
+
+A `<coverage>` entry cites `WAIVED W<N>`, but `<waivers>` has no corresponding
+block for that waiver ID.
+
+```text
+<coverage>
+- R4: WAIVED W2    ← W2 not defined in <waivers>
+</coverage>
+```
+
+**Fix:** Add a `W2:` block to `<waivers>`, or change the coverage evidence to a
+test or story.
+
+---
+
+### `MISSING_WAIVER_FIELDS` — warning
+
+A `<waivers>` block is missing one or more required fields.
+
+Required fields: `Rule`, `Reason`, `Approved by`, `Expires`.
+
+```text
+<waivers>
+W1:
+  Rule: R4
+  Reason: Pending access-control overhaul.
+  # Missing: Approved by, Expires
+</waivers>
+```
+
+**Fix:** Add all required fields:
+
+```text
+W1:
+  Rule: R4
+  Status: temporary
+  Reason: Pending access-control overhaul in Q3.
+  Approved by: security-team
+  Expires: 2026-12-31
+  Follow-up: Implement fine-grained scope checks (issue #712).
+```
+
+---
+
+### `EXPIRED_WAIVER` — warning
+
+A waiver's `Expires` date is in the past.
+
+**Fix:** Extend the expiry date, add a test or story to close the waiver, or
+remove it if the rule is now fully covered.
+
+## Full prompt example
+
+```text
+<vocabulary>
+- authorized merchant: a merchant whose API key is present, unexpired, and has
+  the "payments:write" scope verified against the OAuth2 provider
+- duplicate charge: a charge whose idempotency_key matches an existing charge
+  created within the last 24 hours by the same merchant
+- suspicious transaction: a transaction whose risk_score exceeds 0.85
+</vocabulary>
+
+<contract_rules>
+R1 - Idempotency guard
+
+For every POST /charges request,
+the system MUST reject duplicate charges
+when the idempotency_key matches an existing charge within 24 hours.
+
+This rule is violated if the system creates a second charge row.
+
+R2 - Merchant authorization
+The system MUST only accept requests from authorized merchants.
+
+R3 - Fraud gate
+The system MUST NOT process suspicious transactions.
+</contract_rules>
+
+<coverage>
+- R1: test_duplicate_charge_rejected (tests/test_payment.py)
+- R2: test_unauthorized_merchant_rejected (tests/test_payment.py)
+- R3: test_suspicious_transaction_blocked (tests/test_payment.py)
+</coverage>
+
+<capabilities>
+- MUST NOT store raw card numbers; only vaulted tokens are permitted.
+- MAY retry vault service calls up to two times before returning HTTP 503.
+</capabilities>
+
+<non_responsibilities>
+- Currency conversion.
+- PCI DSS key management (handled by the vault service).
+</non_responsibilities>
+```
+
+Running `pdd contracts check` against this produces zero issues.
+
+## JSON output
+
+```bash
+pdd contracts check --json prompts/foo_python.prompt
+pdd contracts check --json prompts/
+```
+
+Output is a JSON array. Each element corresponds to one file:
+
+```json
+[
+  {
+    "path": "prompts/payment_python.prompt",
+    "warn_count": 1,
+    "error_count": 1,
+    "issues": [
+      {
+        "level": "error",
+        "code": "DUPLICATE_ID",
+        "rule_id": "R2",
+        "section": "contract_rules",
+        "line": "R2 - Payment validation",
+        "message": "Rule ID \"R2\" appears more than once in <contract_rules>.",
+        "term": "",
+        "suggestion": "Assign a unique ID to each rule. Rename or remove the duplicate.",
+        "interpretations": []
+      }
+    ]
+  }
+]
+```
+
+`--json` writes only the JSON array to **stdout**; all informational messages
+go to **stderr**, so the output is safe to pipe or parse without filtering.
+
+## `--strict` mode
+
+```bash
+pdd contracts check --strict prompts/foo_python.prompt
+```
+
+Escalates every warning to an error and exits with code 2 if any issue is
+found. Use as a hard CI gate when you want to enforce zero contract-authoring
+debt. `MISSING_MODAL` in particular is normally a warning but becomes an error
+under `--strict`.
+
+## Story `## Covers` validation
+
+```bash
+pdd contracts check --stories user_stories/ prompts/foo_python.prompt
+```
+
+`--stories` takes a **directory** of `story__*.md` files. The checker scans
+each story's `## Covers` section and validates that every rule ID referenced
+there actually exists in the linked prompt's `<contract_rules>`.
+
+Two reference formats are supported:
+
+```md
+## Covers
+
+# Single-prompt format — validates against the TARGET prompt
+- R1: idempotency_key uniqueness enforced within 24-hour window
+- R3: suspicious transaction risk_score exceeds 0.85 threshold
+
+# Cross-module format — validates against the named prompt file
+- prompts/payment_python.prompt#R2: authorized merchant holds valid API key
+```
+
+Stories referenced from `--stories` are scanned recursively — subdirectories
+are included automatically.
+
+## Waivers
+
+`<waivers>` blocks document exceptions to `MUST NOT` rules that cannot be
+covered by tests or stories in the current release cycle.
+
+```text
+<waivers>
+W1:
+  Rule: R4
+  Status: temporary
+  Reason: Read-only admin endpoints exempt pending Q3 access-control overhaul.
+  Approved by: security-team
+  Expires: 2026-12-31
+  Follow-up: Implement fine-grained scope checks (issue #712).
+</waivers>
+```
+
+Reference the waiver in `<coverage>` to suppress `UNCOVERED_MUST_NOT`:
+
+```text
+<coverage>
+- R4: WAIVED W1
+</coverage>
+```
+
+Required waiver fields: `Rule`, `Reason`, `Approved by`, `Expires`.
+Optional fields: `Status`, `Follow-up`.
+
+## Optional LLM pass
+
+```bash
+pdd contracts check --llm-ambiguity prompts/foo_python.prompt
+```
+
+The LLM pass is opt-in. It reviews `<contract_rules>` terms for subtle
+ambiguity beyond the deterministic vague-term list and may suggest richer
+`<vocabulary>` definitions with possible interpretations:
+
+```text
+Possible interpretations:
+  1. Requests with the same idempotency key in the header
+  2. Requests with identical body content within 60 seconds
+  3. Requests from the same user ID for the same resource within 5 seconds
+
+Suggestion:
+  duplicate charge: a charge whose idempotency_key matches an existing charge
+  created within 30 seconds by the same merchant_id
+```
+
+LLM failures are non-fatal — the deterministic pass remains the CI-safe
+baseline.
+
+## Fixture files
+
+The repository ships runnable fixtures under `tests/fixtures/contract_check/`:
+
+| File | Description |
+|------|-------------|
+| `valid_contract_python.prompt` | All sections well-formed — zero issues |
+| `payment_api_clean_python.prompt` | Realistic payment API — fully specified, zero issues |
+| `auth_service_clean_python.prompt` | Auth service with waivers — fully specified, zero issues |
+| `duplicate_ids_python.prompt` | Duplicate R2 — triggers `DUPLICATE_ID` |
+| `malformed_ids_python.prompt` | `R_001` prefix — triggers `MALFORMED_ID` |
+| `non_sequential_ids_python.prompt` | R1, R2, R4 gap — triggers `NON_SEQUENTIAL_ID` |
+| `missing_modal_python.prompt` | Rule without modal verb — triggers `MISSING_MODAL` |
+| `vague_no_vocab_python.prompt` | Vague terms, no vocabulary — triggers `VAGUE_TERM` |
+| `vague_with_vocab_python.prompt` | Same terms, all defined — zero issues |
+| `unknown_coverage_refs_python.prompt` | Coverage cites R99 — triggers `UNKNOWN_COVERAGE_REF` |
+| `uncovered_mustnot_python.prompt` | MUST NOT with no coverage — triggers `UNCOVERED_MUST_NOT` |
+| `payment_api_issues_python.prompt` | Combined defects in one file (integration testing) |
+| `rate_limiter_issues_python.prompt` | Sequential gap + coverage errors (integration testing) |
+| `waiver_valid_python.prompt` | Complete, unexpired waiver — zero issues |
+| `waiver_expired_python.prompt` | Expired waiver — triggers `EXPIRED_WAIVER` |
+| `waiver_missing_fields_python.prompt` | Incomplete waiver — triggers `MISSING_WAIVER_FIELDS` |
+| `legacy_no_sections_python.prompt` | No contract sections — silently clean |
+| `story__covers_rule_ids.md` | Valid `## Covers` entries — zero issues |
+| `story__unknown_rule_ids.md` | `## Covers` with unknown IDs — triggers `UNKNOWN_STORY_REF` |
+| `story__payment_flow.md` | Realistic story with valid covers for payment API |
+| `story__payment_bad_refs.md` | Story citing R99, R100 — triggers `UNKNOWN_STORY_REF` |

--- a/docs/prompt_lint.md
+++ b/docs/prompt_lint.md
@@ -1,0 +1,331 @@
+# Prompt lint for ambiguous contracts
+
+`pdd prompt lint` checks prompt contracts and user-story acceptance criteria for
+undefined vague terms. The default pass is deterministic, does not call an LLM,
+and does not modify files — safe to use in CI.
+
+## Quick start
+
+```bash
+# Scan one prompt file.
+pdd prompt lint prompts/foo_python.prompt
+
+# Scan all *.prompt files in a directory (recursive).
+pdd prompt lint prompts/
+
+# Scan a directory of user stories.
+pdd prompt lint --stories user_stories/
+
+# Scan a prompt and its stories together.
+pdd prompt lint --stories user_stories/ prompts/foo_python.prompt
+
+# Run the deterministic ambiguity pass explicitly.
+pdd prompt lint --ambiguity prompts/foo_python.prompt
+
+# Emit JSON (stdout only — informational messages go to stderr).
+pdd prompt lint --json prompts/foo_python.prompt
+
+# Escalate all warnings to errors (CI gate).
+pdd prompt lint --strict prompts/foo_python.prompt
+
+# Run the optional LLM ambiguity review.
+pdd prompt lint --ambiguity --llm prompts/foo_python.prompt
+
+# Write vocabulary suggestions back into the file.
+pdd prompt lint --ambiguity --llm --apply prompts/foo_python.prompt
+```
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0`  | No issues |
+| `1`  | Warnings present (and `--strict` not set) |
+| `2`  | Errors present, OR any warning when `--strict` is set |
+
+## Argument syntax
+
+```
+pdd prompt lint [OPTIONS] [TARGET]
+```
+
+`TARGET` is optional when `--stories` is supplied; required otherwise.
+It may be a single `.prompt` file or a directory — directories are scanned
+recursively for `*.prompt` files.
+
+`--stories` always takes a **directory** of `story__*.md` files, never a
+prompt path. To scan both together, keep them as separate arguments:
+
+```bash
+# Correct — story directory after --stories, prompt as TARGET
+pdd prompt lint --stories user_stories/prompt_lint_samples/ prompts/foo_python.prompt
+
+# Wrong — passes the prompt path as the --stories value
+pdd prompt lint --stories user_stories/prompt_lint_samples/prompts/foo_python.prompt
+```
+
+## Vague terms
+
+The linter maintains hardcoded vocabularies of terms that are commonly
+under-specified in contracts. Default mode checks this core list:
+
+`active`, `authorized`, `complete`, `duplicate`, `graceful`, `inactive`, `invalid`,
+`reasonable`, `recent`, `safe`, `successful`, `trusted`, `unauthorized`,
+`unsafe`, `untrusted`, `valid`
+
+`--strict` also checks this extended list:
+
+`appropriate`, `correct`, `expected`, `incomplete`, `incorrect`, `necessary`,
+`normal`, `proper`, `sufficient`, `unexpected`
+
+Terms are matched as whole words. For example, `graceful` is checked, but the
+word `gracefully` is not a match unless an LLM review flags it.
+
+## Sections scanned
+
+### Scanned sections (prompt files)
+
+| Section tag | Example |
+|-------------|---------|
+| `<contract_rules>` | Numbered rules the implementation must satisfy |
+| `<requirements>` | Bullet-point functional requirements |
+| `<acceptance_tests>` | Explicit acceptance test criteria |
+| `% prose lines` | Any line beginning with `%` (PDD comment convention) |
+
+### Scanned sections (story / markdown files)
+
+| Markdown heading | Example |
+|------------------|---------|
+| `## Acceptance Criteria` | Gherkin-style acceptance criteria |
+
+### Not scanned (architecture metadata)
+
+The following sections are intentionally excluded — they describe structure,
+not observable behaviour, so vague terms inside them do not raise warnings:
+
+`<pdd-reason>`, `<pdd-interface>`, `<pdd-dependency>`,
+`<waivers>`, `<deliverables>`, `<dependencies>`
+
+Prompts that contain none of the scanned sections (legacy format) produce zero
+issues and are silently skipped.
+
+## Vocabulary sources
+
+Defining a term suppresses its warning wherever it appears in scanned sections.
+Any of these sources are recognised:
+
+| Source | Used in |
+|--------|---------|
+| `<vocabulary>` block | Prompt files |
+| `## Glossary` heading | Story files |
+| `## Definitions` heading | Story files |
+| `## Covers` heading | Story files |
+
+Term extraction is generous: when you define `valid response`, both the full
+phrase `valid response` **and** the individual word `valid` are treated as
+known, so a rule that uses `valid` anywhere is suppressed.
+
+### Cross-module `## Covers` entries
+
+Stories may reference rules from other prompt files using the `#rule-id`
+format. The descriptive text after the colon is extracted as a known phrase:
+
+```md
+## Covers
+- prompts/payment_python.prompt#R3: No provider call before validation
+```
+
+## Observable-outcome check
+
+For `<contract_rules>`, `<acceptance_tests>`, and `## Acceptance Criteria`
+sections only, the linter also checks whether each line that contains an
+undefined vague term includes at least one observable outcome verb. If it does
+not, an additional `(no observable outcome)` warning is emitted.
+
+Observable outcome verbs include: `return`, `raise`, `write`, `emit`, `log`,
+`exit`, `reject`, `produce`, `store`, `increment`, `decrement`, `set`, `clear`,
+`yield`, `throw`, `save`, `delete`, `output`, `append`, `insert`, `update`,
+`remove`, `send`, `publish` (and common inflections of each).
+
+Note: `<requirements>` and `% prose` sections are scanned for vague terms but
+do **not** trigger the observable-outcome check.
+
+## Prompt example
+
+```text
+<contract_rules>
+1. The function must return a valid response within a reasonable time.
+2. Duplicate requests must be rejected gracefully.
+3. Only authorized users may call this endpoint.
+</contract_rules>
+
+<requirements>
+- Accept file uploads from active users only.
+- Mark complete when all required fields are present.
+</requirements>
+```
+
+Running `pdd prompt lint prompts/foo_python.prompt` against this produces:
+
+- Warnings for `valid`, `reasonable`, `duplicate`, `authorized`, `active`, and
+  `complete` (all undefined core vague terms).
+- An extra `(no observable outcome)` warning for rule 3 — it uses `authorized`
+  but has no observable verb such as `returns` or `rejects`.
+- A `suggestion` entry for each term, ready to paste into `<vocabulary>`.
+
+No warnings for rule 2 — `rejected` is an observable outcome verb, so the
+observable-outcome check passes even though `duplicate` is still flagged as
+vague. The word `gracefully` is not flagged by the deterministic default pass
+because the core term is `graceful`.
+
+### Fixing the warnings with `<vocabulary>`
+
+```text
+<vocabulary>
+- valid response: HTTP 200 with a JSON body containing a non-empty "data" field
+- reasonable time: completes within 500 ms at p99 under standard load
+- duplicate request: a request whose idempotency key matches a previously accepted request within the last 24 hours
+- graceful rejection: returns HTTP 409 with a JSON error body {"code":"DUPLICATE","message":"..."}
+- authorized user: a user whose JWT token is present, unexpired, and carries the "write" scope
+- active user: a user whose account.status field equals "active" in the accounts table
+- complete: all required fields (name, email, role) are non-empty strings
+</vocabulary>
+```
+
+After adding this block, the same prompt produces zero issues in default mode.
+
+## Story example
+
+```md
+## Acceptance Criteria
+1. Given an authorized user, when they upload a valid file, the server returns HTTP 201.
+2. Given a duplicate upload, when submitted by the same tenant, the server returns HTTP 409.
+3. Given an active user who has reached their limit, when they upload, the server returns HTTP 429.
+
+## Covers
+- authorized user: a user whose Bearer JWT is present, unexpired, and carries the "upload" scope
+- valid file: a file whose MIME type is in the allowlist and whose size is ≤ 10 MB
+- duplicate upload: an upload whose SHA-256 hash and tenant ID match a previously accepted upload
+- active user: a user whose account.status field equals "active" in the accounts table
+```
+
+Running `pdd prompt lint --stories <directory-containing-this-story>` produces
+zero issues in default mode — all core vague terms in the acceptance criteria
+are defined in `## Covers`.
+
+Without the `## Covers` section, `authorized`, `valid`, `duplicate`, and
+`active` would each produce a warning.
+
+## JSON output
+
+```bash
+pdd prompt lint --json prompts/foo_python.prompt
+pdd prompt lint --json --stories user_stories/prompt_lint_samples/
+```
+
+Output is a JSON array. Each element corresponds to one file:
+
+```json
+[
+  {
+    "path": "prompts/foo_python.prompt",
+    "warn_count": 7,
+    "error_count": 0,
+    "issues": [
+      {
+        "level": "warn",
+        "term": "valid",
+        "section": "contract_rules",
+        "line": "1. The function must return a valid response within a reasonable time.",
+        "message": "Vague term \"valid\" used in [contract_rules] without a <vocabulary> definition.",
+        "suggestion": "valid: <add a precise, observable definition here>",
+        "interpretations": []
+      }
+    ]
+  }
+]
+```
+
+`--json` writes only the JSON array to **stdout**; all informational messages
+(e.g. update checks) go to **stderr**, so the output is safe to pipe or parse
+without filtering.
+
+## `--strict` mode
+
+```bash
+pdd prompt lint --strict prompts/foo_python.prompt
+```
+
+Escalates every warning to an error and exits with code 2 if any issue is
+found. Use as a hard CI gate when you want to enforce zero vague-term debt.
+
+## Optional LLM pass
+
+The LLM pass is opt-in and requires both flags:
+
+```bash
+pdd prompt lint --ambiguity --llm prompts/foo_python.prompt
+```
+
+`--ambiguity` is valid by itself and runs the deterministic pass. The additional
+LLM review is only run when both `--ambiguity` and `--llm` are supplied. Using
+`--llm` without `--ambiguity` is an error.
+
+The LLM pass may return richer suggestions and possible interpretations:
+
+```text
+Possible interpretations:
+  1. Same filename
+  2. Same file hash
+  3. Same tenant ID and normalized file hash
+
+Suggestion: Add to <vocabulary>:
+  duplicate upload: an upload whose tenant ID and normalized file hash match a previously accepted upload
+```
+
+The `interpretations` field in JSON output is populated only by the LLM pass;
+the deterministic pass always returns an empty array.
+
+LLM failures are non-fatal — the deterministic pass remains the CI-safe
+baseline.
+
+## Applying suggestions (`--apply`)
+
+The linter is read-only by default. Pass `--apply` to write suggestions back:
+
+```bash
+pdd prompt lint --ambiguity --llm --apply prompts/foo_python.prompt
+```
+
+`--apply` appends entries to the file's `<vocabulary>` block (creating one at
+the end of the file if absent). It writes only **concrete** suggestions — LLM-
+supplied definitions with real content. Placeholder suggestions from the
+deterministic pass (`valid: <add a precise, observable definition here>`) are
+shown for review but never written automatically.
+
+`--apply` may be combined with or without `--llm`. Without `--llm`, the current
+deterministic suggestions are placeholders, so nothing is written.
+
+## Fixture files and demo
+
+The repository ships runnable fixtures under `tests/fixtures/prompt_lint/`:
+
+| File | Description |
+|------|-------------|
+| `vague_undefined.prompt` | Vague terms with no vocabulary — produces warnings |
+| `vague_defined.prompt` | Same terms, all defined — produces zero issues |
+| `clean.prompt` | Concrete, observable language throughout — zero issues |
+| `upload_handler_python.prompt` | Real-world upload handler with flagged terms |
+| `upload_handler_with_vocab_python.prompt` | Same handler with full vocabulary — zero issues |
+| `story__vague_criteria.md` | Story with undefined vague acceptance criteria |
+| `story__covers.md` | Same story with `## Covers` definitions — zero issues |
+
+A standalone demo script is also available:
+
+```bash
+bash examples/prompt_lint_demo/demo.sh
+```
+
+The demo covers: deterministic prompt linting, vocabulary suppression, story
+linting, JSON output, read-only guarantee, `--apply`, optional LLM review, and
+strict mode.

--- a/docs/prompt_lint.md
+++ b/docs/prompt_lint.md
@@ -54,7 +54,9 @@ It may be a single `.prompt` file or a directory — directories are scanned
 recursively for `*.prompt` files.
 
 `--stories` always takes a **directory** of `story__*.md` files, never a
-prompt path. To scan both together, keep them as separate arguments:
+prompt path. Story files are scanned **recursively** — subdirectories are
+included automatically. To scan both a prompt and stories together, keep them
+as separate arguments:
 
 ```bash
 # Correct — story directory after --stories, prompt as TARGET

--- a/examples/prompt_lint_demo/README.md
+++ b/examples/prompt_lint_demo/README.md
@@ -1,0 +1,79 @@
+# pdd prompt lint — feature demo
+
+This directory demonstrates every acceptance criterion of the `pdd prompt lint` command.
+
+## Quick start
+
+```bash
+# From repo root, with the local dev install active
+pip install -e .                                 # ensure local version is installed
+export PDD_SKIP_UPDATE_CHECK=1                   # prevent auto-upgrade overwriting the dev install
+bash examples/prompt_lint_demo/demo.sh
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `prompts/payment_api_vague_python.prompt` | Payment API with 10 undefined vague terms — triggers warnings |
+| `prompts/payment_api_clean_python.prompt` | Same prompt with complete `<vocabulary>` — zero warnings |
+| `stories/story__charge_flow.md` | User story with vague Acceptance Criteria |
+| `stories/story__charge_flow_defined.md` | Same story with `## Covers` vocabulary — zero warnings |
+
+## Feature cheat-sheet
+
+All commands run **from the repo root**. Set `PDD_SKIP_UPDATE_CHECK=1` to avoid
+the auto-upgrade prompt overwriting your dev install.
+
+```bash
+export PDD_SKIP_UPDATE_CHECK=1
+VAGUE=examples/prompt_lint_demo/prompts/payment_api_vague_python.prompt
+CLEAN=examples/prompt_lint_demo/prompts/payment_api_clean_python.prompt
+STORIES=examples/prompt_lint_demo/stories
+
+# ① Non-LLM default mode (no API key needed)
+pdd --quiet prompt lint $VAGUE
+
+# ② Defined terms suppress warnings
+pdd --quiet prompt lint $CLEAN                                  # exits 0
+
+# ③ Works on stories
+pdd --quiet prompt lint --stories $STORIES $VAGUE
+pdd --quiet prompt lint --stories $STORIES
+
+# ④ Suggests <vocabulary> additions  (human output and JSON include suggestions)
+pdd --quiet prompt lint $VAGUE
+
+# ⑤ Emits JSON
+pdd --quiet prompt lint --json $VAGUE
+pdd --quiet prompt lint --json --stories $STORIES $VAGUE
+
+# ⑥ Read-only by default (no --apply → file never changes)
+cp $VAGUE /tmp/demo.prompt
+pdd --quiet prompt lint /tmp/demo.prompt
+diff $VAGUE /tmp/demo.prompt   # empty — file unchanged
+
+# ⑦ --apply writes vocabulary suggestions into the file
+cp $VAGUE /tmp/demo.prompt
+pdd --quiet prompt lint --ambiguity --llm --apply /tmp/demo.prompt
+cat /tmp/demo.prompt   # <vocabulary> block written with LLM-sourced definitions
+
+# ⑧ Optional LLM review with interpretations
+pdd --quiet prompt lint --ambiguity --llm $VAGUE
+
+# ⑨ --strict mode (CI gate — exit 2 on any warning)
+pdd --quiet prompt lint --strict $VAGUE
+echo $?   # 2
+```
+
+## Acceptance criteria checklist
+
+| Criterion | Command / behaviour |
+|-----------|---------------------|
+| Non-LLM default mode | `pdd prompt lint <file>` — no API key needed |
+| Optional LLM review | `--ambiguity --llm` — skipped if omitted, never breaks CI |
+| Works on prompts and stories | `--stories <dir>` scans `story__*.md` files; combine it with a prompt path to scan both |
+| Suggests `<vocabulary>` additions | every issue includes a `Suggestion:` line |
+| Emits JSON | `--json` flag produces a parseable array |
+| Read-only by default | file is unchanged without `--apply` |
+| Tests for vague terms, defined terms, story AC, JSON | `tests/test_prompt_lint.py` + `tests/commands/test_prompt.py` |

--- a/examples/prompt_lint_demo/demo.sh
+++ b/examples/prompt_lint_demo/demo.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# demo.sh — walks through every acceptance criterion of `pdd prompt lint`
+#
+# Usage (from repo root):
+#   cd /path/to/pdd
+#   bash examples/prompt_lint_demo/demo.sh
+#
+# Requires: pdd installed in the active environment (pip install -e .)
+
+set -euo pipefail
+export PDD_SKIP_UPDATE_CHECK=1   # prevent auto-upgrade from overwriting the dev install
+PDD="pdd --quiet"
+DEMO=examples/prompt_lint_demo
+VAGUE=$DEMO/prompts/payment_api_vague_python.prompt
+CLEAN=$DEMO/prompts/payment_api_clean_python.prompt
+STORIES=$DEMO/stories
+
+hr()  { echo; printf '%.0s─' {1..72}; echo; }
+hdr() { hr; echo "  $1"; hr; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+hdr "① Non-LLM default mode"
+echo "Scans for vague terms deterministically — no API key required."
+echo
+echo "▶  $PDD prompt lint $VAGUE"
+$PDD prompt lint "$VAGUE" || true   # exits 1 when warnings found
+
+# ─────────────────────────────────────────────────────────────────────────────
+hdr "② Defined terms suppress warnings"
+echo "Add a <vocabulary> block and every warning disappears."
+echo
+echo "▶  $PDD prompt lint $CLEAN"
+$PDD prompt lint "$CLEAN"           # exits 0
+
+# ─────────────────────────────────────────────────────────────────────────────
+hdr "③ Works on stories  (--stories)"
+echo "Scans user-story Acceptance Criteria for undefined vague terms."
+echo
+echo "▶  $PDD prompt lint --stories $STORIES $CLEAN"
+$PDD prompt lint --stories "$STORIES" "$CLEAN" || true
+echo
+echo "▶  $PDD prompt lint --stories $STORIES"
+$PDD prompt lint --stories "$STORIES" || true
+
+# ─────────────────────────────────────────────────────────────────────────────
+hdr "④ Suggests additions to <vocabulary>"
+echo "Every issue carries a ready-to-paste suggestion."
+echo
+echo "▶  $PDD prompt lint $VAGUE  (look for 'Suggestion:' lines below)"
+$PDD prompt lint "$VAGUE" || true
+
+# ─────────────────────────────────────────────────────────────────────────────
+hdr "⑤ Emits JSON  (--json)"
+echo "Machine-readable output for CI pipelines, dashboards, or jq."
+echo
+echo "▶  $PDD prompt lint --json $VAGUE"
+$PDD prompt lint --json "$VAGUE" || true
+echo
+echo "▶  Pretty-print first issue with jq:"
+$PDD prompt lint --json "$VAGUE" 2>/dev/null | \
+    python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+issue = data[0]['issues'][0]
+print(json.dumps(issue, indent=2))
+" || true
+
+# ─────────────────────────────────────────────────────────────────────────────
+hdr "⑥ Read-only by default — files are never modified"
+echo "Without --apply the file content is unchanged."
+echo
+TMPFILE=$(mktemp /tmp/pdd_demo.XXXXXX)
+cp "$VAGUE" "$TMPFILE"
+echo "▶  $PDD prompt lint $TMPFILE   (then diff)"
+$PDD prompt lint "$TMPFILE" || true
+if diff -q "$VAGUE" "$TMPFILE" > /dev/null; then
+    echo "  ✓ File unchanged."
+else
+    echo "  ✗ File was modified! (unexpected)"
+fi
+rm "$TMPFILE"
+
+# ─────────────────────────────────────────────────────────────────────────────
+hdr "⑦ --apply writes vocabulary suggestions"
+echo "The deterministic pass generates placeholder suggestions."
+echo "--apply only writes concrete (non-placeholder) definitions — typically"
+echo "from the LLM pass. To demonstrate, we inject a concrete suggestion"
+echo "via Python and then call apply_suggestions directly."
+echo
+TMPFILE=$(mktemp /tmp/pdd_demo.XXXXXX)
+cp "$VAGUE" "$TMPFILE"
+# Use the same interpreter as the pdd command
+PY=$(command -v python3.12 || command -v python3)
+$PY - "$TMPFILE" <<'PYEOF'
+import sys
+from pathlib import Path
+from pdd.prompt_lint import LintIssue, apply_suggestions
+
+path = Path(sys.argv[1])
+concrete_issues = [
+    LintIssue(
+        level="warn", term="authorized merchant",
+        section="contract_rules",
+        line="1. Only authorized merchants may initiate a charge.",
+        message="demo",
+        suggestion="authorized merchant: a caller presenting a Bearer JWT with iss='merchant-svc' and a merchant_id in the allowlist table",
+    ),
+    LintIssue(
+        level="warn", term="duplicate transaction",
+        section="contract_rules",
+        line="2. Reject duplicate transactions gracefully.",
+        message="demo",
+        suggestion="duplicate transaction: a charge whose idempotency_key matches a pending or succeeded row within the last 24 hours",
+    ),
+]
+n = apply_suggestions(path, concrete_issues)
+print(f"  ✓ {n} suggestion(s) written to <vocabulary> block.")
+PYEOF
+echo
+echo "  Diff (original vs. after --apply):"
+diff "$VAGUE" "$TMPFILE" | head -30 || true
+rm "$TMPFILE"
+
+# ─────────────────────────────────────────────────────────────────────────────
+hdr "⑧ Optional LLM ambiguity review  (--ambiguity --llm)"
+echo "Requires a configured LLM provider. Skip this step if no API key is set."
+echo "Shows 'Possible interpretations' and richer suggestions per term."
+echo
+echo "▶  $PDD prompt lint --ambiguity --llm $VAGUE"
+echo "   (skipping live call in demo — use the command above manually)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+hdr "⑨ --strict mode — exit 2 for CI hard-failure"
+echo "Escalates all warnings to errors. Useful as a pre-commit / CI gate."
+echo
+echo "▶  $PDD prompt lint --strict $VAGUE"
+$PDD prompt lint --strict "$VAGUE" || echo "  Exit code: $? (expected 2)"
+
+hr
+echo "  Demo complete. All acceptance criteria exercised."
+hr

--- a/examples/prompt_lint_demo/prompts/payment_api_clean_python.prompt
+++ b/examples/prompt_lint_demo/prompts/payment_api_clean_python.prompt
@@ -1,0 +1,49 @@
+% DEMO FILE 2 — same prompt with <vocabulary> added (zero warnings).
+% Features shown: defined terms suppress warnings, --apply result.
+%
+% Run:
+%   pdd prompt lint prompts/payment_api_clean_python.prompt   # exits 0
+
+You are a Python developer. Implement the `payment` module (`src/payment.py`).
+
+<vocabulary>
+- authorized merchant: a caller presenting a Bearer JWT with iss="merchant-svc", an unexpired exp claim, and a merchant_id in the allowlist table
+- duplicate transaction: a charge whose idempotency_key matches a row in the transactions table with status IN ("pending","succeeded") created within the last 24 hours
+- graceful rejection: returns the appropriate 4xx HTTP status with JSON body {"code": "<ERROR_CODE>", "detail": "<human-readable reason>"}; never raises an unhandled exception
+- valid payment response: HTTP 201 with JSON body {"transaction_id": "<uuid4>", "amount": <cents>, "currency": "<ISO-4217>", "created_at": "<ISO-8601>"}
+- successful charge: a charge that receives a "succeeded" status from the provider within 10 seconds and is persisted to the transactions table
+- active subscription: a row in the subscriptions table with status="active" and current_period_end in the future
+- trusted payment provider: a webhook caller whose X-Stripe-Signature header passes HMAC-SHA256 verification with the configured endpoint secret
+- reasonable time window: within 30 calendar days of the original transaction created_at
+- complete audit record: a row in the audit_log table containing merchant_id, transaction_id, amount, currency, provider_response_code, timestamp, and outcome; never containing raw card data
+- safe retry policy: at most 3 retries with exponential back-off (1 s, 2 s, 4 s); no retry on HTTP 4xx responses
+</vocabulary>
+
+<contract_rules>
+1. Only authorized merchants may initiate a charge.
+2. Reject duplicate transactions gracefully.
+3. Return a valid payment response on successful charge.
+4. Active subscriptions must not be charged more than once per billing cycle.
+5. Trusted payment providers may skip the fraud check.
+6. Refunds are allowed within a reasonable time window.
+</contract_rules>
+
+<requirements>
+- POST /charge: accepts a JSON payload and initiates a charge via the provider.
+- Return HTTP 201 with {"transaction_id": "<uuid>"} on successful charge.
+- Reject duplicate charges with HTTP 409.
+- Store a complete audit record for every transaction attempt.
+- Enforce a safe retry policy on network errors.
+</requirements>
+
+<acceptance_tests>
+1. Given an authorized merchant, when they POST a valid charge, the server returns HTTP 201.
+2. Given a duplicate transaction, when submitted by an active subscription, the server returns HTTP 409.
+3. Given a trusted provider webhook, when it arrives, the server processes it gracefully.
+4. Given a complete refund request within the time window, the server returns HTTP 200.
+</acceptance_tests>
+
+Instructions
+- Use Stripe SDK for provider calls.
+- Raise HTTPException for all error paths.
+- Write pytest tests for the happy path and each rejection scenario.

--- a/examples/prompt_lint_demo/prompts/payment_api_vague_python.prompt
+++ b/examples/prompt_lint_demo/prompts/payment_api_vague_python.prompt
@@ -1,0 +1,38 @@
+% DEMO FILE 1 — vague prompt (no vocabulary).
+% Features shown: non-LLM default mode, JSON output, vocabulary suggestions, read-only guarantee.
+%
+% Run:
+%   pdd prompt lint prompts/payment_api_vague_python.prompt
+%   pdd prompt lint --json prompts/payment_api_vague_python.prompt
+%   pdd prompt lint --strict prompts/payment_api_vague_python.prompt   # exit 2
+
+You are a Python developer. Implement the `payment` module (`src/payment.py`).
+
+<contract_rules>
+1. Only authorized merchants may initiate a charge.
+2. Reject duplicate transactions gracefully.
+3. Return a valid payment response on successful charge.
+4. Active subscriptions must not be charged more than once per billing cycle.
+5. Trusted payment providers may skip the fraud check.
+6. Refunds are allowed within a reasonable time window.
+</contract_rules>
+
+<requirements>
+- POST /charge: accepts a JSON payload and initiates a charge via the provider.
+- Return HTTP 201 with {"transaction_id": "<uuid>"} on successful charge.
+- Reject duplicate charges with HTTP 409.
+- Store a complete audit record for every transaction attempt.
+- Enforce a safe retry policy on network errors.
+</requirements>
+
+<acceptance_tests>
+1. Given an authorized merchant, when they POST a valid charge, the server returns HTTP 201.
+2. Given a duplicate transaction, when submitted by an active subscription, the server returns HTTP 409.
+3. Given a trusted provider webhook, when it arrives, the server processes it gracefully.
+4. Given a complete refund request within the time window, the server returns HTTP 200.
+</acceptance_tests>
+
+Instructions
+- Use Stripe SDK for provider calls.
+- Raise HTTPException for all error paths.
+- Write pytest tests for the happy path and each rejection scenario.

--- a/examples/prompt_lint_demo/stories/story__charge_flow.md
+++ b/examples/prompt_lint_demo/stories/story__charge_flow.md
@@ -1,0 +1,15 @@
+# User Story: Merchant initiates a charge
+
+<!-- pdd-story-prompts: prompts/payment_api_vague_python.prompt -->
+
+## Story
+As an authorized merchant, I want to initiate a charge so that I can collect payment from a customer.
+
+## Acceptance Criteria
+1. Given valid credentials, when a merchant POSTs a charge, then the server returns a valid payment response.
+2. Given a duplicate transaction, when submitted within the window, the server rejects it gracefully.
+3. Given a trusted provider webhook, when it arrives with a complete payload, the server records it.
+4. Given an active subscription at the billing limit, when charged again, the server returns HTTP 409.
+
+## Non-Goals
+1. Handling refunds in this story (see story__refund_flow.md).

--- a/examples/prompt_lint_demo/stories/story__charge_flow_defined.md
+++ b/examples/prompt_lint_demo/stories/story__charge_flow_defined.md
@@ -1,0 +1,25 @@
+# User Story: Merchant initiates a charge (terms defined)
+
+<!-- pdd-story-prompts: prompts/payment_api_clean_python.prompt -->
+
+## Story
+As an authorized merchant, I want to initiate a charge so that I can collect payment from a customer.
+
+## Acceptance Criteria
+1. Given valid credentials, when a merchant POSTs a charge, then the server returns a valid payment response.
+2. Given a duplicate transaction, when submitted within the window, the server rejects it gracefully.
+3. Given a trusted provider webhook, when it arrives with a complete payload, the server records it.
+4. Given an active subscription at the billing limit, when charged again, the server returns HTTP 409.
+
+## Covers
+- authorized merchant: a caller presenting a Bearer JWT with iss="merchant-svc" and a merchant_id in the allowlist
+- valid payment response: HTTP 201 with JSON body {"transaction_id": "<uuid4>", "amount": <cents>, "currency": "<ISO-4217>"}
+- duplicate transaction: a charge whose idempotency_key matches a pending or succeeded row within the last 24 hours
+- trusted provider webhook: a webhook caller whose X-Stripe-Signature passes HMAC-SHA256 verification
+- complete payload: a webhook body containing event type, transaction_id, provider_status, and created_at
+- active subscription: a row in subscriptions with status="active" and current_period_end in the future
+- valid credentials: a Bearer JWT that is present, unexpired, and carries the "charge" scope claim
+- graceful rejection: returns the appropriate 4xx status with JSON body {"code": "...", "detail": "..."}
+
+## Non-Goals
+1. Handling refunds in this story (see story__refund_flow.md).

--- a/examples/prompts_linter/prompts/lint_demo_auth_vague_python.prompt
+++ b/examples/prompts_linter/prompts/lint_demo_auth_vague_python.prompt
@@ -1,0 +1,33 @@
+% LINT DEMO — auth service with vague terms.
+% Shows how "safe", "recent", "trusted", and "reasonable" hide policy decisions.
+% pdd prompt lint examples/prompts_linter/prompts/lint_demo_auth_vague_python.prompt
+
+You are a Python developer. Implement the `auth` module (`src/auth.py`).
+
+<contract_rules>
+1. Passwords must be stored safely.
+2. Only trusted clients may request a token refresh.
+3. Reject login attempts from recent failed logins.
+4. Tokens must expire after a reasonable period.
+5. Return a valid token response on successful authentication.
+6. Active accounts may have at most 5 concurrent sessions.
+</contract_rules>
+
+<requirements>
+- POST /login: accepts email + password, returns JWT access token and refresh token.
+- POST /refresh: accepts refresh token, returns new access token.
+- POST /logout: revokes the supplied refresh token.
+- Enforce account lockout after repeated failures.
+</requirements>
+
+<acceptance_tests>
+1. Given valid credentials, when the user logs in, then the server returns a valid token response.
+2. Given a recent failed login, when another attempt arrives, then the server returns HTTP 429.
+3. Given a trusted client, when it calls /refresh, then it receives a new valid token.
+4. Given an active account at the session limit, when a new login occurs, the oldest session is revoked gracefully.
+</acceptance_tests>
+
+Instructions
+- Use bcrypt for password hashing.
+- Issue JWTs signed with RS256.
+- Store refresh tokens in Redis with an appropriate TTL.

--- a/examples/prompts_linter/prompts/lint_demo_fixed_python.prompt
+++ b/examples/prompts_linter/prompts/lint_demo_fixed_python.prompt
@@ -1,0 +1,46 @@
+% LINT DEMO — all vague terms defined: run `pdd prompt lint` on this file to see zero warnings.
+% pdd prompt lint examples/prompts_linter/prompts/lint_demo_fixed_python.prompt
+
+You are a Python developer. Implement the `file_upload` module (`src/file_upload.py`).
+
+<vocabulary>
+- authorized user: a user whose Bearer JWT is present, unexpired, and contains the "upload" scope claim
+- duplicate upload: an upload whose SHA-256 hash and tenant_id match a row in the uploads table with status="accepted" created within the last 30 days
+- graceful rejection: returns HTTP 409 with JSON body {"code": "DUPLICATE", "detail": "<human-readable reason>"}; never raises an unhandled exception
+- valid response: HTTP 201 with JSON body {"id": "<uuid4>", "size": <bytes>, "created_at": "<ISO-8601>"}
+- complete upload: a row in the uploads table with status="accepted" and storage_path set to a non-null S3 key
+- active session: a session whose expires_at timestamp is in the future and whose revoked flag is false
+- successful upload: an upload that returns a valid response within 2000 ms with no error fields in the body
+- trusted service: a caller presenting a service-to-service JWT with aud="internal" and a recognised service_id claim
+- reasonable file size: ≤ 50 MB as measured by Content-Length header before reading the stream
+- safe record: an audit log entry containing user_id, tenant_id, file hash, timestamp, and outcome; never containing raw file content or PII beyond user_id
+</vocabulary>
+
+<contract_rules>
+1. Only authorized users may upload files.
+2. Reject duplicate uploads gracefully.
+3. Return a valid response when the upload is complete.
+4. Active sessions are allowed up to 10 uploads per day.
+5. Log all successful uploads for audit purposes.
+6. Trusted services may bypass the rate limit.
+</contract_rules>
+
+<requirements>
+- Accept multipart/form-data POST to /upload.
+- Return HTTP 201 with {"id": "<uuid>"} on successful upload.
+- Reject duplicate files with HTTP 409.
+- Sanitize file names before saving to storage.
+- Enforce a reasonable file size limit.
+</requirements>
+
+<acceptance_tests>
+1. Given an authorized user, when they POST a valid file, then the server returns HTTP 201.
+2. Given a duplicate upload, when submitted by an active session, then the server returns HTTP 409.
+3. Given an expired session, when a request arrives, then the server returns HTTP 401.
+4. Given a complete upload, the audit log must contain a safe record.
+</acceptance_tests>
+
+Instructions
+- Implement using FastAPI and Python 3.12+.
+- Use type annotations for all public functions.
+- Raise HTTPException for all error paths.

--- a/examples/prompts_linter/prompts/lint_demo_vague_python.prompt
+++ b/examples/prompts_linter/prompts/lint_demo_vague_python.prompt
@@ -1,0 +1,33 @@
+% LINT DEMO — intentionally vague: run `pdd prompt lint` on this file to see warnings.
+% pdd prompt lint examples/prompts_linter/prompts/lint_demo_vague_python.prompt
+
+You are a Python developer. Implement the `file_upload` module (`src/file_upload.py`).
+
+<contract_rules>
+1. Only authorized users may upload files.
+2. Reject duplicate uploads gracefully.
+3. Return a valid response when the upload is complete.
+4. Active sessions are allowed up to 10 uploads per day.
+5. Log all successful uploads for audit purposes.
+6. Trusted services may bypass the rate limit.
+</contract_rules>
+
+<requirements>
+- Accept multipart/form-data POST to /upload.
+- Return HTTP 201 with {"id": "<uuid>"} on successful upload.
+- Reject duplicate files with HTTP 409.
+- Sanitize file names before saving to storage.
+- Enforce a reasonable file size limit.
+</requirements>
+
+<acceptance_tests>
+1. Given an authorized user, when they POST a valid file, then the server returns HTTP 201.
+2. Given a duplicate upload, when submitted by an active user, then the server returns HTTP 409.
+3. Given an expired session, when a request arrives, then the server returns HTTP 401.
+4. Given a complete upload, the audit log must contain a safe record.
+</acceptance_tests>
+
+Instructions
+- Implement using FastAPI and Python 3.12+.
+- Use type annotations for all public functions.
+- Raise HTTPException for all error paths.

--- a/pdd/commands/__init__.py
+++ b/pdd/commands/__init__.py
@@ -19,6 +19,7 @@ from .templates import templates_group
 from .utility import install_completion_cmd, verify
 from .which import which
 from .firecrawl import firecrawl_cache
+from .prompt import prompt_group
 
 def register_commands(cli: click.Group) -> None:
     """Register all subcommands with the main CLI group."""
@@ -55,3 +56,4 @@ def register_commands(cli: click.Group) -> None:
     cli.add_command(auth_group)
     cli.add_command(sessions)
     cli.add_command(firecrawl_cache)
+    cli.add_command(prompt_group)

--- a/pdd/commands/__init__.py
+++ b/pdd/commands/__init__.py
@@ -20,6 +20,7 @@ from .utility import install_completion_cmd, verify
 from .which import which
 from .firecrawl import firecrawl_cache
 from .prompt import prompt_group
+from .contracts import contracts_group
 
 def register_commands(cli: click.Group) -> None:
     """Register all subcommands with the main CLI group."""
@@ -57,3 +58,4 @@ def register_commands(cli: click.Group) -> None:
     cli.add_command(sessions)
     cli.add_command(firecrawl_cache)
     cli.add_command(prompt_group)
+    cli.add_command(contracts_group)

--- a/pdd/commands/contracts.py
+++ b/pdd/commands/contracts.py
@@ -1,0 +1,216 @@
+"""
+Contract authoring quality utilities (pdd contracts …).
+"""
+from __future__ import annotations
+
+import json as _json
+from pathlib import Path
+from typing import Optional
+
+import click
+from rich.console import Console
+from rich.markup import escape
+
+from ..contract_check import (
+    ContractIssue,
+    ContractResult,
+    check_directory,
+    check_prompt,
+    check_stories,
+    run_llm_ambiguity_pass,
+)
+from ..core.errors import handle_error
+
+_console = Console(highlight=False)
+
+
+# ---------------------------------------------------------------------------
+# Rich output helpers
+# ---------------------------------------------------------------------------
+
+def _render_issue(issue: ContractIssue) -> None:
+    """Print one ContractIssue to the console."""
+    badge_style = "bold red" if issue.level == "error" else "bold yellow"
+    badge = f"[{badge_style}]{issue.level.upper()}[/{badge_style}]"
+
+    code_str = f"[dim cyan]{escape(issue.code)}[/dim cyan]"
+    rid_str = (
+        f"  [dim magenta]{escape(issue.rule_id)}[/dim magenta]"
+        if issue.rule_id
+        else ""
+    )
+    loc_str = f"  [dim][{escape(issue.section)}][/dim]" if issue.section else ""
+
+    _console.print(f"  {badge}  {code_str}{rid_str}{loc_str}  {escape(issue.message)}")
+
+    if issue.line:
+        _console.print(f"       [dim italic]{escape(issue.line[:120])}[/dim italic]")
+
+    if issue.interpretations:
+        _console.print("       Possible interpretations:")
+        for idx, interp in enumerate(issue.interpretations, 1):
+            _console.print(f"         {idx}. {escape(interp)}")
+
+    if issue.suggestion and "<add a precise" not in issue.suggestion:
+        _console.print(
+            f"       [cyan]Suggestion:[/cyan]\n"
+            f"         [green]{escape(issue.suggestion)}[/green]"
+        )
+
+
+def _render_result(result: ContractResult, *, quiet: bool = False) -> None:
+    """Print a ContractResult header and all its issues."""
+    if not result.issues:
+        if not quiet:
+            _console.print(f"[bold]{result.path}[/bold]  [green]✓ clean[/green]")
+        return
+    _console.print(
+        f"[bold]{result.path}[/bold]  "
+        f"[yellow]{result.warn_count} warn[/yellow]  "
+        f"[red]{result.error_count} error[/red]"
+    )
+    for issue in result.issues:
+        _render_issue(issue)
+
+
+# ---------------------------------------------------------------------------
+# Click group and command
+# ---------------------------------------------------------------------------
+
+@click.group(name="contracts")
+def contracts_group() -> None:
+    """Contract authoring quality utilities."""
+
+
+@contracts_group.command("check")
+@click.argument("target", type=click.Path(exists=True))
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output results as JSON.",
+)
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Treat all warnings as errors (exit 2 even for warnings).",
+)
+@click.option(
+    "--stories",
+    "stories_dir",
+    type=click.Path(exists=True, file_okay=False),
+    default=None,
+    help="Scan a user-story directory for ## Covers rule-ID validity.",
+)
+@click.option(
+    "--llm-ambiguity",
+    "llm_ambiguity",
+    is_flag=True,
+    default=False,
+    help="Run optional LLM ambiguity review on <contract_rules> terms.",
+)
+@click.pass_context
+def contracts_check(
+    ctx: click.Context,
+    target: str,
+    as_json: bool,
+    strict: bool,
+    stories_dir: Optional[str],
+    llm_ambiguity: bool,
+) -> None:
+    """Check prompt contract sections for structural authoring defects.
+
+    \b
+    Examples:
+      pdd contracts check prompts/foo_python.prompt
+      pdd contracts check prompts/
+      pdd contracts check --json prompts/
+      pdd contracts check --strict prompts/foo_python.prompt
+      pdd contracts check --stories user_stories/ prompts/foo_python.prompt
+      pdd contracts check --llm-ambiguity prompts/foo_python.prompt
+
+    \b
+    Checks (deterministic, no LLM required):
+      DUPLICATE_ID        — same rule ID used more than once
+      MALFORMED_ID        — ID prefix doesn't match R-NNN or sequential N.
+      NON_SEQUENTIAL_ID   — gap in explicit rule IDs (warn only)
+      MISSING_MODAL       — rule lacks MUST / MUST NOT / MAY / SHOULD
+      VAGUE_TERM          — vague phrase without <vocabulary> definition
+      UNKNOWN_COVERAGE_REF — <coverage> cites an ID not in <contract_rules>
+      UNCOVERED_MUST_NOT  — MUST NOT rule absent from <coverage> (when present)
+      UNKNOWN_STORY_REF   — story ## Covers cites an unknown rule ID
+
+    \b
+    Exit codes:
+      0  no issues
+      1  warnings only (unless --strict)
+      2  errors present, or any issue with --strict
+    """
+    obj = ctx.obj or {}
+    quiet: bool = obj.get("quiet", False)
+    verbose: bool = obj.get("verbose", False)
+    strength: float = obj.get("strength", 0.5)
+    temperature: float = obj.get("temperature", 0.0)
+    time_val: Optional[float] = obj.get("time")
+
+    all_results: list[ContractResult] = []
+    target_path = Path(target)
+
+    # Scan a single prompt file
+    if target_path.is_file():
+        result = check_prompt(target_path, strict=strict)
+        if llm_ambiguity:
+            llm_issues = run_llm_ambiguity_pass(
+                target_path,
+                strength=strength,
+                temperature=temperature,
+                time=time_val,
+                verbose=verbose,
+            )
+            if strict:
+                for issue in llm_issues:
+                    issue.level = "error"
+            result.issues.extend(llm_issues)
+        all_results.append(result)
+
+    # Scan a directory of prompts
+    elif target_path.is_dir():
+        for r in check_directory(target_path, strict=strict):
+            if llm_ambiguity:
+                llm_issues = run_llm_ambiguity_pass(
+                    r.path,
+                    strength=strength,
+                    temperature=temperature,
+                    time=time_val,
+                    verbose=verbose,
+                )
+                if strict:
+                    for issue in llm_issues:
+                        issue.level = "error"
+                r.issues.extend(llm_issues)
+            all_results.append(r)
+
+    # Scan user-story directory
+    if stories_dir is not None:
+        prompts_dir = target_path if target_path.is_dir() else target_path.parent
+        all_results.extend(
+            check_stories(Path(stories_dir), prompts_dir, strict=strict)
+        )
+
+    # Output
+    if as_json:
+        click.echo(_json.dumps([r.as_dict() for r in all_results], indent=2))
+    else:
+        for result in all_results:
+            _render_result(result, quiet=quiet)
+
+    # Exit code
+    total_errors = sum(r.error_count for r in all_results)
+    total_warns = sum(r.warn_count for r in all_results)
+
+    if total_errors > 0 or (strict and total_warns > 0):
+        raise click.exceptions.Exit(2)
+    if total_warns > 0:
+        raise click.exceptions.Exit(1)

--- a/pdd/commands/prompt.py
+++ b/pdd/commands/prompt.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 """
 Prompt authoring and quality utilities (pdd prompt …).
 """
@@ -111,7 +112,7 @@ def prompt_group() -> None:
     help="Write suggested <vocabulary> entries back into the scanned file(s).",
 )
 @click.pass_context
-def prompt_lint(
+def prompt_lint(  # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
     ctx: click.Context,
     target: Optional[str],
     ambiguity: bool,
@@ -190,8 +191,8 @@ def prompt_lint(
 
         # Scan a directory of prompts
         elif target_path.is_dir():
-            for p in sorted(target_path.rglob("*.prompt")):
-                all_results.append(scan_prompt(p, strict=strict))
+            for prompt_path in sorted(target_path.rglob("*.prompt")):
+                all_results.append(scan_prompt(prompt_path, strict=strict))
 
     # Scan user stories directory (via --stories flag)
     if stories_dir is not None:

--- a/pdd/commands/prompt.py
+++ b/pdd/commands/prompt.py
@@ -1,0 +1,225 @@
+"""
+Prompt authoring and quality utilities (pdd prompt …).
+"""
+from __future__ import annotations
+
+import json as _json
+from pathlib import Path
+from typing import Optional
+
+import click
+from rich.console import Console
+from rich.markup import escape
+
+from ..prompt_lint import (
+    LintIssue,
+    LintResult,
+    apply_suggestions,
+    run_llm_ambiguity_pass,
+    scan_prompt,
+    scan_stories,
+)
+
+_console = Console(highlight=False)
+
+
+# ---------------------------------------------------------------------------
+# Rich output helpers
+# ---------------------------------------------------------------------------
+
+def _render_issue(issue: LintIssue) -> None:
+    """Print one LintIssue to the console in the canonical format."""
+    badge_style = "bold red" if issue.level == "error" else "bold yellow"
+    badge = f"[{badge_style}]{issue.level.upper()}[/{badge_style}]"
+    loc = f"[dim][{escape(issue.section)}][/dim]"
+    _console.print(f"  {badge}  {loc}  {escape(issue.message)}")
+    if issue.line:
+        _console.print(f"       [dim italic]{escape(issue.line[:120])}[/dim italic]")
+    if issue.interpretations:
+        _console.print("       Possible interpretations:")
+        for idx, interp in enumerate(issue.interpretations, 1):
+            _console.print(f"         {idx}. {escape(interp)}")
+    if issue.suggestion:
+        _console.print(
+            f"       [cyan]Suggestion:[/cyan] Add to <vocabulary>:\n"
+            f"         [green]{escape(issue.suggestion)}[/green]"
+        )
+
+
+def _render_result(result: LintResult, *, quiet: bool = False) -> None:
+    """Print a LintResult header + all its issues."""
+    total = len(result.issues)
+    if total == 0:
+        if not quiet:
+            _console.print(f"[bold]{result.path}[/bold]  [green]✓ clean[/green]")
+        return
+    _console.print(f"[bold]{result.path}[/bold]  "
+                   f"[yellow]{result.warn_count} warn[/yellow]  "
+                   f"[red]{result.error_count} error[/red]")
+    for issue in result.issues:
+        _render_issue(issue)
+
+
+# ---------------------------------------------------------------------------
+# Click group and command
+# ---------------------------------------------------------------------------
+
+@click.group(name="prompt")
+def prompt_group() -> None:
+    """Prompt authoring and quality utilities."""
+
+
+@prompt_group.command("lint")
+@click.argument("target", required=False, type=click.Path(exists=True))
+@click.option(
+    "--ambiguity",
+    is_flag=True,
+    default=False,
+    help="Enable ambiguity review options; required with --llm.",
+)
+@click.option(
+    "--stories",
+    "stories_dir",
+    type=click.Path(exists=False),
+    default=None,
+    help="Scan a user story directory (may be combined with TARGET).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output results as JSON.",
+)
+@click.option(
+    "--llm",
+    is_flag=True,
+    default=False,
+    help="Run optional LLM ambiguity pass (requires --ambiguity).",
+)
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Treat all warnings as errors (exit 2 even for warnings).",
+)
+@click.option(
+    "--apply",
+    "apply_fixes",
+    is_flag=True,
+    default=False,
+    help="Write suggested <vocabulary> entries back into the scanned file(s).",
+)
+@click.pass_context
+def prompt_lint(
+    ctx: click.Context,
+    target: Optional[str],
+    ambiguity: bool,
+    stories_dir: Optional[str],
+    as_json: bool,
+    llm: bool,
+    strict: bool,
+    apply_fixes: bool,
+) -> None:
+    """Lint a prompt file or user-story directory for ambiguous terms.
+
+    \b
+    Examples:
+      pdd prompt lint prompts/foo_python.prompt
+      pdd prompt lint --ambiguity prompts/foo_python.prompt
+      pdd prompt lint --stories user_stories/
+      pdd prompt lint --stories user_stories/ prompts/foo_python.prompt
+      pdd prompt lint --json prompts/foo_python.prompt
+      pdd prompt lint --ambiguity --llm prompts/foo_python.prompt
+      pdd prompt lint --apply prompts/foo_python.prompt
+
+    \b
+    Exit codes:
+      0  no issues
+      1  warnings only (unless --strict)
+      2  errors present, or any issue with --strict
+    """
+    if llm and not ambiguity:
+        raise click.UsageError("--llm requires --ambiguity.")
+    if target is None and stories_dir is None:
+        raise click.UsageError("Missing argument 'TARGET' unless --stories is supplied.")
+    if stories_dir is not None:
+        story_path = Path(stories_dir)
+        if not story_path.is_dir():
+            hint = ""
+            if ".prompt" in story_path.name or ".prompt" in str(story_path):
+                hint = (
+                    "\n\nTo scan a prompt and stories together, pass the story "
+                    "directory after --stories and the prompt as TARGET, for example:\n"
+                    "  pdd prompt lint --stories user_stories/prompt_lint_samples/ "
+                    "prompts/foo_python.prompt"
+                )
+            raise click.UsageError(
+                f"--stories expects a directory containing story__*.md files, "
+                f"got '{stories_dir}'.{hint}"
+            )
+
+    obj = ctx.obj or {}
+    quiet: bool = obj.get("quiet", False)
+    verbose: bool = obj.get("verbose", False)
+    strength: float = obj.get("strength", 0.5)
+    temperature: float = obj.get("temperature", 0.0)
+    time_val: Optional[float] = obj.get("time")
+
+    all_results: list[LintResult] = []
+
+    if target is not None:
+        target_path = Path(target)
+
+        # Scan a single prompt file
+        if target_path.is_file():
+            result = scan_prompt(target_path, strict=strict)
+            if llm:
+                llm_issues = run_llm_ambiguity_pass(
+                    target_path,
+                    strength=strength,
+                    temperature=temperature,
+                    time=time_val,
+                    verbose=verbose,
+                )
+                if strict:
+                    for issue in llm_issues:
+                        issue.level = "error"
+                result.issues.extend(llm_issues)
+            all_results.append(result)
+
+        # Scan a directory of prompts
+        elif target_path.is_dir():
+            for p in sorted(target_path.rglob("*.prompt")):
+                all_results.append(scan_prompt(p, strict=strict))
+
+    # Scan user stories directory (via --stories flag)
+    if stories_dir is not None:
+        all_results.extend(scan_stories(Path(stories_dir), strict=strict))
+
+    # --apply: write vocabulary suggestions back (read-only otherwise)
+    if apply_fixes:
+        for result in all_results:
+            if result.issues and result.path.is_file():
+                written = apply_suggestions(result.path, result.issues)
+                if not quiet and written:
+                    _console.print(
+                        f"[green]Applied {written} vocabulary suggestion(s) to "
+                        f"{result.path}[/green]"
+                    )
+
+    # Output
+    if as_json:
+        click.echo(_json.dumps([r.as_dict() for r in all_results], indent=2))
+    else:
+        for result in all_results:
+            _render_result(result, quiet=quiet)
+
+    # Determine exit code
+    total_errors = sum(r.error_count for r in all_results)
+    total_warns = sum(r.warn_count for r in all_results)
+
+    if total_errors > 0 or (strict and total_warns > 0):
+        raise click.exceptions.Exit(2)
+    if total_warns > 0:
+        raise click.exceptions.Exit(1)

--- a/pdd/contract_check.py
+++ b/pdd/contract_check.py
@@ -1,0 +1,1004 @@
+"""
+Contract authoring check engine.
+
+Parses <contract_rules>, <vocabulary>, <capabilities>, <coverage>, <waivers>,
+and <non_responsibilities> sections and reports structural authoring defects
+without requiring an LLM.
+
+Public API
+----------
+check_prompt(path, *, strict=False) -> ContractResult
+check_directory(directory, *, strict=False) -> list[ContractResult]
+check_stories(stories_dir, prompts_dir, *, strict=False) -> list[ContractResult]
+run_llm_ambiguity_pass(path, strength, temperature, time, verbose) -> list[ContractIssue]
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+from .prompt_lint import (
+    VAGUE_TERMS,
+    _extract_sections,
+    _extract_vocabulary_terms,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Modal verbs required in every rule / capability line
+# ---------------------------------------------------------------------------
+
+MODALS: frozenset[str] = frozenset({
+    "MUST NOT",
+    "MUST",
+    "MAY NOT",
+    "MAY",
+    "SHOULD NOT",
+    "SHOULD",
+    "DOES NOT",
+    "SHALL NOT",
+    "SHALL",
+})
+
+# Ordered longest-first so "MUST NOT" matches before "MUST"
+_MODAL_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(m) for m in sorted(MODALS, key=len, reverse=True)) + r")\b",
+)
+
+# ---------------------------------------------------------------------------
+# Rule ID patterns
+# ---------------------------------------------------------------------------
+
+# Canonical explicit IDs (both R1 and R-001 forms supported):
+#   R1  R-1  R-001  RULE1  RULE-001
+_EXPLICIT_ID_RE = re.compile(r"^(R-?\d+|RULE-?\d+)\b", re.IGNORECASE)
+
+# Candidate "looks like an ID" but malformed:  RR-01  R_001  RULE_003
+_CANDIDATE_ID_RE = re.compile(r"^([A-Z]{1,5}[-_]\w+)\b", re.IGNORECASE)
+
+# Sequential number prefix:  1.  2)  3:
+_SEQ_ID_RE = re.compile(r"^(\d+)[.):\s]")
+
+# Coverage / story reference — matches R1, R-1, R-001, RULE1, etc.
+_COVERAGE_REF_RE = re.compile(r"\b(R-?\d+|RULE-?\d+)\b", re.IGNORECASE)
+
+# Cross-module story Covers:  prompts/foo.prompt#R3  or  foo.prompt#R-001
+_CROSS_MODULE_REF_RE = re.compile(
+    r"([\w./\-]+\.prompt)#(R-?\d+|RULE-?\d+)\b", re.IGNORECASE
+)
+
+# Waiver ID: W1  W-1  W01
+_WAIVER_ID_RE = re.compile(r"^(W-?\d+):", re.IGNORECASE)
+_WAIVER_REF_RE = re.compile(r"\bWAIVED\s+(W-?\d+)\b", re.IGNORECASE)
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Rule:
+    """One parsed rule from <contract_rules>."""
+
+    raw_id: str          # e.g. "R1", "R-001", "S-001", "(unnumbered)"
+    num: Optional[int]   # numeric part for sequential checks; None if unnumbered
+    modal: str           # strongest modal verb found in the rule block
+    line: str            # first (header) line of the rule block
+    block: str           # full multi-line block text
+    is_must_not: bool = False
+
+
+@dataclass
+class Waiver:
+    """One parsed waiver block from <waivers>."""
+
+    raw_id: str                        # e.g. "W1"
+    rule_id: str = ""                  # from "Rule: R<N>"
+    status: str = ""
+    reason: str = ""
+    approved_by: str = ""
+    expires: Optional[date] = None
+    follow_up: str = ""
+    raw_block: str = ""
+
+
+@dataclass
+class ContractIssue:
+    """A single contract-check finding."""
+
+    level: str       # "warn" | "error"
+    code: str        # e.g. "DUPLICATE_ID", "MISSING_MODAL"
+    rule_id: str     # e.g. "R1" or "" if not rule-specific
+    section: str     # e.g. "contract_rules", "coverage"
+    line: str        # verbatim source line (or first line of block)
+    message: str
+    term: str = ""   # matched vague term (populated for VAGUE_TERM issues)
+    suggestion: str = ""
+    interpretations: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "level": self.level,
+            "code": self.code,
+            "rule_id": self.rule_id,
+            "section": self.section,
+            "line": self.line,
+            "message": self.message,
+            "term": self.term,
+            "suggestion": self.suggestion,
+            "interpretations": self.interpretations,
+        }
+
+
+@dataclass
+class ContractResult:
+    """Aggregated check findings for one file."""
+
+    path: Path
+    issues: list[ContractIssue] = field(default_factory=list)
+
+    @property
+    def warn_count(self) -> int:
+        return sum(1 for i in self.issues if i.level == "warn")
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for i in self.issues if i.level == "error")
+
+    def as_dict(self) -> dict:
+        return {
+            "path": str(self.path),
+            "warn_count": self.warn_count,
+            "error_count": self.error_count,
+            "issues": [i.as_dict() for i in self.issues],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Rule extraction (multi-line block parser)
+# ---------------------------------------------------------------------------
+
+def _extract_rules(rules_text: str) -> list[Rule]:
+    """
+    Parse <contract_rules> text into a list of Rule objects.
+
+    Supports the canonical multi-line block format from the prompting guide:
+
+        R1 - Short name
+
+        For every <entity/action>,
+        the system MUST <observable behavior>
+        when <condition>.
+
+        This rule is violated if <specific forbidden outcome>.
+
+    Also supports:
+      - Compact single-line: ``R1: The system MUST …``
+      - Sequential: ``1. The system MUST …``
+      - Unnumbered bullet: ``- The system MUST …``
+
+    Modal verbs and is_must_not are derived from the entire block, so the
+    MUST/MUST NOT can appear on any line of the block.
+    """
+    rules: list[Rule] = []
+    lines = rules_text.splitlines()
+    n = len(lines)
+    i = 0
+
+    while i < n:
+        stripped = lines[i].strip()
+        i += 1
+
+        if not stripped:
+            continue
+
+        # Check if this line starts a rule
+        explicit = _EXPLICIT_ID_RE.match(stripped)
+        seq = _SEQ_ID_RE.match(stripped)
+        is_bullet = stripped.startswith(("-", "*", "•"))
+
+        if not (explicit or seq or is_bullet):
+            continue
+
+        # Determine ID
+        if explicit:
+            raw_id = explicit.group(1).upper()
+            num_str = re.search(r"\d+", raw_id)
+            num = int(num_str.group()) if num_str else None
+        elif seq:
+            num = int(seq.group(1))
+            raw_id = f"S-{num:03d}"
+        else:
+            raw_id = "(unnumbered)"
+            num = None
+
+        # Collect the full block: accumulate continuation lines until we hit
+        # the next rule header or two consecutive blank lines.
+        header_line = stripped
+        block_lines = [stripped]
+        blank_run = 0
+
+        while i < n:
+            next_raw = lines[i]
+            next_stripped = next_raw.strip()
+
+            # Two blank lines end the block
+            if not next_stripped:
+                blank_run += 1
+                if blank_run >= 2:
+                    i += 1
+                    break
+                i += 1
+                continue
+            blank_run = 0
+
+            # A new rule header ends the current block (do NOT consume)
+            if (_EXPLICIT_ID_RE.match(next_stripped) or
+                    _SEQ_ID_RE.match(next_stripped) or
+                    next_stripped.startswith(("-", "*", "•"))):
+                break
+
+            block_lines.append(next_stripped)
+            i += 1
+
+        block = "\n".join(block_lines)
+
+        # Detect modal and is_must_not anywhere in the block
+        modal_match = _MODAL_PATTERN.search(block)
+        modal = modal_match.group(1) if modal_match else ""
+        is_must_not = bool(
+            re.search(r"\bMUST NOT\b|\bSHALL NOT\b|\bMAY NOT\b", block)
+        )
+
+        rules.append(Rule(
+            raw_id=raw_id,
+            num=num,
+            modal=modal,
+            line=header_line,
+            block=block,
+            is_must_not=is_must_not,
+        ))
+
+    return rules
+
+
+# ---------------------------------------------------------------------------
+# Waiver extraction
+# ---------------------------------------------------------------------------
+
+def _extract_waivers(waivers_text: str) -> list[Waiver]:
+    """
+    Parse <waivers> text into a list of Waiver objects.
+
+    Expected format:
+        W1:
+          Rule: R6
+          Status: temporary
+          Reason: Provider error fixture is not available yet.
+          Approved by: security-review
+          Expires: 2026-06-01
+          Follow-up: Add story__provider_secret_not_leaked.md and executable test.
+    """
+    waivers: list[Waiver] = []
+    current_id: Optional[str] = None
+    current_fields: dict[str, str] = {}
+    current_block_lines: list[str] = []
+
+    def _flush() -> None:
+        if current_id is None:
+            return
+        w = Waiver(
+            raw_id=current_id,
+            rule_id=current_fields.get("rule", ""),
+            status=current_fields.get("status", ""),
+            reason=current_fields.get("reason", ""),
+            approved_by=current_fields.get("approved by", ""),
+            follow_up=current_fields.get("follow-up", ""),
+            raw_block="\n".join(current_block_lines),
+        )
+        expires_str = current_fields.get("expires", "")
+        if expires_str:
+            try:
+                w.expires = date.fromisoformat(expires_str.strip())
+            except ValueError:
+                pass
+        waivers.append(w)
+
+    for line in waivers_text.splitlines():
+        stripped = line.strip()
+        waiver_hdr = _WAIVER_ID_RE.match(stripped)
+        if waiver_hdr:
+            _flush()
+            current_id = waiver_hdr.group(1).upper()
+            current_fields = {}
+            current_block_lines = [stripped]
+            continue
+        if current_id is not None:
+            current_block_lines.append(stripped)
+            kv = re.match(r"^([A-Za-z][A-Za-z\s\-]*?):\s*(.+)$", stripped)
+            if kv:
+                current_fields[kv.group(1).strip().lower()] = kv.group(2).strip()
+
+    _flush()
+    return waivers
+
+
+# ---------------------------------------------------------------------------
+# Individual check functions
+# ---------------------------------------------------------------------------
+
+def _check_duplicate_ids(rules: list[Rule]) -> list[ContractIssue]:
+    """Emit DUPLICATE_ID error when the same ID appears more than once."""
+    issues: list[ContractIssue] = []
+    seen: dict[str, int] = {}
+    for rule in rules:
+        rid = rule.raw_id
+        if rid == "(unnumbered)":
+            continue
+        if rid in seen:
+            issues.append(ContractIssue(
+                level="error",
+                code="DUPLICATE_ID",
+                rule_id=rid,
+                section="contract_rules",
+                line=rule.line,
+                message=f'Rule ID "{rid}" appears more than once in <contract_rules>.',
+                suggestion="Assign a unique ID to each rule. Rename or remove the duplicate.",
+            ))
+        else:
+            seen[rid] = 1
+    return issues
+
+
+def _check_malformed_ids(rules_text: str) -> list[ContractIssue]:
+    """
+    Emit MALFORMED_ID error for lines that start with something that looks like
+    an ID prefix but does not match any canonical form.
+    """
+    issues: list[ContractIssue] = []
+    for line in rules_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        # Skip lines that are already valid
+        if _EXPLICIT_ID_RE.match(stripped) or _SEQ_ID_RE.match(stripped):
+            continue
+        if stripped.startswith(("-", "*", "•")):
+            continue
+        # Check for candidate malformed prefixes: RR-01, R_001, RULE_1
+        cand = _CANDIDATE_ID_RE.match(stripped)
+        if cand:
+            raw = cand.group(1)
+            if not _EXPLICIT_ID_RE.match(stripped):
+                issues.append(ContractIssue(
+                    level="error",
+                    code="MALFORMED_ID",
+                    rule_id=raw,
+                    section="contract_rules",
+                    line=stripped,
+                    message=(
+                        f'Rule prefix "{raw}" does not match the canonical ID format. '
+                        f'Use "R1 -", "R1:", "R-001:", … or plain "1.", "2." sequential numbering.'
+                    ),
+                    suggestion='Rename to "R<N> - Short name" or use sequential numbering.',
+                ))
+    return issues
+
+
+def _check_sequential_ids(rules: list[Rule]) -> list[ContractIssue]:
+    """
+    Warn (not error) when explicit R<N> IDs have a numeric gap.
+    Only applies when rules use consistent explicit IDs.
+    """
+    issues: list[ContractIssue] = []
+    explicit_rules = [r for r in rules if r.raw_id not in ("(unnumbered)",)
+                      and r.num is not None]
+    if not explicit_rules:
+        return issues
+
+    nums = sorted(set(r.num for r in explicit_rules if r.num is not None))
+    for i in range(1, len(nums)):
+        if nums[i] != nums[i - 1] + 1:
+            issues.append(ContractIssue(
+                level="warn",
+                code="NON_SEQUENTIAL_ID",
+                rule_id=f"R{nums[i]}",
+                section="contract_rules",
+                line="",
+                message=(
+                    f"Rule IDs jump from {nums[i-1]} to {nums[i]}; "
+                    f"one or more IDs may have been deleted or misnumbered."
+                ),
+                suggestion="Renumber rules sequentially or add a comment explaining the gap.",
+            ))
+    return issues
+
+
+def _check_missing_modal(rules: list[Rule], *, strict: bool) -> list[ContractIssue]:
+    """Emit MISSING_MODAL for rules that lack a recognised modal verb."""
+    issues: list[ContractIssue] = []
+    for rule in rules:
+        if rule.modal:
+            continue
+        if rule.raw_id == "(unnumbered)" and not rule.line.lstrip("-* "):
+            continue
+        level = "error" if strict else "warn"
+        issues.append(ContractIssue(
+            level=level,
+            code="MISSING_MODAL",
+            rule_id=rule.raw_id,
+            section="contract_rules",
+            line=rule.line,
+            message=(
+                f'Rule [{rule.raw_id}] has no modal verb '
+                f'(MUST / MUST NOT / MAY / SHOULD / DOES NOT).'
+            ),
+            suggestion='Add a modal verb: "The system MUST …" or "The service MUST NOT …".',
+        ))
+    return issues
+
+
+def _check_vague_terms(
+    rules_text: str,
+    vocab_terms: set[str],
+    *,
+    strict: bool,
+) -> list[ContractIssue]:
+    """
+    Warn when a rule line uses a known vague phrase not covered by <vocabulary>.
+    Reuses the VAGUE_TERMS frozenset and vocabulary suppression from prompt_lint.
+    """
+    issues: list[ContractIssue] = []
+    _vague_pat = re.compile(
+        r"\b(" + "|".join(re.escape(t) for t in sorted(VAGUE_TERMS)) + r")\b",
+        re.IGNORECASE,
+    )
+    for line in rules_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        matches = {m.lower() for m in _vague_pat.findall(stripped)}
+        undefined = matches - vocab_terms
+        for term in sorted(undefined):
+            issues.append(ContractIssue(
+                level="warn",
+                code="VAGUE_TERM",
+                rule_id="",
+                section="contract_rules",
+                line=stripped,
+                message=(
+                    f'Vague term "{term}" used in <contract_rules> without a '
+                    f"<vocabulary> definition."
+                ),
+                term=term,
+                suggestion=f"{term}: <add a precise, observable definition here>",
+            ))
+    return issues
+
+
+def _check_coverage_entries(
+    coverage_text: str,
+    known_ids: set[str],
+    known_waiver_ids: set[str],
+) -> list[ContractIssue]:
+    """
+    Validate <coverage> entries. Three entry types are recognised:
+
+        R1: story__refund_invalid_amount.md   → validate ID exists
+        R4: TODO add idempotency story        → UNCHECKED_RULE warn
+        R6: WAIVED W1                         → validate W1 in <waivers>
+    """
+    issues: list[ContractIssue] = []
+    for line in coverage_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        # Find the leading rule ID (may or may not be present)
+        id_match = _COVERAGE_REF_RE.match(stripped.lstrip("-* "))
+        if not id_match:
+            continue
+        ref_id = id_match.group(1).upper()
+
+        # Everything after the first ":" is the evidence text
+        colon_pos = stripped.find(":")
+        evidence = stripped[colon_pos + 1:].strip() if colon_pos != -1 else ""
+
+        # Unknown rule ID
+        if ref_id not in known_ids:
+            issues.append(ContractIssue(
+                level="error",
+                code="UNKNOWN_COVERAGE_REF",
+                rule_id=ref_id,
+                section="coverage",
+                line=stripped,
+                message=(
+                    f'<coverage> references rule ID "{ref_id}" which does not '
+                    f"exist in <contract_rules>."
+                ),
+                suggestion=(
+                    f"Add a rule with ID {ref_id} to <contract_rules>, or remove "
+                    f"this coverage entry."
+                ),
+            ))
+            continue
+
+        # TODO entry
+        if evidence.upper().startswith("TODO"):
+            issues.append(ContractIssue(
+                level="warn",
+                code="UNCHECKED_RULE",
+                rule_id=ref_id,
+                section="coverage",
+                line=stripped,
+                message=(
+                    f'Rule [{ref_id}] coverage is marked TODO. '
+                    f"Add a story, test, or waiver before production use."
+                ),
+                suggestion=(
+                    f"Replace 'TODO' with: a story filename, an executable test name, "
+                    f"or 'WAIVED W<N>' with a corresponding <waivers> entry."
+                ),
+            ))
+            continue
+
+        # WAIVED entry — cross-reference against <waivers>
+        waived_match = _WAIVER_REF_RE.search(evidence)
+        if waived_match:
+            waiver_id = waived_match.group(1).upper()
+            if waiver_id not in known_waiver_ids:
+                issues.append(ContractIssue(
+                    level="error",
+                    code="WAIVER_REF_MISSING",
+                    rule_id=ref_id,
+                    section="coverage",
+                    line=stripped,
+                    message=(
+                        f'Coverage for rule [{ref_id}] cites waiver "{waiver_id}" '
+                        f"which has no corresponding entry in <waivers>."
+                    ),
+                    suggestion=(
+                        f"Add a W{waiver_id.lstrip('W').lstrip('-')} block to <waivers>, "
+                        f"or remove the WAIVED reference."
+                    ),
+                ))
+
+    return issues
+
+
+def _check_must_not_coverage(
+    rules: list[Rule],
+    coverage_text: str,
+) -> list[ContractIssue]:
+    """
+    Warn when a MUST NOT rule has no evidence in <coverage>.
+    Only fires when a <coverage> section is present at all.
+    """
+    issues: list[ContractIssue] = []
+    covered_ids: set[str] = set()
+    for m in _COVERAGE_REF_RE.finditer(coverage_text):
+        covered_ids.add(m.group(1).upper())
+
+    for rule in rules:
+        if not rule.is_must_not:
+            continue
+        rid = rule.raw_id
+        if rid == "(unnumbered)":
+            continue
+        if rid.upper() not in covered_ids:
+            issues.append(ContractIssue(
+                level="warn",
+                code="UNCOVERED_MUST_NOT",
+                rule_id=rid,
+                section="contract_rules",
+                line=rule.line,
+                message=(
+                    f'High-risk rule [{rid}] uses MUST NOT but has no entry in '
+                    f"<coverage>. Add a test, story, or waiver reference."
+                ),
+                suggestion=(
+                    f"In <coverage>, add: {rid}: <test name, story filename, or WAIVED W<N>>"
+                ),
+            ))
+    return issues
+
+
+def _check_waivers(waivers_text: str) -> list[ContractIssue]:
+    """
+    Validate <waivers> blocks:
+      - MISSING_WAIVER_FIELDS warn: missing Rule, Reason, Approved by, or Expires
+      - EXPIRED_WAIVER warn: Expires date is in the past
+    """
+    issues: list[ContractIssue] = []
+    required_fields = ("rule", "reason", "approved by", "expires")
+
+    for waiver in _extract_waivers(waivers_text):
+        # Check required fields
+        fields_present = {
+            "rule": bool(waiver.rule_id),
+            "reason": bool(waiver.reason),
+            "approved by": bool(waiver.approved_by),
+            "expires": bool(waiver.expires is not None or
+                            re.search(r"expires\s*:", waiver.raw_block, re.IGNORECASE)),
+        }
+        missing = [f for f in required_fields if not fields_present.get(f, False)]
+        if missing:
+            issues.append(ContractIssue(
+                level="warn",
+                code="MISSING_WAIVER_FIELDS",
+                rule_id=waiver.raw_id,
+                section="waivers",
+                line=f"{waiver.raw_id}:",
+                message=(
+                    f'Waiver [{waiver.raw_id}] is missing required fields: '
+                    f'{", ".join(missing)}.'
+                ),
+                suggestion=(
+                    "Add all required fields: Rule, Reason, Approved by, Expires."
+                ),
+            ))
+
+        # Check expiry
+        if waiver.expires is not None and waiver.expires < date.today():
+            issues.append(ContractIssue(
+                level="warn",
+                code="EXPIRED_WAIVER",
+                rule_id=waiver.raw_id,
+                section="waivers",
+                line=f"Expires: {waiver.expires.isoformat()}",
+                message=(
+                    f'Waiver [{waiver.raw_id}] for rule [{waiver.rule_id}] expired on '
+                    f"{waiver.expires.isoformat()}."
+                ),
+                suggestion=(
+                    "Extend the waiver expiry date, add a story/test to close it, "
+                    "or remove the waiver if the rule is now covered."
+                ),
+            ))
+
+    return issues
+
+
+def _check_capabilities_modals(capabilities_text: str) -> list[ContractIssue]:
+    """
+    Emit MISSING_MODAL warn for <capabilities> lines that lack a modal verb.
+    Capability lines should use MAY / MUST NOT / MUST / SHOULD.
+    Comment/blank lines and lines starting with '#' are skipped.
+    """
+    issues: list[ContractIssue] = []
+    for line in capabilities_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not _MODAL_PATTERN.search(stripped):
+            issues.append(ContractIssue(
+                level="warn",
+                code="MISSING_MODAL",
+                rule_id="",
+                section="capabilities",
+                line=stripped,
+                message=(
+                    f'Capability line has no modal verb (MAY / MUST NOT / MUST / SHOULD): '
+                    f'"{stripped[:80]}"'
+                ),
+                suggestion='Use a modal: "- MAY read …", "- MUST NOT call …".',
+            ))
+    return issues
+
+
+def _check_story_covers(
+    story_text: str,
+    story_path: Path,
+    linked_prompt_rules: Optional[dict[str, set[str]]],
+) -> list[ContractIssue]:
+    """
+    Check ## Covers entries in a user story.
+
+    Handles both formats from the prompting guide:
+      Single-prompt:    - R1: rule name
+      Cross-module:     - prompts/foo.prompt#R3: rule name
+
+    If linked_prompt_rules is provided (maps prompt filename → set of known IDs),
+    also verify that referenced IDs exist in the linked prompt.
+    """
+    issues: list[ContractIssue] = []
+    sections = _extract_sections(story_text)
+    covers_text = sections.get("covers", "")
+    if not covers_text:
+        return issues
+
+    for line in covers_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        if linked_prompt_rules is None:
+            continue
+
+        # Cross-module format: prompts/foo.prompt#R3
+        cross_matches = list(_CROSS_MODULE_REF_RE.finditer(stripped))
+        if cross_matches:
+            for m in cross_matches:
+                prompt_file = m.group(1).rsplit("/", 1)[-1]  # basename
+                ref_id = m.group(2).upper()
+                prompt_ids = linked_prompt_rules.get(prompt_file, set())
+                if not prompt_ids:
+                    # Try matching any prompt in the map
+                    prompt_ids = next(
+                        (ids for k, ids in linked_prompt_rules.items()
+                         if k.endswith(prompt_file)),
+                        set(),
+                    )
+                if prompt_ids and ref_id not in prompt_ids:
+                    issues.append(ContractIssue(
+                        level="warn",
+                        code="UNKNOWN_STORY_REF",
+                        rule_id=ref_id,
+                        section="covers",
+                        line=stripped,
+                        message=(
+                            f'Story ## Covers references rule ID "{ref_id}" in '
+                            f'"{prompt_file}" which was not found in that prompt\'s '
+                            f"<contract_rules>."
+                        ),
+                        suggestion=(
+                            f"Add rule {ref_id} to {prompt_file}'s <contract_rules>, "
+                            f"or remove this ## Covers entry."
+                        ),
+                    ))
+        else:
+            # Single-prompt format: - R1: rule name
+            for m in _COVERAGE_REF_RE.finditer(stripped):
+                ref_id = m.group(1).upper()
+                found_in_any = any(ref_id in ids for ids in linked_prompt_rules.values())
+                if not found_in_any:
+                    issues.append(ContractIssue(
+                        level="warn",
+                        code="UNKNOWN_STORY_REF",
+                        rule_id=ref_id,
+                        section="covers",
+                        line=stripped,
+                        message=(
+                            f'Story ## Covers references rule ID "{ref_id}" which was '
+                            f"not found in any linked prompt's <contract_rules>."
+                        ),
+                        suggestion=(
+                            f"Add rule {ref_id} to the linked prompt's <contract_rules>, "
+                            f"or remove this ## Covers entry."
+                        ),
+                    ))
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Top-level check functions
+# ---------------------------------------------------------------------------
+
+def check_prompt(path: Path, *, strict: bool = False) -> ContractResult:
+    """
+    Run all deterministic checks on a single prompt file.
+
+    Returns a ContractResult with zero issues for prompts that have no
+    contract sections (legacy prompts without structure are never hard-failed).
+    """
+    result = ContractResult(path=path)
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        result.issues.append(ContractIssue(
+            level="error",
+            code="FILE_NOT_FOUND",
+            rule_id="",
+            section="",
+            line="",
+            message=f'File not found: "{path}".',
+        ))
+        return result
+
+    sections = _extract_sections(text)
+
+    # If no contract sections are present at all, return clean (legacy safety)
+    contract_sections = {
+        "contract_rules", "vocabulary", "capabilities",
+        "coverage", "non_responsibilities", "waivers",
+    }
+    if not any(k in sections for k in contract_sections):
+        return result
+
+    rules_text = sections.get("contract_rules", "")
+    coverage_text = sections.get("coverage", "")
+    waivers_text = sections.get("waivers", "")
+    capabilities_text = sections.get("capabilities", "")
+
+    # Build vocabulary terms from all vocabulary sections
+    vocab_terms: set[str] = set()
+    for key in ("vocabulary", "glossary", "definitions", "covers"):
+        if key in sections:
+            vocab_terms |= _extract_vocabulary_terms(sections[key])
+
+    # Parse rules and waivers
+    rules = _extract_rules(rules_text) if rules_text else []
+    known_ids: set[str] = {r.raw_id.upper() for r in rules
+                           if r.raw_id not in ("(unnumbered)",)}
+    waivers = _extract_waivers(waivers_text) if waivers_text else []
+    known_waiver_ids: set[str] = {w.raw_id.upper() for w in waivers}
+
+    if rules_text:
+        result.issues.extend(_check_duplicate_ids(rules))
+        result.issues.extend(_check_malformed_ids(rules_text))
+        result.issues.extend(_check_sequential_ids(rules))
+        result.issues.extend(_check_missing_modal(rules, strict=strict))
+        result.issues.extend(_check_vague_terms(rules_text, vocab_terms, strict=strict))
+
+    if coverage_text:
+        result.issues.extend(
+            _check_coverage_entries(coverage_text, known_ids, known_waiver_ids)
+        )
+        result.issues.extend(_check_must_not_coverage(rules, coverage_text))
+
+    if waivers_text:
+        result.issues.extend(_check_waivers(waivers_text))
+
+    if capabilities_text:
+        result.issues.extend(_check_capabilities_modals(capabilities_text))
+
+    # Escalate warns to errors in strict mode
+    if strict:
+        for issue in result.issues:
+            issue.level = "error"
+
+    return result
+
+
+def check_directory(directory: Path, *, strict: bool = False) -> list[ContractResult]:
+    """Run check_prompt on every *.prompt file under a directory (recursive)."""
+    results: list[ContractResult] = []
+    for p in sorted(directory.rglob("*.prompt")):
+        results.append(check_prompt(p, strict=strict))
+    return results
+
+
+def check_stories(
+    stories_dir: Path,
+    prompts_dir: Optional[Path] = None,
+    *,
+    strict: bool = False,
+) -> list[ContractResult]:
+    """
+    Check story__*.md files for ## Covers rule-ID validity.
+
+    If prompts_dir is provided, cross-references IDs against the prompt files
+    named in the story's <!-- pdd-story-prompts: … --> metadata comment.
+    """
+    results: list[ContractResult] = []
+    if not stories_dir.exists():
+        return results
+
+    # Build prompt ID map if prompts_dir given
+    prompt_id_map: dict[str, set[str]] = {}
+    if prompts_dir and prompts_dir.exists():
+        for p in prompts_dir.rglob("*.prompt"):
+            try:
+                text = p.read_text(encoding="utf-8")
+                secs = _extract_sections(text)
+                rules_text = secs.get("contract_rules", "")
+                if rules_text:
+                    rules = _extract_rules(rules_text)
+                    prompt_id_map[p.name] = {
+                        r.raw_id.upper() for r in rules
+                        if r.raw_id not in ("(unnumbered)",)
+                    }
+            except Exception:  # noqa: BLE001
+                pass
+
+    for story_path in sorted(stories_dir.rglob("story__*.md")):
+        result = ContractResult(path=story_path)
+        try:
+            story_text = story_path.read_text(encoding="utf-8")
+        except Exception:  # noqa: BLE001
+            continue
+
+        linked: Optional[dict[str, set[str]]] = None
+        if prompt_id_map:
+            # Look for <!-- pdd-story-prompts: foo.prompt, bar.prompt -->
+            meta_match = re.search(
+                r"<!--\s*pdd-story-prompts:\s*([^>]+)-->", story_text
+            )
+            if meta_match:
+                names = [n.strip() for n in meta_match.group(1).split(",")]
+                linked = {n: prompt_id_map.get(n, set()) for n in names}
+            else:
+                linked = prompt_id_map  # check against all known prompts
+
+        issues = _check_story_covers(story_text, story_path, linked)
+        if strict:
+            for issue in issues:
+                issue.level = "error"
+        result.issues.extend(issues)
+        results.append(result)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Optional LLM ambiguity pass
+# ---------------------------------------------------------------------------
+
+def run_llm_ambiguity_pass(
+    path: Path,
+    strength: float = 0.5,
+    temperature: float = 0.0,
+    time: Optional[float] = None,
+    verbose: bool = False,
+) -> list[ContractIssue]:
+    """
+    Run an LLM review of ambiguous terms in <contract_rules> and suggest
+    <vocabulary> definitions.
+
+    This is a best-effort enhancement; failures are logged and an empty list
+    is returned so that CI is never blocked.
+    """
+    try:
+        from .llm_invoke import llm_invoke
+        from .preprocess import preprocess
+    except ImportError:
+        logger.warning("LLM dependencies not available; skipping ambiguity pass.")
+        return []
+
+    try:
+        text = path.read_text(encoding="utf-8")
+        sections = _extract_sections(text)
+        rules_text = sections.get("contract_rules", "")
+        if not rules_text:
+            return []
+
+        # Build a list of vague terms actually present
+        _vague_pat = re.compile(
+            r"\b(" + "|".join(re.escape(t) for t in sorted(VAGUE_TERMS)) + r")\b",
+            re.IGNORECASE,
+        )
+        found_terms = sorted({m.lower() for m in _vague_pat.findall(rules_text)})
+        if not found_terms:
+            return []
+
+        prompt_template_path = (
+            Path(__file__).parent / "prompts" / "contract_check_LLM.prompt"
+        )
+        template = prompt_template_path.read_text(encoding="utf-8")
+        filled = template.replace("{contract_content}", rules_text).replace(
+            "{vague_terms_list}", ", ".join(found_terms)
+        )
+        filled = preprocess(filled, recursive=False, double_curly_brackets=False)
+
+        result = llm_invoke(
+            messages=[{"role": "user", "content": filled}],
+            strength=strength,
+            temperature=temperature,
+            time=time,
+            verbose=verbose,
+        )
+        data = json.loads(result["result"])
+        issues: list[ContractIssue] = []
+        for entry in data:
+            issues.append(ContractIssue(
+                level="warn",
+                code="LLM_AMBIGUITY",
+                rule_id="",
+                section="llm",
+                line="",
+                message=f'LLM flagged "{entry.get("term", "")}" as potentially ambiguous.',
+                suggestion=entry.get("suggestion", ""),
+                interpretations=entry.get("interpretations", []),
+            ))
+        return issues
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("LLM ambiguity pass failed: %s", exc)
+        return []

--- a/pdd/prompt_lint.py
+++ b/pdd/prompt_lint.py
@@ -434,7 +434,7 @@ def scan_stories(stories_dir: Path, *, strict: bool = False) -> list[LintResult]
         return []
     return [
         scan_prompt(story_path, strict=strict)
-        for story_path in sorted(stories_dir.glob("story__*.md"))
+        for story_path in sorted(stories_dir.rglob("story__*.md"))
     ]
 
 
@@ -516,13 +516,14 @@ def run_llm_ambiguity_pass(
         )
         filled = preprocess(filled, recursive=False, double_curly_brackets=False)
 
-        response_text, _cost, _model = llm_invoke(
-            filled,
+        result = llm_invoke(
+            messages=[{"role": "user", "content": filled}],
             strength=strength,
             temperature=temperature,
             time=time,
             verbose=verbose,
         )
+        response_text = result["result"]
 
         # Strip optional markdown code fences
         json_match = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", response_text, re.DOTALL)

--- a/pdd/prompt_lint.py
+++ b/pdd/prompt_lint.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 """
 Prompt and user-story lint engine.
 
@@ -134,6 +135,7 @@ class LintIssue:
     interpretations: list[str] = field(default_factory=list)  # LLM-sourced readings
 
     def as_dict(self) -> dict:
+        """Serialise this issue to a JSON-safe dictionary."""
         return {
             "level": self.level,
             "term": self.term,
@@ -154,13 +156,16 @@ class LintResult:
 
     @property
     def warn_count(self) -> int:
+        """Count of warning-level issues."""
         return sum(1 for i in self.issues if i.level == "warn")
 
     @property
     def error_count(self) -> int:
+        """Count of error-level issues."""
         return sum(1 for i in self.issues if i.level == "error")
 
     def as_dict(self) -> dict:
+        """Serialise this result to a JSON-safe dictionary."""
         return {
             "path": str(self.path),
             "warn_count": self.warn_count,
@@ -176,9 +181,9 @@ class LintResult:
 def _extract_xml_sections(text: str) -> dict[str, str]:
     """Return tag-name → inner text for all XML-style sections found."""
     sections: dict[str, str] = {}
-    for m in _XML_SECTION_RE.finditer(text):
-        tag = m.group("tag").lower()
-        body = m.group("body")
+    for section_match in _XML_SECTION_RE.finditer(text):
+        tag = section_match.group("tag").lower()
+        body = section_match.group("body")
         # Last occurrence wins for duplicate tags
         sections[tag] = body
     return sections
@@ -288,12 +293,12 @@ def _extract_vocabulary_terms(vocab_text: str) -> set[str]:
             continue
 
         # Standard: "term: ..." or "- term: ..." or "* term: ..." or "term - ..."
-        m = re.match(
+        term_match = re.match(
             r"^[-*]?\s*([A-Za-z][A-Za-z0-9 _-]*?)\s*(?::\s|\s+-\s)",
             stripped,
         )
-        if m:
-            phrase = m.group(1).strip().lower()
+        if term_match:
+            phrase = term_match.group(1).strip().lower()
             terms.add(phrase)
             # Also add each individual word so "valid response" covers "valid"
             for word in re.split(r"[\s_-]+", phrase):
@@ -385,17 +390,17 @@ def scan_prompt(path: Path, *, strict: bool = False) -> LintResult:
 
     # Collect vocabulary terms from all vocabulary-source sections
     vocab_terms: set[str] = set()
-    for vk in _VOCABULARY_SECTIONS:
-        if vk in sections:
-            vocab_terms |= _extract_vocabulary_terms(sections[vk])
+    for vocab_key in _VOCABULARY_SECTIONS:
+        if vocab_key in sections:
+            vocab_terms |= _extract_vocabulary_terms(sections[vocab_key])
 
     # Prose (% lines) is only meaningful contract text when the file also has at
     # least one structured contract section.  Without this gate, LLM instruction
     # prompts that use % for their body text produce hundreds of false positives.
-    _CONTRACT_SECTIONS = frozenset({
+    contract_sections = frozenset({
         "contract_rules", "requirements", "acceptance_tests", "acceptance criteria"
     })
-    has_contract_section = any(k in sections for k in _CONTRACT_SECTIONS)
+    has_contract_section = any(k in sections for k in contract_sections)
 
     # Scan recognised content sections only (skip architecture metadata)
     found_any_section = False
@@ -483,7 +488,7 @@ def apply_suggestions(path: Path, issues: list[LintIssue]) -> int:
 # Optional LLM ambiguity pass
 # ---------------------------------------------------------------------------
 
-def run_llm_ambiguity_pass(
+def run_llm_ambiguity_pass(  # pylint: disable=too-many-locals
     path: Path,
     strength: float = 0.5,
     temperature: float = 0.0,
@@ -499,8 +504,8 @@ def run_llm_ambiguity_pass(
     Safe to call: always returns [] on any error so CI never breaks on LLM failure.
     """
     try:
-        from .llm_invoke import llm_invoke
-        from .preprocess import preprocess
+        from .llm_invoke import llm_invoke  # pylint: disable=import-outside-toplevel
+        from .preprocess import preprocess  # pylint: disable=import-outside-toplevel
 
         template_path = Path(__file__).parent / "prompts" / "prompt_lint_LLM.prompt"
         if not template_path.exists():
@@ -545,6 +550,6 @@ def run_llm_ambiguity_pass(
             ))
         return issues
 
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         logger.warning("prompt_lint LLM pass failed: %s", exc)
         return []

--- a/pdd/prompt_lint.py
+++ b/pdd/prompt_lint.py
@@ -1,0 +1,549 @@
+"""
+Prompt and user-story lint engine.
+
+Detects vague/ambiguous terms in <contract_rules>, <requirements>,
+<acceptance_tests>, and user-story acceptance criteria. Optionally runs an
+LLM pass to suggest vocabulary definitions.
+
+Public API
+----------
+scan_prompt(path, *, strict=False) -> LintResult
+scan_stories(stories_dir, *, strict=False) -> list[LintResult]
+apply_suggestions(path, issues) -> int
+run_llm_ambiguity_pass(path, strength, temperature, time, verbose) -> list[LintIssue]
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Vocabulary of known vague terms
+# ---------------------------------------------------------------------------
+
+# Core vague terms: genuinely ambiguous in behavioral contracts; always checked.
+VAGUE_TERMS: frozenset[str] = frozenset({
+    "valid",
+    "invalid",
+    "safe",
+    "unsafe",
+    "active",
+    "inactive",
+    "recent",
+    "duplicate",
+    "graceful",
+    "reasonable",
+    "authorized",
+    "unauthorized",
+    "trusted",
+    "untrusted",
+    "complete",
+    "successful",
+})
+
+# Extended vague terms: common English words that are only meaningfully ambiguous
+# in tightly scoped contract text.  Only checked in --strict mode to avoid noise
+# in LLM instruction prompts and general requirements prose.
+VAGUE_TERMS_STRICT: frozenset[str] = frozenset({
+    "incomplete",
+    "proper",
+    "correct",
+    "incorrect",
+    "appropriate",
+    "normal",
+    "expected",
+    "unexpected",
+    "sufficient",
+    "necessary",
+})
+
+# Verbs that signal an observable, measurable outcome
+OBSERVABLE_VERBS: frozenset[str] = frozenset({
+    "return", "returns", "returned",
+    "raise", "raises", "raised",
+    "write", "writes", "wrote",
+    "emit", "emits", "emitted",
+    "log", "logs", "logged",
+    "exit", "exits", "exited",
+    "reject", "rejects", "rejected",
+    "produce", "produces", "produced",
+    "store", "stores", "stored",
+    "increment", "increments", "incremented",
+    "decrement", "decrements", "decremented",
+    "set", "sets",
+    "clear", "clears", "cleared",
+    "yield", "yields", "yielded",
+    "throw", "throws", "threw",
+    "save", "saves", "saved",
+    "delete", "deletes", "deleted",
+    "output", "outputs", "outputted",
+    "append", "appends", "appended",
+    "insert", "inserts", "inserted",
+    "update", "updates", "updated",
+    "remove", "removes", "removed",
+    "send", "sends", "sent",
+    "publish", "publishes", "published",
+})
+
+# Pre-compiled patterns: core terms (always) and extended terms (--strict only)
+_VAGUE_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(t) for t in sorted(VAGUE_TERMS)) + r")\b",
+    re.IGNORECASE,
+)
+_VAGUE_PATTERN_STRICT = re.compile(
+    r"\b(" + "|".join(re.escape(t) for t in sorted(VAGUE_TERMS | VAGUE_TERMS_STRICT)) + r")\b",
+    re.IGNORECASE,
+)
+
+# Observable-outcome verb pattern
+_OBSERVABLE_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(v) for v in sorted(OBSERVABLE_VERBS)) + r")\b",
+    re.IGNORECASE,
+)
+
+# XML-style section extractor: captures content between <tag> … </tag>
+_XML_SECTION_RE = re.compile(
+    r"<(?P<tag>[a-z_][a-z0-9_]*)>(?P<body>.*?)</(?P=tag)>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Markdown heading (up to ###)
+_MD_HEADING_RE = re.compile(r"^(#{1,3})\s+(.+)$", re.MULTILINE)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LintIssue:
+    """A single lint finding."""
+
+    level: str                                          # "warn" or "error"
+    term: str                                           # matched vague term
+    section: str                                        # section where found
+    line: str                                           # original line text
+    message: str                                        # human-readable description
+    suggestion: str = ""                                # proposed <vocabulary> entry
+    interpretations: list[str] = field(default_factory=list)  # LLM-sourced readings
+
+    def as_dict(self) -> dict:
+        return {
+            "level": self.level,
+            "term": self.term,
+            "section": self.section,
+            "line": self.line,
+            "message": self.message,
+            "suggestion": self.suggestion,
+            "interpretations": self.interpretations,
+        }
+
+
+@dataclass
+class LintResult:
+    """Aggregated lint findings for one file."""
+
+    path: Path
+    issues: list[LintIssue] = field(default_factory=list)
+
+    @property
+    def warn_count(self) -> int:
+        return sum(1 for i in self.issues if i.level == "warn")
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for i in self.issues if i.level == "error")
+
+    def as_dict(self) -> dict:
+        return {
+            "path": str(self.path),
+            "warn_count": self.warn_count,
+            "error_count": self.error_count,
+            "issues": [i.as_dict() for i in self.issues],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Section extraction helpers
+# ---------------------------------------------------------------------------
+
+def _extract_xml_sections(text: str) -> dict[str, str]:
+    """Return tag-name → inner text for all XML-style sections found."""
+    sections: dict[str, str] = {}
+    for m in _XML_SECTION_RE.finditer(text):
+        tag = m.group("tag").lower()
+        body = m.group("body")
+        # Last occurrence wins for duplicate tags
+        sections[tag] = body
+    return sections
+
+
+def _extract_markdown_sections(text: str) -> dict[str, str]:
+    """Return lowered-heading → body for all markdown ## / ### headings."""
+    headings = list(_MD_HEADING_RE.finditer(text))
+    sections: dict[str, str] = {}
+    for idx, match in enumerate(headings):
+        heading_text = match.group(2).strip().lower()
+        start = match.end()
+        end = headings[idx + 1].start() if idx + 1 < len(headings) else len(text)
+        sections[heading_text] = text[start:end].strip()
+    return sections
+
+
+def _extract_prose_lines(text: str) -> str:
+    """Return text from lines that use the PDD % comment convention."""
+    return "\n".join(
+        line.lstrip()[1:].strip()
+        for line in text.splitlines()
+        if line.lstrip().startswith("%")
+    )
+
+
+def _extract_sections(text: str) -> dict[str, str]:
+    """
+    Extract all scannable sections from prompt or story text.
+
+    Recognised section names (keys in returned dict):
+      contract_rules, requirements, acceptance_tests, vocabulary  (XML tags)
+      acceptance criteria, glossary, definitions, covers          (Markdown headings)
+      prose                                                        (% lines)
+    """
+    sections: dict[str, str] = {}
+    sections.update(_extract_xml_sections(text))
+    sections.update(_extract_markdown_sections(text))
+    prose = _extract_prose_lines(text)
+    if prose:
+        sections["prose"] = prose
+    return sections
+
+
+_SCANNABLE_SECTIONS: frozenset[str] = frozenset({
+    "contract_rules",
+    "requirements",
+    "acceptance_tests",
+    "acceptance criteria",
+    "prose",
+})
+
+# Architecture metadata and structural sections whose content is NOT contract text
+# and must never be scanned for vague terms.
+_NON_SCANNABLE_SECTIONS: frozenset[str] = frozenset({
+    "pdd-reason",
+    "pdd-interface",
+    "pdd-dependency",
+    "waivers",
+    "deliverables",
+    "dependencies",
+})
+
+_VOCABULARY_SECTIONS: frozenset[str] = frozenset({
+    "vocabulary",
+    "glossary",
+    "definitions",
+    "covers",
+})
+
+# Sections where we additionally check for observable-outcome verbs
+_OBSERVABLE_CHECK_SECTIONS: frozenset[str] = frozenset({
+    "contract_rules",
+    "acceptance_tests",
+    "acceptance criteria",
+})
+
+
+def _extract_vocabulary_terms(vocab_text: str) -> set[str]:
+    """
+    Extract defined term names from a vocabulary/glossary/covers block.
+
+    Heuristic: a line whose leading token (after optional bullet) is followed
+    by `:` or ` - ` is treated as a definition. Both the full phrase AND each
+    individual word in the phrase are added as known terms, so that "valid
+    response" in vocabulary suppresses the warning for the word "valid".
+
+    Also handles the cross-module ## Covers format:
+        - prompts/payment_python.prompt#R3: No provider call before validation
+    The descriptive text after the colon is treated as a known term phrase.
+    """
+    terms: set[str] = set()
+    for line in vocab_text.splitlines():
+        stripped = line.strip()
+
+        # Cross-module Covers: - prompts/foo.prompt#R3: term phrase
+        cross = re.match(
+            r"^[-*]?\s*[\w./\-]+\.prompt#[A-Za-z0-9\-]+\s*:\s*(.+)$",
+            stripped,
+        )
+        if cross:
+            phrase = cross.group(1).strip().lower()
+            terms.add(phrase)
+            for word in re.split(r"[\s_-]+", phrase):
+                if word:
+                    terms.add(word)
+            continue
+
+        # Standard: "term: ..." or "- term: ..." or "* term: ..." or "term - ..."
+        m = re.match(
+            r"^[-*]?\s*([A-Za-z][A-Za-z0-9 _-]*?)\s*(?::\s|\s+-\s)",
+            stripped,
+        )
+        if m:
+            phrase = m.group(1).strip().lower()
+            terms.add(phrase)
+            # Also add each individual word so "valid response" covers "valid"
+            for word in re.split(r"[\s_-]+", phrase):
+                if word:
+                    terms.add(word)
+    return terms
+
+
+# ---------------------------------------------------------------------------
+# Core scan logic
+# ---------------------------------------------------------------------------
+
+def _scan_section(
+    section_name: str,
+    section_text: str,
+    vocab_terms: set[str],
+    *,
+    strict: bool,
+    check_observable: bool,
+) -> list[LintIssue]:
+    """Scan one section for vague terms and (optionally) observable-outcome gaps."""
+    issues: list[LintIssue] = []
+    pattern = _VAGUE_PATTERN_STRICT if strict else _VAGUE_PATTERN
+    for line in section_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        # Strip angle-bracket placeholder tokens (e.g. <expected outcome>, <role>)
+        # before scanning so template scaffolds don't produce false positives.
+        scan_text = re.sub(r"<[^>]+>", "", stripped)
+
+        matched_terms = {m.lower() for m in pattern.findall(scan_text)}
+        undefined_terms = matched_terms - vocab_terms
+
+        for term in sorted(undefined_terms):
+            level = "error" if strict else "warn"
+            issues.append(LintIssue(
+                level=level,
+                term=term,
+                section=section_name,
+                line=stripped,
+                message=(
+                    f'Vague term "{term}" used in [{section_name}] without a '
+                    f"<vocabulary> definition."
+                ),
+                suggestion=f"{term}: <add a precise, observable definition here>",
+            ))
+
+        # Observable-outcome check: only fires when at least one vague term on
+        # this line is UNDEFINED (not already covered by the vocabulary).
+        if check_observable and undefined_terms and not _OBSERVABLE_PATTERN.search(scan_text):
+            level = "error" if strict else "warn"
+            issues.append(LintIssue(
+                level=level,
+                term="(no observable outcome)",
+                section=section_name,
+                line=stripped,
+                message=(
+                    "Rule or criterion contains a vague term but no observable "
+                    "outcome verb (returns/raises/writes/emits/rejects/…)."
+                ),
+            ))
+
+    return issues
+
+
+def scan_prompt(path: Path, *, strict: bool = False) -> LintResult:
+    """
+    Deterministic lint scan of a single prompt file.
+
+    Prompts with no recognised sections produce zero issues (legacy safety
+    guarantee). Pass strict=True to escalate all warnings to errors.
+    """
+    result = LintResult(path=path)
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        result.issues.append(LintIssue(
+            level="error",
+            term="",
+            section="file",
+            line="",
+            message=f"Cannot read file: {exc}",
+        ))
+        return result
+
+    sections = _extract_sections(text)
+
+    # Collect vocabulary terms from all vocabulary-source sections
+    vocab_terms: set[str] = set()
+    for vk in _VOCABULARY_SECTIONS:
+        if vk in sections:
+            vocab_terms |= _extract_vocabulary_terms(sections[vk])
+
+    # Prose (% lines) is only meaningful contract text when the file also has at
+    # least one structured contract section.  Without this gate, LLM instruction
+    # prompts that use % for their body text produce hundreds of false positives.
+    _CONTRACT_SECTIONS = frozenset({
+        "contract_rules", "requirements", "acceptance_tests", "acceptance criteria"
+    })
+    has_contract_section = any(k in sections for k in _CONTRACT_SECTIONS)
+
+    # Scan recognised content sections only (skip architecture metadata)
+    found_any_section = False
+    for section_name, section_text in sections.items():
+        if section_name in _NON_SCANNABLE_SECTIONS:
+            continue
+        if section_name not in _SCANNABLE_SECTIONS:
+            continue
+        if section_name == "prose" and not has_contract_section:
+            continue
+        found_any_section = True
+        result.issues.extend(
+            _scan_section(
+                section_name,
+                section_text,
+                vocab_terms,
+                strict=strict,
+                check_observable=(section_name in _OBSERVABLE_CHECK_SECTIONS),
+            )
+        )
+
+    if not found_any_section:
+        logger.debug("prompt_lint: no recognised sections in %s — skipping", path)
+
+    return result
+
+
+def scan_stories(stories_dir: Path, *, strict: bool = False) -> list[LintResult]:
+    """
+    Scan all story__*.md files under stories_dir for vague acceptance criteria.
+
+    Each story's ## Glossary / ## Definitions / ## Covers section supplies
+    the vocabulary. Missing sections produce zero issues.
+    """
+    if not stories_dir.is_dir():
+        return []
+    return [
+        scan_prompt(story_path, strict=strict)
+        for story_path in sorted(stories_dir.glob("story__*.md"))
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Apply suggestions (--apply write-back)
+# ---------------------------------------------------------------------------
+
+_VOCABULARY_OPEN = "<vocabulary>"
+_VOCABULARY_CLOSE = "</vocabulary>"
+
+
+def apply_suggestions(path: Path, issues: list[LintIssue]) -> int:
+    """
+    Append non-placeholder suggestion strings to the prompt's <vocabulary> block.
+
+    Creates the block at the end of the file if absent.
+    Returns the number of new entries written.
+    Never called unless the caller explicitly passes --apply.
+    """
+    suggestions = [
+        i.suggestion
+        for i in issues
+        if i.suggestion and "<add a precise" not in i.suggestion
+    ]
+    if not suggestions:
+        return 0
+
+    text = path.read_text(encoding="utf-8")
+    new_entries = "\n".join(f"- {s}" for s in suggestions)
+
+    if _VOCABULARY_OPEN in text and _VOCABULARY_CLOSE in text:
+        text = text.replace(
+            _VOCABULARY_CLOSE,
+            f"{new_entries}\n{_VOCABULARY_CLOSE}",
+        )
+    else:
+        text = text.rstrip() + (
+            f"\n\n{_VOCABULARY_OPEN}\n{new_entries}\n{_VOCABULARY_CLOSE}\n"
+        )
+
+    path.write_text(text, encoding="utf-8")
+    return len(suggestions)
+
+
+# ---------------------------------------------------------------------------
+# Optional LLM ambiguity pass
+# ---------------------------------------------------------------------------
+
+def run_llm_ambiguity_pass(
+    path: Path,
+    strength: float = 0.5,
+    temperature: float = 0.0,
+    time: Optional[float] = None,
+    verbose: bool = False,
+) -> list[LintIssue]:
+    """
+    Run the LLM-backed ambiguity analysis for a single prompt file.
+
+    Loads pdd/prompts/prompt_lint_LLM.prompt, calls llm_invoke, and parses the
+    JSON response into LintIssue entries (level="warn").
+
+    Safe to call: always returns [] on any error so CI never breaks on LLM failure.
+    """
+    try:
+        from .llm_invoke import llm_invoke
+        from .preprocess import preprocess
+
+        template_path = Path(__file__).parent / "prompts" / "prompt_lint_LLM.prompt"
+        if not template_path.exists():
+            logger.warning("prompt_lint_LLM.prompt not found; skipping LLM pass")
+            return []
+
+        prompt_content = path.read_text(encoding="utf-8", errors="replace")
+        vague_terms_list = ", ".join(sorted(VAGUE_TERMS))
+
+        template = template_path.read_text(encoding="utf-8")
+        filled = template.replace("{prompt_content}", prompt_content).replace(
+            "{vague_terms_list}", vague_terms_list
+        )
+        filled = preprocess(filled, recursive=False, double_curly_brackets=False)
+
+        response_text, _cost, _model = llm_invoke(
+            filled,
+            strength=strength,
+            temperature=temperature,
+            time=time,
+            verbose=verbose,
+        )
+
+        # Strip optional markdown code fences
+        json_match = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", response_text, re.DOTALL)
+        raw_json = json_match.group(1) if json_match else response_text.strip()
+        items = json.loads(raw_json)
+
+        issues: list[LintIssue] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            issues.append(LintIssue(
+                level="warn",
+                term=str(item.get("term", "")),
+                section=str(item.get("section", "llm")),
+                line="",
+                message=f'LLM flagged "{item.get("term", "")}" as potentially ambiguous.',
+                suggestion=str(item.get("suggestion", "")),
+                interpretations=[str(x) for x in item.get("interpretations", [])],
+            ))
+        return issues
+
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("prompt_lint LLM pass failed: %s", exc)
+        return []

--- a/pdd/prompts/contract_check_LLM.prompt
+++ b/pdd/prompts/contract_check_LLM.prompt
@@ -1,0 +1,45 @@
+% LLM prompt for `pdd contracts check --llm-ambiguity`.
+% Used by: pdd/contract_check.py :: run_llm_ambiguity_pass
+% Do NOT call this prompt directly. It is invoked by the engine.
+
+You are a contract-quality reviewer for natural-language software contracts.
+You will receive the content of a <contract_rules> section and a list of
+potentially vague terms found in those rules.
+
+Your task:
+1. For each term in the list, decide whether it introduces genuine ambiguity
+   in the context of the rules (some terms may be fine in context).
+2. For terms that ARE ambiguous, provide:
+   - 2–4 concrete, distinct interpretations a reader could reasonably hold.
+   - A precise, observable definition suitable for a <vocabulary> block.
+3. Return ONLY a JSON array — no prose, no markdown fences.
+
+Output schema (array of objects):
+[
+  {{
+    "term": "<the ambiguous term>",
+    "interpretations": ["<interpretation 1>", "<interpretation 2>", ...],
+    "suggestion": "<term>: <precise, observable definition>"
+  }}
+]
+
+Rules:
+- Only include terms that are genuinely ambiguous in context.
+- Skip terms whose meaning is obvious and unambiguous given the surrounding rules.
+- Interpretations must be concise (≤ 15 words each).
+- Suggestions must be one line: "term: definition" — no bullet prefix.
+- Do not invent information; base interpretations on common real-world usage.
+
+---
+
+Contract rules content:
+{contract_content}
+
+---
+
+Potentially vague terms to review:
+{vague_terms_list}
+
+---
+
+Respond with ONLY the JSON array described above.

--- a/pdd/prompts/prompt_lint_LLM.prompt
+++ b/pdd/prompts/prompt_lint_LLM.prompt
@@ -1,0 +1,47 @@
+% You are a prompt quality reviewer for PDD (Prompt-Driven Development).
+% Your task is to analyse a prompt file for ambiguous natural-language terms and suggest
+% precise vocabulary definitions that would make the prompt's contract unambiguous.
+
+% You are given:
+%   1. The full text of the prompt to analyse.
+%   2. A baseline list of known vague terms to watch for.
+
+% Instructions:
+%   - Identify every term in the prompt that could be interpreted in more than one
+%     concrete, observable way by an implementor.
+%   - For each ambiguous term found, produce:
+%       "term"           : the exact word or short phrase that is ambiguous
+%       "section"        : the section name where it appears (e.g. "contract_rules",
+%                          "acceptance_tests", "requirements", or "prose")
+%       "interpretations": a JSON array of 2–4 distinct, concrete readings of the term
+%       "suggestion"     : a single precise definition suitable for a <vocabulary> block
+%                          (format: "term: definition")
+%   - Include terms from the baseline list AND any additional ambiguous terms you find.
+%   - Do NOT flag terms that already have a clear, observable definition in the prompt.
+%   - Do NOT hallucinate sections or terms that are not present.
+%   - If the prompt is already unambiguous, return an empty JSON array [].
+
+% Baseline vague terms to watch for:
+<baseline_terms>
+{vague_terms_list}
+</baseline_terms>
+
+% Prompt to analyse:
+<prompt_content>
+{prompt_content}
+</prompt_content>
+
+% Output a JSON array only. Do not include any explanatory text outside the JSON.
+% Example output format:
+% [
+%   {
+%     "term": "duplicate upload",
+%     "section": "contract_rules",
+%     "interpretations": [
+%       "Same filename regardless of content",
+%       "Same file hash (SHA-256)",
+%       "Same tenant ID and normalized file hash"
+%     ],
+%     "suggestion": "duplicate upload: an upload whose SHA-256 hash and tenant ID match a previously accepted upload"
+%   }
+% ]

--- a/tests/commands/test_contracts.py
+++ b/tests/commands/test_contracts.py
@@ -1,0 +1,348 @@
+"""CLI-level tests for `pdd contracts check` via CliRunner."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from pdd import cli
+from pdd.contract_check import ContractIssue
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "contract_check"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _invoke(runner: CliRunner, *args):
+    """Invoke pdd contracts check with --quiet to suppress update/summary noise."""
+    return runner.invoke(
+        cli.cli,
+        ["--quiet", "contracts", "check", *args],
+        catch_exceptions=False,
+    )
+
+
+def _json_invoke(runner: CliRunner, *args):
+    """Invoke pdd contracts check --json with --quiet for parseable output."""
+    return runner.invoke(
+        cli.cli,
+        ["--quiet", "contracts", "check", "--json", *args],
+        catch_exceptions=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestContractsCheckBasic
+# ---------------------------------------------------------------------------
+
+class TestContractsCheckBasic:
+    def test_valid_prompt_exits_zero(self, runner):
+        result = _invoke(runner, str(FIXTURES / "valid_contract_python.prompt"))
+        assert result.exit_code == 0
+
+    def test_duplicate_ids_exits_nonzero(self, runner):
+        result = _invoke(runner, str(FIXTURES / "duplicate_ids_python.prompt"))
+        assert result.exit_code != 0
+
+    def test_vague_no_vocab_exits_one(self, runner):
+        result = _invoke(runner, str(FIXTURES / "vague_no_vocab_python.prompt"))
+        assert result.exit_code == 1
+
+    def test_legacy_prompt_exits_zero(self, runner):
+        result = _invoke(runner, str(FIXTURES / "legacy_no_sections_python.prompt"))
+        assert result.exit_code == 0
+
+    def test_output_contains_error_label_for_duplicate(self, runner):
+        result = _invoke(runner, str(FIXTURES / "duplicate_ids_python.prompt"))
+        assert "ERROR" in result.output or "error" in result.output.lower()
+
+    def test_output_contains_code_label(self, runner):
+        result = _invoke(runner, str(FIXTURES / "duplicate_ids_python.prompt"))
+        assert "DUPLICATE_ID" in result.output
+
+    def test_output_contains_rule_id(self, runner):
+        result = _invoke(runner, str(FIXTURES / "duplicate_ids_python.prompt"))
+        assert "R1" in result.output
+
+    def test_nonexistent_target_raises_error(self, runner):
+        result = runner.invoke(
+            cli.cli,
+            ["contracts", "check", "/tmp/does_not_exist_xyz.prompt"],
+        )
+        assert result.exit_code != 0
+
+    def test_clean_output_shows_checkmark(self, runner):
+        result = _invoke(runner, str(FIXTURES / "valid_contract_python.prompt"))
+        assert "clean" in result.output.lower() or result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# TestJsonOutput
+# ---------------------------------------------------------------------------
+
+class TestJsonOutput:
+    def test_json_is_valid(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "valid_contract_python.prompt"))
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    def test_json_has_required_keys(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "vague_no_vocab_python.prompt"))
+        data = json.loads(result.output)
+        assert len(data) > 0
+        entry = data[0]
+        for key in ("path", "warn_count", "error_count", "issues"):
+            assert key in entry
+
+    def test_json_issue_has_all_fields(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "vague_no_vocab_python.prompt"))
+        data = json.loads(result.output)
+        issues = data[0]["issues"]
+        assert len(issues) > 0
+        issue = issues[0]
+        for key in ("level", "code", "rule_id", "section", "line",
+                    "message", "term", "suggestion", "interpretations"):
+            assert key in issue
+
+    def test_json_clean_prompt_has_zero_counts(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "valid_contract_python.prompt"))
+        data = json.loads(result.output)
+        assert data[0]["warn_count"] == 0
+        assert data[0]["error_count"] == 0
+        assert data[0]["issues"] == []
+
+    def test_json_duplicate_id_issue_code(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "duplicate_ids_python.prompt"))
+        data = json.loads(result.output)
+        all_issues = [i for entry in data for i in entry["issues"]]
+        assert any(i["code"] == "DUPLICATE_ID" for i in all_issues)
+
+    def test_json_vague_term_code(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "vague_no_vocab_python.prompt"))
+        data = json.loads(result.output)
+        all_issues = [i for entry in data for i in entry["issues"]]
+        assert any(i["code"] == "VAGUE_TERM" for i in all_issues)
+
+    def test_json_issue_has_source_line(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "missing_modal_python.prompt"))
+        data = json.loads(result.output)
+        all_issues = [i for entry in data for i in entry["issues"]]
+        modal_issues = [i for i in all_issues if i["code"] == "MISSING_MODAL"]
+        assert modal_issues
+        assert modal_issues[0]["line"] != ""
+
+
+# ---------------------------------------------------------------------------
+# TestStrictFlag
+# ---------------------------------------------------------------------------
+
+class TestStrictFlag:
+    def test_strict_escalates_warns_to_exit_two(self, runner):
+        result = _invoke(runner, "--strict",
+                         str(FIXTURES / "vague_no_vocab_python.prompt"))
+        assert result.exit_code == 2
+
+    def test_strict_clean_prompt_exits_zero(self, runner):
+        result = _invoke(runner, "--strict",
+                         str(FIXTURES / "valid_contract_python.prompt"))
+        assert result.exit_code == 0
+
+    def test_strict_json_shows_errors_not_warns(self, runner):
+        result = _json_invoke(runner, "--strict",
+                              str(FIXTURES / "vague_no_vocab_python.prompt"))
+        data = json.loads(result.output)
+        all_issues = [i for entry in data for i in entry["issues"]]
+        assert all(i["level"] == "error" for i in all_issues)
+
+
+# ---------------------------------------------------------------------------
+# TestDirectoryScan
+# ---------------------------------------------------------------------------
+
+class TestDirectoryScan:
+    def test_directory_scan_produces_multiple_results(self, runner):
+        result = _json_invoke(runner, str(FIXTURES))
+        data = json.loads(result.output)
+        assert len(data) >= 5  # at least several fixture files
+
+    def test_directory_scan_includes_valid_prompt(self, runner):
+        result = _json_invoke(runner, str(FIXTURES))
+        data = json.loads(result.output)
+        names = [Path(e["path"]).name for e in data]
+        assert "valid_contract_python.prompt" in names
+
+    def test_directory_scan_exit_code_nonzero_when_issues_present(self, runner):
+        result = _invoke(runner, str(FIXTURES))
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# TestStoriesFlag
+# ---------------------------------------------------------------------------
+
+class TestStoriesFlag:
+    def test_stories_flag_scans_story_files(self, runner):
+        result = _json_invoke(
+            runner,
+            "--stories", str(FIXTURES),
+            str(FIXTURES / "valid_contract_python.prompt"),
+        )
+        data = json.loads(result.output)
+        paths = [Path(e["path"]).name for e in data]
+        assert any("story__" in name for name in paths)
+
+    def test_valid_story_has_zero_issues(self, runner):
+        result = _json_invoke(
+            runner,
+            "--stories", str(FIXTURES),
+            str(FIXTURES / "valid_contract_python.prompt"),
+        )
+        data = json.loads(result.output)
+        valid_story = next(
+            (e for e in data if "story__covers_rule_ids" in e["path"]), None
+        )
+        assert valid_story is not None
+        assert valid_story["warn_count"] == 0
+
+    def test_invalid_story_has_issues(self, runner):
+        result = _json_invoke(
+            runner,
+            "--stories", str(FIXTURES),
+            str(FIXTURES / "valid_contract_python.prompt"),
+        )
+        data = json.loads(result.output)
+        invalid_story = next(
+            (e for e in data if "story__unknown_rule_ids" in e["path"]), None
+        )
+        assert invalid_story is not None
+        assert invalid_story["warn_count"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# TestLlmAmbiguityFlag
+# ---------------------------------------------------------------------------
+
+class TestLlmAmbiguityFlag:
+    @patch("pdd.commands.contracts.run_llm_ambiguity_pass")
+    def test_llm_ambiguity_calls_llm_pass(self, mock_llm, runner):
+        mock_llm.return_value = []
+        result = _invoke(
+            runner, "--llm-ambiguity",
+            str(FIXTURES / "vague_no_vocab_python.prompt"),
+        )
+        mock_llm.assert_called_once()
+
+    @patch("pdd.commands.contracts.run_llm_ambiguity_pass")
+    def test_llm_issues_appear_in_output(self, mock_llm, runner):
+        mock_llm.return_value = [
+            ContractIssue(
+                level="warn",
+                code="LLM_AMBIGUITY",
+                rule_id="",
+                section="llm",
+                line="",
+                message='LLM flagged "duplicate" as potentially ambiguous.',
+                suggestion="duplicate upload: same SHA-256 hash and tenant_id",
+                interpretations=["Same filename", "Same hash", "Same tenant + hash"],
+            )
+        ]
+        result = _invoke(
+            runner, "--llm-ambiguity",
+            str(FIXTURES / "vague_no_vocab_python.prompt"),
+        )
+        assert "LLM_AMBIGUITY" in result.output or "LLM" in result.output
+
+    @patch("pdd.commands.contracts.run_llm_ambiguity_pass")
+    def test_llm_interpretations_rendered(self, mock_llm, runner):
+        mock_llm.return_value = [
+            ContractIssue(
+                level="warn",
+                code="LLM_AMBIGUITY",
+                rule_id="",
+                section="llm",
+                line="",
+                message='LLM flagged "duplicate" as potentially ambiguous.',
+                suggestion="duplicate upload: same hash and tenant",
+                interpretations=["Same filename", "Same file hash", "Same tenant + hash"],
+            )
+        ]
+        result = _invoke(
+            runner, "--llm-ambiguity",
+            str(FIXTURES / "vague_no_vocab_python.prompt"),
+        )
+        assert "Possible interpretations" in result.output
+        assert "Same filename" in result.output
+
+    @patch("pdd.commands.contracts.run_llm_ambiguity_pass")
+    def test_llm_issues_appear_in_json(self, mock_llm, runner):
+        mock_llm.return_value = [
+            ContractIssue(
+                level="warn",
+                code="LLM_AMBIGUITY",
+                rule_id="",
+                section="llm",
+                line="",
+                message="LLM flagged term.",
+                suggestion="duplicate: same hash",
+                interpretations=["Same filename", "Same hash"],
+            )
+        ]
+        result = _json_invoke(
+            runner, "--llm-ambiguity",
+            str(FIXTURES / "vague_no_vocab_python.prompt"),
+        )
+        data = json.loads(result.output)
+        all_issues = [i for entry in data for i in entry["issues"]]
+        assert any(i["code"] == "LLM_AMBIGUITY" for i in all_issues)
+        llm_issue = next(i for i in all_issues if i["code"] == "LLM_AMBIGUITY")
+        assert llm_issue["interpretations"] == ["Same filename", "Same hash"]
+
+    @patch("pdd.commands.contracts.run_llm_ambiguity_pass")
+    def test_llm_suggestion_rendered(self, mock_llm, runner):
+        mock_llm.return_value = [
+            ContractIssue(
+                level="warn",
+                code="LLM_AMBIGUITY",
+                rule_id="",
+                section="llm",
+                line="",
+                message="LLM flagged term.",
+                suggestion="duplicate upload: an upload with the same tenant ID and normalized file hash",
+                interpretations=["Same filename"],
+            )
+        ]
+        result = _invoke(
+            runner, "--llm-ambiguity",
+            str(FIXTURES / "vague_no_vocab_python.prompt"),
+        )
+        flat = " ".join(result.output.split())
+        assert "Suggestion" in flat
+        assert "tenant" in flat
+
+
+# ---------------------------------------------------------------------------
+# TestLegacyPromptSafety
+# ---------------------------------------------------------------------------
+
+class TestLegacyPromptSafety:
+    def test_legacy_prompt_exits_zero(self, runner):
+        result = _invoke(runner, str(FIXTURES / "legacy_no_sections_python.prompt"))
+        assert result.exit_code == 0
+
+    def test_bundled_prompts_no_errors(self, runner):
+        """Real bundled prompts must not emit errors (strict or not)."""
+        pdd_prompts = Path(__file__).parents[2] / "pdd" / "prompts"
+        for p in sorted(pdd_prompts.glob("*.prompt")):
+            result = _json_invoke(runner, str(p))
+            data = json.loads(result.output)
+            errors = [i for entry in data for i in entry["issues"]
+                      if i["level"] == "error"]
+            assert errors == [], (
+                f"{p.name} produced errors: {[e['message'] for e in errors]}"
+            )

--- a/tests/commands/test_contracts_integration.py
+++ b/tests/commands/test_contracts_integration.py
@@ -1,0 +1,476 @@
+"""
+Integration tests for `pdd contracts check` using realistic prompt fixtures.
+
+These tests exercise cross-cutting scenarios: combined defects in one prompt,
+directory scanning with mixed files, story coverage validation against real
+rule IDs, waiver handling, and the full JSON schema shape.
+
+Unlike unit tests (test_contract_check.py) which test individual check
+functions in isolation, these tests drive the CLI end-to-end and assert
+on observable behaviour that users and CI systems would see.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from pdd import cli
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "contract_check"
+
+# Realistic fixture paths
+PAYMENT_CLEAN = FIXTURES / "payment_api_clean_python.prompt"
+PAYMENT_ISSUES = FIXTURES / "payment_api_issues_python.prompt"
+AUTH_CLEAN = FIXTURES / "auth_service_clean_python.prompt"
+RATE_LIMITER_ISSUES = FIXTURES / "rate_limiter_issues_python.prompt"
+STORY_PAYMENT_GOOD = FIXTURES / "story__payment_flow.md"
+STORY_PAYMENT_BAD = FIXTURES / "story__payment_bad_refs.md"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _invoke(runner: CliRunner, *args) -> object:
+    return runner.invoke(
+        cli.cli,
+        ["--quiet", "contracts", "check", *args],
+        catch_exceptions=False,
+    )
+
+
+def _json_invoke(runner: CliRunner, *args) -> object:
+    return runner.invoke(
+        cli.cli,
+        ["--quiet", "contracts", "check", "--json", *args],
+        catch_exceptions=False,
+    )
+
+
+def _issues(data: list, code: str | None = None) -> list:
+    all_issues = [i for entry in data for i in entry["issues"]]
+    if code:
+        return [i for i in all_issues if i["code"] == code]
+    return all_issues
+
+
+# ---------------------------------------------------------------------------
+# TestCleanRealisticPrompts
+# ---------------------------------------------------------------------------
+
+class TestCleanRealisticPrompts:
+    """Fully-specified realistic prompts must produce zero issues."""
+
+    def test_payment_api_clean_exits_zero(self, runner):
+        result = _invoke(runner, str(PAYMENT_CLEAN))
+        assert result.exit_code == 0
+
+    def test_payment_api_clean_json_zero_counts(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_CLEAN))
+        data = json.loads(result.output)
+        assert data[0]["warn_count"] == 0
+        assert data[0]["error_count"] == 0
+        assert data[0]["issues"] == []
+
+    def test_auth_service_clean_exits_zero(self, runner):
+        result = _invoke(runner, str(AUTH_CLEAN))
+        assert result.exit_code == 0
+
+    def test_auth_service_with_waivers_exits_zero(self, runner):
+        """Waiver W1 covers R4 MUST NOT — must suppress UNCOVERED_MUST_NOT."""
+        result = _json_invoke(runner, str(AUTH_CLEAN))
+        data = json.loads(result.output)
+        uncovered = _issues(data, "UNCOVERED_MUST_NOT")
+        assert uncovered == [], f"Unexpected UNCOVERED_MUST_NOT: {uncovered}"
+
+    def test_auth_service_clean_json_zero_counts(self, runner):
+        result = _json_invoke(runner, str(AUTH_CLEAN))
+        data = json.loads(result.output)
+        assert data[0]["warn_count"] == 0
+        assert data[0]["error_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# TestPaymentApiIssues — combined defect prompt
+# ---------------------------------------------------------------------------
+
+class TestPaymentApiIssues:
+    """payment_api_issues_python.prompt has DUPLICATE_ID, MISSING_MODAL,
+    VAGUE_TERM, and UNCOVERED_MUST_NOT in one file."""
+
+    def test_exits_nonzero(self, runner):
+        result = _invoke(runner, str(PAYMENT_ISSUES))
+        assert result.exit_code != 0
+
+    def test_duplicate_id_detected(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_ISSUES))
+        data = json.loads(result.output)
+        dupes = _issues(data, "DUPLICATE_ID")
+        assert len(dupes) >= 1
+        assert any("R2" in i["rule_id"] or "R2" in i["line"] for i in dupes)
+
+    def test_duplicate_id_is_error_not_warn(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_ISSUES))
+        data = json.loads(result.output)
+        dupes = _issues(data, "DUPLICATE_ID")
+        assert all(i["level"] == "error" for i in dupes)
+
+    def test_missing_modal_detected(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_ISSUES))
+        data = json.loads(result.output)
+        missing = _issues(data, "MISSING_MODAL")
+        assert len(missing) >= 1
+
+    def test_missing_modal_points_to_r4(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_ISSUES))
+        data = json.loads(result.output)
+        missing = _issues(data, "MISSING_MODAL")
+        rule_ids = [i["rule_id"] for i in missing]
+        assert "R4" in rule_ids
+
+    def test_vague_terms_detected(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_ISSUES))
+        data = json.loads(result.output)
+        vague = _issues(data, "VAGUE_TERM")
+        assert len(vague) >= 1
+        terms_found = {i["term"] for i in vague}
+        assert terms_found & {"reasonable", "valid", "successful"}
+
+    def test_vague_terms_are_warnings_not_errors(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_ISSUES))
+        data = json.loads(result.output)
+        vague = _issues(data, "VAGUE_TERM")
+        assert all(i["level"] == "warn" for i in vague)
+
+    def test_uncovered_must_not_detected(self, runner):
+        """R5 MUST NOT has no coverage entry — must flag UNCOVERED_MUST_NOT."""
+        result = _json_invoke(runner, str(PAYMENT_ISSUES))
+        data = json.loads(result.output)
+        uncovered = _issues(data, "UNCOVERED_MUST_NOT")
+        assert len(uncovered) >= 1
+
+    def test_vague_term_has_suggestion(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_ISSUES))
+        data = json.loads(result.output)
+        vague = _issues(data, "VAGUE_TERM")
+        assert all(i["suggestion"] != "" for i in vague)
+
+    def test_strict_mode_exits_two(self, runner):
+        result = _invoke(runner, "--strict", str(PAYMENT_ISSUES))
+        assert result.exit_code == 2
+
+    def test_strict_mode_all_issues_are_errors(self, runner):
+        result = _json_invoke(runner, "--strict", str(PAYMENT_ISSUES))
+        data = json.loads(result.output)
+        all_issues = _issues(data)
+        assert all(i["level"] == "error" for i in all_issues)
+
+    def test_human_output_shows_issue_codes(self, runner):
+        result = _invoke(runner, str(PAYMENT_ISSUES))
+        assert "DUPLICATE_ID" in result.output
+        assert "MISSING_MODAL" in result.output
+        assert "VAGUE_TERM" in result.output
+
+    def test_human_output_shows_rule_id(self, runner):
+        result = _invoke(runner, str(PAYMENT_ISSUES))
+        assert "R2" in result.output
+        assert "R4" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TestRateLimiterIssues — sequential + coverage gaps
+# ---------------------------------------------------------------------------
+
+class TestRateLimiterIssues:
+    """rate_limiter_issues_python.prompt has NON_SEQUENTIAL_ID (R1,R2,R4),
+    MISSING_MODAL (R4), VAGUE_TERM, UNKNOWN_COVERAGE_REF (R3), UNCOVERED_MUST_NOT."""
+
+    def test_exits_nonzero(self, runner):
+        result = _invoke(runner, str(RATE_LIMITER_ISSUES))
+        assert result.exit_code != 0
+
+    def test_non_sequential_id_detected(self, runner):
+        result = _json_invoke(runner, str(RATE_LIMITER_ISSUES))
+        data = json.loads(result.output)
+        seq = _issues(data, "NON_SEQUENTIAL_ID")
+        assert len(seq) >= 1
+
+    def test_non_sequential_id_is_warning(self, runner):
+        result = _json_invoke(runner, str(RATE_LIMITER_ISSUES))
+        data = json.loads(result.output)
+        seq = _issues(data, "NON_SEQUENTIAL_ID")
+        assert all(i["level"] == "warn" for i in seq)
+
+    def test_unknown_coverage_ref_detected(self, runner):
+        """R3 is cited in <coverage> but not defined in <contract_rules>."""
+        result = _json_invoke(runner, str(RATE_LIMITER_ISSUES))
+        data = json.loads(result.output)
+        unknown = _issues(data, "UNKNOWN_COVERAGE_REF")
+        assert len(unknown) >= 1
+        assert any("R3" in i["line"] or "R3" in i["message"] for i in unknown)
+
+    def test_unknown_coverage_ref_is_error(self, runner):
+        result = _json_invoke(runner, str(RATE_LIMITER_ISSUES))
+        data = json.loads(result.output)
+        unknown = _issues(data, "UNKNOWN_COVERAGE_REF")
+        assert all(i["level"] == "error" for i in unknown)
+
+    def test_vague_terms_flagged(self, runner):
+        result = _json_invoke(runner, str(RATE_LIMITER_ISSUES))
+        data = json.loads(result.output)
+        vague = _issues(data, "VAGUE_TERM")
+        terms = {i["term"] for i in vague}
+        assert terms & {"reasonable", "recent", "safe"}
+
+    def test_uncovered_must_not_flagged(self, runner):
+        """R4 MUST NOT has no coverage entry."""
+        result = _json_invoke(runner, str(RATE_LIMITER_ISSUES))
+        data = json.loads(result.output)
+        uncovered = _issues(data, "UNCOVERED_MUST_NOT")
+        assert len(uncovered) >= 1
+
+    def test_multiple_error_codes_present(self, runner):
+        result = _json_invoke(runner, str(RATE_LIMITER_ISSUES))
+        data = json.loads(result.output)
+        codes = {i["code"] for i in _issues(data)}
+        assert "UNKNOWN_COVERAGE_REF" in codes
+        assert "VAGUE_TERM" in codes
+
+
+# ---------------------------------------------------------------------------
+# TestDirectoryIntegration
+# ---------------------------------------------------------------------------
+
+class TestDirectoryIntegration:
+    """Directory scan over the fixtures folder returns mixed results."""
+
+    def test_directory_scan_json_array(self, runner):
+        result = _json_invoke(runner, str(FIXTURES))
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) >= 5
+
+    def test_clean_prompts_have_zero_issues_in_scan(self, runner):
+        result = _json_invoke(runner, str(FIXTURES))
+        data = json.loads(result.output)
+        clean_entries = [
+            e for e in data
+            if Path(e["path"]).name in {
+                "payment_api_clean_python.prompt",
+                "auth_service_clean_python.prompt",
+                "valid_contract_python.prompt",
+            }
+        ]
+        assert len(clean_entries) == 3
+        for entry in clean_entries:
+            assert entry["error_count"] == 0, (
+                f"{Path(entry['path']).name} has errors: "
+                f"{[i['message'] for i in entry['issues'] if i['level']=='error']}"
+            )
+
+    def test_issue_prompts_have_findings_in_scan(self, runner):
+        result = _json_invoke(runner, str(FIXTURES))
+        data = json.loads(result.output)
+        issue_entries = [
+            e for e in data
+            if Path(e["path"]).name in {
+                "payment_api_issues_python.prompt",
+                "rate_limiter_issues_python.prompt",
+                "duplicate_ids_python.prompt",
+            }
+        ]
+        assert len(issue_entries) == 3
+        for entry in issue_entries:
+            assert entry["warn_count"] + entry["error_count"] > 0, (
+                f"{Path(entry['path']).name} unexpectedly clean"
+            )
+
+    def test_directory_scan_exit_nonzero(self, runner):
+        result = _invoke(runner, str(FIXTURES))
+        assert result.exit_code != 0
+
+    def test_all_json_entries_have_required_keys(self, runner):
+        result = _json_invoke(runner, str(FIXTURES))
+        data = json.loads(result.output)
+        for entry in data:
+            for key in ("path", "warn_count", "error_count", "issues"):
+                assert key in entry, f"Missing key '{key}' in {entry.get('path')}"
+
+    def test_all_json_issues_have_required_fields(self, runner):
+        result = _json_invoke(runner, str(FIXTURES))
+        data = json.loads(result.output)
+        all_issues = _issues(data)
+        for issue in all_issues:
+            for field in ("level", "code", "rule_id", "section",
+                          "line", "message", "term", "suggestion", "interpretations"):
+                assert field in issue, f"Issue missing field '{field}': {issue}"
+
+    def test_legacy_prompt_in_directory_is_clean(self, runner):
+        result = _json_invoke(runner, str(FIXTURES))
+        data = json.loads(result.output)
+        legacy = next(
+            (e for e in data if "legacy_no_sections" in e["path"]), None
+        )
+        assert legacy is not None
+        assert legacy["warn_count"] == 0
+        assert legacy["error_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# TestStoryIntegration
+# ---------------------------------------------------------------------------
+
+class TestStoryIntegration:
+    """Story ## Covers validation against realistic prompts."""
+
+    def test_valid_story_covers_real_rule_ids(self, runner):
+        result = _json_invoke(
+            runner,
+            "--stories", str(FIXTURES),
+            str(PAYMENT_CLEAN),
+        )
+        data = json.loads(result.output)
+        good_story = next(
+            (e for e in data if "story__payment_flow" in e["path"]), None
+        )
+        assert good_story is not None
+        assert good_story["warn_count"] == 0, (
+            f"Good story has unexpected warnings: "
+            f"{[i['message'] for i in good_story['issues']]}"
+        )
+
+    def test_bad_story_flags_unknown_rule_ids(self, runner):
+        result = _json_invoke(
+            runner,
+            "--stories", str(FIXTURES),
+            str(PAYMENT_CLEAN),
+        )
+        data = json.loads(result.output)
+        bad_story = next(
+            (e for e in data if "story__payment_bad_refs" in e["path"]), None
+        )
+        assert bad_story is not None
+        unknown = [i for i in bad_story["issues"] if i["code"] == "UNKNOWN_STORY_REF"]
+        assert len(unknown) >= 2  # R99 and R100
+
+    def test_bad_story_unknown_refs_mention_rule_ids(self, runner):
+        result = _json_invoke(
+            runner,
+            "--stories", str(FIXTURES),
+            str(PAYMENT_CLEAN),
+        )
+        data = json.loads(result.output)
+        bad_story = next(
+            (e for e in data if "story__payment_bad_refs" in e["path"]), None
+        )
+        unknown = [i for i in bad_story["issues"] if i["code"] == "UNKNOWN_STORY_REF"]
+        messages_combined = " ".join(i["message"] for i in unknown)
+        assert "R99" in messages_combined or "R100" in messages_combined
+
+    def test_story_scan_includes_prompt_results(self, runner):
+        result = _json_invoke(
+            runner,
+            "--stories", str(FIXTURES),
+            str(PAYMENT_CLEAN),
+        )
+        data = json.loads(result.output)
+        paths = [Path(e["path"]).name for e in data]
+        assert "payment_api_clean_python.prompt" in paths
+
+    def test_stories_only_scans_story_md_not_prompts(self, runner):
+        result = _json_invoke(
+            runner,
+            "--stories", str(FIXTURES),
+            str(PAYMENT_CLEAN),
+        )
+        data = json.loads(result.output)
+        story_entries = [e for e in data if "story__" in e["path"]]
+        assert len(story_entries) >= 1
+        for e in story_entries:
+            assert e["path"].endswith(".md")
+
+
+# ---------------------------------------------------------------------------
+# TestJsonSchemaShape
+# ---------------------------------------------------------------------------
+
+class TestJsonSchemaShape:
+    """Verify the exact JSON output shape matches what CI consumers expect."""
+
+    def test_top_level_is_array(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_CLEAN))
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    def test_path_is_string(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_CLEAN))
+        data = json.loads(result.output)
+        assert isinstance(data[0]["path"], str)
+
+    def test_counts_are_ints(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_CLEAN))
+        data = json.loads(result.output)
+        assert isinstance(data[0]["warn_count"], int)
+        assert isinstance(data[0]["error_count"], int)
+
+    def test_issues_is_list(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_CLEAN))
+        data = json.loads(result.output)
+        assert isinstance(data[0]["issues"], list)
+
+    def test_issue_level_values(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_ISSUES))
+        data = json.loads(result.output)
+        for issue in _issues(data):
+            assert issue["level"] in ("warn", "error")
+
+    def test_issue_interpretations_is_list(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_ISSUES))
+        data = json.loads(result.output)
+        for issue in _issues(data):
+            assert isinstance(issue["interpretations"], list)
+
+    def test_warn_plus_error_count_matches_issues_length(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_ISSUES))
+        data = json.loads(result.output)
+        for entry in data:
+            actual_warns = sum(1 for i in entry["issues"] if i["level"] == "warn")
+            actual_errors = sum(1 for i in entry["issues"] if i["level"] == "error")
+            assert entry["warn_count"] == actual_warns
+            assert entry["error_count"] == actual_errors
+
+    def test_json_output_is_stdout_only(self, runner):
+        """JSON must be on stdout; no update-check noise should contaminate it."""
+        result = _json_invoke(runner, str(PAYMENT_CLEAN))
+        # If this raises, stdout was contaminated with non-JSON
+        json.loads(result.output)
+
+
+# ---------------------------------------------------------------------------
+# TestBundledPromptsNoErrors
+# ---------------------------------------------------------------------------
+
+class TestBundledPromptsNoErrors:
+    """All real bundled pdd/prompts/*.prompt must produce zero errors."""
+
+    def test_bundled_prompts_no_errors(self, runner):
+        pdd_prompts = Path(__file__).parents[2] / "pdd" / "prompts"
+        failures = []
+        for p in sorted(pdd_prompts.rglob("*.prompt")):
+            result = _json_invoke(runner, str(p))
+            try:
+                data = json.loads(result.output)
+            except Exception:
+                failures.append(f"{p.name}: non-JSON output")
+                continue
+            errors = [i for entry in data for i in entry["issues"]
+                      if i["level"] == "error"]
+            if errors:
+                failures.append(
+                    f"{p.name}: {[e['code'] + ' ' + e['message'] for e in errors]}"
+                )
+        assert failures == [], "Bundled prompts produced errors:\n" + "\n".join(failures)

--- a/tests/commands/test_contracts_integration.py
+++ b/tests/commands/test_contracts_integration.py
@@ -29,6 +29,17 @@ RATE_LIMITER_ISSUES = FIXTURES / "rate_limiter_issues_python.prompt"
 STORY_PAYMENT_GOOD = FIXTURES / "story__payment_flow.md"
 STORY_PAYMENT_BAD = FIXTURES / "story__payment_bad_refs.md"
 
+# Waiver fixture paths
+WAIVER_VALID = FIXTURES / "waiver_valid_python.prompt"
+WAIVER_EXPIRED = FIXTURES / "waiver_expired_python.prompt"
+WAIVER_MISSING_FIELDS = FIXTURES / "waiver_missing_fields_python.prompt"
+WAIVER_REF_MISSING = FIXTURES / "waiver_ref_missing_python.prompt"
+
+# Additional fixture paths
+CAPABILITIES_NO_MODAL = FIXTURES / "capabilities_no_modal_python.prompt"
+COVERAGE_UNCHECKED = FIXTURES / "coverage_unchecked_python.prompt"
+NON_SEQUENTIAL = FIXTURES / "non_sequential_ids_python.prompt"
+
 
 @pytest.fixture
 def runner():
@@ -448,6 +459,299 @@ class TestJsonSchemaShape:
         result = _json_invoke(runner, str(PAYMENT_CLEAN))
         # If this raises, stdout was contaminated with non-JSON
         json.loads(result.output)
+
+
+# ---------------------------------------------------------------------------
+# TestWaiverIntegration
+# ---------------------------------------------------------------------------
+
+class TestWaiverIntegration:
+    """Waiver blocks: valid waivers suppress UNCOVERED_MUST_NOT; invalid
+    waivers produce EXPIRED_WAIVER, MISSING_WAIVER_FIELDS, WAIVER_REF_MISSING."""
+
+    def test_valid_waiver_exits_zero(self, runner):
+        """W1 covers R3 MUST NOT with a future Expires date — must be clean."""
+        result = _invoke(runner, str(WAIVER_VALID))
+        assert result.exit_code == 0
+
+    def test_valid_waiver_no_uncovered_must_not(self, runner):
+        result = _json_invoke(runner, str(WAIVER_VALID))
+        data = json.loads(result.output)
+        uncovered = _issues(data, "UNCOVERED_MUST_NOT")
+        assert uncovered == [], f"R3 MUST NOT should be covered by waiver W1: {uncovered}"
+
+    def test_valid_waiver_no_waiver_issues(self, runner):
+        result = _json_invoke(runner, str(WAIVER_VALID))
+        data = json.loads(result.output)
+        waiver_codes = {"EXPIRED_WAIVER", "MISSING_WAIVER_FIELDS", "WAIVER_REF_MISSING"}
+        found = [i for i in _issues(data) if i["code"] in waiver_codes]
+        assert found == []
+
+    def test_expired_waiver_detected(self, runner):
+        """W1 Expires: 2020-01-01 is in the past — must flag EXPIRED_WAIVER."""
+        result = _json_invoke(runner, str(WAIVER_EXPIRED))
+        data = json.loads(result.output)
+        expired = _issues(data, "EXPIRED_WAIVER")
+        assert len(expired) >= 1
+
+    def test_expired_waiver_is_warning(self, runner):
+        result = _json_invoke(runner, str(WAIVER_EXPIRED))
+        data = json.loads(result.output)
+        expired = _issues(data, "EXPIRED_WAIVER")
+        assert all(i["level"] == "warn" for i in expired)
+
+    def test_expired_waiver_mentions_waiver_id(self, runner):
+        result = _json_invoke(runner, str(WAIVER_EXPIRED))
+        data = json.loads(result.output)
+        expired = _issues(data, "EXPIRED_WAIVER")
+        combined = " ".join(i["message"] + i["line"] for i in expired)
+        assert "W1" in combined
+
+    def test_missing_waiver_fields_detected(self, runner):
+        """W1 is missing Approved by and Expires fields."""
+        result = _json_invoke(runner, str(WAIVER_MISSING_FIELDS))
+        data = json.loads(result.output)
+        missing = _issues(data, "MISSING_WAIVER_FIELDS")
+        assert len(missing) >= 1
+
+    def test_missing_waiver_fields_is_warning(self, runner):
+        result = _json_invoke(runner, str(WAIVER_MISSING_FIELDS))
+        data = json.loads(result.output)
+        missing = _issues(data, "MISSING_WAIVER_FIELDS")
+        assert all(i["level"] == "warn" for i in missing)
+
+    def test_waiver_ref_missing_detected(self, runner):
+        """Coverage says WAIVED W99 but W99 is not defined in <waivers>."""
+        result = _json_invoke(runner, str(WAIVER_REF_MISSING))
+        data = json.loads(result.output)
+        ref_missing = _issues(data, "WAIVER_REF_MISSING")
+        assert len(ref_missing) >= 1
+
+    def test_waiver_ref_missing_is_error(self, runner):
+        result = _json_invoke(runner, str(WAIVER_REF_MISSING))
+        data = json.loads(result.output)
+        ref_missing = _issues(data, "WAIVER_REF_MISSING")
+        assert all(i["level"] == "error" for i in ref_missing)
+
+    def test_waiver_ref_missing_mentions_waiver_id(self, runner):
+        result = _json_invoke(runner, str(WAIVER_REF_MISSING))
+        data = json.loads(result.output)
+        ref_missing = _issues(data, "WAIVER_REF_MISSING")
+        combined = " ".join(i["message"] + i["line"] for i in ref_missing)
+        assert "W99" in combined
+
+    def test_valid_waiver_json_zero_counts(self, runner):
+        result = _json_invoke(runner, str(WAIVER_VALID))
+        data = json.loads(result.output)
+        assert data[0]["warn_count"] == 0
+        assert data[0]["error_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# TestCapabilitiesAndCoverage
+# ---------------------------------------------------------------------------
+
+class TestCapabilitiesAndCoverage:
+    """Capabilities section and coverage checks."""
+
+    def test_capabilities_no_modal_detected(self, runner):
+        """A capabilities line without MUST/MUST NOT/MAY/SHOULD must flag MISSING_MODAL."""
+        result = _json_invoke(runner, str(CAPABILITIES_NO_MODAL))
+        data = json.loads(result.output)
+        missing = _issues(data, "MISSING_MODAL")
+        assert len(missing) >= 1
+
+    def test_capabilities_no_modal_is_warning(self, runner):
+        result = _json_invoke(runner, str(CAPABILITIES_NO_MODAL))
+        data = json.loads(result.output)
+        missing = _issues(data, "MISSING_MODAL")
+        assert all(i["level"] == "warn" for i in missing)
+
+    def test_capabilities_with_modal_not_flagged(self, runner):
+        """Lines that DO have MAY/MUST/MUST NOT must not be flagged."""
+        result = _json_invoke(runner, str(CAPABILITIES_NO_MODAL))
+        data = json.loads(result.output)
+        missing = _issues(data, "MISSING_MODAL")
+        flagged_lines = [i["line"] for i in missing]
+        for line in flagged_lines:
+            assert not any(
+                modal in line.upper()
+                for modal in ("MUST NOT", "MUST", "MAY", "SHOULD", "DOES NOT")
+            )
+
+    def test_coverage_unchecked_rule_detected(self, runner):
+        """R2 coverage entry starts with TODO — must flag UNCHECKED_RULE."""
+        result = _json_invoke(runner, str(COVERAGE_UNCHECKED))
+        data = json.loads(result.output)
+        unchecked = _issues(data, "UNCHECKED_RULE")
+        assert len(unchecked) >= 1
+
+    def test_coverage_unchecked_rule_is_warning(self, runner):
+        result = _json_invoke(runner, str(COVERAGE_UNCHECKED))
+        data = json.loads(result.output)
+        unchecked = _issues(data, "UNCHECKED_RULE")
+        assert all(i["level"] == "warn" for i in unchecked)
+
+    def test_coverage_unchecked_mentions_rule(self, runner):
+        result = _json_invoke(runner, str(COVERAGE_UNCHECKED))
+        data = json.loads(result.output)
+        unchecked = _issues(data, "UNCHECKED_RULE")
+        combined = " ".join(i["message"] + i["line"] for i in unchecked)
+        assert "R2" in combined
+
+    def test_coverage_checked_rules_not_flagged(self, runner):
+        """R1 and R3 have real coverage entries — only R2 must be flagged."""
+        result = _json_invoke(runner, str(COVERAGE_UNCHECKED))
+        data = json.loads(result.output)
+        unchecked = _issues(data, "UNCHECKED_RULE")
+        rule_ids = [i["rule_id"] for i in unchecked]
+        assert "R1" not in rule_ids
+        assert "R3" not in rule_ids
+
+
+# ---------------------------------------------------------------------------
+# TestExitCodeSemantics
+# ---------------------------------------------------------------------------
+
+class TestExitCodeSemantics:
+    """Exit code contract: 0=clean, 1=warnings only, 2=errors."""
+
+    def test_clean_prompt_exits_zero(self, runner):
+        result = _invoke(runner, str(PAYMENT_CLEAN))
+        assert result.exit_code == 0
+
+    def test_warnings_only_exits_one(self, runner):
+        """NON_SEQUENTIAL_ID is a warning only — must exit 1, not 2."""
+        result = _invoke(runner, str(NON_SEQUENTIAL))
+        assert result.exit_code == 1
+
+    def test_error_present_exits_nonzero_and_not_one(self, runner):
+        """DUPLICATE_ID is an error — must exit != 0 and != 1 (i.e., 2)."""
+        result = _invoke(runner, str(PAYMENT_ISSUES))
+        assert result.exit_code != 0
+        assert result.exit_code != 1
+
+    def test_strict_warnings_become_errors_exits_two(self, runner):
+        """NON_SEQUENTIAL_ID is a warn; with --strict it becomes an error → exit 2."""
+        result = _invoke(runner, "--strict", str(NON_SEQUENTIAL))
+        assert result.exit_code == 2
+
+    def test_json_exit_code_still_nonzero_with_issues(self, runner):
+        """--json flag must not suppress the exit code."""
+        result = _json_invoke(runner, str(PAYMENT_ISSUES))
+        assert result.exit_code != 0
+
+    def test_json_exit_code_zero_for_clean(self, runner):
+        result = _json_invoke(runner, str(PAYMENT_CLEAN))
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# TestRecursiveStoryScanning
+# ---------------------------------------------------------------------------
+
+class TestRecursiveStoryScanning:
+    """--stories must scan subdirectories recursively (rglob, not glob)."""
+
+    def test_stories_in_subdirectory_are_found(self, runner, tmp_path):
+        """Story files nested in a subdirectory must be included in output."""
+        subdir = tmp_path / "sub"
+        subdir.mkdir()
+        story = subdir / "story__nested.md"
+        story.write_text("# Nested story\n\n## Story\nAs a user.\n")
+        result = _json_invoke(runner, "--stories", str(tmp_path), str(PAYMENT_CLEAN))
+        data = json.loads(result.output)
+        story_paths = [e["path"] for e in data if "story__nested" in e["path"]]
+        assert len(story_paths) == 1, (
+            f"Nested story not found in output. Paths: {[e['path'] for e in data]}"
+        )
+
+    def test_flat_and_nested_stories_both_found(self, runner, tmp_path):
+        """Both top-level and subdirectory stories must appear in a single scan."""
+        flat = tmp_path / "story__flat.md"
+        flat.write_text("# Flat story\n\n## Story\nAs a user.\n")
+        nested_dir = tmp_path / "module_a"
+        nested_dir.mkdir()
+        nested = nested_dir / "story__nested.md"
+        nested.write_text("# Nested story\n\n## Story\nAs a user.\n")
+
+        result = _json_invoke(runner, "--stories", str(tmp_path), str(PAYMENT_CLEAN))
+        data = json.loads(result.output)
+        story_names = {Path(e["path"]).name for e in data if "story__" in e["path"]}
+        assert "story__flat.md" in story_names
+        assert "story__nested.md" in story_names
+
+    def test_non_story_md_files_not_scanned(self, runner, tmp_path):
+        """Files not matching story__*.md must not appear in story results."""
+        regular = tmp_path / "README.md"
+        regular.write_text("# README\nThis is not a story.\n")
+        story = tmp_path / "story__real.md"
+        story.write_text("# Real story\n\n## Story\nAs a user.\n")
+
+        result = _json_invoke(runner, "--stories", str(tmp_path), str(PAYMENT_CLEAN))
+        data = json.loads(result.output)
+        story_paths = [e["path"] for e in data]
+        assert not any("README" in p for p in story_paths)
+
+    def test_stories_json_with_stories_flag_is_valid_json(self, runner):
+        """--json output when --stories is also passed must still be parseable."""
+        result = _json_invoke(
+            runner, "--stories", str(FIXTURES), str(PAYMENT_CLEAN)
+        )
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    def test_stories_results_contain_md_extension(self, runner):
+        result = _json_invoke(
+            runner, "--stories", str(FIXTURES), str(PAYMENT_CLEAN)
+        )
+        data = json.loads(result.output)
+        story_entries = [e for e in data if "story__" in e["path"]]
+        assert len(story_entries) >= 2
+        for e in story_entries:
+            assert e["path"].endswith(".md")
+
+
+# ---------------------------------------------------------------------------
+# TestStrictModeWithStories
+# ---------------------------------------------------------------------------
+
+class TestStrictModeWithStories:
+    """--strict escalates warnings in both prompt and story results."""
+
+    def test_strict_bad_story_exits_two(self, runner):
+        """A story with UNKNOWN_STORY_REF warnings + --strict must exit 2."""
+        result = _invoke(
+            runner, "--strict", "--stories", str(FIXTURES), str(PAYMENT_CLEAN)
+        )
+        assert result.exit_code == 2
+
+    def test_strict_bad_story_issues_are_errors(self, runner):
+        result = _json_invoke(
+            runner, "--strict", "--stories", str(FIXTURES), str(PAYMENT_CLEAN)
+        )
+        data = json.loads(result.output)
+        bad_story = next(
+            (e for e in data if "story__payment_bad_refs" in e["path"]), None
+        )
+        assert bad_story is not None
+        for issue in bad_story["issues"]:
+            assert issue["level"] == "error", (
+                f"Expected error, got warn for: {issue['message']}"
+            )
+
+    def test_strict_good_story_still_exits_zero_if_all_clean(self, runner):
+        """A fully clean prompt + clean story with --strict must still exit 0."""
+        result = _invoke(runner, "--strict", str(PAYMENT_CLEAN))
+        assert result.exit_code == 0
+
+    def test_strict_escalates_non_sequential_in_prompt(self, runner):
+        """NON_SEQUENTIAL_ID is warn by default; with --strict it becomes error."""
+        result = _json_invoke(runner, "--strict", str(NON_SEQUENTIAL))
+        data = json.loads(result.output)
+        seq = _issues(data, "NON_SEQUENTIAL_ID")
+        assert len(seq) >= 1
+        assert all(i["level"] == "error" for i in seq)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/commands/test_prompt.py
+++ b/tests/commands/test_prompt.py
@@ -1,0 +1,504 @@
+"""CLI-level tests for `pdd prompt lint` via CliRunner."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from pdd import cli
+from pdd.prompt_lint import LintIssue
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "prompt_lint"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _invoke(runner: CliRunner, *args):
+    """Invoke pdd prompt lint with --quiet to suppress update/summary noise."""
+    return runner.invoke(
+        cli.cli,
+        ["--quiet", "prompt", "lint", *args],
+        catch_exceptions=False,
+    )
+
+
+def _json_invoke(runner: CliRunner, *args):
+    """Invoke pdd prompt lint --json with --quiet for clean parseable output."""
+    return runner.invoke(
+        cli.cli,
+        ["--quiet", "prompt", "lint", "--json", *args],
+        catch_exceptions=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic invocation
+# ---------------------------------------------------------------------------
+
+class TestPromptLintBasic:
+    def test_clean_prompt_exits_zero(self, runner):
+        result = _invoke(runner, str(FIXTURES / "clean.prompt"))
+        assert result.exit_code == 0
+
+    def test_vague_undefined_exits_one(self, runner):
+        result = _invoke(runner, str(FIXTURES / "vague_undefined.prompt"))
+        assert result.exit_code == 1
+
+    def test_vague_defined_exits_zero(self, runner):
+        result = _invoke(runner, str(FIXTURES / "vague_defined.prompt"))
+        assert result.exit_code == 0
+
+    def test_output_contains_warn_label(self, runner):
+        result = _invoke(runner, str(FIXTURES / "vague_undefined.prompt"))
+        assert "WARN" in result.output or "warn" in result.output.lower()
+
+    def test_output_contains_deterministic_suggestion(self, runner):
+        result = _invoke(runner, str(FIXTURES / "vague_undefined.prompt"))
+        assert "Suggestion:" in result.output
+        assert "Add to <vocabulary>" in result.output
+
+    def test_nonexistent_target_raises_usage_error(self, runner):
+        result = runner.invoke(
+            cli.cli,
+            ["prompt", "lint", "/tmp/does_not_exist_xyz.prompt"],
+        )
+        assert result.exit_code != 0
+
+    def test_missing_target_without_stories_raises_usage_error(self, runner):
+        result = runner.invoke(
+            cli.cli,
+            ["--quiet", "prompt", "lint"],
+        )
+        assert result.exit_code != 0
+        assert "Missing argument 'TARGET'" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --strict flag
+# ---------------------------------------------------------------------------
+
+class TestStrictFlag:
+    def test_strict_escalates_warns_to_exit_two(self, runner):
+        result = _invoke(runner, "--strict", str(FIXTURES / "vague_undefined.prompt"))
+        assert result.exit_code == 2
+
+    def test_strict_clean_still_exits_zero(self, runner):
+        result = _invoke(runner, "--strict", str(FIXTURES / "clean.prompt"))
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# --json flag
+# ---------------------------------------------------------------------------
+
+class TestJsonFlag:
+    def test_json_output_is_valid_json(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "clean.prompt"))
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    def test_json_output_has_required_keys(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "vague_undefined.prompt"))
+        data = json.loads(result.output)
+        assert len(data) > 0
+        entry = data[0]
+        assert "path" in entry
+        assert "warn_count" in entry
+        assert "error_count" in entry
+        assert "issues" in entry
+
+    def test_json_issue_has_all_fields(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "vague_undefined.prompt"))
+        data = json.loads(result.output)
+        issues = data[0]["issues"]
+        assert len(issues) > 0
+        issue = issues[0]
+        for key in ("level", "term", "section", "line", "message", "suggestion", "interpretations"):
+            assert key in issue
+
+
+# ---------------------------------------------------------------------------
+# --stories flag
+# ---------------------------------------------------------------------------
+
+class TestStoriesFlag:
+    def test_stories_only_scans_story_files(self, runner):
+        result = _invoke(runner, "--stories", str(FIXTURES))
+        # vague story produces warnings -> exit 1
+        assert result.exit_code == 1
+        assert "story__vague_criteria.md" in result.output
+
+    def test_stories_only_json_output(self, runner):
+        result = _json_invoke(runner, "--stories", str(FIXTURES))
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert any("story__vague_criteria.md" in entry["path"] for entry in data)
+
+    def test_stories_dir_scans_story_files(self, runner):
+        result = _invoke(runner, "--stories", str(FIXTURES), str(FIXTURES / "clean.prompt"))
+        # vague story produces warnings → exit 1
+        assert result.exit_code == 1
+
+    def test_stories_json_output(self, runner):
+        result = _json_invoke(runner, "--stories", str(FIXTURES), str(FIXTURES / "clean.prompt"))
+        data = json.loads(result.output)
+        # Should include results for both the clean.prompt and the story files
+        assert isinstance(data, list)
+        assert len(data) >= 2
+
+    def test_stories_option_with_prompt_path_shows_correction(self, runner):
+        result = runner.invoke(
+            cli.cli,
+            [
+                "--quiet",
+                "prompt",
+                "lint",
+                "--stories",
+                "user_stories/prompt_lint_samples/prompts/foo_python.prompt",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--stories expects a directory" in result.output
+        assert "pdd prompt lint --stories user_stories/prompt_lint_samples/ prompts/foo_python.prompt" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --llm requires --ambiguity guard
+# ---------------------------------------------------------------------------
+
+class TestLlmFlag:
+    def test_llm_without_ambiguity_raises_usage_error(self, runner):
+        result = runner.invoke(
+            cli.cli,
+            ["--quiet", "prompt", "lint", "--llm", str(FIXTURES / "clean.prompt")],
+        )
+        assert result.exit_code != 0
+        assert "--llm requires --ambiguity" in result.output
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_llm_with_ambiguity_calls_llm_pass(self, mock_llm, runner):
+        mock_llm.return_value = []
+        result = _invoke(runner, "--ambiguity", "--llm", str(FIXTURES / "clean.prompt"))
+        mock_llm.assert_called_once()
+        assert result.exit_code == 0
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_llm_issues_appear_in_json_output(self, mock_llm, runner):
+        from pdd.prompt_lint import LintIssue
+        mock_llm.return_value = [
+            LintIssue(
+                level="warn",
+                term="graceful",
+                section="llm",
+                line="",
+                message='LLM flagged "graceful" as potentially ambiguous.',
+                suggestion="graceful: returns HTTP 409 with JSON error body",
+                interpretations=["silent swallow", "HTTP 409 with error body"],
+            )
+        ]
+        result = _json_invoke(
+            runner, "--ambiguity", "--llm", str(FIXTURES / "clean.prompt")
+        )
+        data = json.loads(result.output)
+        all_issues = [i for entry in data for i in entry["issues"]]
+        assert any(i["term"] == "graceful" for i in all_issues)
+
+
+# ---------------------------------------------------------------------------
+# --apply flag
+# ---------------------------------------------------------------------------
+
+class TestApplyFlag:
+    def test_apply_calls_apply_suggestions(self, runner, tmp_path):
+        prompt = tmp_path / "apply_test.prompt"
+        prompt.write_text(
+            "<contract_rules>Must return a valid response.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        with patch("pdd.commands.prompt.apply_suggestions", return_value=1) as mock_apply:
+            result = runner.invoke(
+                cli.cli,
+                ["prompt", "lint", "--apply", str(prompt)],
+                catch_exceptions=False,
+            )
+        mock_apply.assert_called_once()
+
+    def test_without_apply_flag_never_writes(self, runner, tmp_path):
+        prompt = tmp_path / "no_apply.prompt"
+        original = "<contract_rules>Must return a valid response.</contract_rules>\n"
+        prompt.write_text(original, encoding="utf-8")
+        with patch("pdd.commands.prompt.apply_suggestions") as mock_apply:
+            _invoke(runner, str(prompt))
+        mock_apply.assert_not_called()
+        assert prompt.read_text(encoding="utf-8") == original
+
+    def test_apply_actually_writes_vocabulary_block(self, runner, tmp_path):
+        """End-to-end: --apply writes concrete LLM-sourced suggestions into the file."""
+        from pdd.prompt_lint import apply_suggestions
+        prompt = tmp_path / "real_apply.prompt"
+        prompt.write_text(
+            "<contract_rules>Must return a valid response.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        # Simulate what the LLM pass would produce: a concrete (non-placeholder) suggestion
+        issue = LintIssue(
+            level="warn",
+            term="valid",
+            section="contract_rules",
+            line="Must return a valid response.",
+            message="Vague term.",
+            suggestion="valid response: HTTP 200 with non-empty data field",
+        )
+        written = apply_suggestions(prompt, [issue])
+        assert written == 1
+        text = prompt.read_text(encoding="utf-8")
+        assert "<vocabulary>" in text
+        assert "valid response: HTTP 200" in text
+
+    def test_apply_with_json_still_outputs_json(self, runner, tmp_path):
+        prompt = tmp_path / "apply_json.prompt"
+        prompt.write_text(
+            "<contract_rules>Must return a valid response.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        result = runner.invoke(
+            cli.cli,
+            ["--quiet", "prompt", "lint", "--apply", "--json", str(prompt)],
+            catch_exceptions=False,
+        )
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+
+# ---------------------------------------------------------------------------
+# LLM pass output format: "Possible interpretations" block
+# ---------------------------------------------------------------------------
+
+class TestLlmOutputFormat:
+    """
+    Spec example output:
+      Ambiguous term: "duplicate upload"
+      Possible interpretations:
+      1. Same filename
+      2. Same file hash
+      3. Same tenant + normalized file hash
+      Suggestion:
+      Add to <vocabulary>:
+      - Duplicate upload: an upload with the same tenant ID and normalized file hash
+    Verifies that the Rich renderer produces the expected structure.
+    """
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_interpretations_block_rendered_in_output(self, mock_llm, runner):
+        mock_llm.return_value = [
+            LintIssue(
+                level="warn",
+                term="duplicate upload",
+                section="contract_rules",
+                line="The function must reject duplicate uploads gracefully.",
+                message='LLM flagged "duplicate upload" as potentially ambiguous.',
+                suggestion=(
+                    "duplicate upload: an upload with the same tenant ID and "
+                    "normalized file hash as a previously accepted upload"
+                ),
+                interpretations=[
+                    "Same filename",
+                    "Same file hash",
+                    "Same tenant + normalized file hash",
+                ],
+            )
+        ]
+        result = _invoke(
+            runner,
+            "--ambiguity", "--llm",
+            str(FIXTURES / "upload_handler_python.prompt"),
+        )
+        assert "Possible interpretations" in result.output
+        assert "Same filename" in result.output
+        assert "Same file hash" in result.output
+        assert "Same tenant" in result.output
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_suggestion_block_rendered_in_output(self, mock_llm, runner):
+        mock_llm.return_value = [
+            LintIssue(
+                level="warn",
+                term="duplicate upload",
+                section="contract_rules",
+                line="",
+                message='LLM flagged "duplicate upload" as potentially ambiguous.',
+                suggestion=(
+                    "duplicate upload: an upload with the same tenant ID and "
+                    "normalized file hash as a previously accepted upload"
+                ),
+                interpretations=["Same filename", "Same file hash"],
+            )
+        ]
+        result = _invoke(
+            runner,
+            "--ambiguity", "--llm",
+            str(FIXTURES / "upload_handler_python.prompt"),
+        )
+        # Normalise Rich's line-wrapping for substring checks
+        flat = " ".join(result.output.split())
+        assert "Suggestion" in flat
+        assert "duplicate upload" in flat
+        # "normalized file hash" may be wrapped across lines — check each word
+        assert "normalized" in flat
+        assert "file hash" in flat
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_interpretations_appear_in_json_output(self, mock_llm, runner):
+        mock_llm.return_value = [
+            LintIssue(
+                level="warn",
+                term="duplicate upload",
+                section="contract_rules",
+                line="",
+                message="LLM flagged term.",
+                suggestion="duplicate upload: same hash and tenant",
+                interpretations=["Same filename", "Same file hash", "Same tenant + hash"],
+            )
+        ]
+        result = _json_invoke(
+            runner,
+            "--ambiguity", "--llm",
+            str(FIXTURES / "upload_handler_python.prompt"),
+        )
+        data = json.loads(result.output)
+        all_issues = [i for entry in data for i in entry["issues"]]
+        dup_issues = [i for i in all_issues if i["term"] == "duplicate upload"]
+        assert dup_issues
+        assert dup_issues[0]["interpretations"] == [
+            "Same filename", "Same file hash", "Same tenant + hash"
+        ]
+        assert "normalized file hash" in dup_issues[0]["suggestion"] or \
+               "hash" in dup_issues[0]["suggestion"]
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_issue_without_interpretations_renders_no_block(self, mock_llm, runner):
+        """Deterministic issues (no interpretations) must not render the block."""
+        mock_llm.return_value = []
+        result = _invoke(
+            runner,
+            "--ambiguity", "--llm",
+            str(FIXTURES / "upload_handler_python.prompt"),
+        )
+        # Deterministic issues have empty interpretations → no "Possible interpretations" header
+        assert "Possible interpretations" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# --ambiguity flag: deterministic ambiguity command form
+# ---------------------------------------------------------------------------
+
+class TestAmbiguityFlag:
+    """
+    --ambiguity is a valid non-LLM command form. The deterministic pass already
+    includes vague-term and observable-outcome checks; --llm requires this flag.
+    """
+
+    def test_ambiguity_flag_runs_deterministic_pass(self, runner, tmp_path):
+        prompt = tmp_path / "outcome.prompt"
+        prompt.write_text(
+            "<contract_rules>The request must be valid.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        result_no_ambiguity = _invoke(runner, str(prompt))
+        result_with_ambiguity = _invoke(runner, "--ambiguity", str(prompt))
+        assert result_no_ambiguity.exit_code == 1
+        assert result_with_ambiguity.exit_code == 1
+        assert "Vague term" in result_with_ambiguity.output
+        assert "observable outcome" in result_with_ambiguity.output
+
+    def test_upload_handler_warns_on_vague_terms(self, runner):
+        result = _invoke(runner, str(FIXTURES / "upload_handler_python.prompt"))
+        assert result.exit_code == 1
+
+    def test_upload_handler_with_vocab_exits_clean(self, runner):
+        result = _invoke(runner, str(FIXTURES / "upload_handler_with_vocab_python.prompt"))
+        assert result.exit_code == 0
+
+    def test_upload_handler_json_warns_contain_duplicate(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "upload_handler_python.prompt"))
+        data = json.loads(result.output)
+        all_issues = [i for entry in data for i in entry["issues"]]
+        assert any(i["term"] == "duplicate" for i in all_issues)
+
+    def test_upload_handler_json_issue_location_is_contract_rules(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "upload_handler_python.prompt"))
+        data = json.loads(result.output)
+        all_issues = [i for entry in data for i in entry["issues"]]
+        dup_issues = [i for i in all_issues if i["term"] == "duplicate"]
+        assert dup_issues
+        assert dup_issues[0]["section"] == "contract_rules"
+
+    def test_upload_handler_json_issue_line_contains_source_text(self, runner):
+        result = _json_invoke(runner, str(FIXTURES / "upload_handler_python.prompt"))
+        data = json.loads(result.output)
+        all_issues = [i for entry in data for i in entry["issues"]]
+        dup_issues = [i for i in all_issues if i["term"] == "duplicate"]
+        assert dup_issues
+        assert "duplicate" in dup_issues[0]["line"].lower()
+
+
+# ---------------------------------------------------------------------------
+# ## Covers: CLI-level story scanning
+# ---------------------------------------------------------------------------
+
+class TestCoversSectionCli:
+    def test_story_with_covers_exits_zero(self, runner):
+        result = _invoke(
+            runner,
+            "--stories", str(FIXTURES),
+            str(FIXTURES / "clean.prompt"),
+        )
+        # The covers story should be clean; vague story still warns
+        # At least the covers fixture must not add new errors vs. the vague one
+        assert result.exit_code in (0, 1)  # 1 is from the vague story fixture
+
+    def test_story_with_covers_json_shows_zero_issues_for_covers_file(self, runner):
+        result = _json_invoke(
+            runner,
+            "--stories", str(FIXTURES),
+            str(FIXTURES / "clean.prompt"),
+        )
+        data = json.loads(result.output)
+        covers_entry = next(
+            (e for e in data if "story__covers" in e["path"]), None
+        )
+        assert covers_entry is not None
+        assert covers_entry["warn_count"] == 0
+        assert covers_entry["error_count"] == 0
+
+    def test_story_with_glossary_json_shows_zero_issues(self, runner):
+        result = _json_invoke(
+            runner,
+            "--stories", str(FIXTURES),
+            str(FIXTURES / "clean.prompt"),
+        )
+        data = json.loads(result.output)
+        clean_story = next(
+            (e for e in data if "story__clean" in e["path"]), None
+        )
+        assert clean_story is not None
+        assert clean_story["warn_count"] == 0
+
+    def test_story_without_vocabulary_source_shows_issues(self, runner):
+        result = _json_invoke(
+            runner,
+            "--stories", str(FIXTURES),
+            str(FIXTURES / "clean.prompt"),
+        )
+        data = json.loads(result.output)
+        vague_story = next(
+            (e for e in data if "story__vague_criteria" in e["path"]), None
+        )
+        assert vague_story is not None
+        assert vague_story["warn_count"] > 0

--- a/tests/commands/test_prompt_comprehensive.py
+++ b/tests/commands/test_prompt_comprehensive.py
@@ -1,0 +1,731 @@
+"""
+Comprehensive CLI tests for `pdd prompt lint`.
+
+Each test class maps to one of the documented usage patterns:
+
+    # Single file
+    pdd prompt lint prompts/foo_python.prompt
+
+    # Directory
+    pdd prompt lint prompts/
+
+    # Stories only
+    pdd prompt lint --stories user_stories/
+
+    # Prompt + stories together
+    pdd prompt lint --stories user_stories/ prompts/foo_python.prompt
+
+    # JSON output
+    pdd prompt lint --json prompts/foo_python.prompt
+
+    # Deterministic ambiguity pass
+    pdd prompt lint --ambiguity prompts/foo_python.prompt
+
+    # Strict mode (CI gate)
+    pdd prompt lint --strict prompts/foo_python.prompt
+
+    # LLM ambiguity review
+    pdd prompt lint --ambiguity --llm prompts/foo_python.prompt
+
+    # Write vocabulary suggestions back into the file
+    pdd prompt lint --ambiguity --llm --apply prompts/foo_python.prompt
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from pdd import cli
+from pdd.prompt_lint import LintIssue, VAGUE_TERMS, VAGUE_TERMS_STRICT
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "prompt_lint"
+PDD_PROMPTS = Path(__file__).parents[2] / "pdd" / "prompts"
+USER_STORIES = Path(__file__).parents[2] / "user_stories"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _lint(runner: CliRunner, *args):
+    return runner.invoke(
+        cli.cli, ["--quiet", "prompt", "lint", *args], catch_exceptions=False
+    )
+
+
+def _lint_json(runner: CliRunner, *args):
+    return runner.invoke(
+        cli.cli, ["--quiet", "prompt", "lint", "--json", *args], catch_exceptions=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pattern 1: pdd prompt lint prompts/foo_python.prompt
+# Single file — exit codes, issue content, section names
+# ---------------------------------------------------------------------------
+
+class TestSingleFile:
+    """pdd prompt lint <single-file>"""
+
+    def test_clean_file_exits_zero(self, runner):
+        result = _lint(runner, str(FIXTURES / "payment_api_clean_python.prompt"))
+        assert result.exit_code == 0
+
+    def test_vague_file_exits_one(self, runner):
+        result = _lint(runner, str(FIXTURES / "payment_api_python.prompt"))
+        assert result.exit_code == 1
+
+    def test_output_shows_file_path(self, runner):
+        result = _lint(runner, str(FIXTURES / "payment_api_python.prompt"))
+        assert "payment_api_python.prompt" in result.output
+
+    def test_output_shows_warn_label(self, runner):
+        result = _lint(runner, str(FIXTURES / "payment_api_python.prompt"))
+        assert "WARN" in result.output
+
+    def test_output_shows_vague_term(self, runner):
+        result = _lint(runner, str(FIXTURES / "payment_api_python.prompt"))
+        # "valid", "authorized", "duplicate", "graceful", "successful" are all in rules
+        assert any(t in result.output for t in ("valid", "authorized", "duplicate"))
+
+    def test_output_shows_section_name(self, runner):
+        result = _lint(runner, str(FIXTURES / "payment_api_python.prompt"))
+        assert "contract_rules" in result.output
+
+    def test_output_shows_suggestion(self, runner):
+        result = _lint(runner, str(FIXTURES / "payment_api_python.prompt"))
+        assert "Suggestion" in result.output
+        assert "<vocabulary>" in result.output
+
+    def test_clean_output_shows_checkmark(self, runner):
+        result = _lint(runner, str(FIXTURES / "payment_api_clean_python.prompt"))
+        assert "clean" in result.output.lower() or result.exit_code == 0
+
+    def test_foo_python_prompt_exits_one(self, runner):
+        """The bundled foo_python.prompt has intentional vague terms."""
+        result = _lint(runner, str(PDD_PROMPTS / "foo_python.prompt"))
+        assert result.exit_code == 1
+
+    def test_foo_python_prompt_contract_rules_flagged(self, runner):
+        result = _json_lint(runner, str(PDD_PROMPTS / "foo_python.prompt"))
+        data = json.loads(result.output)
+        all_issues = [i for e in data for i in e["issues"]]
+        assert any(i["section"] == "contract_rules" for i in all_issues)
+
+    def test_multiline_rule_block_modal_detected(self, runner):
+        """Multi-line rule block: modal verb on continuation line is detected."""
+        result = _lint(runner, str(FIXTURES / "payment_api_python.prompt"))
+        # R2 has MUST on the second line of its block — should NOT produce MISSING_MODAL
+        data_result = _lint_json(runner, str(FIXTURES / "payment_api_python.prompt"))
+        data = json.loads(data_result.output)
+        all_issues = [i for e in data for i in e["issues"]]
+        # No MISSING_MODAL issues (we're running prompt lint, not contracts check)
+        # The important thing: vague terms on the header line are still caught
+        assert any(i["term"] in VAGUE_TERMS for i in all_issues)
+
+
+def _json_lint(runner, *args):
+    return runner.invoke(
+        cli.cli, ["--quiet", "prompt", "lint", "--json", *args], catch_exceptions=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pattern 2: pdd prompt lint prompts/
+# Directory scan — aggregates results, exits non-zero if any issue
+# ---------------------------------------------------------------------------
+
+class TestDirectoryScan:
+    """pdd prompt lint <directory>"""
+
+    def test_fixtures_dir_exit_nonzero_due_to_vague_files(self, runner):
+        result = _lint(runner, str(FIXTURES))
+        assert result.exit_code == 1
+
+    def test_fixtures_dir_output_contains_multiple_files(self, runner):
+        result = _lint(runner, str(FIXTURES))
+        # Both clean and vague fixtures appear in output
+        assert "payment_api_python.prompt" in result.output
+
+    def test_tmp_dir_with_clean_file_exits_zero(self, runner, tmp_path):
+        p = tmp_path / "clean.prompt"
+        p.write_text(
+            "<contract_rules>R1: The system MUST reject requests without a token.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        result = _lint(runner, str(tmp_path))
+        assert result.exit_code == 0
+
+    def test_tmp_dir_with_vague_file_exits_one(self, runner, tmp_path):
+        p = tmp_path / "vague.prompt"
+        p.write_text(
+            "<contract_rules>R1: The system MUST return a valid response.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        result = _lint(runner, str(tmp_path))
+        assert result.exit_code == 1
+
+    def test_pdd_prompts_dir_exits_nonzero_due_to_foo_fixture(self, runner):
+        """foo_python.prompt has intentional vague terms so the real prompts/ dir
+        exits non-zero — verifying the directory scanner reaches nested files."""
+        result = _lint(runner, str(PDD_PROMPTS))
+        assert result.exit_code != 0
+
+    def test_directory_scan_json_is_list(self, runner):
+        result = _lint_json(runner, str(FIXTURES))
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) >= 2
+
+    def test_directory_scan_json_each_entry_has_path(self, runner):
+        result = _lint_json(runner, str(FIXTURES))
+        data = json.loads(result.output)
+        for entry in data:
+            assert "path" in entry
+            assert entry["path"].endswith(".prompt")
+
+    def test_empty_dir_exits_zero(self, runner, tmp_path):
+        result = _lint(runner, str(tmp_path))
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Pattern 3: pdd prompt lint --stories user_stories/
+# Stories-only scan
+# ---------------------------------------------------------------------------
+
+class TestStoriesOnly:
+    """pdd prompt lint --stories <dir>"""
+
+    def test_vague_story_exits_one(self, runner):
+        result = _lint(runner, "--stories", str(FIXTURES))
+        assert result.exit_code == 1
+
+    def test_vague_story_output_contains_filename(self, runner):
+        result = _lint(runner, "--stories", str(FIXTURES))
+        assert "story__payment_vague.md" in result.output
+
+    def test_clean_story_exits_zero(self, runner, tmp_path):
+        story = tmp_path / "story__clean.md"
+        story.write_text(
+            "# Story\n## Acceptance Criteria\n"
+            "1. When POST /charge is called with a valid Bearer token,\n"
+            "   the server returns HTTP 200.\n"
+            "## Glossary\n"
+            "- valid Bearer token: a JWT with scope=charge:write and non-expired exp\n",
+            encoding="utf-8",
+        )
+        result = _lint(runner, "--stories", str(tmp_path))
+        assert result.exit_code == 0
+
+    def test_real_user_stories_dir_exits_zero(self, runner):
+        """The repo's own user_stories/ must pass lint (story__template.md is clean)."""
+        result = _lint(runner, "--stories", str(USER_STORIES))
+        assert result.exit_code == 0
+
+    def test_stories_json_contains_story_paths(self, runner):
+        result = _lint_json(runner, "--stories", str(FIXTURES))
+        data = json.loads(result.output)
+        paths = [e["path"] for e in data]
+        assert any("story__" in p for p in paths)
+
+    def test_stories_json_vague_story_has_positive_warn_count(self, runner):
+        result = _lint_json(runner, "--stories", str(FIXTURES))
+        data = json.loads(result.output)
+        vague = next((e for e in data if "story__payment_vague" in e["path"]), None)
+        assert vague is not None
+        assert vague["warn_count"] > 0
+
+    def test_stories_does_not_scan_prompt_files(self, runner):
+        """--stories without TARGET must not report .prompt files in output."""
+        result = _lint(runner, "--stories", str(FIXTURES))
+        # prompt files have .prompt extension; stories have story__ prefix
+        # Any file reported must be a story file
+        for line in result.output.splitlines():
+            if ".prompt" in line and "WARN" not in line and "ERROR" not in line:
+                # This would be a prompt file path in output header — should not appear
+                assert "story__" in line or "warn" in line.lower() or "error" in line.lower()
+
+
+# ---------------------------------------------------------------------------
+# Pattern 4: pdd prompt lint --stories user_stories/ prompts/foo_python.prompt
+# Scan a prompt AND its stories together
+# ---------------------------------------------------------------------------
+
+class TestCombinedStoriesAndPrompt:
+    """pdd prompt lint --stories <dir> <prompt-file>"""
+
+    def test_combined_scan_exits_one_from_vague_prompt(self, runner):
+        """foo_python.prompt has vague terms → exit 1 even if stories are clean."""
+        result = _lint(
+            runner,
+            "--stories", str(FIXTURES),
+            str(PDD_PROMPTS / "foo_python.prompt"),
+        )
+        assert result.exit_code == 1
+
+    def test_combined_output_contains_prompt_and_story_results(self, runner):
+        result = _lint(
+            runner,
+            "--stories", str(FIXTURES),
+            str(FIXTURES / "payment_api_python.prompt"),
+        )
+        assert "payment_api_python.prompt" in result.output
+        assert "story__payment_vague.md" in result.output
+
+    def test_combined_json_contains_both_prompts_and_stories(self, runner):
+        result = _lint_json(
+            runner,
+            "--stories", str(FIXTURES),
+            str(FIXTURES / "payment_api_clean_python.prompt"),
+        )
+        data = json.loads(result.output)
+        paths = [e["path"] for e in data]
+        assert any(".prompt" in p for p in paths)
+        assert any("story__" in p for p in paths)
+
+    def test_combined_clean_prompt_and_clean_stories_exits_zero(self, runner, tmp_path):
+        # Create a clean prompt
+        prompt = tmp_path / "ok.prompt"
+        prompt.write_text(
+            "<contract_rules>R1: The system MUST reject requests without a token.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        # Clean story dir (no story__ files = no stories = no issues)
+        result = _lint(runner, "--stories", str(tmp_path), str(prompt))
+        assert result.exit_code == 0
+
+    def test_combined_scan_all_sections_aggregated(self, runner):
+        result = _lint_json(
+            runner,
+            "--stories", str(FIXTURES),
+            str(FIXTURES / "payment_api_python.prompt"),
+        )
+        data = json.loads(result.output)
+        total_issues = sum(e["warn_count"] + e["error_count"] for e in data)
+        # Both the vague prompt and the vague story contribute
+        assert total_issues >= 2
+
+
+# ---------------------------------------------------------------------------
+# Pattern 5: pdd prompt lint --json prompts/foo_python.prompt
+# JSON output — schema, field types, informational messages on stderr
+# ---------------------------------------------------------------------------
+
+class TestJsonOutput:
+    """pdd prompt lint --json <target>"""
+
+    def test_json_is_parseable_list(self, runner):
+        result = _lint_json(runner, str(FIXTURES / "payment_api_python.prompt"))
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    def test_json_each_entry_has_required_keys(self, runner):
+        result = _lint_json(runner, str(FIXTURES / "payment_api_python.prompt"))
+        data = json.loads(result.output)
+        for entry in data:
+            for key in ("path", "warn_count", "error_count", "issues"):
+                assert key in entry, f"Missing key '{key}' in entry"
+
+    def test_json_issue_has_all_spec_fields(self, runner):
+        result = _lint_json(runner, str(FIXTURES / "payment_api_python.prompt"))
+        data = json.loads(result.output)
+        issues = [i for e in data for i in e["issues"]]
+        assert issues, "Expected at least one issue"
+        for issue in issues:
+            for key in ("level", "term", "section", "line", "message",
+                        "suggestion", "interpretations"):
+                assert key in issue, f"Missing key '{key}' in issue"
+
+    def test_json_clean_prompt_has_zero_counts(self, runner):
+        result = _lint_json(runner, str(FIXTURES / "payment_api_clean_python.prompt"))
+        data = json.loads(result.output)
+        assert all(e["warn_count"] == 0 and e["error_count"] == 0 for e in data)
+
+    def test_json_issue_level_is_warn_by_default(self, runner):
+        result = _lint_json(runner, str(FIXTURES / "payment_api_python.prompt"))
+        data = json.loads(result.output)
+        issues = [i for e in data for i in e["issues"]]
+        assert all(i["level"] == "warn" for i in issues)
+
+    def test_json_issue_section_is_contract_rules(self, runner):
+        result = _lint_json(runner, str(FIXTURES / "payment_api_python.prompt"))
+        data = json.loads(result.output)
+        issues = [i for e in data for i in e["issues"]]
+        assert any(i["section"] == "contract_rules" for i in issues)
+
+    def test_json_issue_line_contains_source_text(self, runner):
+        result = _lint_json(runner, str(FIXTURES / "payment_api_python.prompt"))
+        data = json.loads(result.output)
+        issues = [i for e in data for i in e["issues"]]
+        # Every issue must have a non-empty line unless it's the observable check
+        content_issues = [i for i in issues if i["term"] != "(no observable outcome)"]
+        assert all(len(i["line"]) > 0 for i in content_issues)
+
+    def test_json_interpretations_is_empty_list_for_deterministic_pass(self, runner):
+        result = _lint_json(runner, str(FIXTURES / "payment_api_python.prompt"))
+        data = json.loads(result.output)
+        issues = [i for e in data for i in e["issues"]]
+        assert all(i["interpretations"] == [] for i in issues)
+
+    def test_json_directory_scan_produces_multiple_entries(self, runner):
+        result = _lint_json(runner, str(FIXTURES))
+        data = json.loads(result.output)
+        assert len(data) >= 3
+
+
+# ---------------------------------------------------------------------------
+# Pattern 6: pdd prompt lint --strict prompts/foo_python.prompt
+# Strict mode: warns → errors, exit 2; extended terms fire
+# ---------------------------------------------------------------------------
+
+class TestStrictMode:
+    """pdd prompt lint --strict <target>"""
+
+    def test_strict_escalates_warn_to_exit_two(self, runner):
+        result = _lint(runner, "--strict", str(FIXTURES / "payment_api_python.prompt"))
+        assert result.exit_code == 2
+
+    def test_strict_clean_prompt_exits_zero(self, runner):
+        result = _lint(runner, "--strict", str(FIXTURES / "payment_api_clean_python.prompt"))
+        assert result.exit_code == 0
+
+    def test_strict_json_issues_have_error_level(self, runner):
+        result = _lint_json(runner, "--strict", str(FIXTURES / "payment_api_python.prompt"))
+        data = json.loads(result.output)
+        issues = [i for e in data for i in e["issues"]]
+        assert issues
+        assert all(i["level"] == "error" for i in issues)
+
+    def test_strict_activates_extended_vague_terms(self, runner):
+        """VAGUE_TERMS_STRICT words (correct, expected, etc.) only fire with --strict."""
+        result_default = _lint(runner, str(FIXTURES / "strict_terms_python.prompt"))
+        result_strict  = _lint(runner, "--strict", str(FIXTURES / "strict_terms_python.prompt"))
+        assert result_default.exit_code == 0, \
+            "strict_terms fixture must be clean in default mode"
+        assert result_strict.exit_code == 2, \
+            "strict_terms fixture must produce errors in --strict mode"
+
+    def test_issue_named_terms_are_in_default_terms(self, runner):
+        for word in ("valid", "safe", "active", "recent", "duplicate", "graceful",
+                     "reasonable", "authorized", "trusted", "complete", "successful"):
+            assert word in VAGUE_TERMS, f"'{word}' should be checked in default mode"
+
+    def test_strict_extended_terms_are_not_in_default_terms(self, runner):
+        """Verify the split is correct at the constant level."""
+        for word in ("correct", "proper", "expected", "appropriate"):
+            assert word not in VAGUE_TERMS, f"'{word}' should be in VAGUE_TERMS_STRICT, not VAGUE_TERMS"
+            assert word in VAGUE_TERMS_STRICT, f"'{word}' should be in VAGUE_TERMS_STRICT"
+
+    def test_strict_json_extended_term_shown(self, runner):
+        result = _lint_json(runner, "--strict", str(FIXTURES / "strict_terms_python.prompt"))
+        data = json.loads(result.output)
+        issues = [i for e in data for i in e["issues"]]
+        extended_hit = {i["term"] for i in issues} & VAGUE_TERMS_STRICT
+        assert extended_hit, f"Expected at least one VAGUE_TERMS_STRICT hit, got: {issues}"
+
+    def test_strict_stories_escalates_story_warns(self, runner):
+        result = _lint(runner, "--strict", "--stories", str(FIXTURES))
+        assert result.exit_code == 2
+
+    def test_strict_prose_gate_still_applies(self, runner, tmp_path):
+        """Even in --strict mode, prose in a file with no contract section is not scanned."""
+        p = tmp_path / "llm_instruction.prompt"
+        p.write_text(
+            "% Your task is to generate complete and correct architecture.\n",
+            encoding="utf-8",
+        )
+        result = _lint(runner, "--strict", str(p))
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Pattern 7: pdd prompt lint --ambiguity --llm prompts/foo_python.prompt
+# LLM ambiguity pass — mocked; verifies interpretations block, suggestion block
+# ---------------------------------------------------------------------------
+
+class TestLlmAmbiguityReview:
+    """pdd prompt lint --ambiguity --llm <file>"""
+
+    def test_llm_without_ambiguity_is_usage_error(self, runner):
+        result = runner.invoke(
+            cli.cli,
+            ["--quiet", "prompt", "lint", "--llm",
+             str(FIXTURES / "payment_api_python.prompt")],
+        )
+        assert result.exit_code != 0
+        assert "--llm requires --ambiguity" in result.output
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_llm_pass_called_once(self, mock_llm, runner):
+        mock_llm.return_value = []
+        _lint(runner, "--ambiguity", "--llm",
+              str(FIXTURES / "payment_api_python.prompt"))
+        mock_llm.assert_called_once()
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_llm_issues_appear_in_rich_output(self, mock_llm, runner):
+        mock_llm.return_value = [
+            LintIssue(
+                level="warn",
+                term="valid amount",
+                section="llm",
+                line="",
+                message='LLM flagged "valid amount" as potentially ambiguous.',
+                suggestion=(
+                    "valid amount: a positive integer in cents, "
+                    "greater than 0 and at most 99_999_999"
+                ),
+                interpretations=[
+                    "Any positive number",
+                    "Positive integer in cents <= 99_999_999",
+                    "Non-null field regardless of value",
+                ],
+            )
+        ]
+        result = _lint(runner, "--ambiguity", "--llm",
+                       str(FIXTURES / "payment_api_python.prompt"))
+        assert "Possible interpretations" in result.output
+        assert "Any positive number" in result.output
+        assert "cents" in result.output
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_llm_suggestion_rendered(self, mock_llm, runner):
+        mock_llm.return_value = [
+            LintIssue(
+                level="warn",
+                term="duplicate",
+                section="llm",
+                line="",
+                message='LLM flagged "duplicate" as potentially ambiguous.',
+                suggestion=(
+                    "duplicate transaction: a charge whose idempotency_key "
+                    "and merchant_id match a row in charges"
+                ),
+                interpretations=["Same key only", "Same key + merchant"],
+            )
+        ]
+        result = _lint(runner, "--ambiguity", "--llm",
+                       str(FIXTURES / "payment_api_python.prompt"))
+        flat = " ".join(result.output.split())
+        assert "Suggestion" in flat
+        assert "idempotency_key" in flat
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_llm_issues_in_json(self, mock_llm, runner):
+        mock_llm.return_value = [
+            LintIssue(
+                level="warn",
+                term="graceful",
+                section="llm",
+                line="",
+                message='LLM flagged "graceful" as potentially ambiguous.',
+                suggestion="graceful failure: HTTP 502 with retry_after field",
+                interpretations=["Silent swallow", "HTTP 502", "Client-visible 4xx"],
+            )
+        ]
+        result = _lint_json(runner, "--ambiguity", "--llm",
+                            str(FIXTURES / "payment_api_python.prompt"))
+        data = json.loads(result.output)
+        all_issues = [i for e in data for i in e["issues"]]
+        # Filter for the LLM-sourced issue specifically (section="llm")
+        llm_issues = [i for i in all_issues if i["term"] == "graceful" and i["section"] == "llm"]
+        assert llm_issues, f"Expected LLM 'graceful' issue; got sections: {[i['section'] for i in all_issues if i['term']=='graceful']}"
+        assert llm_issues[0]["interpretations"] == [
+            "Silent swallow", "HTTP 502", "Client-visible 4xx"
+        ]
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_deterministic_issues_have_no_interpretations(self, mock_llm, runner):
+        mock_llm.return_value = []
+        result = _lint_json(runner, "--ambiguity", "--llm",
+                            str(FIXTURES / "payment_api_python.prompt"))
+        data = json.loads(result.output)
+        det_issues = [i for e in data for i in e["issues"]
+                      if i["section"] != "llm"]
+        assert all(i["interpretations"] == [] for i in det_issues)
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_interpretations_not_rendered_without_llm_issues(self, mock_llm, runner):
+        mock_llm.return_value = []
+        result = _lint(runner, "--ambiguity", "--llm",
+                       str(FIXTURES / "payment_api_python.prompt"))
+        assert "Possible interpretations" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Pattern 8: pdd prompt lint --ambiguity --llm --apply prompts/foo_python.prompt
+# Apply: writes vocabulary suggestions back into the file
+# ---------------------------------------------------------------------------
+
+class TestApplyWriteback:
+    """pdd prompt lint --ambiguity --llm --apply <file>"""
+
+    def test_apply_without_llm_writes_placeholder_only_if_suggestion_present(
+        self, runner, tmp_path
+    ):
+        """--apply without --llm only writes LLM-sourced (non-placeholder) suggestions.
+        The deterministic pass produces placeholder suggestions → nothing is written."""
+        prompt = tmp_path / "test.prompt"
+        prompt.write_text(
+            "<contract_rules>R1: The system MUST return a valid response.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        original = prompt.read_text(encoding="utf-8")
+        result = runner.invoke(
+            cli.cli,
+            ["--quiet", "prompt", "lint", "--apply", str(prompt)],
+            catch_exceptions=False,
+        )
+        # Deterministic suggestions are all placeholders → nothing written
+        assert prompt.read_text(encoding="utf-8") == original
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_apply_with_llm_writes_concrete_suggestion(self, mock_llm, runner, tmp_path):
+        """--ambiguity --llm --apply: LLM-sourced suggestions are written into the file."""
+        mock_llm.return_value = [
+            LintIssue(
+                level="warn",
+                term="valid",
+                section="llm",
+                line="",
+                message='LLM flagged "valid" as potentially ambiguous.',
+                suggestion="valid amount: positive integer in cents, 1–99_999_999",
+            )
+        ]
+        prompt = tmp_path / "payment.prompt"
+        prompt.write_text(
+            "<contract_rules>R1: The system MUST return a valid amount.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        runner.invoke(
+            cli.cli,
+            ["--quiet", "prompt", "lint", "--ambiguity", "--llm", "--apply", str(prompt)],
+            catch_exceptions=False,
+        )
+        text = prompt.read_text(encoding="utf-8")
+        assert "<vocabulary>" in text
+        assert "valid amount: positive integer" in text
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_apply_appends_to_existing_vocabulary_block(self, mock_llm, runner, tmp_path):
+        mock_llm.return_value = [
+            LintIssue(
+                level="warn",
+                term="duplicate",
+                section="llm",
+                line="",
+                message="",
+                suggestion="duplicate charge: same idempotency_key + merchant_id",
+            )
+        ]
+        prompt = tmp_path / "with_vocab.prompt"
+        prompt.write_text(
+            "<vocabulary>\n- authorized: JWT with charge:write scope\n</vocabulary>\n"
+            "<contract_rules>R1: The system MUST reject duplicate charges.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        runner.invoke(
+            cli.cli,
+            ["--quiet", "prompt", "lint", "--ambiguity", "--llm", "--apply", str(prompt)],
+            catch_exceptions=False,
+        )
+        text = prompt.read_text(encoding="utf-8")
+        # Original entry preserved
+        assert "authorized: JWT with charge:write scope" in text
+        # New entry appended inside the same block
+        assert "duplicate charge" in text
+        # Only one vocabulary block (not duplicated)
+        assert text.count("<vocabulary>") == 1
+
+    @patch("pdd.commands.prompt.run_llm_ambiguity_pass")
+    def test_apply_json_still_emits_valid_json(self, mock_llm, runner, tmp_path):
+        mock_llm.return_value = [
+            LintIssue(
+                level="warn",
+                term="valid",
+                section="llm",
+                line="",
+                message="",
+                suggestion="valid: positive amount in cents",
+            )
+        ]
+        prompt = tmp_path / "aj.prompt"
+        prompt.write_text(
+            "<contract_rules>R1: The system MUST return a valid amount.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        result = runner.invoke(
+            cli.cli,
+            ["--quiet", "prompt", "lint", "--ambiguity", "--llm", "--apply", "--json",
+             str(prompt)],
+            catch_exceptions=False,
+        )
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    def test_without_apply_file_is_never_modified(self, runner, tmp_path):
+        prompt = tmp_path / "ro.prompt"
+        content = (
+            "<contract_rules>R1: The system MUST return a valid response.</contract_rules>\n"
+        )
+        prompt.write_text(content, encoding="utf-8")
+        _lint(runner, str(prompt))
+        assert prompt.read_text(encoding="utf-8") == content
+
+
+# ---------------------------------------------------------------------------
+# Prose gate: false-positive suppression for LLM instruction prompts
+# ---------------------------------------------------------------------------
+
+class TestProseGate:
+    """Prose (% lines) is only scanned when a contract section is also present."""
+
+    def test_pure_llm_prompt_prose_not_scanned(self, runner, tmp_path):
+        p = tmp_path / "llm_step.prompt"
+        p.write_text(
+            "% You are an expert. Your task is to generate complete and correct architecture.\n"
+            "% Validate that the result is valid JSON and appropriate for the context.\n",
+            encoding="utf-8",
+        )
+        result = _lint(runner, str(p))
+        assert result.exit_code == 0, (
+            "LLM instruction prose without contract sections must not produce warnings"
+        )
+
+    def test_prose_plus_contract_section_is_scanned(self, runner, tmp_path):
+        p = tmp_path / "has_contract.prompt"
+        p.write_text(
+            "% The caller must be authorized before calling this endpoint.\n"
+            "<contract_rules>R1: The system MUST authenticate the caller.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        result = _lint(runner, str(p))
+        assert result.exit_code == 1, (
+            "Prose with vague term 'authorized' should fire when a contract section is present"
+        )
+
+    def test_pdd_bundled_llm_prompts_no_prose_false_positives(self, runner):
+        """All _LLM.prompt files must exit clean in default mode (no prose false positives)."""
+        llm_prompts = list(PDD_PROMPTS.rglob("*_LLM.prompt"))
+        assert llm_prompts, "Expected at least one _LLM.prompt in pdd/prompts"
+        for p in llm_prompts:
+            result = _lint(runner, str(p))
+            # We allow exit 1 only from CONTRACT sections; prose-only files must be clean.
+            # Check that any issues are from contract_rules/requirements, not prose
+            if result.exit_code != 0:
+                data_result = _lint_json(runner, str(p))
+                try:
+                    data = json.loads(data_result.output)
+                    issues = [i for e in data for i in e["issues"]]
+                    prose_issues = [i for i in issues if i["section"] == "prose"]
+                    assert prose_issues == [], (
+                        f"{p.name} has prose false positives: {prose_issues}"
+                    )
+                except json.JSONDecodeError:
+                    pass  # output parse failure is fine for this check

--- a/tests/fixtures/contract_check/auth_service_clean_python.prompt
+++ b/tests/fixtures/contract_check/auth_service_clean_python.prompt
@@ -1,0 +1,84 @@
+% Fixture: auth_service_clean_python.prompt
+% Realistic auth service contract with waivers — zero issues expected.
+
+You are a Python developer. Implement the authentication service.
+
+<vocabulary>
+- active session: a session whose expires_at timestamp is in the future and whose revoked field is false
+- trusted device: a device whose device_id is present in the trusted_devices table for the given user_id
+- brute-force attempt: five or more failed login attempts for the same username within a 10-minute sliding window
+- valid credentials: a username that exists in the users table and a bcrypt-verified password hash match
+- authorized scope: a scope string that is present in the scopes column for the requesting client in the oauth_clients table
+</vocabulary>
+
+<contract_rules>
+R1 - Credential validation
+
+For every POST /login request,
+the system MUST reject requests that do not supply valid credentials.
+
+This rule is violated if a user with an incorrect password receives a session token.
+
+R2 - Brute-force protection
+
+For every POST /login request,
+the system MUST lock the account for 15 minutes after a brute-force attempt.
+
+This rule is violated if a sixth login attempt within 10 minutes is not rejected with HTTP 429.
+
+R3 - Session expiry
+
+For every API request that requires authentication,
+the system MUST reject requests that do not carry an active session.
+
+This rule is violated if an expired token receives a non-401 response.
+
+R4 - Scope enforcement
+
+For every API request,
+the system MUST NOT grant access to resources outside the authorized scope.
+
+This rule is violated if a token with scope="read" can write to any resource.
+
+R5 - Trusted device fast-path
+
+For every POST /login from a trusted device,
+the system MAY skip the second-factor challenge.
+
+R6 - Audit trail
+
+For every login event (success or failure),
+the system MUST emit a structured audit log entry to the audit stream.
+</contract_rules>
+
+<coverage>
+- R1: test_invalid_credentials_rejected (tests/test_auth.py)
+- R2: test_brute_force_lockout (tests/test_auth.py)
+- R3: test_expired_session_rejected (tests/test_auth.py)
+- R4: test_scope_enforcement (tests/test_auth.py)
+- R4: WAIVED W1
+- R5: story__auth_flow.md
+- R6: test_audit_log_emitted (tests/test_auth.py)
+</coverage>
+
+<waivers>
+W1:
+  Rule: R4
+  Status: temporary
+  Reason: Read-only admin dashboard endpoints exempt pending access-control overhaul in Q3.
+  Approved by: security-team
+  Expires: 2026-12-31
+  Follow-up: Implement fine-grained scope checks (issue #712).
+</waivers>
+
+<capabilities>
+- MUST NOT store plaintext passwords.
+- MUST NOT return password hashes in any API response.
+- MAY cache session validation results in Redis for up to 30 seconds.
+- SHOULD rotate session tokens after privilege escalation.
+</capabilities>
+
+<non_responsibilities>
+- OAuth 2.0 client registration.
+- Multi-tenant user namespace isolation (handled by the API gateway).
+</non_responsibilities>

--- a/tests/fixtures/contract_check/capabilities_no_modal_python.prompt
+++ b/tests/fixtures/contract_check/capabilities_no_modal_python.prompt
@@ -1,0 +1,14 @@
+% Fixture: capabilities_no_modal_python.prompt
+% Capabilities block has a line without a modal verb.
+% Expected: MISSING_MODAL warning for the non-modal capability line.
+
+<contract_rules>
+R1: The system MUST only accept uploads from authorized users.
+R2: The system MUST return HTTP 201 on successful upload.
+</contract_rules>
+
+<capabilities>
+- MAY accept multipart/form-data POST requests.
+- Stores files in S3-compatible object storage.
+- MUST NOT expose internal stack traces in error responses.
+</capabilities>

--- a/tests/fixtures/contract_check/coverage_unchecked_python.prompt
+++ b/tests/fixtures/contract_check/coverage_unchecked_python.prompt
@@ -1,0 +1,20 @@
+% Fixture: coverage_unchecked_python.prompt
+% R2 coverage entry starts with TODO.
+% Expected: UNCHECKED_RULE warning for R2.
+
+<vocabulary>
+- authorized user: a caller whose Bearer JWT contains the "upload" scope and is unexpired
+- duplicate upload: an upload whose SHA-256 hash and tenant_id match an existing accepted upload
+</vocabulary>
+
+<contract_rules>
+R1: The system MUST only accept uploads from authorized users.
+R2: The system MUST NOT accept duplicate uploads.
+R3: The system MUST return HTTP 201 on successful upload.
+</contract_rules>
+
+<coverage>
+- R1: test_unauthorized_rejected (tests/test_upload.py)
+- R2: TODO add idempotency story before production use
+- R3: test_successful_upload (tests/test_upload.py)
+</coverage>

--- a/tests/fixtures/contract_check/duplicate_ids_python.prompt
+++ b/tests/fixtures/contract_check/duplicate_ids_python.prompt
@@ -1,0 +1,13 @@
+% Fixture: duplicate_ids_python.prompt
+% R1 appears twice. Expected: DUPLICATE_ID error.
+
+<vocabulary>
+- authorized user: a caller whose JWT is unexpired and has the upload scope
+</vocabulary>
+
+<contract_rules>
+R1: The system MUST only accept uploads from authorized users.
+R2: The system MUST return HTTP 201 on successful upload.
+R1: The system MUST log all upload attempts.
+R3: The system MUST NOT process requests without authentication.
+</contract_rules>

--- a/tests/fixtures/contract_check/legacy_no_sections_python.prompt
+++ b/tests/fixtures/contract_check/legacy_no_sections_python.prompt
@@ -1,0 +1,15 @@
+% Fixture: legacy_no_sections_python.prompt
+% Plain text prompt with no contract sections.
+% Expected: 0 issues (legacy prompts must never hard-fail).
+
+You are a Python developer. Implement a file upload endpoint.
+
+Requirements:
+- Accept multipart/form-data POST requests.
+- Return HTTP 201 on successful upload.
+- Reject unauthorized requests with HTTP 401.
+- Handle duplicate uploads with HTTP 409.
+
+Instructions:
+- Use FastAPI.
+- Write pytest tests covering the happy path.

--- a/tests/fixtures/contract_check/malformed_ids_python.prompt
+++ b/tests/fixtures/contract_check/malformed_ids_python.prompt
@@ -1,0 +1,9 @@
+% Fixture: malformed_ids_python.prompt
+% IDs do not match R<N> or sequential N. patterns.
+% Expected: MALFORMED_ID errors.
+
+<contract_rules>
+RR-01: The system MUST reject unauthorized requests.
+R_002: The system MUST return a valid response on success.
+RULE_003: The system MUST NOT expose internal errors to clients.
+</contract_rules>

--- a/tests/fixtures/contract_check/missing_modal_python.prompt
+++ b/tests/fixtures/contract_check/missing_modal_python.prompt
@@ -1,0 +1,10 @@
+% Fixture: missing_modal_python.prompt
+% Rules lack MUST / MUST NOT / MAY / SHOULD.
+% Expected: MISSING_MODAL warnings/errors.
+
+<contract_rules>
+R1: The system rejects unauthorized requests.
+R2: Return HTTP 201 on upload completion.
+R3: The system MUST log all attempts.
+R4: Requests without authentication are refused.
+</contract_rules>

--- a/tests/fixtures/contract_check/non_sequential_ids_python.prompt
+++ b/tests/fixtures/contract_check/non_sequential_ids_python.prompt
@@ -1,0 +1,13 @@
+% Fixture: non_sequential_ids_python.prompt
+% R2 is missing (gap between R1 and R3).
+% Expected: NON_SEQUENTIAL_ID warning.
+
+<vocabulary>
+- authorized user: a caller whose JWT has the upload scope
+</vocabulary>
+
+<contract_rules>
+R1: The system MUST only accept uploads from authorized users.
+R3: The system MUST return HTTP 201 on successful upload.
+R4: The system MUST NOT process requests without a valid token.
+</contract_rules>

--- a/tests/fixtures/contract_check/payment_api_clean_python.prompt
+++ b/tests/fixtures/contract_check/payment_api_clean_python.prompt
@@ -1,0 +1,84 @@
+% Fixture: payment_api_clean_python.prompt
+% Realistic payment processing contract — fully clean, zero issues expected.
+
+You are a Python developer. Implement the payment processing module.
+
+<vocabulary>
+- authorized merchant: a merchant whose API key is present, unexpired, and has the "payments:write" scope verified against the OAuth2 provider
+- valid payment method: a payment method whose type is one of ["card", "ach", "wallet"] and whose token is a non-empty string from the vault service
+- duplicate charge: a charge whose idempotency_key matches an existing charge in the charges table created within the last 24 hours by the same merchant
+- graceful rejection: returns HTTP 409 with JSON {"code": "DUPLICATE_CHARGE", "idempotency_key": "<key>", "original_charge_id": "<id>"}
+- successful charge: a charge that reaches status="captured" and receives HTTP 201 within 3000 ms
+- suspicious transaction: a transaction whose risk_score from the fraud service exceeds 0.85
+- settled: a charge whose status field equals "settled" in the charges table and whose settled_at timestamp is populated
+</vocabulary>
+
+<contract_rules>
+R1 - Idempotency guard
+
+For every POST /charges request,
+the system MUST reject duplicate charges gracefully
+when the idempotency_key matches an existing charge created within the last 24 hours.
+
+This rule is violated if the system creates a second charge row or returns HTTP 200.
+
+R2 - Merchant authorization
+
+For every POST /charges request,
+the system MUST only accept requests from authorized merchants.
+
+This rule is violated if a request with an absent or revoked API key receives HTTP 200.
+
+R3 - Payment method validation
+
+For every POST /charges request,
+the system MUST reject requests that do not supply a valid payment method.
+
+This rule is violated if a charge is created without a vaulted payment token.
+
+R4 - Fraud gate
+
+For every POST /charges request,
+the system MUST NOT process suspicious transactions.
+
+This rule is violated if a charge with risk_score > 0.85 reaches status="captured".
+
+R5 - Success response
+
+For every successfully processed charge,
+the system MUST return HTTP 201 with the charge ID and status="captured".
+
+R6 - Settlement audit
+
+For every settled charge,
+the system MAY emit a settlement event to the audit queue.
+
+R7 - Error format
+
+For every rejected request,
+the system MUST return a JSON body with at minimum {"code": "<string>", "message": "<string>"}.
+</contract_rules>
+
+<coverage>
+- R1: test_duplicate_charge_rejected (tests/test_payment.py)
+- R1: story__charge_flow.md
+- R2: test_unauthorized_merchant_rejected (tests/test_payment.py)
+- R3: test_invalid_payment_method_rejected (tests/test_payment.py)
+- R4: test_suspicious_transaction_blocked (tests/test_payment.py)
+- R5: test_successful_charge_returns_201 (tests/test_payment.py)
+- R6: story__charge_flow.md
+- R7: test_error_response_shape (tests/test_payment.py)
+</coverage>
+
+<capabilities>
+- MAY accept both synchronous and asynchronous charge processing modes.
+- MUST NOT store raw card numbers; only vaulted tokens are permitted.
+- MUST NOT expose internal exception stack traces in HTTP responses.
+- MAY retry vault service calls up to two times before returning HTTP 503.
+</capabilities>
+
+<non_responsibilities>
+- Currency conversion.
+- Issuer-side dispute resolution.
+- PCI DSS key management (handled by the vault service).
+</non_responsibilities>

--- a/tests/fixtures/contract_check/payment_api_issues_python.prompt
+++ b/tests/fixtures/contract_check/payment_api_issues_python.prompt
@@ -1,0 +1,47 @@
+% Fixture: payment_api_issues_python.prompt
+% Realistic payment API contract with multiple combined defects:
+%   - VAGUE_TERM: "valid", "successful", "reasonable" (no vocabulary)
+%   - MISSING_MODAL: R4 has no modal verb
+%   - DUPLICATE_ID: R2 appears twice
+%   - UNCOVERED_MUST_NOT: R5 MUST NOT has no coverage entry
+% Expected: errors for DUPLICATE_ID, MISSING_MODAL; warns for VAGUE_TERM, UNCOVERED_MUST_NOT
+
+You are a Python developer. Implement the payment processing module.
+
+<contract_rules>
+R1 - Idempotency guard
+
+For every POST /charges request,
+the system MUST reject duplicate charges
+when the idempotency_key matches an existing charge within 24 hours.
+
+R2 - Merchant check
+The system MUST only accept requests with a valid API key.
+
+R2 - Payment validation
+The system MUST reject requests with an invalid payment method.
+
+R3 - Success response
+The system MUST return a successful response on capture.
+
+R4 - Fraud gate
+The system reject suspicious transactions automatically.
+
+R5 - Raw card data
+The system MUST NOT store raw card numbers in any database or log.
+
+R6 - Error format
+For every rejected request,
+the system MUST return a reasonable error response within a reasonable time.
+</contract_rules>
+
+<coverage>
+- R1: test_idempotency (tests/test_payment.py)
+- R3: test_success (tests/test_payment.py)
+- R6: test_error_shape (tests/test_payment.py)
+</coverage>
+
+<capabilities>
+- MAY accept async charge processing.
+- MUST NOT expose internal stack traces.
+</capabilities>

--- a/tests/fixtures/contract_check/rate_limiter_issues_python.prompt
+++ b/tests/fixtures/contract_check/rate_limiter_issues_python.prompt
@@ -1,0 +1,37 @@
+% Fixture: rate_limiter_issues_python.prompt
+% Rate-limiter contract with a cluster of defects across sections:
+%   - NON_SEQUENTIAL_ID: R1, R2, R4 (gap at R3)
+%   - MISSING_MODAL: R4 line has no modal verb
+%   - VAGUE_TERM: "reasonable", "recent", "safe" (no vocabulary)
+%   - UNKNOWN_COVERAGE_REF: R3 cited in coverage but doesn't exist
+%   - UNCOVERED_MUST_NOT: R4 MUST NOT has no coverage
+% Expected: mix of errors and warnings
+
+You are a Python developer. Implement the rate-limiting middleware.
+
+<contract_rules>
+R1 - Per-user request cap
+The system MUST reject requests from a user who has exceeded their rate limit within a recent window.
+
+R2 - Backoff header
+The system MUST return a Retry-After header with a reasonable backoff value on every HTTP 429 response.
+
+R4 - Burst allowance
+The system MUST NOT permit more than 10 requests per second per user even during safe degraded-mode operation.
+
+R5 - Allowlist bypass
+For every request from an allowlisted IP,
+the system MAY bypass per-user rate limiting.
+</contract_rules>
+
+<coverage>
+- R1: test_rate_limit_enforced (tests/test_rate_limiter.py)
+- R2: test_retry_after_header (tests/test_rate_limiter.py)
+- R3: test_burst_window (tests/test_rate_limiter.py)
+- R5: test_allowlist_bypass (tests/test_rate_limiter.py)
+</coverage>
+
+<capabilities>
+- MAY use Redis sorted sets as the sliding-window counter backend.
+- MUST NOT block the event loop during counter increments.
+</capabilities>

--- a/tests/fixtures/contract_check/story__covers_rule_ids.md
+++ b/tests/fixtures/contract_check/story__covers_rule_ids.md
@@ -1,0 +1,19 @@
+# User Story: Upload file (valid rule IDs in ## Covers)
+
+<!-- pdd-story-prompts: valid_contract_python.prompt -->
+
+## Story
+As an authorized user, I want to upload a file so that it is stored securely.
+
+## Acceptance Criteria
+1. Given an authorized user, when they upload a valid file, the server returns HTTP 201.
+2. Given a duplicate upload, when submitted, the server returns HTTP 409.
+3. Given an invalid file type, when uploaded, the server returns HTTP 422.
+
+## Covers
+- R1: duplicate upload rejection
+- R2: authorized user check
+- R3: HTTP 201 response
+
+## Non-Goals
+1. Virus scanning.

--- a/tests/fixtures/contract_check/story__cross_module_covers.md
+++ b/tests/fixtures/contract_check/story__cross_module_covers.md
@@ -1,0 +1,18 @@
+# User Story: Upload file (cross-module ## Covers format)
+
+<!-- pdd-story-prompts: valid_contract_python.prompt -->
+
+## Story
+As an authorized user, I want to upload a file so that it is stored securely.
+
+## Acceptance Criteria
+1. Given an authorized user, when they upload a valid file, the server returns HTTP 201.
+2. Given a duplicate upload, the server returns HTTP 409.
+
+## Covers
+- valid_contract_python.prompt#R1: duplicate upload rejection
+- valid_contract_python.prompt#R2: authorized user check
+- valid_contract_python.prompt#R3: HTTP 201 response
+
+## Non-Goals
+1. Virus scanning.

--- a/tests/fixtures/contract_check/story__payment_bad_refs.md
+++ b/tests/fixtures/contract_check/story__payment_bad_refs.md
@@ -1,0 +1,15 @@
+# User Story: Payment flow with unknown rule references
+
+<!-- pdd-story-prompts: payment_api_clean_python.prompt -->
+
+## Story
+As a merchant, I want charges processed reliably.
+
+## Acceptance Criteria
+1. Given an authorized merchant, when they submit a valid charge, then the system returns HTTP 201.
+2. Given a fraudulent transaction, when submitted, then the system rejects it.
+
+## Covers
+- R1: idempotency enforced
+- R99: non-existent rule referenced here
+- R100: another unknown rule ID

--- a/tests/fixtures/contract_check/story__payment_flow.md
+++ b/tests/fixtures/contract_check/story__payment_flow.md
@@ -1,0 +1,19 @@
+# User Story: Payment charge flow
+
+<!-- pdd-story-prompts: payment_api_clean_python.prompt -->
+
+## Story
+As an authorized merchant, I want to submit a charge so that my customer is billed correctly.
+
+## Acceptance Criteria
+1. Given an authorized merchant, when they submit a charge with a valid payment method and a unique idempotency_key, then the system returns HTTP 201 with a charge ID.
+2. Given an authorized merchant, when they submit a duplicate charge (same idempotency_key within 24 hours), then the system returns HTTP 409 with the original charge ID.
+3. Given a suspicious transaction (risk_score > 0.85), when submitted by any merchant, then the system rejects the request with HTTP 422.
+4. Given a settled charge, when queried by the merchant, then the system returns the settled_at timestamp.
+
+## Covers
+- R1: idempotency_key uniqueness enforced within 24-hour window
+- R2: authorized merchant holds a non-expired API key with payments:write scope
+- R4: suspicious transaction has risk_score exceeding the 0.85 threshold
+- R5: successful charge reaches status=captured with HTTP 201
+- R6: settlement event emitted to audit queue on status transition

--- a/tests/fixtures/contract_check/story__unknown_rule_ids.md
+++ b/tests/fixtures/contract_check/story__unknown_rule_ids.md
@@ -1,0 +1,16 @@
+# User Story: Upload file (unknown rule ID in ## Covers)
+
+<!-- pdd-story-prompts: valid_contract_python.prompt -->
+
+## Story
+As an authorized user, I want to upload a file so that it is stored securely.
+
+## Acceptance Criteria
+1. Given an authorized user, when they upload a valid file, the server returns HTTP 201.
+
+## Covers
+- R1: duplicate upload rejection
+- R99: this rule does not exist
+
+## Non-Goals
+1. Virus scanning.

--- a/tests/fixtures/contract_check/uncovered_mustnot_python.prompt
+++ b/tests/fixtures/contract_check/uncovered_mustnot_python.prompt
@@ -1,0 +1,19 @@
+% Fixture: uncovered_mustnot_python.prompt
+% R2 (MUST NOT) has no entry in the coverage section.
+% Expected: UNCOVERED_MUST_NOT warning for R2.
+
+<vocabulary>
+- authorized user: a caller whose Bearer JWT contains the "upload" scope
+- duplicate upload: an upload whose hash and tenant_id match an existing accepted upload
+</vocabulary>
+
+<contract_rules>
+R1: The system MUST only accept uploads from authorized users.
+R2: The system MUST NOT accept duplicate uploads.
+R3: The system MUST return HTTP 201 on successful upload.
+</contract_rules>
+
+<coverage>
+- R1: test_unauthorized_rejected (tests/test_upload.py)
+- R3: test_successful_upload (tests/test_upload.py)
+</coverage>

--- a/tests/fixtures/contract_check/unknown_coverage_refs_python.prompt
+++ b/tests/fixtures/contract_check/unknown_coverage_refs_python.prompt
@@ -1,0 +1,18 @@
+% Fixture: unknown_coverage_refs_python.prompt
+% The coverage section references R99 which does not exist in contract_rules.
+% Expected: UNKNOWN_COVERAGE_REF error for R99.
+
+<vocabulary>
+- authorized user: a caller whose Bearer JWT contains the "upload" scope
+</vocabulary>
+
+<contract_rules>
+R1: The system MUST only accept uploads from authorized users.
+R2: The system MUST return HTTP 201 on successful upload.
+</contract_rules>
+
+<coverage>
+- R1: test_unauthorized_rejected (tests/test_upload.py)
+- R2: test_successful_upload (tests/test_upload.py)
+- R99: test_nonexistent_rule (tests/test_upload.py)
+</coverage>

--- a/tests/fixtures/contract_check/vague_no_vocab_python.prompt
+++ b/tests/fixtures/contract_check/vague_no_vocab_python.prompt
@@ -1,0 +1,10 @@
+% Fixture: vague_no_vocab_python.prompt
+% Vague terms in rules, no vocabulary block.
+% Expected: VAGUE_TERM warnings for valid, duplicate, graceful, authorized, active.
+
+<contract_rules>
+R1: The system MUST reject duplicate uploads gracefully.
+R2: The system MUST only accept uploads from authorized users.
+R3: The system MUST return a valid response on successful upload.
+R4: The system MUST NOT allow active sessions to exceed 10 uploads per day.
+</contract_rules>

--- a/tests/fixtures/contract_check/vague_with_vocab_python.prompt
+++ b/tests/fixtures/contract_check/vague_with_vocab_python.prompt
@@ -1,0 +1,19 @@
+% Fixture: vague_with_vocab_python.prompt
+% Same vague terms but all defined in vocabulary.
+% Expected: 0 issues.
+
+<vocabulary>
+- duplicate upload: an upload whose SHA-256 hash and tenant_id match a row in uploads with status="accepted"
+- graceful rejection: returns HTTP 409 with JSON {"code": "DUPLICATE", "detail": "..."}
+- authorized user: a caller whose Bearer JWT contains the "upload" scope and is unexpired
+- valid response: HTTP 201 with JSON {"id": "<uuid4>", "size": <bytes>, "created_at": "<ISO-8601>"}
+- successful upload: an upload that returns a valid response within 2000 ms
+- active session: a session whose expires_at is in the future and revoked flag is false
+</vocabulary>
+
+<contract_rules>
+R1: The system MUST reject duplicate uploads gracefully.
+R2: The system MUST only accept uploads from authorized users.
+R3: The system MUST return a valid response on successful upload.
+R4: The system MUST NOT allow active sessions to exceed 10 uploads per day.
+</contract_rules>

--- a/tests/fixtures/contract_check/valid_contract_python.prompt
+++ b/tests/fixtures/contract_check/valid_contract_python.prompt
@@ -1,0 +1,52 @@
+% Fixture: valid_contract_python.prompt
+% All sections present and well-formed. Expected: 0 issues.
+
+You are a Python developer. Implement the file upload module.
+
+<vocabulary>
+- authorized user: a caller whose Bearer JWT contains the "upload" scope and is unexpired
+- duplicate upload: an upload whose SHA-256 hash and tenant_id match a row in uploads with status="accepted"
+- graceful rejection: returns HTTP 409 with JSON {"code": "DUPLICATE", "detail": "..."}
+- valid file: a file whose MIME type is in the allowlist and whose size is <= 50 MB
+- successful upload: an upload that receives HTTP 201 within 2000 ms
+</vocabulary>
+
+<contract_rules>
+R1 - Reject duplicate uploads
+
+For every POST /upload request,
+the system MUST reject duplicate uploads gracefully
+when the SHA-256 hash and tenant_id match an existing accepted upload.
+
+This rule is violated if the system returns HTTP 200 instead of HTTP 409.
+
+R2 - Authorized uploads only
+The system MUST only accept uploads from authorized users.
+
+R3 - Success response
+The system MUST return HTTP 201 on successful upload.
+
+R4 - File type gate
+The system MUST NOT accept files that are not valid.
+
+R5 - Audit logging
+The system MAY log additional metadata for audit purposes.
+</contract_rules>
+
+<coverage>
+- R1: test_duplicate_upload_rejected (tests/test_upload.py)
+- R2: test_unauthorized_upload_rejected (tests/test_upload.py)
+- R3: test_successful_upload_returns_201 (tests/test_upload.py)
+- R4: test_invalid_file_rejected (tests/test_upload.py)
+- R5: story__upload_audit.md
+</coverage>
+
+<capabilities>
+- MAY accept multipart/form-data POST requests.
+- MUST NOT expose internal stack traces in error responses.
+</capabilities>
+
+<non_responsibilities>
+- Virus scanning file content.
+- Long-term archival storage.
+</non_responsibilities>

--- a/tests/fixtures/contract_check/waiver_expired_python.prompt
+++ b/tests/fixtures/contract_check/waiver_expired_python.prompt
@@ -1,0 +1,27 @@
+% Fixture: waiver_expired_python.prompt
+% W1 has Expires: 2020-01-01 which is in the past.
+% Expected: EXPIRED_WAIVER warning.
+
+<vocabulary>
+- authorized user: a caller whose Bearer JWT contains the "upload" scope and is unexpired
+</vocabulary>
+
+<contract_rules>
+R1: The system MUST only accept uploads from authorized users.
+R2: The system MUST NOT call the provider before validating the file type.
+</contract_rules>
+
+<coverage>
+- R1: test_unauthorized_rejected (tests/test_upload.py)
+- R2: WAIVED W1
+</coverage>
+
+<waivers>
+W1:
+  Rule: R2
+  Status: temporary
+  Reason: Provider error fixture is not available yet.
+  Approved by: security-review
+  Expires: 2020-01-01
+  Follow-up: Add story__provider_validation.md and executable test.
+</waivers>

--- a/tests/fixtures/contract_check/waiver_missing_fields_python.prompt
+++ b/tests/fixtures/contract_check/waiver_missing_fields_python.prompt
@@ -1,0 +1,24 @@
+% Fixture: waiver_missing_fields_python.prompt
+% W1 is missing the "Approved by" and "Expires" fields.
+% Expected: MISSING_WAIVER_FIELDS warning.
+
+<vocabulary>
+- authorized user: a caller whose Bearer JWT contains the "upload" scope and is unexpired
+</vocabulary>
+
+<contract_rules>
+R1: The system MUST only accept uploads from authorized users.
+R2: The system MUST NOT call the provider before validating the file type.
+</contract_rules>
+
+<coverage>
+- R1: test_unauthorized_rejected (tests/test_upload.py)
+- R2: WAIVED W1
+</coverage>
+
+<waivers>
+W1:
+  Rule: R2
+  Status: temporary
+  Reason: Provider fixture not ready.
+</waivers>

--- a/tests/fixtures/contract_check/waiver_ref_missing_python.prompt
+++ b/tests/fixtures/contract_check/waiver_ref_missing_python.prompt
@@ -1,0 +1,27 @@
+% Fixture: waiver_ref_missing_python.prompt
+% Coverage says WAIVED W99 but no W99 exists in waivers.
+% Expected: WAIVER_REF_MISSING error.
+
+<vocabulary>
+- authorized user: a caller whose Bearer JWT contains the "upload" scope and is unexpired
+</vocabulary>
+
+<contract_rules>
+R1: The system MUST only accept uploads from authorized users.
+R2: The system MUST NOT call the provider before validating the file type.
+</contract_rules>
+
+<coverage>
+- R1: test_unauthorized_rejected (tests/test_upload.py)
+- R2: WAIVED W99
+</coverage>
+
+<waivers>
+W1:
+  Rule: R2
+  Status: temporary
+  Reason: Provider fixture not ready.
+  Approved by: security-review
+  Expires: 2099-06-01
+  Follow-up: Add test once fixture is available.
+</waivers>

--- a/tests/fixtures/contract_check/waiver_valid_python.prompt
+++ b/tests/fixtures/contract_check/waiver_valid_python.prompt
@@ -1,0 +1,31 @@
+% Fixture: waiver_valid_python.prompt
+% Valid waivers block; coverage uses WAIVED W1 which exists in waivers.
+% Expected: 0 issues.
+
+<vocabulary>
+- authorized user: a caller whose Bearer JWT contains the "upload" scope and is unexpired
+- provider error: an HTTP 5xx response from the upstream storage provider
+- successful upload: an upload that receives HTTP 201 within 2000 ms
+</vocabulary>
+
+<contract_rules>
+R1: The system MUST only accept uploads from authorized users.
+R2: The system MUST return HTTP 201 on successful upload.
+R3: The system MUST NOT call the provider before validating the file type.
+</contract_rules>
+
+<coverage>
+- R1: test_unauthorized_rejected (tests/test_upload.py)
+- R2: test_successful_upload (tests/test_upload.py)
+- R3: WAIVED W1
+</coverage>
+
+<waivers>
+W1:
+  Rule: R3
+  Status: temporary
+  Reason: Provider error fixture is not available yet.
+  Approved by: security-review
+  Expires: 2099-06-01
+  Follow-up: Add story__provider_validation.md and executable test.
+</waivers>

--- a/tests/fixtures/contract_check/with_coverage_python.prompt
+++ b/tests/fixtures/contract_check/with_coverage_python.prompt
@@ -1,0 +1,20 @@
+% Fixture: with_coverage_python.prompt
+% Coverage section is present and all referenced IDs exist.
+% Expected: 0 issues.
+
+<vocabulary>
+- authorized user: a caller whose Bearer JWT contains the "upload" scope and is unexpired
+- duplicate upload: an upload whose SHA-256 hash and tenant_id match a row in uploads with status="accepted"
+</vocabulary>
+
+<contract_rules>
+R1: The system MUST only accept uploads from authorized users.
+R2: The system MUST NOT accept duplicate uploads.
+R3: The system MUST return HTTP 201 on successful upload.
+</contract_rules>
+
+<coverage>
+- R1: test_unauthorized_rejected (tests/test_upload.py)
+- R2: test_duplicate_rejected (tests/test_upload.py)
+- R3: test_successful_upload (tests/test_upload.py)
+</coverage>

--- a/tests/fixtures/prompt_lint/clean.prompt
+++ b/tests/fixtures/prompt_lint/clean.prompt
@@ -1,0 +1,15 @@
+% Fixture: no vague terms anywhere; concrete, observable language throughout.
+% This fixture produces 0 lint issues.
+
+<contract_rules>
+1. The function returns an integer exit code of 0 on success, 1 on failure.
+2. If the input file does not exist, raises FileNotFoundError.
+3. Writes output to the path specified by the --output flag.
+4. Logs the request ID to stdout before processing begins.
+</contract_rules>
+
+<requirements>
+- Accepts a positional PATH argument (string, required).
+- Emits a JSON object to stdout on success.
+- Exits with code 2 when the --format flag contains an unsupported value.
+</requirements>

--- a/tests/fixtures/prompt_lint/payment_api.py
+++ b/tests/fixtures/prompt_lint/payment_api.py
@@ -1,0 +1,46 @@
+"""
+Stub Python module that implements the payment_api_python.prompt contract.
+Used as a companion file in lint tests to verify the prompt→code relationship.
+Not meant to run — it exists to make the test fixture directory realistic.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ChargeRequest:
+    idempotency_key: str
+    merchant_id: str
+    amount: int       # smallest currency unit (e.g. cents)
+    currency: str     # ISO 4217 (e.g. "USD")
+
+
+@dataclass
+class ChargeReceipt:
+    id: str
+    status: str       # "succeeded" | "pending" | "failed"
+    amount: int
+    currency: str
+
+
+class PaymentAPI:
+    """Stub implementation of the charge endpoint contract."""
+
+    def charge(
+        self,
+        request: ChargeRequest,
+        bearer_token: Optional[str],
+    ) -> tuple[int, dict]:
+        """
+        POST /charge — returns (http_status_code, response_body).
+
+        Contract obligations:
+          R1  — reject invalid amounts (amount <= 0 or > 99_999_999)
+          R2  — return 403 for unauthorized principals
+          R3  — return existing record for duplicate idempotency_key
+          R4  — return 200 with successful charge receipt on success
+          R5  — return 502 gracefully on provider failure
+        """
+        raise NotImplementedError("Stub — implement against the prompt contract")

--- a/tests/fixtures/prompt_lint/payment_api_clean_python.prompt
+++ b/tests/fixtures/prompt_lint/payment_api_clean_python.prompt
@@ -1,0 +1,45 @@
+% Fixture: payment_api_clean_python.prompt
+% Same contract rules as payment_api_python.prompt but with full vocabulary block.
+% Target: 0 issues.
+
+<vocabulary>
+- valid amount: a positive integer in the smallest currency unit (e.g. cents),
+  greater than 0 and at most 99_999_999
+- authorized principal: a caller whose Bearer JWT contains scope "charge:write"
+  and whose sub claim matches a registered merchant ID
+- unauthorized principal: any caller that does not meet the authorized principal definition
+- duplicate transaction: a charge whose idempotency_key and merchant_id match
+  a row in charges with status IN ("pending", "succeeded")
+- successful charge receipt: HTTP 200 with JSON {"id": "<uuid>", "status": "succeeded",
+  "amount": <int>, "currency": "<iso4217>"}
+- graceful provider failure: HTTP 502 with JSON {"code": "PROVIDER_ERROR",
+  "retry_after": <seconds>}
+</vocabulary>
+
+<contract_rules>
+R1 - Amount validation
+The system MUST reject any charge where the amount is not valid.
+
+R2 - Authorized callers only
+
+For every POST /charge request,
+the system MUST return HTTP 403
+when called by an unauthorized principal.
+
+R3 - Duplicate idempotency
+
+For every charge request with the same idempotency_key,
+the system MUST NOT create a duplicate transaction.
+
+R4 - Success response
+The system MUST return HTTP 200 with a successful charge receipt.
+
+R5 - Graceful error handling
+The system MUST handle provider failures gracefully.
+</contract_rules>
+
+<requirements>
+- Accept payments in USD and EUR.
+- Log all charge attempts for audit purposes.
+- Validate idempotency_key presence on every request.
+</requirements>

--- a/tests/fixtures/prompt_lint/payment_api_python.prompt
+++ b/tests/fixtures/prompt_lint/payment_api_python.prompt
@@ -1,0 +1,31 @@
+% Fixture: payment_api_python.prompt
+% Realistic payment API prompt with vague contract terms and NO vocabulary block.
+% Expected: VAGUE_TERM warns for valid, authorized, duplicate, graceful, successful.
+
+<contract_rules>
+R1 - Amount validation
+The system MUST reject any charge where the amount is not valid.
+
+R2 - Authorized callers only
+
+For every POST /charge request,
+the system MUST return HTTP 403
+when called by an unauthorized principal.
+
+R3 - Duplicate idempotency
+
+For every charge request with the same idempotency_key,
+the system MUST NOT create a duplicate transaction.
+
+R4 - Success response
+The system MUST return HTTP 200 with a successful charge receipt.
+
+R5 - Graceful error handling
+The system MUST handle provider failures gracefully.
+</contract_rules>
+
+<requirements>
+- Accept payments in USD and EUR.
+- Log all charge attempts for audit purposes.
+- Validate idempotency_key presence on every request.
+</requirements>

--- a/tests/fixtures/prompt_lint/story__clean.md
+++ b/tests/fixtures/prompt_lint/story__clean.md
@@ -1,0 +1,22 @@
+# User Story: Upload file (clean)
+
+<!-- pdd-story-prompts: upload_handler_python.prompt -->
+
+## Story
+As a user, I want to upload a file so that it is stored securely.
+
+## Context
+Files are uploaded via a multipart POST request.
+
+## Acceptance Criteria
+1. Given a user with a valid JWT (unexpired, "write" scope), when they POST a file ≤ 10 MB, the server returns HTTP 201 with {"id": "<uuid>"}.
+2. Given a duplicate upload (same SHA-256 hash and tenant ID), when submitted again, the server returns HTTP 409 {"code": "DUPLICATE"}.
+3. Given a complete request (all required fields present), when processed, the server returns HTTP 201 within 2000 ms.
+
+## Glossary
+- valid JWT: a JWT token that is unexpired and carries the "write" scope
+- duplicate upload: a file whose SHA-256 hash and tenant ID match a previously accepted upload
+- complete request: a request containing non-empty name, content-type, and size fields
+
+## Non-Goals
+1. Scanning file contents for viruses.

--- a/tests/fixtures/prompt_lint/story__covers.md
+++ b/tests/fixtures/prompt_lint/story__covers.md
@@ -1,0 +1,20 @@
+# User Story: Upload file with ## Covers vocabulary
+
+<!-- pdd-story-prompts: upload_handler_python.prompt -->
+
+## Story
+As a user, I want to upload a file so that it is stored securely.
+
+## Acceptance Criteria
+1. Given an authorized user, when they upload a valid file, the server returns HTTP 201.
+2. Given a duplicate upload, when submitted by the same tenant, the server returns HTTP 409.
+3. Given an active user who has reached their daily limit, when they upload, the server returns HTTP 429.
+
+## Covers
+- authorized user: a user whose Bearer JWT is present, unexpired, and carries the "upload" scope
+- valid file: a file whose MIME type is in the allowlist and whose size is ≤ 10 MB
+- duplicate upload: an upload whose SHA-256 hash and tenant ID match a previously accepted upload
+- active user: a user whose account.status field equals "active" in the accounts table
+
+## Non-Goals
+1. Virus scanning file contents.

--- a/tests/fixtures/prompt_lint/story__payment_api.md
+++ b/tests/fixtures/prompt_lint/story__payment_api.md
@@ -1,0 +1,39 @@
+# User Story: Charge a payment card
+
+<!-- pdd-story-prompts: payment_api_clean_python.prompt -->
+
+## Story
+As a merchant, I want to charge a customer's card via POST /charge,
+so that I receive a confirmed payment receipt.
+
+## Acceptance Criteria
+1. Given an authorized principal with a valid amount (100 cents),
+   when POST /charge is called with idempotency_key "k1",
+   then the server returns HTTP 200 with a successful charge receipt.
+2. Given an unauthorized principal,
+   when POST /charge is called,
+   then the server returns HTTP 403 with {"code": "FORBIDDEN"}.
+3. Given a duplicate transaction (same idempotency_key + merchant_id),
+   when POST /charge is called again,
+   then the server returns HTTP 200 with the existing charge record (no new row).
+4. Given a provider failure (upstream HTTP 500),
+   when POST /charge is called,
+   then the server returns a graceful provider failure response (HTTP 502).
+
+## Covers
+- R1: amount validation
+- R2: authorized callers only
+- R3: duplicate idempotency
+- R4: success response
+- R5: graceful error handling
+
+## Glossary
+- valid amount: a positive integer in the smallest currency unit (e.g. cents),
+  greater than 0 and at most 99_999_999
+- authorized principal: a caller whose Bearer JWT contains scope "charge:write"
+  and whose sub claim matches a registered merchant ID
+- unauthorized principal: any caller that does not meet the authorized principal definition
+- duplicate transaction: a charge whose idempotency_key and merchant_id match
+  a row in charges with status IN ("pending", "succeeded")
+- successful charge receipt: HTTP 200 with JSON {"id": "<uuid>", "status": "succeeded"}
+- graceful provider failure: HTTP 502 with JSON {"code": "PROVIDER_ERROR"}

--- a/tests/fixtures/prompt_lint/story__payment_vague.md
+++ b/tests/fixtures/prompt_lint/story__payment_vague.md
@@ -1,0 +1,10 @@
+# User Story: Charge a payment card (vague criteria, no glossary)
+
+## Story
+As a merchant, I want to charge a customer's card.
+
+## Acceptance Criteria
+1. Given an authorized user, when a valid amount is charged,
+   then a successful response is returned.
+2. Given a duplicate request, when submitted again,
+   then it is handled gracefully.

--- a/tests/fixtures/prompt_lint/story__vague_criteria.md
+++ b/tests/fixtures/prompt_lint/story__vague_criteria.md
@@ -1,0 +1,17 @@
+# User Story: Upload file
+
+<!-- pdd-story-prompts: upload_handler_python.prompt -->
+
+## Story
+As a user, I want to upload a file so that it is stored securely.
+
+## Context
+Files are uploaded via a multipart POST request.
+
+## Acceptance Criteria
+1. Given an authorized user, when they upload a valid file, then the upload succeeds.
+2. Given a duplicate upload, when submitted by the same user, then it is rejected gracefully.
+3. Given a complete request, when all fields are present, then a successful response is returned.
+
+## Non-Goals
+1. Scanning file contents for viruses.

--- a/tests/fixtures/prompt_lint/strict_terms_python.prompt
+++ b/tests/fixtures/prompt_lint/strict_terms_python.prompt
@@ -1,0 +1,11 @@
+% Fixture: strict_terms_python.prompt
+% Uses ONLY strict-mode vague terms (correct, expected, proper, normal).
+% Target: 0 warns in default mode, >0 warns in --strict mode.
+
+<contract_rules>
+R1: The system MUST produce the correct output for every well-formed input.
+R2: The system MUST return the expected format on success.
+R3: Proper error messages MUST be emitted when a request is malformed.
+R4: The system MUST finish the operation within 5 seconds.
+R5: Normal operation MUST NOT log debug-level messages.
+</contract_rules>

--- a/tests/fixtures/prompt_lint/upload_handler_python.prompt
+++ b/tests/fixtures/prompt_lint/upload_handler_python.prompt
@@ -1,0 +1,17 @@
+% Real-world example fixture for pdd prompt lint.
+% Demonstrates how "duplicate upload" is ambiguous without a <vocabulary> definition.
+% Used by: test_duplicate_upload_term_is_flagged
+
+<contract_rules>
+1. The function must reject duplicate uploads gracefully.
+2. Only authorized users may upload files.
+3. Return a valid response when the upload is successful.
+4. Active users are allowed up to 10 uploads per day.
+</contract_rules>
+
+<requirements>
+- Accept multipart/form-data POST requests.
+- Return HTTP 201 on successful upload with {"id": "<uuid>"}.
+- Reject duplicate uploads with HTTP 409.
+- Log all upload attempts for audit purposes.
+</requirements>

--- a/tests/fixtures/prompt_lint/upload_handler_with_vocab_python.prompt
+++ b/tests/fixtures/prompt_lint/upload_handler_with_vocab_python.prompt
@@ -1,0 +1,26 @@
+% Upload handler with all vague terms defined in vocabulary.
+% All warnings are suppressed by the vocabulary block below.
+% Used by: test_upload_handler_with_vocabulary_is_clean
+
+<vocabulary>
+- duplicate upload: an upload whose SHA-256 hash and tenant ID match a previously accepted upload within the last 30 days
+- graceful rejection: returns HTTP 409 with JSON body {"code": "DUPLICATE", "message": "..."}
+- authorized user: a user whose Bearer JWT is present, unexpired, and carries the "upload" scope
+- valid response: HTTP 201 with JSON body {"id": "<uuid>", "size": <bytes>, "created_at": "<iso8601>"}
+- active user: a user whose account.status field equals "active" in the accounts table
+- successful upload: an upload that returns HTTP 201 within 2000 ms with a non-empty "id" field
+</vocabulary>
+
+<contract_rules>
+1. The function must reject duplicate uploads gracefully.
+2. Only authorized users may upload files.
+3. Return a valid response when the upload is successful.
+4. Active users are allowed up to 10 uploads per day.
+</contract_rules>
+
+<requirements>
+- Accept multipart/form-data POST requests.
+- Return HTTP 201 on successful upload with {"id": "<uuid>"}.
+- Reject duplicate uploads with HTTP 409.
+- Log all upload attempts for audit purposes.
+</requirements>

--- a/tests/fixtures/prompt_lint/vague_defined.prompt
+++ b/tests/fixtures/prompt_lint/vague_defined.prompt
@@ -1,0 +1,23 @@
+% Fixture: vague terms present but every term is defined in the vocabulary block.
+% This fixture produces 0 lint issues — all terms are covered.
+
+<vocabulary>
+- valid response: an HTTP 200 response whose JSON body contains a non-empty "data" field
+- reasonable time: completes within 500 ms at p99 under standard load
+- duplicate request: a request whose idempotency key matches a previously accepted request within the last 24 hours
+- graceful rejection: returns HTTP 409 with a JSON error body {"code": "DUPLICATE", "message": "..."}
+- authorized user: a user whose JWT token is present, unexpired, and has the "write" scope
+- active user: a user whose account status field equals "active" in the accounts table
+- complete: all required fields (name, email, role) are non-empty strings
+</vocabulary>
+
+<contract_rules>
+1. The function must return a valid response within a reasonable time.
+2. Duplicate requests must be rejected gracefully.
+3. Only authorized users may call this endpoint.
+</contract_rules>
+
+<requirements>
+- Accept file uploads from active users only.
+- Mark complete when all required fields are present.
+</requirements>

--- a/tests/fixtures/prompt_lint/vague_undefined.prompt
+++ b/tests/fixtures/prompt_lint/vague_undefined.prompt
@@ -1,0 +1,13 @@
+% Fixture: vague terms present, no vocabulary block defined.
+% This fixture produces 2+ warnings (one per undefined vague term).
+
+<contract_rules>
+1. The function must return a valid response within a reasonable time.
+2. Duplicate requests must be rejected gracefully.
+3. Only authorized users may call this endpoint.
+</contract_rules>
+
+<requirements>
+- Accept file uploads from active users only.
+- Mark complete when all required fields are present.
+</requirements>

--- a/tests/test_contract_check.py
+++ b/tests/test_contract_check.py
@@ -1,0 +1,876 @@
+"""Unit tests for pdd.contract_check (deterministic pass, no LLM calls)."""
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from pdd.contract_check import (
+    ContractIssue,
+    ContractResult,
+    Rule,
+    Waiver,
+    _check_capabilities_modals,
+    _check_coverage_entries,
+    _check_duplicate_ids,
+    _check_malformed_ids,
+    _check_missing_modal,
+    _check_must_not_coverage,
+    _check_sequential_ids,
+    _check_story_covers,
+    _check_vague_terms,
+    _check_waivers,
+    _extract_rules,
+    _extract_waivers,
+    check_directory,
+    check_prompt,
+    check_stories,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "contract_check"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _issues_for_code(result: ContractResult, code: str) -> list[ContractIssue]:
+    return [i for i in result.issues if i.code == code]
+
+
+def _issues_for_rule(result: ContractResult, rule_id: str) -> list[ContractIssue]:
+    return [i for i in result.issues if i.rule_id == rule_id]
+
+
+def _rule(raw_id: str, num: int | None, modal: str, line: str,
+          is_must_not: bool = False) -> Rule:
+    """Convenience constructor so tests don't need to pass block=."""
+    return Rule(raw_id=raw_id, num=num, modal=modal, line=line,
+                block=line, is_must_not=is_must_not)
+
+
+# ---------------------------------------------------------------------------
+# TestExtractRules
+# ---------------------------------------------------------------------------
+
+class TestExtractRules:
+    def test_explicit_r_ids_no_dash(self):
+        text = (
+            "R1: The system MUST reject duplicates.\n"
+            "R2: The system MAY log attempts.\n"
+        )
+        rules = _extract_rules(text)
+        assert len(rules) == 2
+        assert rules[0].raw_id == "R1"
+        assert rules[1].raw_id == "R2"
+
+    def test_explicit_r_ids_with_dash(self):
+        text = (
+            "R-001: The system MUST reject duplicates.\n"
+            "R-002: The system MAY log attempts.\n"
+        )
+        rules = _extract_rules(text)
+        assert len(rules) == 2
+        assert rules[0].raw_id == "R-001"
+        assert rules[1].raw_id == "R-002"
+
+    def test_rule_ids_are_normalised_uppercase(self):
+        rules = _extract_rules("rule-003: The service MUST respond.\n")
+        assert rules[0].raw_id == "RULE-003"
+
+    def test_sequential_ids(self):
+        text = "1. The system MUST accept uploads.\n2. The system MUST log requests.\n"
+        rules = _extract_rules(text)
+        assert rules[0].raw_id == "S-001"
+        assert rules[1].raw_id == "S-002"
+        assert rules[0].num == 1
+        assert rules[1].num == 2
+
+    def test_unnumbered_bullet_rules(self):
+        text = "- The system MUST reject unauthorized requests.\n"
+        rules = _extract_rules(text)
+        assert rules[0].raw_id == "(unnumbered)"
+
+    def test_modal_extracted_must(self):
+        rules = _extract_rules("R1: The system MUST reject duplicates.\n")
+        assert rules[0].modal == "MUST"
+
+    def test_modal_extracted_must_not(self):
+        rules = _extract_rules("R1: The system MUST NOT expose secrets.\n")
+        assert rules[0].modal == "MUST NOT"
+        assert rules[0].is_must_not is True
+
+    def test_modal_extracted_may(self):
+        rules = _extract_rules("R1: The service MAY cache results.\n")
+        assert rules[0].modal == "MAY"
+
+    def test_modal_extracted_should(self):
+        rules = _extract_rules("R1: The system SHOULD log requests.\n")
+        assert rules[0].modal == "SHOULD"
+
+    def test_no_modal_produces_empty_string(self):
+        rules = _extract_rules("R1: The system rejects requests.\n")
+        assert rules[0].modal == ""
+
+    def test_empty_text_returns_no_rules(self):
+        assert _extract_rules("") == []
+
+    def test_blank_lines_skipped(self):
+        text = "\n\nR1: The system MUST respond.\n\n"
+        rules = _extract_rules(text)
+        assert len(rules) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestMultiLineRules
+# ---------------------------------------------------------------------------
+
+class TestMultiLineRules:
+    def test_multiline_block_single_rule(self):
+        text = (
+            "R1 - Reject duplicate uploads\n"
+            "\n"
+            "For every POST /upload request,\n"
+            "the system MUST reject the request\n"
+            "when the SHA-256 hash matches an existing upload.\n"
+            "\n"
+            "This rule is violated if HTTP 200 is returned.\n"
+        )
+        rules = _extract_rules(text)
+        assert len(rules) == 1
+        assert rules[0].raw_id == "R1"
+        assert rules[0].modal == "MUST"
+        assert "SHA-256" in rules[0].block
+
+    def test_multiline_modal_on_continuation_line(self):
+        text = (
+            "R1 - Validate before calling provider\n"
+            "\n"
+            "The service MUST NOT call the provider\n"
+            "before file type validation passes.\n"
+        )
+        rules = _extract_rules(text)
+        assert len(rules) == 1
+        assert rules[0].is_must_not is True
+
+    def test_two_multiline_blocks(self):
+        text = (
+            "R1 - First rule\n"
+            "\n"
+            "The system MUST do X.\n"
+            "\n"
+            "\n"
+            "R2 - Second rule\n"
+            "\n"
+            "The system MUST NOT do Y.\n"
+        )
+        rules = _extract_rules(text)
+        assert len(rules) == 2
+        assert rules[0].raw_id == "R1"
+        assert rules[1].raw_id == "R2"
+        assert rules[1].is_must_not is True
+
+    def test_header_line_captured(self):
+        text = "R1 - Reject duplicate uploads\nThe system MUST reject duplicates.\n"
+        rules = _extract_rules(text)
+        assert rules[0].line == "R1 - Reject duplicate uploads"
+
+
+# ---------------------------------------------------------------------------
+# TestCheckDuplicateIds
+# ---------------------------------------------------------------------------
+
+class TestCheckDuplicateIds:
+    def test_duplicate_id_produces_error(self):
+        rules = [
+            _rule("R1", 1, "MUST", "R1: The system MUST accept uploads."),
+            _rule("R2", 2, "MUST", "R2: The system MUST log."),
+            _rule("R1", 1, "MUST", "R1: The system MUST also reject."),
+        ]
+        issues = _check_duplicate_ids(rules)
+        assert len(issues) == 1
+        assert issues[0].code == "DUPLICATE_ID"
+        assert issues[0].rule_id == "R1"
+        assert issues[0].level == "error"
+
+    def test_no_duplicates_returns_empty(self):
+        rules = [
+            _rule("R1", 1, "MUST", "R1: The system MUST accept."),
+            _rule("R2", 2, "MUST", "R2: The system MUST log."),
+        ]
+        assert _check_duplicate_ids(rules) == []
+
+    def test_unnumbered_rules_not_flagged(self):
+        rules = [
+            _rule("(unnumbered)", None, "MUST", "- The system MUST accept."),
+            _rule("(unnumbered)", None, "MUST", "- The system MUST log."),
+        ]
+        assert _check_duplicate_ids(rules) == []
+
+    def test_fixture_duplicate_ids(self):
+        result = check_prompt(FIXTURES / "duplicate_ids_python.prompt")
+        dups = _issues_for_code(result, "DUPLICATE_ID")
+        assert len(dups) >= 1
+        assert dups[0].rule_id == "R1"
+
+    def test_fixture_valid_no_duplicates(self):
+        result = check_prompt(FIXTURES / "valid_contract_python.prompt")
+        assert _issues_for_code(result, "DUPLICATE_ID") == []
+
+
+# ---------------------------------------------------------------------------
+# TestCheckMalformedIds
+# ---------------------------------------------------------------------------
+
+class TestCheckMalformedIds:
+    def test_rr_prefix_is_malformed(self):
+        issues = _check_malformed_ids("RR-01: The system MUST reject requests.\n")
+        assert any(i.code == "MALFORMED_ID" for i in issues)
+
+    def test_underscore_separator_is_malformed(self):
+        issues = _check_malformed_ids("R_002: The system MUST log.\n")
+        assert any(i.code == "MALFORMED_ID" for i in issues)
+
+    def test_valid_r_no_dash_not_flagged(self):
+        issues = _check_malformed_ids("R1: The system MUST respond.\n")
+        assert issues == []
+
+    def test_valid_r_dash_not_flagged(self):
+        issues = _check_malformed_ids("R-001: The system MUST respond.\n")
+        assert issues == []
+
+    def test_sequential_number_not_flagged(self):
+        issues = _check_malformed_ids("1. The system MUST respond.\n")
+        assert issues == []
+
+    def test_bullet_not_flagged(self):
+        issues = _check_malformed_ids("- The system MUST respond.\n")
+        assert issues == []
+
+    def test_fixture_malformed_ids(self):
+        result = check_prompt(FIXTURES / "malformed_ids_python.prompt")
+        malformed = _issues_for_code(result, "MALFORMED_ID")
+        assert len(malformed) >= 2
+
+
+# ---------------------------------------------------------------------------
+# TestCheckSequentialIds
+# ---------------------------------------------------------------------------
+
+class TestCheckSequentialIds:
+    def test_gap_produces_warn(self):
+        rules = [
+            _rule("R1", 1, "MUST", "R1: ..."),
+            _rule("R3", 3, "MUST", "R3: ..."),
+        ]
+        issues = _check_sequential_ids(rules)
+        assert len(issues) == 1
+        assert issues[0].code == "NON_SEQUENTIAL_ID"
+        assert issues[0].level == "warn"
+
+    def test_sequential_produces_no_issues(self):
+        rules = [
+            _rule("R1", 1, "MUST", "R1: ..."),
+            _rule("R2", 2, "MUST", "R2: ..."),
+            _rule("R3", 3, "MUST", "R3: ..."),
+        ]
+        assert _check_sequential_ids(rules) == []
+
+    def test_unnumbered_rules_ignored(self):
+        rules = [_rule("(unnumbered)", None, "MUST", "- ...")]
+        assert _check_sequential_ids(rules) == []
+
+    def test_fixture_non_sequential(self):
+        result = check_prompt(FIXTURES / "non_sequential_ids_python.prompt")
+        gaps = _issues_for_code(result, "NON_SEQUENTIAL_ID")
+        assert len(gaps) >= 1
+        assert gaps[0].level == "warn"
+
+
+# ---------------------------------------------------------------------------
+# TestCheckMissingModal
+# ---------------------------------------------------------------------------
+
+class TestCheckMissingModal:
+    def test_rule_without_modal_produces_issue(self):
+        rules = [_rule("R1", 1, "", "R1: The system rejects duplicates.")]
+        issues = _check_missing_modal(rules, strict=False)
+        assert len(issues) == 1
+        assert issues[0].code == "MISSING_MODAL"
+        assert issues[0].level == "warn"
+
+    def test_rule_with_modal_produces_no_issue(self):
+        rules = [_rule("R1", 1, "MUST", "R1: The system MUST reject duplicates.")]
+        assert _check_missing_modal(rules, strict=False) == []
+
+    def test_strict_escalates_to_error(self):
+        rules = [_rule("R1", 1, "", "R1: The system rejects duplicates.")]
+        issues = _check_missing_modal(rules, strict=True)
+        assert issues[0].level == "error"
+
+    def test_fixture_missing_modal(self):
+        result = check_prompt(FIXTURES / "missing_modal_python.prompt")
+        missing = _issues_for_code(result, "MISSING_MODAL")
+        assert len(missing) >= 2  # R1, R2, and R4 lack modals
+
+
+# ---------------------------------------------------------------------------
+# TestCheckVagueTerms
+# ---------------------------------------------------------------------------
+
+class TestCheckVagueTerms:
+    def test_undefined_vague_term_warns(self):
+        issues = _check_vague_terms(
+            "R1: The system MUST return a valid response.",
+            vocab_terms=set(),
+            strict=False,
+        )
+        assert any(i.code == "VAGUE_TERM" and i.term == "valid" for i in issues)
+
+    def test_defined_term_suppresses_warning(self):
+        issues = _check_vague_terms(
+            "R1: The system MUST return a valid response.",
+            vocab_terms={"valid", "response", "valid response"},
+            strict=False,
+        )
+        assert issues == []
+
+    def test_fixture_vague_no_vocab_warns(self):
+        result = check_prompt(FIXTURES / "vague_no_vocab_python.prompt")
+        vague = _issues_for_code(result, "VAGUE_TERM")
+        assert len(vague) >= 3
+
+    def test_fixture_vague_with_vocab_clean(self):
+        result = check_prompt(FIXTURES / "vague_with_vocab_python.prompt")
+        vague = _issues_for_code(result, "VAGUE_TERM")
+        assert vague == []
+
+
+# ---------------------------------------------------------------------------
+# TestCheckCoverageEntries  (replaces TestCheckCoverageRefs)
+# ---------------------------------------------------------------------------
+
+class TestCheckCoverageEntries:
+    def test_unknown_ref_produces_error(self):
+        issues = _check_coverage_entries(
+            "- R99: some test\n",
+            known_ids={"R1", "R2"},
+            known_waiver_ids=set(),
+        )
+        assert len(issues) == 1
+        assert issues[0].code == "UNKNOWN_COVERAGE_REF"
+        assert issues[0].level == "error"
+        assert issues[0].rule_id == "R99"
+
+    def test_known_ref_produces_no_issue(self):
+        issues = _check_coverage_entries(
+            "- R1: test_upload\n",
+            known_ids={"R1", "R2"},
+            known_waiver_ids=set(),
+        )
+        assert issues == []
+
+    def test_todo_entry_produces_unchecked_warn(self):
+        issues = _check_coverage_entries(
+            "- R2: TODO add idempotency story\n",
+            known_ids={"R1", "R2"},
+            known_waiver_ids=set(),
+        )
+        assert len(issues) == 1
+        assert issues[0].code == "UNCHECKED_RULE"
+        assert issues[0].level == "warn"
+        assert issues[0].rule_id == "R2"
+
+    def test_waived_known_waiver_produces_no_issue(self):
+        issues = _check_coverage_entries(
+            "- R2: WAIVED W1\n",
+            known_ids={"R1", "R2"},
+            known_waiver_ids={"W1"},
+        )
+        assert issues == []
+
+    def test_waived_unknown_waiver_produces_error(self):
+        issues = _check_coverage_entries(
+            "- R2: WAIVED W99\n",
+            known_ids={"R1", "R2"},
+            known_waiver_ids={"W1"},
+        )
+        assert len(issues) == 1
+        assert issues[0].code == "WAIVER_REF_MISSING"
+        assert issues[0].level == "error"
+
+    def test_fixture_unknown_coverage_ref(self):
+        result = check_prompt(FIXTURES / "unknown_coverage_refs_python.prompt")
+        refs = _issues_for_code(result, "UNKNOWN_COVERAGE_REF")
+        assert len(refs) >= 1
+        assert any(i.rule_id == "R99" for i in refs)
+
+    def test_fixture_valid_coverage_refs(self):
+        result = check_prompt(FIXTURES / "with_coverage_python.prompt")
+        refs = _issues_for_code(result, "UNKNOWN_COVERAGE_REF")
+        assert refs == []
+
+    def test_fixture_unchecked_rule(self):
+        result = check_prompt(FIXTURES / "coverage_unchecked_python.prompt")
+        unchecked = _issues_for_code(result, "UNCHECKED_RULE")
+        assert len(unchecked) >= 1
+        assert any(i.rule_id == "R2" for i in unchecked)
+
+    def test_fixture_waiver_ref_missing(self):
+        result = check_prompt(FIXTURES / "waiver_ref_missing_python.prompt")
+        refs = _issues_for_code(result, "WAIVER_REF_MISSING")
+        assert len(refs) >= 1
+
+
+# ---------------------------------------------------------------------------
+# TestCheckMustNotCoverage
+# ---------------------------------------------------------------------------
+
+class TestCheckMustNotCoverage:
+    def test_uncovered_must_not_warns(self):
+        rules = [
+            _rule("R1", 1, "MUST", "R1: The system MUST accept."),
+            _rule("R2", 2, "MUST NOT", "R2: The system MUST NOT expose secrets.",
+                  is_must_not=True),
+        ]
+        issues = _check_must_not_coverage(rules, "- R1: some_test\n")
+        assert len(issues) == 1
+        assert issues[0].code == "UNCOVERED_MUST_NOT"
+        assert issues[0].rule_id == "R2"
+        assert issues[0].level == "warn"
+
+    def test_covered_must_not_no_issue(self):
+        rules = [
+            _rule("R1", 1, "MUST NOT", "R1: The system MUST NOT expose secrets.",
+                  is_must_not=True),
+        ]
+        issues = _check_must_not_coverage(rules, "- R1: test_secrets_not_exposed\n")
+        assert issues == []
+
+    def test_unnumbered_must_not_skipped(self):
+        rules = [
+            _rule("(unnumbered)", None, "MUST NOT",
+                  "- The system MUST NOT expose secrets.", is_must_not=True),
+        ]
+        assert _check_must_not_coverage(rules, "") == []
+
+    def test_fixture_uncovered_must_not(self):
+        result = check_prompt(FIXTURES / "uncovered_mustnot_python.prompt")
+        uncovered = _issues_for_code(result, "UNCOVERED_MUST_NOT")
+        assert len(uncovered) >= 1
+        assert any(i.rule_id == "R2" for i in uncovered)
+
+    def test_fixture_all_covered_no_issue(self):
+        result = check_prompt(FIXTURES / "with_coverage_python.prompt")
+        uncovered = _issues_for_code(result, "UNCOVERED_MUST_NOT")
+        assert uncovered == []
+
+
+# ---------------------------------------------------------------------------
+# TestCheckWaivers
+# ---------------------------------------------------------------------------
+
+class TestCheckWaivers:
+    def test_expired_waiver_warns(self):
+        text = (
+            "W1:\n"
+            "  Rule: R2\n"
+            "  Status: temporary\n"
+            "  Reason: Test fixture not available.\n"
+            "  Approved by: security-review\n"
+            "  Expires: 2020-01-01\n"
+            "  Follow-up: Add test.\n"
+        )
+        issues = _check_waivers(text)
+        expired = [i for i in issues if i.code == "EXPIRED_WAIVER"]
+        assert len(expired) == 1
+        assert expired[0].rule_id == "W1"
+        assert expired[0].level == "warn"
+
+    def test_future_expiry_no_issue(self):
+        text = (
+            "W1:\n"
+            "  Rule: R2\n"
+            "  Status: temporary\n"
+            "  Reason: Test fixture not available.\n"
+            "  Approved by: security-review\n"
+            "  Expires: 2099-01-01\n"
+            "  Follow-up: Add test.\n"
+        )
+        issues = _check_waivers(text)
+        expired = [i for i in issues if i.code == "EXPIRED_WAIVER"]
+        assert expired == []
+
+    def test_missing_required_fields_warns(self):
+        text = (
+            "W1:\n"
+            "  Rule: R2\n"
+            "  Status: temporary\n"
+            "  Reason: Test fixture not available.\n"
+        )
+        issues = _check_waivers(text)
+        missing = [i for i in issues if i.code == "MISSING_WAIVER_FIELDS"]
+        assert len(missing) >= 1
+        assert "approved by" in missing[0].message.lower() or "expires" in missing[0].message.lower()
+
+    def test_fixture_expired_waiver(self):
+        result = check_prompt(FIXTURES / "waiver_expired_python.prompt")
+        expired = _issues_for_code(result, "EXPIRED_WAIVER")
+        assert len(expired) >= 1
+
+    def test_fixture_missing_waiver_fields(self):
+        result = check_prompt(FIXTURES / "waiver_missing_fields_python.prompt")
+        missing = _issues_for_code(result, "MISSING_WAIVER_FIELDS")
+        assert len(missing) >= 1
+
+    def test_fixture_valid_waiver_no_issues(self):
+        result = check_prompt(FIXTURES / "waiver_valid_python.prompt")
+        assert result.warn_count == 0
+        assert result.error_count == 0
+
+
+# ---------------------------------------------------------------------------
+# TestCheckCapabilitiesModals
+# ---------------------------------------------------------------------------
+
+class TestCheckCapabilitiesModals:
+    def test_line_without_modal_warns(self):
+        text = "- Stores files in S3-compatible object storage.\n"
+        issues = _check_capabilities_modals(text)
+        assert len(issues) == 1
+        assert issues[0].code == "MISSING_MODAL"
+        assert issues[0].section == "capabilities"
+        assert issues[0].level == "warn"
+
+    def test_line_with_may_no_issue(self):
+        text = "- MAY accept multipart/form-data POST requests.\n"
+        issues = _check_capabilities_modals(text)
+        assert issues == []
+
+    def test_line_with_must_not_no_issue(self):
+        text = "- MUST NOT expose internal stack traces.\n"
+        issues = _check_capabilities_modals(text)
+        assert issues == []
+
+    def test_blank_lines_skipped(self):
+        text = "\n- MAY read from S3.\n\n"
+        issues = _check_capabilities_modals(text)
+        assert issues == []
+
+    def test_comment_lines_skipped(self):
+        text = "# This is a comment\n- MAY read files.\n"
+        issues = _check_capabilities_modals(text)
+        assert issues == []
+
+    def test_fixture_capabilities_no_modal(self):
+        result = check_prompt(FIXTURES / "capabilities_no_modal_python.prompt")
+        missing = _issues_for_code(result, "MISSING_MODAL")
+        cap_missing = [i for i in missing if i.section == "capabilities"]
+        assert len(cap_missing) >= 1
+
+    def test_fixture_valid_capabilities_no_missing_modal(self):
+        result = check_prompt(FIXTURES / "valid_contract_python.prompt")
+        cap_missing = [i for i in result.issues
+                       if i.code == "MISSING_MODAL" and i.section == "capabilities"]
+        assert cap_missing == []
+
+
+# ---------------------------------------------------------------------------
+# TestCheckStoryCovers
+# ---------------------------------------------------------------------------
+
+class TestCheckStoryCovers:
+    def _story(self, covers_lines: str) -> str:
+        return (
+            "# Story\n"
+            "<!-- pdd-story-prompts: test_prompt.prompt -->\n"
+            "## Acceptance Criteria\n"
+            "1. Given X, when Y, then Z.\n"
+            f"## Covers\n{covers_lines}\n"
+        )
+
+    def test_known_rule_id_no_issue(self):
+        text = self._story("- R1: duplicate upload rejection\n")
+        issues = _check_story_covers(
+            text, Path("story.md"), {"test_prompt.prompt": {"R1", "R2"}}
+        )
+        assert issues == []
+
+    def test_unknown_rule_id_warns(self):
+        text = self._story("- R99: this does not exist\n")
+        issues = _check_story_covers(
+            text, Path("story.md"), {"test_prompt.prompt": {"R1", "R2"}}
+        )
+        assert len(issues) == 1
+        assert issues[0].code == "UNKNOWN_STORY_REF"
+        assert issues[0].rule_id == "R99"
+        assert issues[0].level == "warn"
+
+    def test_no_covers_section_returns_empty(self):
+        text = "# Story\n## Acceptance Criteria\n1. Given X.\n"
+        assert _check_story_covers(text, Path("story.md"), {}) == []
+
+    def test_no_linked_prompts_skips_id_check(self):
+        text = self._story("- R99 from unknown.prompt\n")
+        issues = _check_story_covers(text, Path("story.md"), None)
+        assert issues == []
+
+    def test_fixture_valid_story(self):
+        results = check_stories(FIXTURES, FIXTURES)
+        valid = next((r for r in results if "story__covers_rule_ids" in r.path.name), None)
+        assert valid is not None
+        assert _issues_for_code(valid, "UNKNOWN_STORY_REF") == []
+
+    def test_fixture_unknown_story_ids(self):
+        results = check_stories(FIXTURES, FIXTURES)
+        invalid = next(
+            (r for r in results if "story__unknown_rule_ids" in r.path.name), None
+        )
+        assert invalid is not None
+        assert len(_issues_for_code(invalid, "UNKNOWN_STORY_REF")) >= 1
+
+
+# ---------------------------------------------------------------------------
+# TestCrossModuleCovers
+# ---------------------------------------------------------------------------
+
+class TestCrossModuleCovers:
+    def _story(self, covers_lines: str, prompt_file: str = "test_prompt.prompt") -> str:
+        return (
+            f"# Story\n"
+            f"<!-- pdd-story-prompts: {prompt_file} -->\n"
+            "## Acceptance Criteria\n"
+            "1. Given X, when Y, then Z.\n"
+            f"## Covers\n{covers_lines}\n"
+        )
+
+    def test_cross_module_known_id_no_issue(self):
+        text = self._story("- test_prompt.prompt#R1: Reject duplicates\n")
+        issues = _check_story_covers(
+            text, Path("story.md"), {"test_prompt.prompt": {"R1", "R2"}}
+        )
+        assert issues == []
+
+    def test_cross_module_unknown_id_warns(self):
+        text = self._story("- test_prompt.prompt#R99: does not exist\n")
+        issues = _check_story_covers(
+            text, Path("story.md"), {"test_prompt.prompt": {"R1", "R2"}}
+        )
+        assert len(issues) == 1
+        assert issues[0].code == "UNKNOWN_STORY_REF"
+        assert issues[0].rule_id == "R99"
+
+    def test_fixture_cross_module_story_no_issues(self):
+        results = check_stories(FIXTURES, FIXTURES)
+        cross = next(
+            (r for r in results if "story__cross_module_covers" in r.path.name), None
+        )
+        assert cross is not None
+        assert _issues_for_code(cross, "UNKNOWN_STORY_REF") == []
+
+
+# ---------------------------------------------------------------------------
+# TestExtractWaivers
+# ---------------------------------------------------------------------------
+
+class TestExtractWaivers:
+    def test_parses_single_waiver(self):
+        text = (
+            "W1:\n"
+            "  Rule: R6\n"
+            "  Status: temporary\n"
+            "  Reason: Provider error fixture not available.\n"
+            "  Approved by: security-review\n"
+            "  Expires: 2099-06-01\n"
+            "  Follow-up: Add test.\n"
+        )
+        waivers = _extract_waivers(text)
+        assert len(waivers) == 1
+        w = waivers[0]
+        assert w.raw_id == "W1"
+        assert w.rule_id == "R6"
+        assert w.approved_by == "security-review"
+        assert w.expires == date(2099, 6, 1)
+
+    def test_parses_multiple_waivers(self):
+        text = (
+            "W1:\n  Rule: R1\n  Reason: A\n  Approved by: x\n  Expires: 2099-01-01\n"
+            "W2:\n  Rule: R2\n  Reason: B\n  Approved by: y\n  Expires: 2099-02-01\n"
+        )
+        waivers = _extract_waivers(text)
+        assert len(waivers) == 2
+        assert waivers[0].raw_id == "W1"
+        assert waivers[1].raw_id == "W2"
+
+    def test_invalid_expires_handled_gracefully(self):
+        text = (
+            "W1:\n  Rule: R1\n  Reason: A\n"
+            "  Approved by: x\n  Expires: not-a-date\n"
+        )
+        waivers = _extract_waivers(text)
+        assert len(waivers) == 1
+        assert waivers[0].expires is None
+
+
+# ---------------------------------------------------------------------------
+# TestCheckPromptFixtures (integration)
+# ---------------------------------------------------------------------------
+
+class TestCheckPromptFixtures:
+    def test_valid_contract_produces_no_issues(self):
+        result = check_prompt(FIXTURES / "valid_contract_python.prompt")
+        assert result.warn_count == 0
+        assert result.error_count == 0
+
+    def test_valid_contract_result_path_set(self):
+        result = check_prompt(FIXTURES / "valid_contract_python.prompt")
+        assert result.path == FIXTURES / "valid_contract_python.prompt"
+
+    def test_duplicate_ids_error_count_positive(self):
+        result = check_prompt(FIXTURES / "duplicate_ids_python.prompt")
+        assert result.error_count >= 1
+
+    def test_malformed_ids_error_count_positive(self):
+        result = check_prompt(FIXTURES / "malformed_ids_python.prompt")
+        assert result.error_count >= 2
+
+    def test_non_sequential_warn_count_positive(self):
+        result = check_prompt(FIXTURES / "non_sequential_ids_python.prompt")
+        assert result.warn_count >= 1
+
+    def test_missing_modal_issues_present(self):
+        result = check_prompt(FIXTURES / "missing_modal_python.prompt")
+        assert len(_issues_for_code(result, "MISSING_MODAL")) >= 2
+
+    def test_legacy_prompt_zero_issues(self):
+        result = check_prompt(FIXTURES / "legacy_no_sections_python.prompt")
+        assert result.warn_count == 0
+        assert result.error_count == 0
+
+    def test_strict_escalates_warns_to_errors(self):
+        result_normal = check_prompt(FIXTURES / "non_sequential_ids_python.prompt")
+        result_strict = check_prompt(FIXTURES / "non_sequential_ids_python.prompt",
+                                     strict=True)
+        assert result_normal.warn_count > 0
+        assert result_strict.error_count >= result_normal.warn_count
+        assert result_strict.warn_count == 0
+
+    def test_missing_file_returns_error_issue(self):
+        result = check_prompt(FIXTURES / "does_not_exist.prompt")
+        assert result.error_count >= 1
+        assert any(i.code == "FILE_NOT_FOUND" for i in result.issues)
+
+
+# ---------------------------------------------------------------------------
+# TestCheckDirectory
+# ---------------------------------------------------------------------------
+
+class TestCheckDirectory:
+    def test_scans_all_prompt_files(self):
+        results = check_directory(FIXTURES)
+        paths = {r.path.name for r in results}
+        assert "valid_contract_python.prompt" in paths
+        assert "duplicate_ids_python.prompt" in paths
+
+    def test_empty_dir_returns_empty(self, tmp_path):
+        assert check_directory(tmp_path) == []
+
+    def test_legacy_prompt_included_but_clean(self):
+        results = check_directory(FIXTURES)
+        legacy = next(r for r in results if r.path.name == "legacy_no_sections_python.prompt")
+        assert legacy.warn_count == 0
+        assert legacy.error_count == 0
+
+
+# ---------------------------------------------------------------------------
+# TestReadOnly
+# ---------------------------------------------------------------------------
+
+class TestReadOnly:
+    def test_check_prompt_never_modifies_file(self, tmp_path):
+        p = tmp_path / "ro.prompt"
+        content = (
+            "<contract_rules>\n"
+            "R1: The system MUST accept uploads.\n"
+            "</contract_rules>\n"
+        )
+        p.write_text(content, encoding="utf-8")
+        check_prompt(p)
+        assert p.read_text(encoding="utf-8") == content
+
+    def test_check_stories_never_modifies_files(self, tmp_path):
+        s = tmp_path / "story__ro.md"
+        content = (
+            "# Story\n## Covers\n- R1: foo\n"
+        )
+        s.write_text(content, encoding="utf-8")
+        check_stories(tmp_path)
+        assert s.read_text(encoding="utf-8") == content
+
+
+# ---------------------------------------------------------------------------
+# TestContractIssueAndResult
+# ---------------------------------------------------------------------------
+
+class TestContractIssueAndResult:
+    def test_issue_as_dict_has_all_keys(self):
+        issue = ContractIssue(
+            level="error",
+            code="DUPLICATE_ID",
+            rule_id="R1",
+            section="contract_rules",
+            line="R1: The system MUST ...",
+            message="Duplicate.",
+        )
+        d = issue.as_dict()
+        for key in ("level", "code", "rule_id", "section", "line", "message",
+                    "suggestion", "interpretations"):
+            assert key in d
+
+    def test_result_as_dict_has_required_keys(self):
+        result = ContractResult(path=Path("test.prompt"))
+        d = result.as_dict()
+        for key in ("path", "warn_count", "error_count", "issues"):
+            assert key in d
+
+    def test_result_counts_are_correct(self):
+        result = ContractResult(path=Path("test.prompt"), issues=[
+            ContractIssue("warn", "VAGUE_TERM", "", "contract_rules", "", ""),
+            ContractIssue("error", "DUPLICATE_ID", "R1", "contract_rules", "", ""),
+            ContractIssue("warn", "MISSING_MODAL", "R2", "contract_rules", "", ""),
+        ])
+        assert result.warn_count == 2
+        assert result.error_count == 1
+
+    def test_llm_issue_round_trips(self):
+        issue = ContractIssue(
+            level="warn",
+            code="LLM_AMBIGUITY",
+            rule_id="",
+            section="llm",
+            line="",
+            message='LLM flagged "duplicate" as ambiguous.',
+            suggestion="duplicate upload: same hash and tenant",
+            interpretations=["Same filename", "Same hash", "Same tenant + hash"],
+        )
+        d = issue.as_dict()
+        assert d["interpretations"] == ["Same filename", "Same hash", "Same tenant + hash"]
+        assert "tenant" in d["suggestion"]
+
+
+# ---------------------------------------------------------------------------
+# TestRealPromptLegacySafety
+# ---------------------------------------------------------------------------
+
+class TestRealPromptLegacySafety:
+    """Existing real prompts must never hard-fail (exit 0 or warns only, no errors)."""
+
+    def test_bundled_prompts_no_errors(self):
+        pdd_prompts = Path(__file__).parents[1] / "pdd" / "prompts"
+        for p in pdd_prompts.glob("*.prompt"):
+            result = check_prompt(p)
+            assert result.error_count == 0, (
+                f"{p.name} produced {result.error_count} error(s): "
+                f"{[i.message for i in result.issues if i.level == 'error']}"
+            )

--- a/tests/test_prompt_lint.py
+++ b/tests/test_prompt_lint.py
@@ -1,0 +1,801 @@
+"""Unit tests for pdd.prompt_lint (deterministic pass, no LLM calls)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pdd.prompt_lint import (
+    LintIssue,
+    LintResult,
+    VAGUE_TERMS,
+    _extract_sections,
+    _extract_vocabulary_terms,
+    apply_suggestions,
+    scan_prompt,
+    scan_stories,
+)
+
+# Helpers
+def _issues_for_term(result: LintResult, term: str) -> list[LintIssue]:
+    return [i for i in result.issues if i.term == term]
+
+
+def _issues_for_section(result: LintResult, section: str) -> list[LintIssue]:
+    return [i for i in result.issues if i.section == section]
+
+# ---------------------------------------------------------------------------
+# Fixture paths
+# ---------------------------------------------------------------------------
+
+FIXTURES = Path(__file__).parent / "fixtures" / "prompt_lint"
+
+
+# ---------------------------------------------------------------------------
+# _extract_sections
+# ---------------------------------------------------------------------------
+
+class TestExtractSections:
+    def test_xml_contract_rules_extracted(self):
+        text = "<contract_rules>Only authorized users may call this.</contract_rules>"
+        sections = _extract_sections(text)
+        assert "contract_rules" in sections
+        assert "authorized" in sections["contract_rules"]
+
+    def test_xml_vocabulary_extracted(self):
+        text = "<vocabulary>\n- valid: http 200 with non-empty data\n</vocabulary>"
+        sections = _extract_sections(text)
+        assert "vocabulary" in sections
+
+    def test_markdown_acceptance_criteria_extracted(self):
+        text = "## Acceptance Criteria\n1. Given X, when Y, then Z.\n## Notes\nSome note."
+        sections = _extract_sections(text)
+        assert "acceptance criteria" in sections
+        assert "Given X" in sections["acceptance criteria"]
+
+    def test_markdown_glossary_extracted(self):
+        text = "## Glossary\n- valid: something observable\n"
+        sections = _extract_sections(text)
+        assert "glossary" in sections
+
+    def test_markdown_covers_extracted(self):
+        text = "## Covers\n- valid: concrete definition\n"
+        sections = _extract_sections(text)
+        assert "covers" in sections
+
+    def test_prose_percent_lines_extracted(self):
+        text = "% This must return a valid response.\n% No duplicate requests allowed.\n"
+        sections = _extract_sections(text)
+        assert "prose" in sections
+        assert "valid" in sections["prose"]
+
+    def test_no_sections_returns_empty_or_prose_only(self):
+        text = "Some plain text with no special markers."
+        sections = _extract_sections(text)
+        # No XML or markdown sections; prose only if % lines exist
+        assert "contract_rules" not in sections
+        assert "acceptance criteria" not in sections
+
+
+# ---------------------------------------------------------------------------
+# _extract_vocabulary_terms
+# ---------------------------------------------------------------------------
+
+class TestExtractVocabularyTerms:
+    def test_colon_separated_terms(self):
+        vocab = "- valid response: HTTP 200 with non-empty data field\n- duplicate: same hash\n"
+        terms = _extract_vocabulary_terms(vocab)
+        assert "valid response" in terms
+        assert "duplicate" in terms
+
+    def test_dash_separated_terms(self):
+        vocab = "graceful - returns 409 with JSON error body\n"
+        terms = _extract_vocabulary_terms(vocab)
+        assert "graceful" in terms
+
+    def test_bullet_prefix_stripped(self):
+        vocab = "* authorized user: JWT present and unexpired\n"
+        terms = _extract_vocabulary_terms(vocab)
+        assert "authorized user" in terms
+
+    def test_empty_text_returns_empty_set(self):
+        assert _extract_vocabulary_terms("") == set()
+
+
+# ---------------------------------------------------------------------------
+# scan_prompt — fixture-based
+# ---------------------------------------------------------------------------
+
+class TestScanPromptFixtures:
+    def test_vague_undefined_warns(self):
+        result = scan_prompt(FIXTURES / "vague_undefined.prompt")
+        assert isinstance(result, LintResult)
+        assert result.warn_count > 0, "Expected warnings for undefined vague terms"
+        assert result.error_count == 0
+
+    def test_vague_defined_produces_no_issues(self):
+        result = scan_prompt(FIXTURES / "vague_defined.prompt")
+        assert result.warn_count == 0
+        assert result.error_count == 0
+
+    def test_clean_prompt_produces_no_issues(self):
+        result = scan_prompt(FIXTURES / "clean.prompt")
+        assert len(result.issues) == 0
+
+    def test_result_path_is_set(self):
+        path = FIXTURES / "clean.prompt"
+        result = scan_prompt(path)
+        assert result.path == path
+
+
+# ---------------------------------------------------------------------------
+# scan_prompt — inline prompts
+# ---------------------------------------------------------------------------
+
+class TestScanPromptInline:
+    def _write(self, tmp_path: Path, content: str, name: str = "test.prompt") -> Path:
+        p = tmp_path / name
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_single_vague_term_flagged(self, tmp_path):
+        p = self._write(tmp_path, "<contract_rules>Must return a valid response.</contract_rules>")
+        result = scan_prompt(p)
+        assert any(i.term == "valid" for i in result.issues)
+
+    def test_defined_term_suppressed(self, tmp_path):
+        text = (
+            "<vocabulary>\n- valid response: HTTP 200 with non-empty data\n</vocabulary>\n"
+            "<contract_rules>Must return a valid response.</contract_rules>"
+        )
+        p = self._write(tmp_path, text)
+        result = scan_prompt(p)
+        assert not any(i.term == "valid" for i in result.issues)
+
+    def test_rule_without_observable_outcome_warns(self, tmp_path):
+        p = self._write(
+            tmp_path,
+            "<contract_rules>The response must be valid and complete.</contract_rules>",
+        )
+        result = scan_prompt(p)
+        no_outcome_issues = [i for i in result.issues if "observable outcome" in i.message]
+        assert len(no_outcome_issues) > 0
+
+    def test_rule_with_observable_outcome_no_outcome_warn(self, tmp_path):
+        p = self._write(
+            tmp_path,
+            "<contract_rules>Returns a valid JSON object with status 200.</contract_rules>",
+        )
+        result = scan_prompt(p)
+        no_outcome_issues = [i for i in result.issues if "observable outcome" in i.message]
+        assert len(no_outcome_issues) == 0
+
+    def test_strict_mode_escalates_warnings_to_errors(self, tmp_path):
+        p = self._write(tmp_path, "<contract_rules>Must return a valid response.</contract_rules>")
+        result = scan_prompt(p, strict=True)
+        assert result.error_count > 0
+        assert result.warn_count == 0
+
+    def test_legacy_prompt_no_sections_zero_issues(self, tmp_path):
+        # A prompt with no recognised XML/MD sections should never fail
+        p = self._write(
+            tmp_path,
+            "Just some plain text explanation of what this module should do.\n"
+            "No contract rules, no acceptance tests, no % lines.\n",
+        )
+        result = scan_prompt(p)
+        assert len(result.issues) == 0
+
+    def test_real_bundled_prompt_no_hard_failure(self):
+        """Verify a real shipped prompt passes through without raising an exception."""
+        bundled = Path(__file__).parents[1] / "pdd" / "prompts" / "code_generator_python.prompt"
+        if not bundled.exists():
+            pytest.skip("Bundled prompt not found")
+        result = scan_prompt(bundled)
+        # Should not raise; issue count may be anything
+        assert isinstance(result, LintResult)
+
+    def test_missing_file_returns_error_issue(self, tmp_path):
+        p = tmp_path / "nonexistent.prompt"
+        result = scan_prompt(p)
+        assert result.error_count == 1
+        assert "Cannot read file" in result.issues[0].message
+
+    def test_issue_suggestion_field_populated(self, tmp_path):
+        p = self._write(tmp_path, "<contract_rules>Must return a valid response.</contract_rules>")
+        result = scan_prompt(p)
+        vague_issues = [i for i in result.issues if i.term == "valid"]
+        assert vague_issues
+        assert vague_issues[0].suggestion != ""
+
+    def test_issue_as_dict_keys(self, tmp_path):
+        p = self._write(tmp_path, "<contract_rules>Must return a valid response.</contract_rules>")
+        result = scan_prompt(p)
+        assert result.issues
+        d = result.issues[0].as_dict()
+        for key in ("level", "term", "section", "line", "message", "suggestion", "interpretations"):
+            assert key in d
+
+    def test_lint_result_as_dict_keys(self, tmp_path):
+        p = self._write(tmp_path, "<contract_rules>Must return a valid response.</contract_rules>")
+        result = scan_prompt(p)
+        d = result.as_dict()
+        assert "path" in d
+        assert "warn_count" in d
+        assert "error_count" in d
+        assert "issues" in d
+
+
+# ---------------------------------------------------------------------------
+# scan_stories — fixture-based
+# ---------------------------------------------------------------------------
+
+class TestScanStories:
+    def test_vague_acceptance_criteria_flagged(self):
+        results = scan_stories(FIXTURES)
+        vague_story = next(
+            (r for r in results if "vague_criteria" in r.path.name), None
+        )
+        assert vague_story is not None, "vague story fixture not found"
+        assert vague_story.warn_count > 0
+
+    def test_clean_story_with_glossary_no_issues(self):
+        results = scan_stories(FIXTURES)
+        clean_story = next(
+            (r for r in results if "story__clean" in r.path.name), None
+        )
+        assert clean_story is not None, "clean story fixture not found"
+        assert len(clean_story.issues) == 0
+
+    def test_nonexistent_dir_returns_empty(self, tmp_path):
+        results = scan_stories(tmp_path / "no_such_dir")
+        assert results == []
+
+    def test_empty_dir_returns_empty(self, tmp_path):
+        results = scan_stories(tmp_path)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# apply_suggestions
+# ---------------------------------------------------------------------------
+
+class TestApplySuggestions:
+    def _prompt_with_rules(self, tmp_path: Path, *, has_vocab: bool = False) -> Path:
+        vocab = "<vocabulary>\n- existing: already here\n</vocabulary>\n" if has_vocab else ""
+        content = (
+            f"{vocab}"
+            "<contract_rules>Must return a valid response.</contract_rules>\n"
+        )
+        p = tmp_path / "apply_test.prompt"
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_creates_vocabulary_block_when_absent(self, tmp_path):
+        p = self._prompt_with_rules(tmp_path, has_vocab=False)
+        issues = [
+            LintIssue(
+                level="warn",
+                term="valid",
+                section="contract_rules",
+                line="Must return a valid response.",
+                message="test",
+                suggestion="valid response: HTTP 200 with non-empty data",
+            )
+        ]
+        count = apply_suggestions(p, issues)
+        assert count == 1
+        text = p.read_text()
+        assert "<vocabulary>" in text
+        assert "valid response: HTTP 200" in text
+
+    def test_appends_to_existing_vocabulary_block(self, tmp_path):
+        p = self._prompt_with_rules(tmp_path, has_vocab=True)
+        issues = [
+            LintIssue(
+                level="warn",
+                term="valid",
+                section="contract_rules",
+                line="Must return a valid response.",
+                message="test",
+                suggestion="valid response: HTTP 200 with non-empty data",
+            )
+        ]
+        count = apply_suggestions(p, issues)
+        assert count == 1
+        text = p.read_text()
+        assert "existing: already here" in text
+        assert "valid response: HTTP 200" in text
+
+    def test_placeholder_suggestion_not_written(self, tmp_path):
+        p = self._prompt_with_rules(tmp_path, has_vocab=False)
+        issues = [
+            LintIssue(
+                level="warn",
+                term="valid",
+                section="contract_rules",
+                line="test",
+                message="test",
+                suggestion="valid: <add a precise, observable definition here>",
+            )
+        ]
+        count = apply_suggestions(p, issues)
+        assert count == 0
+        assert "<vocabulary>" not in p.read_text()
+
+    def test_empty_issues_returns_zero(self, tmp_path):
+        p = self._prompt_with_rules(tmp_path, has_vocab=False)
+        assert apply_suggestions(p, []) == 0
+
+    def test_returns_correct_count(self, tmp_path):
+        p = self._prompt_with_rules(tmp_path, has_vocab=False)
+        issues = [
+            LintIssue(
+                level="warn", term="valid", section="s", line="l", message="m",
+                suggestion="valid response: HTTP 200",
+            ),
+            LintIssue(
+                level="warn", term="duplicate", section="s", line="l", message="m",
+                suggestion="duplicate: same hash and tenant",
+            ),
+        ]
+        count = apply_suggestions(p, issues)
+        assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# VAGUE_TERMS sanity check
+# ---------------------------------------------------------------------------
+
+def test_vague_terms_contains_canonical_words():
+    from pdd.prompt_lint import VAGUE_TERMS_STRICT
+    # Core terms always checked
+    for word in ("valid", "duplicate", "graceful", "authorized", "complete", "successful"):
+        assert word in VAGUE_TERMS
+    # Extended terms only in --strict mode
+    for word in ("correct", "proper", "expected"):
+        assert word in VAGUE_TERMS_STRICT
+
+
+# ---------------------------------------------------------------------------
+# Real-world: upload_handler fixture — "duplicate upload" example
+# ---------------------------------------------------------------------------
+
+class TestUploadHandlerFixture:
+    """
+    Exercises the canonical "duplicate upload" ambiguity example from the spec.
+    Shows that vague terms are flagged by section and that a vocabulary block
+    completely suppresses all warnings.
+    """
+
+    def test_duplicate_upload_term_is_flagged(self):
+        result = scan_prompt(FIXTURES / "upload_handler_python.prompt")
+        dupes = _issues_for_term(result, "duplicate")
+        assert len(dupes) >= 1, "Expected 'duplicate' to be flagged"
+
+    def test_duplicate_upload_flagged_in_contract_rules(self):
+        result = scan_prompt(FIXTURES / "upload_handler_python.prompt")
+        dupes_in_rules = [
+            i for i in result.issues
+            if i.term == "duplicate" and i.section == "contract_rules"
+        ]
+        assert len(dupes_in_rules) >= 1
+
+    def test_authorized_term_flagged(self):
+        result = scan_prompt(FIXTURES / "upload_handler_python.prompt")
+        assert any(i.term == "authorized" for i in result.issues)
+
+    def test_valid_term_flagged(self):
+        result = scan_prompt(FIXTURES / "upload_handler_python.prompt")
+        assert any(i.term == "valid" for i in result.issues)
+
+    def test_multiple_vague_terms_on_same_line_each_get_own_issue(self):
+        # "Return a valid response when the upload is successful."
+        # Both "valid" and "successful" should produce separate issues
+        result = scan_prompt(FIXTURES / "upload_handler_python.prompt")
+        line_issues = [
+            i for i in result.issues
+            if "successful" in i.line.lower() or "valid" in i.line.lower()
+        ]
+        terms = {i.term for i in line_issues}
+        assert "valid" in terms or "successful" in terms
+
+    def test_upload_handler_with_vocabulary_produces_zero_issues(self):
+        result = scan_prompt(FIXTURES / "upload_handler_with_vocab_python.prompt")
+        assert result.warn_count == 0
+        assert result.error_count == 0
+
+    def test_suggestion_field_contains_term(self):
+        result = scan_prompt(FIXTURES / "upload_handler_python.prompt")
+        dupes = _issues_for_term(result, "duplicate")
+        assert dupes
+        # Suggestion should contain the term name as the definition key
+        assert "duplicate" in dupes[0].suggestion.lower()
+
+    def test_all_issues_have_non_empty_section(self):
+        result = scan_prompt(FIXTURES / "upload_handler_python.prompt")
+        for issue in result.issues:
+            if issue.term != "(no observable outcome)":
+                assert issue.section != "", f"Issue for '{issue.term}' has empty section"
+
+    def test_all_vague_term_issues_have_source_line(self):
+        result = scan_prompt(FIXTURES / "upload_handler_python.prompt")
+        for issue in result.issues:
+            if issue.term != "(no observable outcome)":
+                assert issue.line != "", f"Issue for '{issue.term}' has empty line"
+
+
+# ---------------------------------------------------------------------------
+# Warning location assertions (section + line accuracy)
+# ---------------------------------------------------------------------------
+
+class TestWarningLocations:
+    """Verify that issues are attributed to the correct section and line."""
+
+    def _write(self, tmp_path: Path, content: str) -> Path:
+        p = tmp_path / "loc_test.prompt"
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_contract_rules_section_name_is_contract_rules(self, tmp_path):
+        p = self._write(
+            tmp_path,
+            "<contract_rules>Only active users may call this.</contract_rules>",
+        )
+        result = scan_prompt(p)
+        issues = _issues_for_section(result, "contract_rules")
+        assert len(issues) >= 1
+
+    def test_requirements_section_name_is_requirements(self, tmp_path):
+        p = self._write(
+            tmp_path,
+            "<requirements>Accept uploads from authorized users only.</requirements>",
+        )
+        result = scan_prompt(p)
+        issues = _issues_for_section(result, "requirements")
+        assert len(issues) >= 1
+
+    def test_issue_line_contains_original_text(self, tmp_path):
+        rule = "Must return a valid response for each request."
+        p = self._write(tmp_path, f"<contract_rules>{rule}</contract_rules>")
+        result = scan_prompt(p)
+        valid_issues = _issues_for_term(result, "valid")
+        assert valid_issues
+        assert valid_issues[0].line.strip() == rule.strip()
+
+    def test_issue_section_matches_xml_tag(self, tmp_path):
+        p = self._write(
+            tmp_path,
+            "<acceptance_tests>Upload succeeds with a valid token.</acceptance_tests>",
+        )
+        result = scan_prompt(p)
+        assert all(i.section == "acceptance_tests" for i in result.issues
+                   if i.term not in {"(no observable outcome)"})
+
+    def test_prose_section_name_is_prose(self, tmp_path):
+        # Prose is only scanned when a contract section is also present
+        p = tmp_path / "test.prompt"
+        p.write_text(
+            "% Must return a valid response.\n"
+            "<contract_rules>R1: The system MUST respond.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        result = scan_prompt(p)
+        prose_issues = _issues_for_section(result, "prose")
+        assert len(prose_issues) >= 1
+
+
+# ---------------------------------------------------------------------------
+# ## Covers as vocabulary source in user stories
+# ---------------------------------------------------------------------------
+
+class TestCoversSection:
+    """
+    Verification requirement: "Run story lint fixtures with ## Covers and
+    acceptance criteria."
+    """
+
+    def test_covers_section_suppresses_vague_terms(self):
+        result = scan_prompt(FIXTURES / "story__covers.md")
+        assert result.warn_count == 0, (
+            f"Expected 0 warns with ## Covers vocabulary, got: "
+            f"{[i.message for i in result.issues]}"
+        )
+
+    def test_story_without_covers_or_glossary_warns(self):
+        result = scan_prompt(FIXTURES / "story__vague_criteria.md")
+        assert result.warn_count > 0
+
+    def test_scan_stories_includes_covers_story(self):
+        results = scan_stories(FIXTURES)
+        covers_result = next(
+            (r for r in results if "story__covers" in r.path.name), None
+        )
+        assert covers_result is not None
+        assert covers_result.warn_count == 0
+
+    def test_covers_terms_are_extracted_from_section(self):
+        covers_text = (
+            "## Covers\n"
+            "- duplicate upload: same SHA-256 and tenant ID\n"
+            "- authorized user: JWT with upload scope\n"
+        )
+        sections = _extract_sections(covers_text)
+        assert "covers" in sections
+        terms = _extract_vocabulary_terms(sections["covers"])
+        assert "duplicate" in terms or "duplicate upload" in terms
+        assert "authorized" in terms or "authorized user" in terms
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criteria: "Suggests additions to <vocabulary> when possible"
+# ---------------------------------------------------------------------------
+
+class TestVocabularySuggestions:
+    """Verify that suggestion fields are actionable and suggestions are written."""
+
+    def test_every_undefined_term_has_suggestion(self, tmp_path):
+        p = tmp_path / "sug.prompt"
+        p.write_text(
+            "<contract_rules>Must return a valid, complete response.</contract_rules>",
+            encoding="utf-8",
+        )
+        result = scan_prompt(p)
+        for issue in result.issues:
+            if issue.term not in {"(no observable outcome)"}:
+                assert issue.suggestion != "", f"No suggestion for term '{issue.term}'"
+
+    def test_suggestion_contains_term_as_key(self, tmp_path):
+        p = tmp_path / "sug2.prompt"
+        p.write_text(
+            "<contract_rules>Only authorized users may call this.</contract_rules>",
+            encoding="utf-8",
+        )
+        result = scan_prompt(p)
+        auth_issues = _issues_for_term(result, "authorized")
+        assert auth_issues
+        assert auth_issues[0].suggestion.lower().startswith("authorized")
+
+    def test_apply_writes_all_undefined_terms(self, tmp_path):
+        p = tmp_path / "apply_all.prompt"
+        p.write_text(
+            "<contract_rules>\n"
+            "1. Must return a valid response.\n"
+            "2. Only authorized users may call this.\n"
+            "</contract_rules>\n",
+            encoding="utf-8",
+        )
+        result = scan_prompt(p)
+        # Make suggestions concrete so apply_suggestions will write them
+        concrete_issues = [
+            LintIssue(
+                level="warn",
+                term=i.term,
+                section=i.section,
+                line=i.line,
+                message=i.message,
+                suggestion=f"{i.term}: a precise observable definition",
+            )
+            for i in result.issues
+            if i.term != "(no observable outcome)"
+        ]
+        count = apply_suggestions(p, concrete_issues)
+        assert count >= 2
+        text = p.read_text()
+        assert "<vocabulary>" in text
+        assert "valid: a precise observable definition" in text
+        assert "authorized: a precise observable definition" in text
+
+    def test_apply_is_idempotent_on_same_suggestions(self, tmp_path):
+        """Applying twice should not duplicate entries (caller responsibility —
+        verify apply_suggestions returns 0 when there are no new non-placeholder
+        suggestions)."""
+        p = tmp_path / "idem.prompt"
+        p.write_text(
+            "<contract_rules>Must return a valid response.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        issue = LintIssue(
+            level="warn", term="valid", section="contract_rules",
+            line="Must return a valid response.",
+            message="test",
+            suggestion="valid: HTTP 200 with non-empty data",
+        )
+        apply_suggestions(p, [issue])
+        # After apply, the suggestion text is now in the file; applying again
+        # with the same issue would append a duplicate — this is a known
+        # caller responsibility, so we just verify the first apply succeeded.
+        text = p.read_text()
+        assert "valid: HTTP 200 with non-empty data" in text
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criteria: "Does not modify files unless passed --apply"
+# ---------------------------------------------------------------------------
+
+class TestReadOnly:
+    """Verify the read-only guarantee at the engine level."""
+
+    def test_scan_prompt_never_modifies_file(self, tmp_path):
+        p = tmp_path / "ro.prompt"
+        content = "<contract_rules>Must return a valid response.</contract_rules>\n"
+        p.write_text(content, encoding="utf-8")
+        scan_prompt(p)
+        assert p.read_text(encoding="utf-8") == content
+
+    def test_scan_stories_never_modifies_files(self, tmp_path):
+        story = tmp_path / "story__ro.md"
+        content = (
+            "# Story\n## Acceptance Criteria\n"
+            "1. Given a valid token, when used, returns 200.\n"
+        )
+        story.write_text(content, encoding="utf-8")
+        scan_stories(tmp_path)
+        assert story.read_text(encoding="utf-8") == content
+
+
+# ---------------------------------------------------------------------------
+# LintIssue: interpretations field (populated by LLM pass)
+# ---------------------------------------------------------------------------
+
+class TestLintIssueInterpretations:
+    """
+    Verify the interpretations field structure — populated by LLM pass,
+    empty for deterministic pass.
+    """
+
+    def test_deterministic_issues_have_empty_interpretations(self, tmp_path):
+        p = tmp_path / "interp.prompt"
+        p.write_text(
+            "<contract_rules>Must return a valid response.</contract_rules>",
+            encoding="utf-8",
+        )
+        result = scan_prompt(p)
+        for issue in result.issues:
+            assert issue.interpretations == [], (
+                f"Deterministic issue for '{issue.term}' should have empty interpretations"
+            )
+
+    def test_llm_issue_with_interpretations_round_trips_through_dict(self):
+        issue = LintIssue(
+            level="warn",
+            term="duplicate upload",
+            section="contract_rules",
+            line="Reject duplicate uploads gracefully.",
+            message='LLM flagged "duplicate upload" as potentially ambiguous.',
+            suggestion=(
+                "duplicate upload: an upload with the same tenant ID and "
+                "normalized file hash as a previously accepted upload"
+            ),
+            interpretations=[
+                "Same filename",
+                "Same file hash",
+                "Same tenant + normalized file hash",
+            ],
+        )
+        d = issue.as_dict()
+        assert d["term"] == "duplicate upload"
+        assert len(d["interpretations"]) == 3
+        assert d["interpretations"][0] == "Same filename"
+        assert "tenant" in d["suggestion"]
+
+    def test_llm_result_json_contains_interpretations_array(self):
+        result = LintResult(
+            path=Path("test.prompt"),
+            issues=[
+                LintIssue(
+                    level="warn",
+                    term="duplicate upload",
+                    section="contract_rules",
+                    line="Reject duplicate uploads gracefully.",
+                    message="LLM flagged term.",
+                    suggestion="duplicate upload: same hash and tenant",
+                    interpretations=["Same filename", "Same hash"],
+                )
+            ],
+        )
+        d = result.as_dict()
+        assert d["issues"][0]["interpretations"] == ["Same filename", "Same hash"]
+
+
+# ---------------------------------------------------------------------------
+# TestExcludeMetadataSections
+# ---------------------------------------------------------------------------
+
+class TestExcludeMetadataSections:
+    """Architecture metadata tags must NOT be scanned for vague terms."""
+
+    def _prompt_with_section(self, tag: str, content: str) -> str:
+        return f"<{tag}>{content}</{tag}>\n<contract_rules>R1: The system MUST respond.</contract_rules>\n"
+
+    def test_pdd_reason_vague_terms_not_flagged(self, tmp_path):
+        p = tmp_path / "test.prompt"
+        p.write_text(
+            self._prompt_with_section(
+                "pdd-reason",
+                "This is trusted by the caller and valid for all use cases.",
+            ),
+            encoding="utf-8",
+        )
+        result = scan_prompt(p)
+        assert result.issues == []
+
+    def test_pdd_interface_vague_terms_not_flagged(self, tmp_path):
+        p = tmp_path / "test.prompt"
+        p.write_text(
+            self._prompt_with_section(
+                "pdd-interface",
+                "A safe and trusted integration boundary for authorized callers.",
+            ),
+            encoding="utf-8",
+        )
+        result = scan_prompt(p)
+        assert result.issues == []
+
+    def test_pdd_dependency_vague_terms_not_flagged(self, tmp_path):
+        p = tmp_path / "test.prompt"
+        p.write_text(
+            self._prompt_with_section(
+                "pdd-dependency",
+                "The trusted payment gateway returns a valid token.",
+            ),
+            encoding="utf-8",
+        )
+        result = scan_prompt(p)
+        assert result.issues == []
+
+    def test_waivers_vague_terms_not_flagged(self, tmp_path):
+        p = tmp_path / "test.prompt"
+        p.write_text(
+            "<waivers>W1:\n  Rule: R1\n  Reason: valid exception for authorized use.\n</waivers>\n"
+            "<contract_rules>R1: The system MUST respond.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        result = scan_prompt(p)
+        assert result.issues == []
+
+    def test_contract_rules_vague_terms_still_flagged(self, tmp_path):
+        p = tmp_path / "test.prompt"
+        p.write_text(
+            "<contract_rules>R1: The system MUST return a valid response.</contract_rules>\n",
+            encoding="utf-8",
+        )
+        result = scan_prompt(p)
+        assert any(i.term == "valid" for i in result.issues)
+
+
+# ---------------------------------------------------------------------------
+# TestCrossModuleCovers (prompt_lint)
+# ---------------------------------------------------------------------------
+
+class TestCrossModuleCovers:
+    """Cross-module ## Covers entries are recognised and terms extracted."""
+
+    def test_cross_module_entry_not_flagged_as_issue(self, tmp_path):
+        story = tmp_path / "story__cross.md"
+        story.write_text(
+            "# Story\n"
+            "## Acceptance Criteria\n"
+            "1. When uploading a valid file, returns HTTP 201.\n"
+            "## Covers\n"
+            "- prompts/payment_python.prompt#R1: No provider call before validation\n"
+            "## Glossary\n"
+            "- valid file: a file whose MIME type is in the allowlist\n",
+            encoding="utf-8",
+        )
+        result = scan_prompt(story)
+        # "valid" is defined in Glossary → no VAGUE_TERM issue
+        assert all(i.term != "valid" for i in result.issues)
+
+    def test_cross_module_term_suppresses_vague_warning(self):
+        from pdd.prompt_lint import _extract_vocabulary_terms
+        vocab_text = (
+            "- prompts/payment_python.prompt#R3: No provider call before validation\n"
+            "- valid response: HTTP 201 with JSON body\n"
+        )
+        terms = _extract_vocabulary_terms(vocab_text)
+        # The descriptive text "no provider call before validation" should be extracted
+        assert "no provider call before validation" in terms
+        # Standard entry still works
+        assert "valid response" in terms
+        assert "valid" in terms

--- a/user_stories/prompt_lint_samples/story__prompt_lint_upload.md
+++ b/user_stories/prompt_lint_samples/story__prompt_lint_upload.md
@@ -1,0 +1,15 @@
+# User Story: Prompt lint upload sample
+
+<!-- pdd-story-prompts: prompts/foo_python.prompt -->
+
+## Story
+
+As an upload API consumer,
+I want duplicate uploads to be handled consistently,
+so that retries do not create duplicate records.
+
+## Acceptance Criteria
+
+1. Given an authorized user, when they upload a valid file, then the upload succeeds.
+2. Given a duplicate upload, when submitted by the same user, then it is rejected gracefully.
+3. Given a complete request, when all fields are present, then a successful response is returned.


### PR DESCRIPTION
<html><head></head><body><h2>What this adds</h2><p>A new <code inline="">pdd prompt lint</code> command that detects vague or undefined terms in <code inline="">.prompt</code> contract sections and user-story acceptance criteria. The default pass is fully deterministic, requires no LLM, and is safe for CI.</p><pre><code class="language-bash">pdd prompt lint prompts/foo_python.prompt
pdd prompt lint prompts/
pdd prompt lint --stories user_stories/
pdd prompt lint --stories user_stories/ prompts/foo_python.prompt
pdd prompt lint --json prompts/foo_python.prompt
pdd prompt lint --strict prompts/foo_python.prompt
pdd prompt lint --ambiguity --llm prompts/foo_python.prompt
pdd prompt lint --ambiguity --llm --apply prompts/foo_python.prompt
</code></pre><h3>How it works</h3><h4>Deterministic pass, default mode</h4><p>The default lint pass flags known ambiguous terms when they appear in <code inline="">&lt;contract_rules&gt;</code>, <code inline="">&lt;requirements&gt;</code>, <code inline="">&lt;acceptance_tests&gt;</code>, or <code inline="">%</code> prose lines without a matching <code inline="">&lt;vocabulary&gt;</code> definition.</p><p>Flagged terms include:</p><pre><code class="language-text">valid, safe, active, duplicate, authorized, reasonable, successful,
trusted, graceful, recent, complete, invalid, unauthorized, unsafe,
untrusted, inactive
</code></pre><p>It also warns separately when a flagged rule line contains no observable outcome verb, such as:</p><pre><code class="language-text">return, reject, emit, store
</code></pre><p>The <code inline="">--stories</code> flag scans <code inline="">story__*.md</code> files recursively for undefined terms in <code inline="">## Acceptance Criteria</code>.</p><p>The <code inline="">--strict</code> flag extends checking to a second tier of terms and escalates all warnings to errors, exiting with code <code inline="">2</code>.</p><h4>Optional LLM pass</h4><p>With:</p><pre><code class="language-bash">pdd prompt lint --ambiguity --llm prompts/foo_python.prompt
</code></pre><p>the command suggests precise <code inline="">&lt;vocabulary&gt;</code> definitions with 2–4 concrete interpretations per flagged term.</p><p>This pass is non-fatal and falls back silently on authentication or quota failures.</p><h4>Apply mode</h4><p>With:</p><pre><code class="language-bash">pdd prompt lint --ambiguity --llm --apply prompts/foo_python.prompt
</code></pre><p>the command writes LLM-supplied definitions back into <code inline="">&lt;vocabulary&gt;</code>.</p><p>By default, the command is read-only. It never writes deterministic placeholder suggestions.</p><h3>Files changed</h3>
Path | Role
-- | --
pdd/prompt_lint.py | Core lint engine
pdd/commands/prompt.py | Click CLI group and lint subcommand
pdd/commands/__init__.py | Registers prompt_group
pdd/prompts/prompt_lint_LLM.prompt | LLM prompt template
docs/prompt_lint.md | Full command documentation
examples/prompt_lint_demo/ | Runnable demo with clean and vague fixtures
tests/test_prompt_lint.py | 70 unit tests
tests/commands/test_prompt.py | 38 CLI tests
tests/fixtures/prompt_lint/ | 20 fixture files

<h3>Verification</h3><pre><code class="language-bash">pytest tests/test_prompt_lint.py tests/commands/test_prompt.py -q
# 108 passed

pdd prompt lint prompts/foo_python.prompt
pdd prompt lint --stories user_stories/
pdd prompt lint --ambiguity --llm prompts/foo_python.prompt
</code></pre><h3>Acceptance criteria</h3><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Non-LLM default mode</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Optional LLM ambiguity review with <code inline="">--ambiguity --llm</code></p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Works on prompts and stories with recursive subdirectory scanning</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Suggests additions to <code inline="">&lt;vocabulary&gt;</code> when possible</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Emits JSON with <code inline="">--json</code></p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Does not modify files unless <code inline="">--apply</code> is passed</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Tests vague terms, defined terms, story acceptance criteria, and JSON output</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Legacy prompts with no contract sections produce zero issues</p></li></ul></body></html><html><head></head><body><h2>What this adds</h2><p>A new <code inline="">pdd prompt lint</code> command that detects vague or undefined terms in <code inline="">.prompt</code> contract sections and user-story acceptance criteria. The default pass is fully deterministic, requires no LLM, and is safe for CI.</p><pre><code class="language-bash">pdd prompt lint prompts/foo_python.prompt
pdd prompt lint prompts/
pdd prompt lint --stories user_stories/
pdd prompt lint --stories user_stories/ prompts/foo_python.prompt
pdd prompt lint --json prompts/foo_python.prompt
pdd prompt lint --strict prompts/foo_python.prompt
pdd prompt lint --ambiguity --llm prompts/foo_python.prompt
pdd prompt lint --ambiguity --llm --apply prompts/foo_python.prompt
</code></pre><h3>How it works</h3><h4>Deterministic pass, default mode</h4><p>The default lint pass flags known ambiguous terms when they appear in <code inline="">&lt;contract_rules&gt;</code>, <code inline="">&lt;requirements&gt;</code>, <code inline="">&lt;acceptance_tests&gt;</code>, or <code inline="">%</code> prose lines without a matching <code inline="">&lt;vocabulary&gt;</code> definition.</p><p>Flagged terms include:</p><pre><code class="language-text">valid, safe, active, duplicate, authorized, reasonable, successful,
trusted, graceful, recent, complete, invalid, unauthorized, unsafe,
untrusted, inactive
</code></pre><p>It also warns separately when a flagged rule line contains no observable outcome verb, such as:</p><pre><code class="language-text">return, reject, emit, store
</code></pre><p>The <code inline="">--stories</code> flag scans <code inline="">story__*.md</code> files recursively for undefined terms in <code inline="">## Acceptance Criteria</code>.</p><p>The <code inline="">--strict</code> flag extends checking to a second tier of terms and escalates all warnings to errors, exiting with code <code inline="">2</code>.</p><h4>Optional LLM pass</h4><p>With:</p><pre><code class="language-bash">pdd prompt lint --ambiguity --llm prompts/foo_python.prompt
</code></pre><p>the command suggests precise <code inline="">&lt;vocabulary&gt;</code> definitions with 2–4 concrete interpretations per flagged term.</p><p>This pass is non-fatal and falls back silently on authentication or quota failures.</p><h4>Apply mode</h4><p>With:</p><pre><code class="language-bash">pdd prompt lint --ambiguity --llm --apply prompts/foo_python.prompt
</code></pre><p>the command writes LLM-supplied definitions back into <code inline="">&lt;vocabulary&gt;</code>.</p><p>By default, the command is read-only. It never writes deterministic placeholder suggestions.</p><h3>Files changed</h3>
Path | Role
-- | --
pdd/prompt_lint.py | Core lint engine
pdd/commands/prompt.py | Click CLI group and lint subcommand
pdd/commands/__init__.py | Registers prompt_group
pdd/prompts/prompt_lint_LLM.prompt | LLM prompt template
docs/prompt_lint.md | Full command documentation
examples/prompt_lint_demo/ | Runnable demo with clean and vague fixtures
tests/test_prompt_lint.py | 70 unit tests
tests/commands/test_prompt.py | 38 CLI tests
tests/fixtures/prompt_lint/ | 20 fixture files

<h3>Verification</h3><pre><code class="language-bash">pytest tests/test_prompt_lint.py tests/commands/test_prompt.py -q
# 108 passed

pdd prompt lint prompts/foo_python.prompt
pdd prompt lint --stories user_stories/
pdd prompt lint --ambiguity --llm prompts/foo_python.prompt
