### PR TITLE
feat(catalog): add vertex_ai/gemini-3.5-flash to bundled model catalog

### DIFF
--- a/pdd/data/llm_model.csv
+++ b/pdd/data/llm_model.csv
@@ -58,6 +58,7 @@ Google Vertex AI,vertex_ai/claude-sonnet-4-6,3.0,15.0,1525,,GOOGLE_APPLICATION_C
 Google Vertex AI,gemini-3.1-pro-preview,2.0,12.0,1456,,GOOGLE_APPLICATION_CREDENTIALS|VERTEXAI_PROJECT|VERTEXAI_LOCATION,0,True,effort,global
 Google Vertex AI,gemini-3.1-pro-preview-customtools,2.0,12.0,1456,,GOOGLE_APPLICATION_CREDENTIALS|VERTEXAI_PROJECT|VERTEXAI_LOCATION,0,True,effort,global
 Google Vertex AI,vertex_ai/zai-org/glm-4.7-maas,0.6,2.2,1440,,GOOGLE_APPLICATION_CREDENTIALS|VERTEXAI_PROJECT|VERTEXAI_LOCATION,0,True,effort,global
+Google Vertex AI,vertex_ai/gemini-3.5-flash,1.5,9.0,1442,,GOOGLE_APPLICATION_CREDENTIALS|VERTEXAI_PROJECT|VERTEXAI_LOCATION,0,True,effort,global
 Google Vertex AI,vertex_ai/gemini-3-flash-preview,0.5,3.0,1437,,GOOGLE_APPLICATION_CREDENTIALS|VERTEXAI_PROJECT|VERTEXAI_LOCATION,0,True,effort,global
 Google Vertex AI,vertex_ai/minimaxai/minimax-m2-maas,0.3,1.2,1313,,GOOGLE_APPLICATION_CREDENTIALS|VERTEXAI_PROJECT|VERTEXAI_LOCATION,0,True,none,global
 Heroku,heroku/claude-4-sonnet,3.0,15.0,1350,,HEROKU_API_KEY,0,True,none,

--- a/pdd/generate_model_catalog.py
+++ b/pdd/generate_model_catalog.py
@@ -143,6 +143,7 @@ STATIC_ELO_FALLBACK: Dict[str, int] = {
     "gemini-3.1-pro-preview": 1461,
     "gemini-3-pro": 1444,              # [CODE] #9
     "gemini-3-pro-preview": 1444,
+    "gemini-3.5-flash": 1442,           # GA release; pdd_cloud catalog (#1136)
     "gemini-3-flash": 1440,            # [CODE] #12
     "gemini-3-flash-preview": 1440,
     "gemini-2.5-pro": 1206,            # [CODE] huge Text→Code drop
@@ -1036,6 +1037,18 @@ _DEFAULT_LOCAL_RUNNER_ROWS: List[Dict[str, Any]] = [
 # LiteLLM's bundled registry. Keep this list small: these are compatibility
 # shims for PDD's own model routing, not a second model catalog.
 _MANDATORY_MODEL_ROWS: List[Dict[str, Any]] = [
+    {
+        "provider": "Google Vertex AI",
+        "model": "vertex_ai/gemini-3.5-flash",
+        "input": 1.5,
+        "output": 9.0,
+        "base_url": "",
+        "api_key": "GOOGLE_APPLICATION_CREDENTIALS|VERTEXAI_PROJECT|VERTEXAI_LOCATION",
+        "max_reasoning_tokens": 0,
+        "structured_output": True,
+        "reasoning_type": "effort",
+        "location": "global",
+    },
     {
         "provider": "Google Vertex AI",
         "model": "vertex_ai/gemini-3-flash-preview",

--- a/tests/test_generate_model_catalog.py
+++ b/tests/test_generate_model_catalog.py
@@ -350,3 +350,46 @@ def test_committed_csv_includes_vertex_gemini_flash_ci_default():
     text = csv_path.read_text(encoding="utf-8")
 
     assert "Google Vertex AI,vertex_ai/gemini-3-flash-preview," in text
+
+
+def test_build_rows_includes_vertex_gemini_3_5_flash_ga_default(monkeypatch):
+    """Issue #1136: the GA Vertex Gemini Flash row (used as the cloud
+    LLM_INVOKE_DEFAULT_MODEL) must be seeded via _MANDATORY_MODEL_ROWS even
+    when litellm.model_cost doesn't carry it yet. Pricing, provider, and
+    location pin the values reviewers depend on."""
+    fake_litellm = type("L", (), {"model_cost": {
+        "vertex_ai/zai-org/glm-4.7-maas": {
+            "mode": "chat",
+            "input_cost_per_token": 0.6e-6,
+            "output_cost_per_token": 2.2e-6,
+            "litellm_provider": "vertex_ai",
+            "supports_function_calling": True,
+        },
+    }})
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+    monkeypatch.setattr(gmc, "_fetch_arena_elo", lambda **_kw: {})
+
+    rows = gmc.build_rows()
+
+    row = next(
+        r for r in rows
+        if r["model"] == "vertex_ai/gemini-3.5-flash"
+    )
+    assert row["provider"] == "Google Vertex AI"
+    assert row["api_key"] == "GOOGLE_APPLICATION_CREDENTIALS|VERTEXAI_PROJECT|VERTEXAI_LOCATION"
+    assert row["location"] == "global"
+    assert row["input"] == 1.5
+    assert row["output"] == 9.0
+    assert row["reasoning_type"] == "effort"
+    assert row["structured_output"] is True
+
+
+def test_committed_csv_includes_vertex_gemini_3_5_flash_ga_default():
+    """Issue #1136: the committed catalog must ship the GA Vertex Gemini Flash
+    row so PDD_MODEL_DEFAULT=vertex_ai/gemini-3.5-flash resolves directly
+    instead of falling through to a surrogate row (which lands on
+    vertex_ai/claude-opus-4-7 under the provider lock from PR #1115)."""
+    csv_path = _ROOT / "pdd" / "data" / "llm_model.csv"
+    text = csv_path.read_text(encoding="utf-8")
+
+    assert "Google Vertex AI,vertex_ai/gemini-3.5-flash," in text

--- a/tests/test_llm_invoke.py
+++ b/tests/test_llm_invoke.py
@@ -4954,6 +4954,52 @@ class TestSelectModelCandidates:
         assert candidates[0]["model"] == "gemini-3.1-pro-preview"
         assert candidates[0]["provider"] == "Google Vertex AI"
 
+    def _make_ga_flash_df(self, llm_mod, tmp_path):
+        """CSV with the GA Vertex Gemini Flash row plus a surrogate-base
+        trap. Mirrors the contract that issue #1136 fixes: the catalog
+        ships vertex_ai/gemini-3.5-flash explicitly so a Vertex-locked
+        deployment doesn't silently surrogate onto vertex_ai/claude-opus-4-7
+        (the first Google Vertex AI row in the bundled CSV)."""
+        content = (
+            "provider,model,input,output,coding_arena_elo,api_key,"
+            "structured_output,reasoning_type,max_tokens,max_completion_tokens,"
+            "max_reasoning_tokens\n"
+            # Surrogate trap — first Vertex row when GA Flash is missing.
+            "Google Vertex AI,vertex_ai/claude-opus-4-7,5.0,25.0,1565,"
+            "GOOGLE_APPLICATION_CREDENTIALS|VERTEXAI_PROJECT|VERTEXAI_LOCATION,"
+            "True,effort,200000,8192,128000\n"
+            # The row issue #1136 adds.
+            "Google Vertex AI,vertex_ai/gemini-3.5-flash,1.5,9.0,1442,"
+            "GOOGLE_APPLICATION_CREDENTIALS|VERTEXAI_PROJECT|VERTEXAI_LOCATION,"
+            "True,effort,1000000,8192,0\n"
+        )
+        csv_path = tmp_path / "ga_flash_models.csv"
+        csv_path.write_text(content)
+        return llm_mod._load_model_data(csv_path)
+
+    def test_issue_1136_vertex_gemini_3_5_flash_resolves_directly(self, llm_mod, tmp_path):
+        """Regression for issue #1136: PDD_MODEL_DEFAULT=vertex_ai/gemini-3.5-flash
+        must resolve to the GA Flash row, not silently surrogate onto the
+        first Vertex row (vertex_ai/claude-opus-4-7) when the GA row is
+        present in the catalog."""
+        df = self._make_ga_flash_df(llm_mod, tmp_path)
+        candidates = llm_mod._select_model_candidates(
+            0.5, "vertex_ai/gemini-3.5-flash", df
+        )
+        assert candidates[0]["model"] == "vertex_ai/gemini-3.5-flash"
+        assert candidates[0]["provider"] == "Google Vertex AI"
+        # Pricing must come from the GA row, not the Opus surrogate trap.
+        assert candidates[0]["input"] == 1.5
+        assert candidates[0]["output"] == 9.0
+
+    def test_issue_1136_gemini_3_5_flash_in_gemini_3_family_clamp(self, llm_mod):
+        """The temperature clamp must fire for vertex_ai/gemini-3.5-flash
+        so PDD's default temperature=0.1 is bumped to 1.0, matching the
+        litellm guidance for Gemini 3 models. The regex was already
+        forward-compatible (PR #900) — pin it explicitly for the GA id."""
+        assert llm_mod._is_gemini_3_model("vertex_ai/gemini-3.5-flash") is True
+        assert llm_mod._is_gemini_3_model("gemini-3.5-flash") is True
+
 
 class TestAlternativeBaseLookups:
     """Direct tests for the `_alternative_base_lookups` helper."""


### PR DESCRIPTION
## Summary

- Adds `Google Vertex AI,vertex_ai/gemini-3.5-flash` to `pdd/data/llm_model.csv`. Pricing `$1.50/$9.00` matches Google's published Vertex rate and the pdd_cloud worker catalog (commit `6e08eb488b`). ELO 1442 matches pdd_cloud. Preview row (`vertex_ai/gemini-3-flash-preview`) is kept for backward compat.
- Adds `vertex_ai/gemini-3.5-flash` to `_MANDATORY_MODEL_ROWS` in `pdd/generate_model_catalog.py` so catalog regeneration preserves it even if litellm dedup removes it; adds `"gemini-3.5-flash": 1442` to `STATIC_ELO_FALLBACK` to pass the `ELO_CUTOFF` guard in the mandatory-row seeder.
- Four new tests (2 catalog, 2 llm_invoke) pin the fix; 344 existing tests all pass.

## Why

`pdd_cloud` runs with `LLM_INVOKE_DEFAULT_MODEL=vertex_ai/gemini-3.5-flash` (pdd_cloud `origin/main`). Without this row, a local `PDD_MODEL_DEFAULT=vertex_ai/gemini-3.5-flash` run falls through to the surrogate-base path. Under the provider lock from PR #1115, the surrogate becomes `vertex_ai/claude-opus-4-7` (first Google Vertex AI row) — wrong model, wrong pricing, wrong ELO for strength interpolation, wrong temperature-clamp behavior.

## Test plan

- [x] `test_committed_csv_includes_vertex_gemini_3_5_flash_ga_default` — CSV substring assertion
- [x] `test_build_rows_includes_vertex_gemini_3_5_flash_ga_default` — seeded via `_MANDATORY_MODEL_ROWS` with fake litellm that lacks the row
- [x] `TestSelectModelCandidates::test_issue_1136_vertex_gemini_3_5_flash_resolves_directly` — resolves to GA row, not `vertex_ai/claude-opus-4-7` surrogate trap
- [x] `TestSelectModelCandidates::test_issue_1136_gemini_3_5_flash_in_gemini_3_family_clamp` — temperature clamp fires for GA id
- [x] `pytest tests/test_generate_model_catalog.py tests/test_llm_invoke.py tests/test_llm_invoke_csv_model_registration.py tests/test_update_model_costs.py` — 344 passed

Closes #1136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)