### PR TITLE
fix(sync): schedule cyclic dependency SCCs instead of deadlocking (#1125)

### DIFF
--- a/architecture.json
+++ b/architecture.json
@@ -465,7 +465,7 @@
     }
   },
   {
-    "reason": "Daily Rising Stars resurface check \u2014 Cloud Scheduler function scanning contribution thresholds to identify high-potential nurtured candidates and detect churned candidates",
+    "reason": "Daily Rising Stars resurface check — Cloud Scheduler function scanning contribution thresholds to identify high-potential nurtured candidates and detect churned candidates",
     "description": "Cloud Function entry point recruiting_resurface_check triggered by Cloud Scheduler (daily). Scans all recruiting/candidates with crmFunnelStage in ('nurture', 'contributing'). For each candidate, evaluates four resurface criteria from config thresholds: (1) merged_prs >= threshold (e.g., 3 merged PRs), (2) hackathon_score >= threshold (e.g., top 25%), (3) platform_usage_days >= threshold (power user), (4) marketplace_examples >= threshold (marketplace contributor). Candidates meeting any criterion are marked resurfaced=true with appropriate ResurfaceReason, CrmFunnelStage updated to 'resurfaced', and CRM GitHub Issue label updated from recruiting-nurture to recruiting-resurfaced. Also detects churned candidates: if last_activity_at > 60 days ago and no contributions, sets crmFunnelStage='churned' and updates CRM label to recruiting-churned. Verifies merged PR counts via GitHub API to prevent gaming. Logs all resurface and churn transitions. Returns summary counts.",
     "dependencies": [],
     "priority": 18,
@@ -1955,7 +1955,7 @@
   },
   {
     "reason": "CLI entry point for the code generator command.",
-    "description": "Command-line interface for code generator. Parses arguments, orchestrates the workflow, and formats output. Raises structured ArchitectureConformanceError failures with output/expected/found/missing fields plus failed-attempt total_cost/model_name (constructor accepts an optional repair_directive override for the <pdd-interface> signature check whose source of truth is the prompt, not architecture.json), and injects a non-empty PDD_REPAIR_DIRECTIVE into the generation prompt inside an <architecture_repair_directive> block so sync retry attempts receive concrete missing-export instructions. Architecture conformance now also enforces the prompt's <pdd-interface> signature across module/cli/command interface types in three categories: (1) missing function/method \u2014 declared callables (including dotted methods like ContentSelector.select) absent from the generated code surface as bare names in missing_symbols; (2) missing parameter \u2014 declared parameter names absent from a matching function/method signature surface as dotted funcname.paramname entries; (3) signature drift \u2014 annotation drift is conservative (raises only when both sides specify and differ) while default drift is strict (raises when the prompt declares a default and the generated code drops or changes it, since callers omitting an optional kwarg would otherwise break with TypeError). Each category emits a distinct error sentence so the agentic_sync_runner repair loop can build a targeted directive (add missing function/method, add missing parameter, or update parameter to match the prompt's annotation/default).",
+    "description": "Command-line interface for code generator. Parses arguments, orchestrates the workflow, and formats output. Raises structured ArchitectureConformanceError failures with output/expected/found/missing fields plus failed-attempt total_cost/model_name (constructor accepts an optional repair_directive override for the <pdd-interface> signature check whose source of truth is the prompt, not architecture.json), and injects a non-empty PDD_REPAIR_DIRECTIVE into the generation prompt inside an <architecture_repair_directive> block so sync retry attempts receive concrete missing-export instructions. Architecture conformance now also enforces the prompt's <pdd-interface> signature across module/cli/command interface types in three categories: (1) missing function/method — declared callables (including dotted methods like ContentSelector.select) absent from the generated code surface as bare names in missing_symbols; (2) missing parameter — declared parameter names absent from a matching function/method signature surface as dotted funcname.paramname entries; (3) signature drift — annotation drift is conservative (raises only when both sides specify and differ) while default drift is strict (raises when the prompt declares a default and the generated code drops or changes it, since callers omitting an optional kwarg would otherwise break with TypeError). Each category emits a distinct error sentence so the agentic_sync_runner repair loop can build a targeted directive (add missing function/method, add missing parameter, or update parameter to match the prompt's annotation/default).",
     "dependencies": [
       "auto_include_python.prompt",
       "agentic_langtest_python.prompt",
@@ -5802,7 +5802,7 @@
   },
   {
     "reason": "Orchestrates the 13-step agentic change workflow for implementing GitHub issues.",
-    "description": "Orchestrates the 13-step agentic change workflow. Includes Step 8.5 (pre-flight drift heal) \u2014 detects prompts whose code has drifted and runs `pdd update` per module inside the worktree before Step 9 rewrites the prompts. Includes Step 10.5 (doc-sync contract verifier) \u2014 before Step 10, calls pdd.sync_order.discover_associated_documents to populate the LLM's associated_documents context, using the authoritative changed-file set so Step 9's worktree fallback path cannot bypass discovery when FILES_* markers are missing; after Step 10, enforces that every discovered doc appears in exactly one of ASSOCIATED_DOCS_MODIFIED / ASSOCIATED_DOCS_CONFLICTS / ASSOCIATED_DOCS_UNCHANGED. Silent drops and bucket overlaps are appended as ORCHESTRATOR_POSTCHECK_WARNINGS and routed to Step 11 via step10_output; PDD_STRICT_DOC_SYNC=1 turns violations into hard workflow aborts (issue #739).",
+    "description": "Orchestrates the 13-step agentic change workflow. Includes Step 8.5 (pre-flight drift heal) — detects prompts whose code has drifted and runs `pdd update` per module inside the worktree before Step 9 rewrites the prompts. Includes Step 10.5 (doc-sync contract verifier) — before Step 10, calls pdd.sync_order.discover_associated_documents to populate the LLM's associated_documents context, using the authoritative changed-file set so Step 9's worktree fallback path cannot bypass discovery when FILES_* markers are missing; after Step 10, enforces that every discovered doc appears in exactly one of ASSOCIATED_DOCS_MODIFIED / ASSOCIATED_DOCS_CONFLICTS / ASSOCIATED_DOCS_UNCHANGED. Silent drops and bucket overlaps are appended as ORCHESTRATOR_POSTCHECK_WARNINGS and routed to Step 11 via step10_output; PDD_STRICT_DOC_SYNC=1 turns violations into hard workflow aborts (issue #739).",
     "dependencies": [
       "architecture_sync_python.prompt",
       "agentic_common_python.prompt",
@@ -6240,9 +6240,9 @@
             "returns": "Tuple[bool, str, float, str]",
             "sideEffects": [
               "Snapshots PR remote head SHA before/after run_agentic_checkup",
-              "When pre and post SHAs differ, reads the checkup worktree HEAD via _read_checkup_worktree_head_sha; if it doesn't equal the post-checkup remote SHA, an external push raced the checkup \u2014 fail closed without re-validating CI because Step 7 never saw the new code",
+              "When pre and post SHAs differ, reads the checkup worktree HEAD via _read_checkup_worktree_head_sha; if it doesn't equal the post-checkup remote SHA, an external push raced the checkup — fail closed without re-validating CI because Step 7 never saw the new code",
               "When the worktree HEAD matches the post-checkup remote SHA, re-runs run_ci_validation_loop with max_retries=0 and expected_head_sha_override=<post-checkup SHA>",
-              "Fails closed when any of pre-checkup SHA, post-checkup SHA, or checkup-worktree HEAD SHA cannot be fetched \u2014 silent success there would re-introduce the post-CI mutation hole closed in PR #1112"
+              "Fails closed when any of pre-checkup SHA, post-checkup SHA, or checkup-worktree HEAD SHA cannot be fetched — silent success there would re-introduce the post-CI mutation hole closed in PR #1112"
             ]
           }
         ]
@@ -7317,7 +7317,7 @@
   },
   {
     "reason": "Global and GitHub issue-driven module identification plus parallel sync orchestration.",
-    "description": "Entry point for no-argument global sync and agentic issue sync. Global sync scans architecture.json for stale/missing modules and dispatches AsyncSyncRunner in dependency order; issue sync parses a GitHub issue URL, identifies modules, validates dependencies, and dispatches AsyncSyncRunner \u2014 or DurableSyncRunner when invoked with durable=True. Issue sync uses build_dep_graph_from_architecture_data against in-memory combined architecture so nested-architecture edges are preserved (Phase 0 of #1328).",
+    "description": "Entry point for no-argument global sync and agentic issue sync. Global sync scans architecture.json for stale/missing modules and dispatches AsyncSyncRunner in dependency order; issue sync parses a GitHub issue URL, identifies modules, validates dependencies, and dispatches AsyncSyncRunner — or DurableSyncRunner when invoked with durable=True. Issue sync uses build_dep_graph_from_architecture_data against in-memory combined architecture so nested-architecture edges are preserved (Phase 0 of #1328).",
     "dependencies": [
       "architecture_sync_python.prompt",
       "auto_deps_main_python.prompt",
@@ -7399,10 +7399,10 @@
         "functions": [
           {
             "name": "AsyncSyncRunner",
-            "signature": "(basenames: List[str], dep_graph: Dict[str, List[str]], sync_options: Dict[str, Any], github_info: Optional[Dict[str, Any]], quiet: bool = False, verbose: bool = False, issue_url: Optional[str] = None, module_cwds: Optional[Dict[str, Path]] = None, initial_cost: float = 0.0)",
+            "signature": "(basenames: List[str], dep_graph: Dict[str, List[str]], sync_options: Dict[str, Any], github_info: Optional[Dict[str, Any]], quiet: bool = False, verbose: bool = False, issue_url: Optional[str] = None, module_cwds: Optional[Dict[str, Path]] = None, module_targets: Optional[Dict[str, str]] = None, initial_cost: float = 0.0)",
             "returns": "AsyncSyncRunner",
             "sideEffects": [
-              "Initializes runner state; total_budget in sync_options forces sequential scheduling and per-child/per-retry remaining-budget caps"
+              "Initializes runner state; total_budget in sync_options forces sequential scheduling and per-child/per-retry remaining-budget caps; computes strongly connected components of the basename-induced dep graph so cyclic dependency sets are scheduled with soft intra-SCC edges and serialized cycle execution"
             ]
           },
           {
@@ -7480,7 +7480,7 @@
     }
   },
   {
-    "reason": "Entry point for the agentic checkup workflow \u2014 fetches GitHub issue, loads project context, and dispatches to the checkup orchestrator or PR review-loop.",
+    "reason": "Entry point for the agentic checkup workflow — fetches GitHub issue, loads project context, and dispatches to the checkup orchestrator or PR review-loop.",
     "description": "Accepts a GitHub issue URL, fetches issue content and comments, loads architecture.json and .pddrc, then invokes either the multi-step checkup orchestrator or the PR-mode primary-reviewer/fixer review loop. PR review-loop context is bounded and includes PR body, changed files, comments, and submitted reviews.",
     "dependencies": [
       "agentic_common_python.prompt",
@@ -7585,7 +7585,7 @@
               "When a budget cap is crossed during a successful fixer turn, still commits and pushes the completed fixes before stopping prior to verifier execution",
               "Feeds fixer rejections back to the primary reviewer and keeps reviewer-rejected findings open until fixed or max rounds",
               "Issue #1088 SHA-backed verification trust boundary: captures the post-push HEAD SHA via _git_rev_parse_head (never inferred from fixer prose), populates FixResult.push_status (pushed | push_failed | not_attempted), FixResult.local_fixer_commit_sha, and FixResult.pushed_head_sha after every fix turn, and rewrites the per-round fix findings.json artifact so the on-disk audit trail carries those fields. The verifier only runs when push_status == pushed AND a non-empty pushed_head_sha was observed; otherwise the round is marked skipped/unverified and the loop stops without claiming the findings as fixed. A clean verify pass pins state.verified_head_sha to that pushed SHA",
-              "Issue #1088 final stale-head re-fetch: _finalize calls _fetch_pr_metadata exactly once at render to read the live remote head_sha whenever there is anything to verify \u2014 state.verified_head_sha is set (a verifier pinned a SHA), state.fresh_final_status == clean (a reviewer cleared the actual worktree HEAD without a subsequent fixer push), any fix was pushed, or any finding is marked fixed. The comparison target is state.verified_head_sha when a verifier ran clean, otherwise the most recent FixResult.pushed_head_sha for partial verifier acceptance, otherwise state.reviewed_head_sha captured from git rev-parse HEAD in the worktree the reviewer inspected (never from later PR metadata). If the remote head differs from the comparison target, the comparison target was never observed, or the re-fetch returned no head_sha, downgrades fresh_final_status to missing, downgrades every verification_status_by_round entry from verified to stale, and reverts every findings_by_key entry from fixed to open so final-state.json cannot present a stale verdict. state.final_refetch_attempted is set so the render layer can distinguish a failed re-fetch (remote-pr-head-sha: unknown) from no re-fetch at all (remote-pr-head-sha: none)",
+              "Issue #1088 final stale-head re-fetch: _finalize calls _fetch_pr_metadata exactly once at render to read the live remote head_sha whenever there is anything to verify — state.verified_head_sha is set (a verifier pinned a SHA), state.fresh_final_status == clean (a reviewer cleared the actual worktree HEAD without a subsequent fixer push), any fix was pushed, or any finding is marked fixed. The comparison target is state.verified_head_sha when a verifier ran clean, otherwise the most recent FixResult.pushed_head_sha for partial verifier acceptance, otherwise state.reviewed_head_sha captured from git rev-parse HEAD in the worktree the reviewer inspected (never from later PR metadata). If the remote head differs from the comparison target, the comparison target was never observed, or the re-fetch returned no head_sha, downgrades fresh_final_status to missing, downgrades every verification_status_by_round entry from verified to stale, and reverts every findings_by_key entry from fixed to open so final-state.json cannot present a stale verdict. state.final_refetch_attempted is set so the render layer can distinguish a failed re-fetch (remote-pr-head-sha: unknown) from no re-fetch at all (remote-pr-head-sha: none)",
               "Qualifies all unverified fixer rationale prose in the final report as fixer=<role> fixer_disposition=<value> / fixer_rationale=<value> and appends verification=unverified, so bare fixer claims such as 'claude: fixed - ...' never appear as verifier evidence",
               "Writes per-round prompt/output/normalized-findings/dedup-state artifacts and a final-state.json under .pdd/checkup-review-loop/issue-{N}-pr-{M}/. final-state.json includes verified_head_sha, remote_pr_head_sha, reviewed_head_sha, and verification_status_by_round so downstream consumers can re-verify the trust boundary",
               "Posts the final report to the source issue and PR only when use_github_state=True (writes-only suppression flag)"
@@ -7651,7 +7651,7 @@
     }
   },
   {
-    "reason": "Multi-step orchestrator for pdd checkup \u2014 8 steps with iterative fix-verify loop, worktree isolation, and fix-capable PR mode that pushes back to the same PR.",
+    "reason": "Multi-step orchestrator for pdd checkup — 8 steps with iterative fix-verify loop, worktree isolation, and fix-capable PR mode that pushes back to the same PR.",
     "description": "Orchestrates the 8-step agentic checkup workflow: discover, deps, build, interfaces, test, fix (6.1/6.2/6.3), verify, create PR. Steps 3-7 run in an iterative while loop (max 3 iterations) with exit on 'All Issues Fixed'; exhausting the loop without that exact signal returns failure and does not push fixes or create/skip through a successful PR gate. Supports resume via workflow state persistence, git worktree isolation, --no-fix mode, and PR verification mode. In PR mode it checks out the PR head in a dedicated worktree, runs the full fix-capable checkup on that PR code, commits eligible generated fixes, pushes them back to the same PR branch, re-runs Step 7 after a rebase-on-updated-head push, posts final PR/issue reports only after the pushed PR head is verified, and skips Step 8 because the PR already exists.",
     "dependencies": [
       "agentic_common_python.prompt",
@@ -7804,7 +7804,7 @@
   },
   {
     "reason": "Agentic instruction for assigning logical graph positions to modules in an\narchitecture file. The agent reads the file and an optional PRD/README, reasons about the\nlogical structure of the system, groups modules into functional swimlanes, and writes the\nupdated file in-place so pdd connect shows a graph that makes the architecture easy to\nunderstand at a glance.",
-    "description": "Takes {project_root} and {architecture_path} as inputs. Agent reads the architecture file and any PRD/README. Reasons about functional groupings, pipeline stages, and dependency relationships. Places modules in swimlane columns (one per major functional area, shared/hub modules in center). Dependency depth drives y-axis (depth \u00d7 500px). Writes updated file in-place with position: {x, y} on every module. Outputs a one-line summary.",
+    "description": "Takes {project_root} and {architecture_path} as inputs. Agent reads the architecture file and any PRD/README. Reasons about functional groupings, pipeline stages, and dependency relationships. Places modules in swimlane columns (one per major functional area, shared/hub modules in center). Dependency depth drives y-axis (depth × 500px). Writes updated file in-place with position: {x, y} on every module. Outputs a one-line summary.",
     "dependencies": [],
     "priority": 219,
     "filename": "arrange_graph_layout_LLM.prompt",

--- a/architecture.json
+++ b/architecture.json
@@ -465,7 +465,7 @@
     }
   },
   {
-    "reason": "Daily Rising Stars resurface check — Cloud Scheduler function scanning contribution thresholds to identify high-potential nurtured candidates and detect churned candidates",
+    "reason": "Daily Rising Stars resurface check \u2014 Cloud Scheduler function scanning contribution thresholds to identify high-potential nurtured candidates and detect churned candidates",
     "description": "Cloud Function entry point recruiting_resurface_check triggered by Cloud Scheduler (daily). Scans all recruiting/candidates with crmFunnelStage in ('nurture', 'contributing'). For each candidate, evaluates four resurface criteria from config thresholds: (1) merged_prs >= threshold (e.g., 3 merged PRs), (2) hackathon_score >= threshold (e.g., top 25%), (3) platform_usage_days >= threshold (power user), (4) marketplace_examples >= threshold (marketplace contributor). Candidates meeting any criterion are marked resurfaced=true with appropriate ResurfaceReason, CrmFunnelStage updated to 'resurfaced', and CRM GitHub Issue label updated from recruiting-nurture to recruiting-resurfaced. Also detects churned candidates: if last_activity_at > 60 days ago and no contributions, sets crmFunnelStage='churned' and updates CRM label to recruiting-churned. Verifies merged PR counts via GitHub API to prevent gaming. Logs all resurface and churn transitions. Returns summary counts.",
     "dependencies": [],
     "priority": 18,
@@ -1955,7 +1955,7 @@
   },
   {
     "reason": "CLI entry point for the code generator command.",
-    "description": "Command-line interface for code generator. Parses arguments, orchestrates the workflow, and formats output. Raises structured ArchitectureConformanceError failures with output/expected/found/missing fields plus failed-attempt total_cost/model_name (constructor accepts an optional repair_directive override for the <pdd-interface> signature check whose source of truth is the prompt, not architecture.json), and injects a non-empty PDD_REPAIR_DIRECTIVE into the generation prompt inside an <architecture_repair_directive> block so sync retry attempts receive concrete missing-export instructions. Architecture conformance now also enforces the prompt's <pdd-interface> signature across module/cli/command interface types in three categories: (1) missing function/method — declared callables (including dotted methods like ContentSelector.select) absent from the generated code surface as bare names in missing_symbols; (2) missing parameter — declared parameter names absent from a matching function/method signature surface as dotted funcname.paramname entries; (3) signature drift — annotation drift is conservative (raises only when both sides specify and differ) while default drift is strict (raises when the prompt declares a default and the generated code drops or changes it, since callers omitting an optional kwarg would otherwise break with TypeError). Each category emits a distinct error sentence so the agentic_sync_runner repair loop can build a targeted directive (add missing function/method, add missing parameter, or update parameter to match the prompt's annotation/default).",
+    "description": "Command-line interface for code generator. Parses arguments, orchestrates the workflow, and formats output. Raises structured ArchitectureConformanceError failures with output/expected/found/missing fields plus failed-attempt total_cost/model_name (constructor accepts an optional repair_directive override for the <pdd-interface> signature check whose source of truth is the prompt, not architecture.json), and injects a non-empty PDD_REPAIR_DIRECTIVE into the generation prompt inside an <architecture_repair_directive> block so sync retry attempts receive concrete missing-export instructions. Architecture conformance now also enforces the prompt's <pdd-interface> signature across module/cli/command interface types in three categories: (1) missing function/method \u2014 declared callables (including dotted methods like ContentSelector.select) absent from the generated code surface as bare names in missing_symbols; (2) missing parameter \u2014 declared parameter names absent from a matching function/method signature surface as dotted funcname.paramname entries; (3) signature drift \u2014 annotation drift is conservative (raises only when both sides specify and differ) while default drift is strict (raises when the prompt declares a default and the generated code drops or changes it, since callers omitting an optional kwarg would otherwise break with TypeError). Each category emits a distinct error sentence so the agentic_sync_runner repair loop can build a targeted directive (add missing function/method, add missing parameter, or update parameter to match the prompt's annotation/default).",
     "dependencies": [
       "auto_include_python.prompt",
       "agentic_langtest_python.prompt",
@@ -5802,7 +5802,7 @@
   },
   {
     "reason": "Orchestrates the 13-step agentic change workflow for implementing GitHub issues.",
-    "description": "Orchestrates the 13-step agentic change workflow. Includes Step 8.5 (pre-flight drift heal) — detects prompts whose code has drifted and runs `pdd update` per module inside the worktree before Step 9 rewrites the prompts. Includes Step 10.5 (doc-sync contract verifier) — before Step 10, calls pdd.sync_order.discover_associated_documents to populate the LLM's associated_documents context, using the authoritative changed-file set so Step 9's worktree fallback path cannot bypass discovery when FILES_* markers are missing; after Step 10, enforces that every discovered doc appears in exactly one of ASSOCIATED_DOCS_MODIFIED / ASSOCIATED_DOCS_CONFLICTS / ASSOCIATED_DOCS_UNCHANGED. Silent drops and bucket overlaps are appended as ORCHESTRATOR_POSTCHECK_WARNINGS and routed to Step 11 via step10_output; PDD_STRICT_DOC_SYNC=1 turns violations into hard workflow aborts (issue #739).",
+    "description": "Orchestrates the 13-step agentic change workflow. Includes Step 8.5 (pre-flight drift heal) \u2014 detects prompts whose code has drifted and runs `pdd update` per module inside the worktree before Step 9 rewrites the prompts. Includes Step 10.5 (doc-sync contract verifier) \u2014 before Step 10, calls pdd.sync_order.discover_associated_documents to populate the LLM's associated_documents context, using the authoritative changed-file set so Step 9's worktree fallback path cannot bypass discovery when FILES_* markers are missing; after Step 10, enforces that every discovered doc appears in exactly one of ASSOCIATED_DOCS_MODIFIED / ASSOCIATED_DOCS_CONFLICTS / ASSOCIATED_DOCS_UNCHANGED. Silent drops and bucket overlaps are appended as ORCHESTRATOR_POSTCHECK_WARNINGS and routed to Step 11 via step10_output; PDD_STRICT_DOC_SYNC=1 turns violations into hard workflow aborts (issue #739).",
     "dependencies": [
       "architecture_sync_python.prompt",
       "agentic_common_python.prompt",
@@ -6240,9 +6240,9 @@
             "returns": "Tuple[bool, str, float, str]",
             "sideEffects": [
               "Snapshots PR remote head SHA before/after run_agentic_checkup",
-              "When pre and post SHAs differ, reads the checkup worktree HEAD via _read_checkup_worktree_head_sha; if it doesn't equal the post-checkup remote SHA, an external push raced the checkup — fail closed without re-validating CI because Step 7 never saw the new code",
+              "When pre and post SHAs differ, reads the checkup worktree HEAD via _read_checkup_worktree_head_sha; if it doesn't equal the post-checkup remote SHA, an external push raced the checkup \u2014 fail closed without re-validating CI because Step 7 never saw the new code",
               "When the worktree HEAD matches the post-checkup remote SHA, re-runs run_ci_validation_loop with max_retries=0 and expected_head_sha_override=<post-checkup SHA>",
-              "Fails closed when any of pre-checkup SHA, post-checkup SHA, or checkup-worktree HEAD SHA cannot be fetched — silent success there would re-introduce the post-CI mutation hole closed in PR #1112"
+              "Fails closed when any of pre-checkup SHA, post-checkup SHA, or checkup-worktree HEAD SHA cannot be fetched \u2014 silent success there would re-introduce the post-CI mutation hole closed in PR #1112"
             ]
           }
         ]
@@ -7274,6 +7274,14 @@
             ]
           },
           {
+            "name": "compute_sccs",
+            "signature": "(graph: Dict[str, List[str]]) -> List[List[str]]",
+            "returns": "List[List[str]]",
+            "sideEffects": [
+              "None"
+            ]
+          },
+          {
             "name": "get_affected_modules",
             "signature": "(sorted_modules: List[str], modified: Set[str], graph: Dict[str, List[str]], cyclic_modules: Optional[Set[str]] = None) -> List[str]",
             "returns": "List[str]",
@@ -7309,7 +7317,7 @@
   },
   {
     "reason": "Global and GitHub issue-driven module identification plus parallel sync orchestration.",
-    "description": "Entry point for no-argument global sync and agentic issue sync. Global sync scans architecture.json for stale/missing modules and dispatches AsyncSyncRunner in dependency order; issue sync parses a GitHub issue URL, identifies modules, validates dependencies, and dispatches AsyncSyncRunner — or DurableSyncRunner when invoked with durable=True. Issue sync uses build_dep_graph_from_architecture_data against in-memory combined architecture so nested-architecture edges are preserved (Phase 0 of #1328).",
+    "description": "Entry point for no-argument global sync and agentic issue sync. Global sync scans architecture.json for stale/missing modules and dispatches AsyncSyncRunner in dependency order; issue sync parses a GitHub issue URL, identifies modules, validates dependencies, and dispatches AsyncSyncRunner \u2014 or DurableSyncRunner when invoked with durable=True. Issue sync uses build_dep_graph_from_architecture_data against in-memory combined architecture so nested-architecture edges are preserved (Phase 0 of #1328).",
     "dependencies": [
       "architecture_sync_python.prompt",
       "auto_deps_main_python.prompt",
@@ -7374,7 +7382,8 @@
     "dependencies": [
       "architecture_sync_python.prompt",
       "agentic_langtest_python.prompt",
-      "agentic_test_orchestrator_python.prompt"
+      "agentic_test_orchestrator_python.prompt",
+      "sync_order_python.prompt"
     ],
     "priority": 216,
     "filename": "agentic_sync_runner_python.prompt",
@@ -7471,7 +7480,7 @@
     }
   },
   {
-    "reason": "Entry point for the agentic checkup workflow — fetches GitHub issue, loads project context, and dispatches to the checkup orchestrator or PR review-loop.",
+    "reason": "Entry point for the agentic checkup workflow \u2014 fetches GitHub issue, loads project context, and dispatches to the checkup orchestrator or PR review-loop.",
     "description": "Accepts a GitHub issue URL, fetches issue content and comments, loads architecture.json and .pddrc, then invokes either the multi-step checkup orchestrator or the PR-mode primary-reviewer/fixer review loop. PR review-loop context is bounded and includes PR body, changed files, comments, and submitted reviews.",
     "dependencies": [
       "agentic_common_python.prompt",
@@ -7576,7 +7585,7 @@
               "When a budget cap is crossed during a successful fixer turn, still commits and pushes the completed fixes before stopping prior to verifier execution",
               "Feeds fixer rejections back to the primary reviewer and keeps reviewer-rejected findings open until fixed or max rounds",
               "Issue #1088 SHA-backed verification trust boundary: captures the post-push HEAD SHA via _git_rev_parse_head (never inferred from fixer prose), populates FixResult.push_status (pushed | push_failed | not_attempted), FixResult.local_fixer_commit_sha, and FixResult.pushed_head_sha after every fix turn, and rewrites the per-round fix findings.json artifact so the on-disk audit trail carries those fields. The verifier only runs when push_status == pushed AND a non-empty pushed_head_sha was observed; otherwise the round is marked skipped/unverified and the loop stops without claiming the findings as fixed. A clean verify pass pins state.verified_head_sha to that pushed SHA",
-              "Issue #1088 final stale-head re-fetch: _finalize calls _fetch_pr_metadata exactly once at render to read the live remote head_sha whenever there is anything to verify — state.verified_head_sha is set (a verifier pinned a SHA), state.fresh_final_status == clean (a reviewer cleared the actual worktree HEAD without a subsequent fixer push), any fix was pushed, or any finding is marked fixed. The comparison target is state.verified_head_sha when a verifier ran clean, otherwise the most recent FixResult.pushed_head_sha for partial verifier acceptance, otherwise state.reviewed_head_sha captured from git rev-parse HEAD in the worktree the reviewer inspected (never from later PR metadata). If the remote head differs from the comparison target, the comparison target was never observed, or the re-fetch returned no head_sha, downgrades fresh_final_status to missing, downgrades every verification_status_by_round entry from verified to stale, and reverts every findings_by_key entry from fixed to open so final-state.json cannot present a stale verdict. state.final_refetch_attempted is set so the render layer can distinguish a failed re-fetch (remote-pr-head-sha: unknown) from no re-fetch at all (remote-pr-head-sha: none)",
+              "Issue #1088 final stale-head re-fetch: _finalize calls _fetch_pr_metadata exactly once at render to read the live remote head_sha whenever there is anything to verify \u2014 state.verified_head_sha is set (a verifier pinned a SHA), state.fresh_final_status == clean (a reviewer cleared the actual worktree HEAD without a subsequent fixer push), any fix was pushed, or any finding is marked fixed. The comparison target is state.verified_head_sha when a verifier ran clean, otherwise the most recent FixResult.pushed_head_sha for partial verifier acceptance, otherwise state.reviewed_head_sha captured from git rev-parse HEAD in the worktree the reviewer inspected (never from later PR metadata). If the remote head differs from the comparison target, the comparison target was never observed, or the re-fetch returned no head_sha, downgrades fresh_final_status to missing, downgrades every verification_status_by_round entry from verified to stale, and reverts every findings_by_key entry from fixed to open so final-state.json cannot present a stale verdict. state.final_refetch_attempted is set so the render layer can distinguish a failed re-fetch (remote-pr-head-sha: unknown) from no re-fetch at all (remote-pr-head-sha: none)",
               "Qualifies all unverified fixer rationale prose in the final report as fixer=<role> fixer_disposition=<value> / fixer_rationale=<value> and appends verification=unverified, so bare fixer claims such as 'claude: fixed - ...' never appear as verifier evidence",
               "Writes per-round prompt/output/normalized-findings/dedup-state artifacts and a final-state.json under .pdd/checkup-review-loop/issue-{N}-pr-{M}/. final-state.json includes verified_head_sha, remote_pr_head_sha, reviewed_head_sha, and verification_status_by_round so downstream consumers can re-verify the trust boundary",
               "Posts the final report to the source issue and PR only when use_github_state=True (writes-only suppression flag)"
@@ -7642,7 +7651,7 @@
     }
   },
   {
-    "reason": "Multi-step orchestrator for pdd checkup — 8 steps with iterative fix-verify loop, worktree isolation, and fix-capable PR mode that pushes back to the same PR.",
+    "reason": "Multi-step orchestrator for pdd checkup \u2014 8 steps with iterative fix-verify loop, worktree isolation, and fix-capable PR mode that pushes back to the same PR.",
     "description": "Orchestrates the 8-step agentic checkup workflow: discover, deps, build, interfaces, test, fix (6.1/6.2/6.3), verify, create PR. Steps 3-7 run in an iterative while loop (max 3 iterations) with exit on 'All Issues Fixed'; exhausting the loop without that exact signal returns failure and does not push fixes or create/skip through a successful PR gate. Supports resume via workflow state persistence, git worktree isolation, --no-fix mode, and PR verification mode. In PR mode it checks out the PR head in a dedicated worktree, runs the full fix-capable checkup on that PR code, commits eligible generated fixes, pushes them back to the same PR branch, re-runs Step 7 after a rebase-on-updated-head push, posts final PR/issue reports only after the pushed PR head is verified, and skips Step 8 because the PR already exists.",
     "dependencies": [
       "agentic_common_python.prompt",
@@ -7795,7 +7804,7 @@
   },
   {
     "reason": "Agentic instruction for assigning logical graph positions to modules in an\narchitecture file. The agent reads the file and an optional PRD/README, reasons about the\nlogical structure of the system, groups modules into functional swimlanes, and writes the\nupdated file in-place so pdd connect shows a graph that makes the architecture easy to\nunderstand at a glance.",
-    "description": "Takes {project_root} and {architecture_path} as inputs. Agent reads the architecture file and any PRD/README. Reasons about functional groupings, pipeline stages, and dependency relationships. Places modules in swimlane columns (one per major functional area, shared/hub modules in center). Dependency depth drives y-axis (depth × 500px). Writes updated file in-place with position: {x, y} on every module. Outputs a one-line summary.",
+    "description": "Takes {project_root} and {architecture_path} as inputs. Agent reads the architecture file and any PRD/README. Reasons about functional groupings, pipeline stages, and dependency relationships. Places modules in swimlane columns (one per major functional area, shared/hub modules in center). Dependency depth drives y-axis (depth \u00d7 500px). Writes updated file in-place with position: {x, y} on every module. Outputs a one-line summary.",
     "dependencies": [],
     "priority": 219,
     "filename": "arrange_graph_layout_LLM.prompt",

--- a/pdd/agentic_sync_runner.py
+++ b/pdd/agentic_sync_runner.py
@@ -1017,12 +1017,19 @@ class AsyncSyncRunner:
     def _get_ready_modules(self) -> List[str]:
         """Pending modules whose deps are all satisfied.
 
-        For modules participating in a multi-node SCC (a true dependency
-        cycle in the target set), intra-SCC dep edges are treated as
-        **soft**: they don't block readiness, only a failed peer
-        does. Execution within a single SCC is serialized — at most one
-        member of a multi-node SCC may be running or scheduled per pass.
-        Cross-SCC dep edges remain hard ordering constraints.
+        For modules participating in a cyclic SCC (size > 1, or 1-node with
+        a self-loop), intra-SCC dep edges are treated as **soft** — only a
+        failed peer blocks readiness — and the union of cross-SCC deps over
+        ALL members of the SCC must be satisfied before any member can
+        start. Otherwise an SCC could begin work while a transitive
+        dependency reached through a cycle peer was still pending or
+        failed, weakening dependency ordering. Cycle execution is
+        serialized: at most one member of a cyclic SCC may be running or
+        scheduled per pass.
+
+        Cross-SCC dep edges remain hard ordering constraints, and a consumer
+        outside the SCC must wait until every member of the dep's SCC has
+        succeeded.
         """
         ready: List[str] = []
         with self.lock:
@@ -1047,41 +1054,49 @@ class AsyncSyncRunner:
                     if own in running_cyclic_sccs or own in picked_cyclic_sccs:
                         continue
 
-                deps = self.dep_graph.get(basename, [])
+                # For a cycle member, the SCC's effective dependencies are
+                # the union of every member's cross-SCC deps; intra-SCC
+                # edges are soft. For non-cycle members, just walk the
+                # module's own deps.
+                if in_cycle:
+                    members_to_walk = list(own)
+                else:
+                    members_to_walk = [basename]
+
                 deps_ok = True
-                for d in deps:
-                    dep_state = self.module_states.get(d)
-                    if dep_state is None:
-                        # Out-of-target deps assumed already synced
-                        continue
-                    # Intra-SCC edges (including a self-loop) are soft when the
-                    # SCC is cyclic; only a failed peer blocks readiness.
-                    intra_scc = in_cycle and d in own
-                    if intra_scc:
-                        if dep_state.status == "failed":
-                            deps_ok = False
-                            break
-                        continue
-                    # Cross-SCC edge: depend on the WHOLE upstream SCC.
-                    # A consumer outside an SCC must wait until every member
-                    # of the dep's SCC has succeeded, otherwise we'd schedule
-                    # the consumer before a pending cycle peer is finished
-                    # (and a failed peer would silently advance the consumer).
-                    dep_scc = self._scc_of.get(d)
-                    if dep_scc is None or dep_scc is own:
-                        if dep_state.status != "success":
-                            deps_ok = False
-                            break
-                    else:
-                        all_success = True
-                        for peer in dep_scc:
-                            peer_state = self.module_states.get(peer)
-                            if peer_state is None or peer_state.status != "success":
-                                all_success = False
+                for member in members_to_walk:
+                    if not deps_ok:
+                        break
+                    for d in self.dep_graph.get(member, []):
+                        dep_state = self.module_states.get(d)
+                        if dep_state is None:
+                            # Out-of-target deps assumed already synced
+                            continue
+                        # Intra-SCC edges (including a self-loop) are soft
+                        # when the SCC is cyclic; only a failed peer blocks
+                        # readiness.
+                        intra_scc = in_cycle and d in own
+                        if intra_scc:
+                            if dep_state.status == "failed":
+                                deps_ok = False
                                 break
-                        if not all_success:
-                            deps_ok = False
-                            break
+                            continue
+                        # Cross-SCC edge: depend on the WHOLE upstream SCC.
+                        dep_scc = self._scc_of.get(d)
+                        if dep_scc is None or dep_scc is own:
+                            if dep_state.status != "success":
+                                deps_ok = False
+                                break
+                        else:
+                            all_success = True
+                            for peer in dep_scc:
+                                peer_state = self.module_states.get(peer)
+                                if peer_state is None or peer_state.status != "success":
+                                    all_success = False
+                                    break
+                            if not all_success:
+                                deps_ok = False
+                                break
                 if deps_ok:
                     ready.append(basename)
                     if in_cycle:

--- a/pdd/agentic_sync_runner.py
+++ b/pdd/agentic_sync_runner.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 from rich.console import Console
 
 from .construct_paths import _is_known_language
+from .sync_order import compute_sccs
 
 console = Console()
 
@@ -841,6 +842,28 @@ class AsyncSyncRunner:
         self.module_states: Dict[str, ModuleState] = {
             b: ModuleState() for b in self.basenames
         }
+        # SCC membership is built over the subgraph induced by `basenames` so
+        # external deps don't pull non-target nodes into a cycle.
+        basename_set = set(self.basenames)
+        subgraph = {
+            b: [d for d in self.dep_graph.get(b, []) if d in basename_set]
+            for b in self.basenames
+        }
+        self._scc_of: Dict[str, frozenset] = {}
+        # SCCs that participate in a real cycle (size > 1, or a 1-node SCC
+        # with a self-loop). A trivial SCC (single node, no self-loop) is NOT
+        # here, so soft-edge logic only applies to actual cycle members.
+        self._cyclic_sccs: set = set()
+        for scc in compute_sccs(subgraph):
+            scc_set = frozenset(scc)
+            is_cyclic = len(scc) > 1 or any(
+                m in subgraph.get(m, []) for m in scc
+            )
+            for m in scc:
+                if m in basename_set:
+                    self._scc_of[m] = scc_set
+            if is_cyclic:
+                self._cyclic_sccs.add(scc_set)
         self.failed: bool = False
         self.budget_exhausted: bool = False
         self.comment_id: Optional[int] = None
@@ -992,13 +1015,38 @@ class AsyncSyncRunner:
             )
 
     def _get_ready_modules(self) -> List[str]:
-        """Pending modules whose deps are all satisfied."""
+        """Pending modules whose deps are all satisfied.
+
+        For modules participating in a multi-node SCC (a true dependency
+        cycle in the target set), intra-SCC dep edges are treated as
+        **soft**: they don't block readiness, only a failed peer
+        does. Execution within a single SCC is serialized — at most one
+        member of a multi-node SCC may be running or scheduled per pass.
+        Cross-SCC dep edges remain hard ordering constraints.
+        """
         ready: List[str] = []
         with self.lock:
+            # SCCs that already have a running member -> peers must wait.
+            running_cyclic_sccs: set = set()
+            for b in self.basenames:
+                if self.module_states[b].status == "running":
+                    own = self._scc_of.get(b)
+                    if own is not None and own in self._cyclic_sccs:
+                        running_cyclic_sccs.add(own)
+
+            # SCCs that already had a member picked in THIS pass -> only one
+            # ready slot per SCC per pass (serialize cycle execution).
+            picked_cyclic_sccs: set = set()
             for basename in self.basenames:
                 state = self.module_states[basename]
                 if state.status != "pending":
                     continue
+                own = self._scc_of.get(basename)
+                in_cycle = own is not None and own in self._cyclic_sccs
+                if in_cycle:
+                    if own in running_cyclic_sccs or own in picked_cyclic_sccs:
+                        continue
+
                 deps = self.dep_graph.get(basename, [])
                 deps_ok = True
                 for d in deps:
@@ -1006,50 +1054,104 @@ class AsyncSyncRunner:
                     if dep_state is None:
                         # Out-of-target deps assumed already synced
                         continue
-                    if dep_state.status != "success":
-                        deps_ok = False
-                        break
+                    # Intra-SCC edges (including a self-loop) are soft when the
+                    # SCC is cyclic; only a failed peer blocks readiness.
+                    intra_scc = in_cycle and d in own
+                    if intra_scc:
+                        if dep_state.status == "failed":
+                            deps_ok = False
+                            break
+                        continue
+                    # Cross-SCC edge: depend on the WHOLE upstream SCC.
+                    # A consumer outside an SCC must wait until every member
+                    # of the dep's SCC has succeeded, otherwise we'd schedule
+                    # the consumer before a pending cycle peer is finished
+                    # (and a failed peer would silently advance the consumer).
+                    dep_scc = self._scc_of.get(d)
+                    if dep_scc is None or dep_scc is own:
+                        if dep_state.status != "success":
+                            deps_ok = False
+                            break
+                    else:
+                        all_success = True
+                        for peer in dep_scc:
+                            peer_state = self.module_states.get(peer)
+                            if peer_state is None or peer_state.status != "success":
+                                all_success = False
+                                break
+                        if not all_success:
+                            deps_ok = False
+                            break
                 if deps_ok:
                     ready.append(basename)
+                    if in_cycle:
+                        picked_cyclic_sccs.add(own)
         return ready
 
     def _get_blocked_modules(self) -> List[str]:
-        """Pending modules transitively blocked by a failed dep."""
+        """Pending modules transitively blocked by a failed dep.
+
+        Operates on the SCC condensation (which is a DAG) so blocked-status
+        propagation through a cycle is sound regardless of which member is
+        visited first. A per-module DFS with a "visiting" set would wrongly
+        cache ``False`` on cycle re-entry before knowing whether the
+        parent's later deps would fail the chain.
+        """
         blocked: List[str] = []
         with self.lock:
-            cache: Dict[str, bool] = {}
+            scc_blocked_cache: Dict[frozenset, bool] = {}
 
-            def is_blocked(module: str, visiting: set) -> bool:
-                cached = cache.get(module)
+            def scc_is_blocked(scc: frozenset, visiting: set) -> bool:
+                cached = scc_blocked_cache.get(scc)
                 if cached is not None:
                     return cached
-                if module in visiting:
-                    cache[module] = False
+                # The condensation is acyclic, so this guard should never
+                # trigger; keep it for safety.
+                if scc in visiting:
                     return False
-                visiting.add(module)
+                visiting.add(scc)
                 try:
-                    for dep in self.dep_graph.get(module, []):
-                        dep_state = self.module_states.get(dep)
-                        if dep_state is None:
-                            continue
-                        if dep_state.status == "failed":
-                            cache[module] = True
+                    # Any member of this SCC itself failed?
+                    for m in scc:
+                        st = self.module_states.get(m)
+                        if st is not None and st.status == "failed":
+                            scc_blocked_cache[scc] = True
                             return True
-                        if dep_state.status == "pending" and is_blocked(
-                            dep, visiting
-                        ):
-                            cache[module] = True
-                            return True
+                    # Any cross-SCC dep is failed, or its SCC is blocked?
+                    for m in scc:
+                        for dep in self.dep_graph.get(m, []):
+                            dep_state = self.module_states.get(dep)
+                            if dep_state is None:
+                                # Out-of-target dep -> treated as synced.
+                                continue
+                            dep_scc = self._scc_of.get(dep)
+                            if dep_scc is None or dep_scc == scc:
+                                continue
+                            # Direct failure of the dep
+                            if dep_state.status == "failed":
+                                scc_blocked_cache[scc] = True
+                                return True
+                            # Dep's SCC may have a failed peer (cycle), or be
+                            # transitively blocked, regardless of the named
+                            # dep's current status. Always recurse to walk the
+                            # condensation DAG correctly.
+                            if scc_is_blocked(dep_scc, visiting):
+                                scc_blocked_cache[scc] = True
+                                return True
                 finally:
-                    visiting.discard(module)
-                cache[module] = False
+                    visiting.discard(scc)
+                scc_blocked_cache[scc] = False
                 return False
 
             for basename in self.basenames:
                 state = self.module_states[basename]
                 if state.status != "pending":
                     continue
-                if is_blocked(basename, set()):
+                own_scc = self._scc_of.get(basename)
+                if own_scc is None:
+                    # Treat as a trivial 1-element SCC of just this basename.
+                    own_scc = frozenset({basename})
+                if scc_is_blocked(own_scc, set()):
                     blocked.append(basename)
         return blocked
 

--- a/pdd/prompts/agentic_sync_runner_python.prompt
+++ b/pdd/prompts/agentic_sync_runner_python.prompt
@@ -2,6 +2,7 @@
 <pdd-dependency>architecture_sync_python.prompt</pdd-dependency>
 <pdd-dependency>agentic_langtest_python.prompt</pdd-dependency>
 <pdd-dependency>agentic_test_orchestrator_python.prompt</pdd-dependency>
+<pdd-dependency>sync_order_python.prompt</pdd-dependency>
 
 % Goal
 Write the `pdd/agentic_sync_runner.py` module.
@@ -22,7 +23,14 @@ Parallel sync engine that runs `pdd sync` for multiple modules concurrently usin
    - Tracks per-module state: pending -> running -> success | failed
 2. Method: `run() -> Tuple[bool, str, float]` — returns (all_success, summary_message, total_cost) where total_cost includes initial_cost + per-module costs
 3. Use `concurrent.futures.ThreadPoolExecutor` with `MAX_WORKERS = 4`; when `sync_options["total_budget"]` is set, run sequentially and pass only the remaining total budget to each child process so the total budget is not multiplied per module.
-4. Dependency-aware scheduling: a module starts only when all its dependencies (within target set) have status "success"
+4. Dependency-aware scheduling, SCC-aware so legitimate dependency cycles (Python late-imports, etc.) do not deadlock the runner:
+   - At construction, compute strongly connected components of the basename-induced subgraph of `dep_graph` via `pdd.sync_order.compute_sccs`. Build:
+     - `self._scc_of: Dict[str, frozenset[str]]` mapping every in-target basename to its SCC (frozenset of co-cyclic peers).
+     - `self._cyclic_sccs: Set[frozenset[str]]` containing every SCC that participates in a real cycle (size > 1, or a 1-node SCC with a self-loop). A trivial SCC (single node, no self-loop) is NOT in this set, so soft-edge logic only applies to actual cycle members.
+   - For a non-cycle pending module, it is ready only when every cross-target dep has status "success" — for any in-target dep, EVERY member of the dep's SCC must be "success" (the consumer waits for the whole upstream SCC, not just the named dep). External (not in `basenames`) deps are assumed already synced.
+   - For a pending cycle member, the SCC's effective dependencies are the union of every member's cross-SCC deps; intra-SCC edges (including self-loops) are soft. Soft-edge means a pending or success peer does not block readiness — only a failed peer does. The same whole-upstream-SCC rule applies to every cross-SCC dep of every cycle member, so an SCC may not start while ANY peer's external dep is still pending (or failed).
+   - Execution within a cyclic SCC is serialized: at most one member of a cyclic SCC may be running or scheduled per `_get_ready_modules` pass.
+   - Blocked-module classification operates on the SCC condensation (a DAG): a pending module is blocked if its SCC has any failed member, any cross-SCC dep is failed, or any cross-SCC dep's SCC is itself blocked. Walking the condensation rather than the raw dep_graph avoids the per-module DFS caching incorrect False on cycle re-entry.
 5. Dependencies outside `basenames` are omitted from `dep_graph` (partial sync). Callers should rely on `build_dep_graph_from_architecture` warnings for visibility when an architecture edge points outside the target set; the runner still assumes those deps are out of scope for this run.
 6. Failure scheduling: when a module fails, set `self.failed = True`, but do not globally pause the queue. Failed modules block only modules that depend on them through `dep_graph`; unrelated modules whose own dependencies are satisfied must continue to run so partial progress is preserved and future retries can resume from more completed modules. Blocked-module classification must be transitive: if `a` fails and `b` depends on `a`, then pending modules that depend on `b` are also blocked. Only total-budget exhaustion stops new scheduling globally, and `_budget_exhausted()` must be checked after every completed future, including failed module results, before scheduling more work.
 7. Each module runs as a `pdd sync` subprocess with `--force`, `--agentic`, `--no-steer` flags; append global `--local` before `sync` if `sync_options["local"]` is truthy; append `--target-coverage` if `sync_options["target_coverage"]` is not None; append `--one-session` if `sync_options["one_session"]` is truthy

--- a/pdd/prompts/sync_order_python.prompt
+++ b/pdd/prompts/sync_order_python.prompt
@@ -47,6 +47,14 @@ A utility module that parses `<include>` tags from prompt files, builds a depend
    - cycles_detected: list of cycles found (each cycle is a list of module names)
    - If cycles exist, sorted_list contains all non-cyclic modules in order
 
+4a. Function: compute_sccs(graph: Dict[str, List[str]]) -> List[List[str]]
+   - Compute strongly connected components of a directed dependency graph using an iterative Tarjan's algorithm (no recursion — deep cycle chains must not blow the Python recursion limit).
+   - Normalize the input graph so every node referenced as a dependency is also present as a key (mirrors topological_sort).
+   - With the input convention `graph[A] == [B]` meaning *A depends on B*, return SCCs in deps-first order: an SCC's external dependencies are emitted before the SCC itself. This is Tarjan's natural emission order (the reverse of a depender-first topological sort of the condensation).
+   - Within each SCC, sort node names alphabetically for determinism.
+   - Trivial SCCs (single node, no self-loop) are returned as single-element lists. A self-loop on a node is its own SCC and must be distinguishable from a non-self-loop singleton by inspecting `graph[node]` (callers detect self-loops via `node in graph.get(node, [])`).
+   - Sort each adjacency list before Tarjan's DFS so the discovery order depends only on graph structure, not the caller's dep-list ordering. The SCC set is invariant to neighbour order, but the order they're emitted in is not.
+
 5. Function: get_affected_modules(sorted_modules: List[str], modified: Set[str], graph: Dict[str, List[str]]) -> List[str]
    - Given modified modules, find all modules that transitively depend on them
    - Build reverse graph to find dependents efficiently

--- a/pdd/sync_order.py
+++ b/pdd/sync_order.py
@@ -321,14 +321,15 @@ def compute_sccs(graph: Dict[str, List[str]]) -> List[List[str]]:
             present as a key (mirrors ``topological_sort``).
 
     Returns:
-        SCCs ordered such that earlier SCCs depend on later ones (reverse
-        topological order of the condensation — sinks first, sources last;
-        this is the natural output order of Tarjan's algorithm). Within
-        each SCC, node names are sorted alphabetically for determinism.
-        Trivial SCCs (single node with no self-loop) are returned as
-        single-element lists. A self-loop on a node is its own SCC
-        (one-element list) — callers can distinguish it from a non-self-loop
-        singleton by inspecting ``graph[node]``.
+        SCCs in deps-first order: with the input convention that
+        ``graph[A] == [B]`` means *A depends on B*, an SCC's external
+        dependencies are emitted before the SCC itself. This is Tarjan's
+        natural emission order (the reverse of a depender-first topological
+        sort of the condensation). Within each SCC, node names are sorted
+        alphabetically for determinism. Trivial SCCs (single node with no
+        self-loop) are returned as single-element lists. A self-loop on a
+        node is its own SCC (one-element list) — callers can distinguish
+        it from a non-self-loop singleton by inspecting ``graph[node]``.
 
     Implementation: iterative Tarjan's algorithm, so deep cycle chains do
     not blow the Python recursion limit.

--- a/pdd/sync_order.py
+++ b/pdd/sync_order.py
@@ -311,6 +311,104 @@ def topological_sort(graph: Dict[str, List[str]]) -> Tuple[List[str], List[List[
     return sorted_list, cycles
 
 
+def compute_sccs(graph: Dict[str, List[str]]) -> List[List[str]]:
+    """
+    Computes strongly connected components of a directed graph.
+
+    Args:
+        graph: Adjacency list (module -> dependencies). The graph is
+            normalized so every node referenced as a dependency is also
+            present as a key (mirrors ``topological_sort``).
+
+    Returns:
+        SCCs ordered such that earlier SCCs depend on later ones (reverse
+        topological order of the condensation — sinks first, sources last;
+        this is the natural output order of Tarjan's algorithm). Within
+        each SCC, node names are sorted alphabetically for determinism.
+        Trivial SCCs (single node with no self-loop) are returned as
+        single-element lists. A self-loop on a node is its own SCC
+        (one-element list) — callers can distinguish it from a non-self-loop
+        singleton by inspecting ``graph[node]``.
+
+    Implementation: iterative Tarjan's algorithm, so deep cycle chains do
+    not blow the Python recursion limit.
+    """
+    # Normalize: include every referenced node as a key.
+    all_nodes: Set[str] = set(graph.keys())
+    for deps in graph.values():
+        all_nodes.update(deps)
+    # Sort each adjacency list so Tarjan's DFS discovery order depends only on
+    # graph structure, not the caller's dep-list ordering. The set of SCCs is
+    # invariant to neighbour order, but the order they're emitted in is not.
+    adj: Dict[str, List[str]] = {n: sorted(graph.get(n, [])) for n in all_nodes}
+
+    index_of: Dict[str, int] = {}
+    lowlink: Dict[str, int] = {}
+    on_stack: Set[str] = set()
+    stack: List[str] = []
+    sccs: List[List[str]] = []
+    next_index = 0
+
+    # Iterative Tarjan: each work-stack frame holds (node, iterator over
+    # neighbors, the neighbor we just recursed into — or None on first entry).
+    for start in sorted(all_nodes):  # sort for deterministic start order
+        if start in index_of:
+            continue
+        # Push initial frame.
+        work_stack: List[Tuple[str, "iter", Optional[str]]] = []
+        index_of[start] = next_index
+        lowlink[start] = next_index
+        next_index += 1
+        stack.append(start)
+        on_stack.add(start)
+        work_stack.append((start, iter(adj[start]), None))
+
+        while work_stack:
+            node, neighbors, just_returned = work_stack[-1]
+            if just_returned is not None:
+                # We're back from a recursion into `just_returned`; fold its
+                # lowlink into ours.
+                lowlink[node] = min(lowlink[node], lowlink[just_returned])
+                # Clear the marker so we resume iterating.
+                work_stack[-1] = (node, neighbors, None)
+
+            recursed = False
+            for nb in neighbors:
+                if nb not in index_of:
+                    # Tree edge: descend.
+                    index_of[nb] = next_index
+                    lowlink[nb] = next_index
+                    next_index += 1
+                    stack.append(nb)
+                    on_stack.add(nb)
+                    # Mark current frame so we know which neighbor to fold on return.
+                    work_stack[-1] = (node, neighbors, nb)
+                    work_stack.append((nb, iter(adj[nb]), None))
+                    recursed = True
+                    break
+                if nb in on_stack:
+                    # Back edge to a node still on the SCC stack.
+                    lowlink[node] = min(lowlink[node], index_of[nb])
+                # else: cross edge to a node already in a finished SCC; ignore.
+
+            if recursed:
+                continue
+
+            # All neighbors processed. If `node` is a root of an SCC, pop it.
+            if lowlink[node] == index_of[node]:
+                component: List[str] = []
+                while True:
+                    w = stack.pop()
+                    on_stack.discard(w)
+                    component.append(w)
+                    if w == node:
+                        break
+                sccs.append(sorted(component))
+            work_stack.pop()
+
+    return sccs
+
+
 def get_affected_modules(sorted_modules: List[str], modified: Set[str], graph: Dict[str, List[str]], cyclic_modules: Optional[Set[str]] = None) -> List[str]:
     """
     Identifies modules that need syncing based on modified modules and dependencies.

--- a/tests/test_agentic_sync_runner.py
+++ b/tests/test_agentic_sync_runner.py
@@ -425,6 +425,49 @@ class TestCycleScheduling:
         # (b). m must therefore be reported as blocked.
         assert runner._get_blocked_modules() == ["m"]
 
+    def test_cycle_member_waits_for_peers_external_dep(self):
+        """A cycle member must wait for any external dep reached through
+        another cycle peer. Graph: a->b, b->[a,x], x->[]. SCC {a,b} effectively
+        depends on x (via b), so neither cycle member is ready until x is.
+        """
+        runner = self._make_runner(
+            ["a", "b", "x"],
+            {"a": ["b"], "b": ["a", "x"], "x": []},
+        )
+        ready = runner._get_ready_modules()
+        # Only x has no deps and is not in a cycle; cycle members must wait
+        # for x to succeed before either can start.
+        assert ready == ["x"], (
+            f"cycle members must not be ready while x is pending; got {ready}"
+        )
+        runner.module_states["x"].status = "success"
+        ready = runner._get_ready_modules()
+        # SCC {a,b} is now unblocked; pick one (basenames order -> a) and
+        # serialize the other.
+        assert ready == ["a"], f"expected ['a'], got {ready}"
+        runner.module_states["a"].status = "success"
+        assert runner._get_ready_modules() == ["b"]
+
+    def test_cycle_member_blocked_by_peers_external_failed_dep(self):
+        """If a cycle peer's external dep failed, no cycle member may run.
+        Graph: a->b, b->[a,x], x failed. {a,b} is blocked via b->x; neither
+        cycle member must be reported as ready.
+        """
+        runner = self._make_runner(
+            ["a", "b", "x"],
+            {"a": ["b"], "b": ["a", "x"], "x": []},
+        )
+        runner.module_states["x"].status = "failed"
+        ready = runner._get_ready_modules()
+        assert ready == [], (
+            f"cycle members must be blocked when a peer's external dep is "
+            f"failed; got ready={ready}"
+        )
+        blocked = runner._get_blocked_modules()
+        assert sorted(blocked) == ["a", "b"], (
+            f"both cycle members must be classified blocked; got {blocked}"
+        )
+
     @patch.object(AsyncSyncRunner, "_sync_one_module")
     @patch.object(AsyncSyncRunner, "_update_github_comment")
     def test_run_completes_with_cycle(self, mock_comment, mock_sync):

--- a/tests/test_agentic_sync_runner.py
+++ b/tests/test_agentic_sync_runner.py
@@ -215,6 +215,296 @@ class TestGetBlockedModules:
         blocked = runner._get_blocked_modules()
         assert blocked == ["b", "c"]
 
+    def test_cycle_with_external_failed_dep_blocks_all_cycle_members(self):
+        """Every member of an SCC must be reported blocked when the SCC has a
+        failed cross-SCC dep, regardless of which member is visited first.
+
+        Graph: 3-cycle A->B->C->A; A also depends on external failed module X.
+        All of A, B, C are pending, X is failed.
+        The DFS-with-cache implementation previously cached False on the
+        cycle re-entry, leaving B and C wrongly unblocked.
+        """
+        runner = AsyncSyncRunner(
+            basenames=["A", "B", "C", "X"],
+            dep_graph={"A": ["B", "X"], "B": ["C"], "C": ["A"], "X": []},
+            sync_options={},
+            github_info=None,
+            quiet=True,
+        )
+        runner.module_states["X"].status = "failed"
+        blocked = runner._get_blocked_modules()
+        assert set(blocked) == {"A", "B", "C"}, (
+            f"All cycle members must be blocked, got {blocked}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AsyncSyncRunner scheduling with cyclic dep graphs
+# ---------------------------------------------------------------------------
+
+class TestCycleScheduling:
+    """Scheduling tests for dep graphs containing cycles.
+
+    ``pdd sync`` previously deadlocked when the target set contained a
+    legitimate dependency cycle (e.g.
+    ``agentic_checkup_orchestrator <-> checkup_review_loop``). The runner must
+    treat intra-SCC edges as soft (so cycle members can still be picked) while
+    serializing execution within an SCC (only one member running at a time)
+    and preserving cross-SCC ordering.
+    """
+
+    def _make_runner(self, basenames, dep_graph, states=None):
+        runner = AsyncSyncRunner(
+            basenames=basenames,
+            dep_graph=dep_graph,
+            sync_options={},
+            github_info=None,
+            quiet=True,
+        )
+        if states:
+            for name, status in states.items():
+                runner.module_states[name].status = status
+        return runner
+
+    def test_cycle_two_modules_no_state_picks_one_ready(self):
+        """A<->B cycle: exactly one member is ready in the first pass."""
+        runner = self._make_runner(
+            ["a", "b"],
+            {"a": ["b"], "b": ["a"]},
+        )
+        ready = runner._get_ready_modules()
+        assert ready == ["a"], (
+            f"Expected exactly the first basename of the cycle, got {ready}"
+        )
+
+    def test_cycle_two_modules_running_blocks_peer(self):
+        """While one cycle member is running, the other must not be scheduled."""
+        runner = self._make_runner(
+            ["a", "b"],
+            {"a": ["b"], "b": ["a"]},
+            states={"a": "running"},
+        )
+        ready = runner._get_ready_modules()
+        assert "b" not in ready
+        assert ready == []
+
+    def test_cycle_two_modules_one_success_unblocks_peer(self):
+        """Once one cycle member succeeds, the other becomes ready."""
+        runner = self._make_runner(
+            ["a", "b"],
+            {"a": ["b"], "b": ["a"]},
+            states={"a": "success"},
+        )
+        ready = runner._get_ready_modules()
+        assert ready == ["b"]
+
+    def test_cycle_two_modules_one_failed_blocks_peer(self):
+        """If one cycle member fails, the other is reported blocked, not ready."""
+        runner = self._make_runner(
+            ["a", "b"],
+            {"a": ["b"], "b": ["a"]},
+            states={"a": "failed"},
+        )
+        ready = runner._get_ready_modules()
+        blocked = runner._get_blocked_modules()
+        assert ready == []
+        assert blocked == ["b"]
+
+    def test_three_cycle_with_external_dependent(self):
+        """Three-module graph with a 2-cycle plus an external dependent.
+
+        ``agentic_checkup`` depends on the 2-cycle pair. The first pass must
+        pick exactly one cycle member (by basenames order), never the dependent.
+        As cycle members succeed, the next becomes ready, then finally the
+        external dependent.
+        """
+        basenames = [
+            "agentic_checkup_orchestrator",
+            "checkup_review_loop",
+            "agentic_checkup",
+        ]
+        dep_graph = {
+            "agentic_checkup_orchestrator": ["checkup_review_loop"],
+            "checkup_review_loop": ["agentic_checkup_orchestrator"],
+            "agentic_checkup": ["checkup_review_loop"],
+        }
+        runner = self._make_runner(basenames, dep_graph)
+
+        ready1 = runner._get_ready_modules()
+        assert ready1 == ["agentic_checkup_orchestrator"], (
+            f"First pass should yield exactly the first cycle member, got {ready1}"
+        )
+
+        runner.module_states["agentic_checkup_orchestrator"].status = "success"
+        ready2 = runner._get_ready_modules()
+        assert ready2 == ["checkup_review_loop"], (
+            f"After first cycle member succeeds, peer must be ready (without "
+            f"the external dependent yet), got {ready2}"
+        )
+
+        runner.module_states["checkup_review_loop"].status = "success"
+        ready3 = runner._get_ready_modules()
+        assert ready3 == ["agentic_checkup"], (
+            f"With both cycle members succeeded, the external dependent must "
+            f"now be ready, got {ready3}"
+        )
+
+    def test_acyclic_graph_unaffected(self):
+        """Regression guard: an acyclic 3-module graph schedules unchanged."""
+        runner = self._make_runner(
+            ["a", "b", "c"],
+            {"a": [], "b": ["a"], "c": ["b"]},
+        )
+        ready = runner._get_ready_modules()
+        assert ready == ["a"]
+
+        runner.module_states["a"].status = "success"
+        ready = runner._get_ready_modules()
+        assert ready == ["b"]
+
+        runner.module_states["b"].status = "success"
+        ready = runner._get_ready_modules()
+        assert ready == ["c"]
+
+    def test_self_loop_does_not_deadlock(self):
+        """A 1-node SCC formed by a self-loop is still a cyclic SCC. The
+        runner must treat the self dep as a soft edge, otherwise the module
+        deadlocks waiting for itself.
+        """
+        runner = self._make_runner(["a"], {"a": ["a"]})
+        ready = runner._get_ready_modules()
+        assert ready == ["a"], (
+            f"Self-loop must not block readiness, got {ready}"
+        )
+
+    def test_self_loop_with_external_dep_waits_for_external(self):
+        """A self-loop SCC also has cross-SCC deps; those gate normally."""
+        runner = self._make_runner(
+            ["a", "b"],
+            {"a": ["a", "b"], "b": []},
+        )
+        # b is the only initial ready; a waits because self-loop is soft but
+        # b is cross-SCC pending.
+        assert sorted(runner._get_ready_modules()) == ["b"]
+        runner.module_states["b"].status = "success"
+        # Now a can run; self-loop dep is soft, b's success satisfies the
+        # cross-SCC edge.
+        assert runner._get_ready_modules() == ["a"]
+
+    def test_external_consumer_waits_for_whole_cycle_scc(self):
+        """A consumer outside an SCC must wait until every cycle member is
+        success, not just its directly-named dep."""
+        runner = self._make_runner(
+            ["a", "b", "m"],
+            {"a": ["b"], "b": ["a"], "m": ["a"]},
+        )
+        # Initially: a/b serialize, m must wait for both
+        ready = runner._get_ready_modules()
+        # First SCC member becomes ready; m must NOT be in ready.
+        assert "m" not in ready
+        assert ready == ["a"]
+        runner.module_states["a"].status = "success"
+        # Now b is the only un-success cycle peer; m still must wait.
+        ready = runner._get_ready_modules()
+        assert ready == ["b"], (
+            f"m must not be ready while b is still pending; got {ready}"
+        )
+        runner.module_states["b"].status = "success"
+        # Whole SCC done -> m becomes ready
+        assert runner._get_ready_modules() == ["m"]
+
+    def test_external_consumer_blocked_when_cycle_peer_fails(self):
+        """If any cycle member fails, downstream consumers must be blocked."""
+        runner = self._make_runner(
+            ["a", "b", "m"],
+            {"a": ["b"], "b": ["a"], "m": ["a"]},
+        )
+        runner.module_states["a"].status = "success"
+        runner.module_states["b"].status = "failed"
+        # m's only direct dep (a) is success — but a's SCC has a failed peer
+        # (b). m must therefore be reported as blocked.
+        assert runner._get_blocked_modules() == ["m"]
+
+    @patch.object(AsyncSyncRunner, "_sync_one_module")
+    @patch.object(AsyncSyncRunner, "_update_github_comment")
+    def test_run_completes_with_cycle(self, mock_comment, mock_sync):
+        """Full run() with a 3-module cycle-bearing graph must succeed end-to-end."""
+        mock_sync.return_value = (True, 0.0, "")
+
+        basenames = [
+            "agentic_checkup_orchestrator",
+            "checkup_review_loop",
+            "agentic_checkup",
+        ]
+        dep_graph = {
+            "agentic_checkup_orchestrator": ["checkup_review_loop"],
+            "checkup_review_loop": ["agentic_checkup_orchestrator"],
+            "agentic_checkup": ["checkup_review_loop"],
+        }
+        runner = AsyncSyncRunner(
+            basenames=basenames,
+            dep_graph=dep_graph,
+            sync_options={},
+            github_info=None,
+            quiet=True,
+        )
+
+        success, msg, cost = runner.run()
+        assert success, f"Expected success but got msg={msg!r}"
+        assert msg == "All 3 modules synced successfully"
+        assert cost == pytest.approx(0.0)
+        # Every basename must have been synced exactly once.
+        synced = sorted(c.args[0] for c in mock_sync.call_args_list)
+        assert synced == sorted(basenames)
+
+    @patch.object(AsyncSyncRunner, "_sync_one_module")
+    @patch.object(AsyncSyncRunner, "_update_github_comment")
+    def test_run_with_cycle_one_failure(self, mock_comment, mock_sync):
+        """If one cycle member fails, the peer + downstream are blocked, not lost."""
+        def fake_sync(basename):
+            if basename == "agentic_checkup_orchestrator":
+                return (False, 0.0, "boom")
+            return (True, 0.0, "")
+
+        mock_sync.side_effect = fake_sync
+
+        basenames = [
+            "agentic_checkup_orchestrator",
+            "checkup_review_loop",
+            "agentic_checkup",
+        ]
+        dep_graph = {
+            "agentic_checkup_orchestrator": ["checkup_review_loop"],
+            "checkup_review_loop": ["agentic_checkup_orchestrator"],
+            "agentic_checkup": ["checkup_review_loop"],
+        }
+        runner = AsyncSyncRunner(
+            basenames=basenames,
+            dep_graph=dep_graph,
+            sync_options={},
+            github_info=None,
+            quiet=True,
+        )
+
+        success, msg, cost = runner.run()
+        assert not success
+        assert (
+            runner.module_states["agentic_checkup_orchestrator"].status
+            == "failed"
+        )
+        assert runner.module_states["checkup_review_loop"].status == "pending"
+        assert runner.module_states["agentic_checkup"].status == "pending"
+        assert "Failed: ['agentic_checkup_orchestrator']" in msg
+        # Both the cycle peer and the external dependent must be reported as
+        # blocked — not silently dropped as "not run".
+        assert (
+            "Skipped (blocked): ['agentic_checkup', 'checkup_review_loop']"
+            in msg
+            or "Skipped (blocked): ['checkup_review_loop', 'agentic_checkup']"
+            in msg
+        )
+        assert "Skipped (not run):" not in msg
+
 
 # ---------------------------------------------------------------------------
 # AsyncSyncRunner._build_comment_body

--- a/tests/test_sync_order.py
+++ b/tests/test_sync_order.py
@@ -564,6 +564,30 @@ def test_topological_sort_non_cyclic_remaining_ordered():
 
 
 # ==============================================================================
+# compute_sccs determinism
+# ==============================================================================
+
+def test_compute_sccs_deterministic_regardless_of_dep_order():
+    """SCC output must depend only on graph structure, not dep-list ordering.
+
+    Two equivalent graphs whose adjacency lists differ only by sibling order
+    must produce identical SCC output. The simple ``a->b, b->a, a->c`` case
+    happens to come out the same regardless of sorting; a graph with more
+    than one peer sink reveals Tarjan's discovery-order dependence.
+    """
+    # Simple case: still must be equal.
+    g_simple_1 = {"a": ["b", "c"], "b": ["a"], "c": []}
+    g_simple_2 = {"a": ["c", "b"], "b": ["a"], "c": []}
+    assert sync_order.compute_sccs(g_simple_1) == sync_order.compute_sccs(g_simple_2)
+
+    # Stronger case: ``a`` has multiple sink neighbours; DFS-discovery order
+    # changes the SCC list order without the per-adjacency sort.
+    g_multi_1 = {"a": ["b", "c", "d"], "b": ["a"], "c": [], "d": []}
+    g_multi_2 = {"a": ["d", "c", "b"], "b": ["a"], "c": [], "d": []}
+    assert sync_order.compute_sccs(g_multi_1) == sync_order.compute_sccs(g_multi_2)
+
+
+# ==============================================================================
 # TDD Tests: Script Path Fix
 # ==============================================================================
 


### PR DESCRIPTION
## Summary
- Detect strongly connected components in the sync target graph and treat intra-SCC dep edges as soft so legitimate dependency cycles (e.g. `agentic_checkup_orchestrator <-> checkup_review_loop`) no longer deadlock `pdd sync` with the misleading `Succeeded: []. Skipped (not run): [...]` message.
- Schedule one cycle member at a time (serialize within an SCC); cross-SCC consumers wait for the entire upstream SCC, so a downstream module never starts before all cycle peers finish.
- Rewrite `_get_blocked_modules` over the SCC condensation (a DAG) so failures propagate through cycles correctly and the DFS can never cache an incorrect `False` on cycle re-entry.

## Closes
Closes #1125

## What changed
- `pdd/sync_order.py`: new `compute_sccs()` (iterative Tarjan's), deterministic ordering.
- `pdd/agentic_sync_runner.py`: `AsyncSyncRunner.__init__` builds `_scc_of` + `_cyclic_sccs` over the basename-induced subgraph; `_get_ready_modules` applies soft intra-SCC edges, serializes SCC execution, and waits for the whole upstream SCC; `_get_blocked_modules` walks the condensation.
- `DurableSyncRunner` (subclass) inherits the fix without changes — verified by smoke test.

## Test plan
- [x] Reproduce the exact graph from #1125 — runner now returns `(True, "All 3 modules synced successfully", 0.0)` (was `(False, "Succeeded: []. Skipped (not run): [...]", 0.0)`).
- [x] New `TestCycleScheduling` covers: 2-cycle ready ordering, running peer serializes, success unblocks peer, failed peer blocks peer, 3-module cycle with external dependent, acyclic regression, self-loop, self-loop + external dep, external consumer waits for whole SCC, external consumer blocked when cycle peer fails, run() succeeds, run() with one failure surfaces `Skipped (blocked)` (never `Skipped (not run)`).
- [x] New `test_compute_sccs_deterministic_regardless_of_dep_order`.
- [x] All existing `TestGetReadyModules` and `TestGetBlockedModules` tests pass unchanged.
- [x] Full repo test suite re-run: no new failures in `test_agentic_sync_runner.py` or `test_sync_order.py` (one pre-existing `test_extract_module_known_languages_comprehensive` lisp test remains, unrelated to this PR).