### PR TITLE
docs: reposition PDD as the last programming language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
-# PDD (Prompt-Driven Development) Command Line Interface
+# PDD: The Last Programming Language™
 
 ![PyPI version](https://img.shields.io/pypi/v/pdd-cli.svg) [![Discord](https://img.shields.io/badge/Discord-join%20chat-7289DA.svg?logo=discord&logoColor=white)](https://discord.gg/Yp4RTh8bG7)
 
 ## Introduction
 
-PDD (Prompt-Driven Development) is a toolkit for AI-powered code generation and maintenance.
+PDD (Prompt-Driven Development) is a prompt-native programming system. `.prompt`
+files are the human-authored source language; Python, TypeScript, Go, and other
+traditional languages are generated artifacts.
+
+PDD is the last programming language in this specific sense: developers author
+durable intent, constraints, examples, and tests, then compile that source into
+whatever implementation language the project needs. Code remains real and
+reviewable, but it is no longer the primary source of truth.
 
 **Getting started is simple:**
 
@@ -35,6 +42,8 @@ For CLI users, PDD also offers powerful **agentic commands** that implement GitH
 For prompt-based workflows, the **`sync`** command automates the complete development cycle with intelligent decision-making, real-time visual feedback, and sophisticated state management.
 
 ## Whitepaper
+
+For the positioning essay behind this shift, read [The Last Programming Language](docs/the-last-programming-language.md).
 
 For a detailed explanation of the concepts, architecture, and benefits of Prompt-Driven Development, please refer to our full whitepaper. This document provides an in-depth look at the PDD philosophy, its advantages over traditional development, and includes benchmarks and case studies.
 
@@ -3663,7 +3672,7 @@ One or more patent applications covering aspects of the PDD workflows and system
 
 ## Conclusion
 
-PDD (Prompt-Driven Development) CLI provides a comprehensive set of tools for managing prompt files, generating code, creating examples, running tests, and handling various aspects of prompt-driven development. By leveraging the power of AI models and iterative processes, PDD aims to streamline the development workflow and improve code quality.
+PDD (Prompt-Driven Development) is a prompt-native programming system for managing `.prompt` source files, generating code, creating examples, running tests, and keeping implementation artifacts synchronized with durable intent. By treating prompts and tests as the source of truth, PDD turns conventional code into reviewable output that can be regenerated as requirements evolve.
 
 The various commands and options allow for flexible usage, from simple code generation to complex workflows involving multiple steps. The ability to track costs and manage output locations through environment variables further enhances the tool's utility in different development environments.
 
@@ -3673,4 +3682,4 @@ As you become more familiar with PDD, you can compose richer workflows by chaini
 
 Remember to stay mindful of security considerations, especially when working with generated code or sensitive data. Regularly update PDD to access the latest features and improvements.
 
-Happy coding with PDD!
+Keep prompts as source; regenerate with PDD.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,3 +1,21 @@
+## Q: Is PDD really a programming language?
+
+*"Yes, if you define the programming language as the human-authored source of truth rather than the CPU's final executable format."*
+
+In PDD, a program is the versioned prompt suite plus its includes, examples, tests, architecture metadata, and configuration. `pdd sync` compiles that source into conventional code and validates the output. Python, TypeScript, Go, Java, and other languages still matter, but they become compilation targets rather than the main thing humans maintain.
+
+## Q: What does "The Last Programming Language" mean?
+
+*"It means PDD moves the durable source from syntax to intent."*
+
+The phrase is a positioning claim for PDD, not a promise that implementation languages disappear. Teams still review generated code, run tests, ship binaries, and debug real systems. The change is that durable behavior lives in prompts and tests, while code can be regenerated from that source as models and project requirements evolve.
+
+## Q: Why not just use Cursor, Claude Code, Codex, or another coding agent?
+
+Those tools are useful, and PDD can work alongside them. The difference is the source-of-truth model.
+
+Interactive coding agents usually treat prompts as transient instructions for patching code. PDD treats prompts as durable source files. That gives teams a reviewable prompt history, repeatable regeneration, explicit includes, accumulating tests, and a path to keep implementation learnings synchronized back into the source.
+
 ## Q: Wouldn't the best language to describe code just be ... code?
 *"Totally get that—that's why every generation of software abstraction still compiles down to real code. We're not trying to replace code as an executable artefact; we're trying to replace code as the primary source-of-truth."*
 

--- a/docs/prompt-driven-development-doctrine.md
+++ b/docs/prompt-driven-development-doctrine.md
@@ -2,6 +2,18 @@
 
 A concise set of principles for building and maintaining software where prompts are the primary artifact, regeneration is the default, and synchronization across code, examples, and tests is non‑negotiable.
 
+## PDD As the Last Programming Language
+
+PDD is not a faster way to type Python, TypeScript, or Go. It is a higher-level
+source language for software intent that compiles into those implementation
+languages. Developers author prompts, tests, examples, includes, and architecture
+metadata; PDD regenerates the code artifacts from that source.
+
+"The Last Programming Language" is a positioning claim, not a claim that target
+languages disappear. Traditional languages remain real execution targets and
+escape hatches. The shift is that humans primarily maintain the durable intent,
+while generated code becomes reviewable compiler output.
+
 ## Why This Doctrine
 - **Maintenance reality:** 80–90% of cost is post‑creation. Patching accretes complexity; regeneration preserves integrity.
 - **Intent over implementation:** Prompts capture the "why"; code captures one "how." We version the former and regenerate the latter.

--- a/docs/prompting_guide.md
+++ b/docs/prompting_guide.md
@@ -2,6 +2,11 @@
 
 This guide shows how to write effective prompts for Prompt‑Driven Development (PDD). It distills best practices from the PDD whitepaper, the PDD doctrine, and working patterns in this repo. It also contrasts PDD prompts with interactive agentic coding tools (e.g., Claude Code, Cursor) where prompts act as ad‑hoc patches instead of the source of truth.
 
+Think of PDD prompts as source files in a prompt-native programming system. The
+prompt suite, includes, examples, tests, architecture metadata, and `.pddrc`
+configuration form the source; `pdd sync` compiles that source into conventional
+code artifacts.
+
 References: pdd/docs/whitepaper.md, pdd/docs/prompt-driven-development-doctrine.md, README.md (repo structure, conventions), [Effective Context Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents), [Anthropic Prompt Engineering Overview](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview).
 
 ---
@@ -30,6 +35,8 @@ Successful fixes can contribute to grounding, but the prompt remains the source 
 - **Shared Preamble:** A standard text file (e.g., `project_preamble.prompt`) included in every prompt to enforce common rules like coding style, forbidden libraries, and formatting.
 - **PDD Directive:** Special tags like `<include>` or `<shell>` that the PDD tool processes *before* sending the text to the AI. The AI sees the *result* (the file content), not the tag.
 - **Source of Truth:** The definitive record. In PDD, the **Prompt** is the source of truth; the code is just a temporary artifact generated from it.
+- **PDD Program:** A versioned prompt suite plus its includes, examples, tests, architecture metadata, and configuration.
+- **Compilation:** Running `pdd sync` or related commands to regenerate conventional code artifacts from PDD source and validate them.
 - **Grounding (Few-Shot History):** The process where the PDD system can use successful past pairs of (Prompt, Code) as "few-shot" examples during generation. This helps regenerated code follow established style and logic, reducing the chance of a completely different implementation.
 - **Drift:** When the generated code slowly diverges from the prompt's intent over time, or when manual edits to code make it inconsistent with the prompt.
 

--- a/docs/the-last-programming-language.md
+++ b/docs/the-last-programming-language.md
@@ -1,0 +1,80 @@
+# The Last Programming Language
+
+PDD is the last programming language in a precise engineering sense: it moves
+the human-authored source of truth from implementation syntax to durable intent.
+
+Developers still ship real Python, TypeScript, Go, Java, Rust, and C++. Those
+languages do not disappear. They become compilation targets: reviewable,
+testable artifacts generated from a higher-level source.
+
+## The Shift
+
+Every major programming abstraction moved humans farther from the machine:
+
+| Era | Human-authored source | Generated or lower-level target |
+| --- | --- | --- |
+| Assembly | CPU instructions | Machine code |
+| C | Portable systems code | Assembly and machine code |
+| Python / TypeScript | High-level application code | Bytecode, JavaScript, native libraries |
+| PDD | Prompts, tests, examples, metadata | Python, TypeScript, Go, docs, tests, APIs |
+
+PDD extends that ladder. The source is no longer line-by-line implementation.
+The source is the intent, constraints, interfaces, acceptance tests, and project
+context that define what the system must do.
+
+## What a PDD Program Is
+
+A PDD program is not a single chat prompt. It is a versioned software source made
+from:
+
+- `.prompt` files that describe module intent and contracts
+- `<include>` directives that import explicit context
+- examples that define usable interfaces
+- tests that constrain behavior across regenerations
+- `architecture.json` metadata that defines module relationships
+- `.pddrc` configuration that controls paths, language targets, and defaults
+
+`pdd sync` compiles that source into conventional code artifacts and verifies the
+result. The generated code can be reviewed and committed, but it is no longer the
+only durable source.
+
+## Why This Is Different From AI Patching
+
+Interactive coding agents usually treat prompts as disposable instructions for
+patching code. That helps with local changes, but the source of truth remains the
+patched codebase and the reasoning often disappears into chat history.
+
+PDD makes the prompt suite durable:
+
+- prompt changes are reviewed like code changes
+- includes make context explicit and repeatable
+- tests accumulate as semantic constraints
+- implementation learnings are back-propagated with `pdd update`
+- regeneration can improve as models improve
+
+The practical distinction is simple: patching asks an agent to modify the
+artifact. PDD modifies the source, then regenerates the artifact.
+
+## What the Claim Does Not Mean
+
+"The Last Programming Language" does not mean developers never inspect code. It
+does not mean target languages stop mattering. It does not remove the need for
+tests, security review, debugging, or operational judgment.
+
+It means the default authoring surface moves up one level. Humans maintain the
+specification that survives regeneration. The toolchain emits the implementation
+that satisfies it.
+
+## Product Implication
+
+PDD should be understood as a compiler toolchain for prompt-native software:
+
+- `.prompt` files are source files
+- includes are imports
+- tests are semantic constraints
+- `pdd sync` is compilation
+- generated code is build output
+- `pdd update` back-propagates implementation discoveries into source
+
+This is why PDD can support any stack. It is not competing with Python or
+TypeScript as an execution environment. It is a source layer above them.

--- a/pdd/docs/prompting_guide.md
+++ b/pdd/docs/prompting_guide.md
@@ -2,6 +2,11 @@
 
 This guide shows how to write effective prompts for Prompt‑Driven Development (PDD). It distills best practices from the PDD whitepaper, the PDD doctrine, and working patterns in this repo. It also contrasts PDD prompts with interactive agentic coding tools (e.g., Claude Code, Cursor) where prompts act as ad‑hoc patches instead of the source of truth.
 
+Think of PDD prompts as source files in a prompt-native programming system. The
+prompt suite, includes, examples, tests, architecture metadata, and `.pddrc`
+configuration form the source; `pdd sync` compiles that source into conventional
+code artifacts.
+
 References: pdd/docs/whitepaper.md, pdd/docs/prompt-driven-development-doctrine.md, README.md (repo structure, conventions), [Effective Context Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents), [Anthropic Prompt Engineering Overview](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview).
 
 ---
@@ -28,6 +33,8 @@ If you are new to Prompt-Driven Development (PDD), follow this recipe:
 - **Shared Preamble:** A standard text file (e.g., `project_preamble.prompt`) included in every prompt to enforce common rules like coding style, forbidden libraries, and formatting.
 - **PDD Directive:** Special tags like `<include>` or `<shell>` that the PDD tool processes *before* sending the text to the AI. The AI sees the *result* (the file content), not the tag.
 - **Source of Truth:** The definitive record. In PDD, the **Prompt** is the source of truth; the code is just a temporary artifact generated from it.
+- **PDD Program:** A versioned prompt suite plus its includes, examples, tests, architecture metadata, and configuration.
+- **Compilation:** Running `pdd sync` or related commands to regenerate conventional code artifacts from PDD source and validate them.
 - **Grounding (Few-Shot History):** The process where the PDD system automatically uses successful past pairs of (Prompt, Code) as "few-shot" examples during generation. This ensures that regenerated code adheres to the established style and logic of the previous version, preventing the model from hallucinating a completely different implementation.
 - **Drift:** When the generated code slowly diverges from the prompt's intent over time, or when manual edits to code make it inconsistent with the prompt.
 

--- a/pypi_description.rst
+++ b/pypi_description.rst
@@ -5,12 +5,14 @@
    :alt: Join us on Discord
    :target: https://discord.gg/Yp4RTh8bG7
 
-PDD (Prompt-Driven Development) Command Line Interface
-======================================================
+PDD: The Last Programming Language™
+====================================
+
+PDD (Prompt-Driven Development) is a prompt-native programming system. ``.prompt`` files are the human-authored source language; Python, TypeScript, Go, and other traditional languages are generated artifacts.
+
+PDD is the last programming language in this specific sense: developers author durable intent, constraints, examples, and tests, then compile that source into whatever implementation language the project needs. Code remains real and reviewable, but it is no longer the primary source of truth.
 
 The primary command is ``sync``, which automatically executes the complete PDD workflow loop—from dependency injection through code generation, testing, and verification. For most use cases, ``sync`` is the recommended starting point, as it intelligently determines what steps are needed and executes them in the correct order.
-
-PDD (Prompt-Driven Development) is a command-line interface that harnesses AI models to generate and maintain code from prompt files. Whether you want to create new features, fix bugs, enhance unit tests, or manage complex prompt structures, pdd-cli streamlines your workflow through an intuitive interface and powerful automation.
 
 .. image:: https://img.youtube.com/vi/5lBxpTSnjqo/0.jpg
    :alt: Watch a video demonstration of PDD
@@ -25,6 +27,7 @@ Why Choose Prompt-Driven Development?
 *   **Enhance Code Quality and Consistency**: By using prompts as a single source of truth, PDD ensures your code, tests, and documentation never drift out of sync. This regenerative process produces a more reliable and understandable codebase compared to the tangled results of repeated patching.
 *   **Improve Collaboration**: Prompts are written in natural language, making them accessible to both technical and non-technical stakeholders. This fosters clearer communication and ensures the final product aligns with business requirements.
 *   **Reduce LLM Costs**: PDD's structured, batch-oriented nature is inherently more token-efficient and allows you to take advantage of significant discounts offered by LLM providers for batch processing APIs, making it a more cost-effective solution than many interactive tools.
+*   **Compile to Any Stack**: PDD does not ask teams to abandon Python, TypeScript, Java, Go, or C++. It treats those languages as targets emitted from a higher-level prompt source.
 
 
 Key Features
@@ -242,6 +245,10 @@ Yes. PDD is designed for both new and existing projects. You can start by creati
 **Do I need to be an expert prompt engineer?**
 
 Not at all. Effective prompts are more about clearly defining your requirements in natural language than about complex "engineering." If you can write a good specification or a clear bug report, you can write a good prompt. The goal is to describe *what* you want the code to do, not how to write it.
+
+**Is PDD really a programming language?**
+
+Yes, in the source-of-truth sense. A PDD program is the versioned prompt suite plus its includes, examples, tests, architecture metadata, and configuration. ``pdd sync`` compiles that source into conventional code and validates the result.
 
 
 Getting Help


### PR DESCRIPTION
## Summary
- Reframe PDD as a prompt-native programming system and use "The Last Programming Language" as the positioning line.
- Add docs/the-last-programming-language.md to define the claim, boundaries, and compiler/toolchain mental model.
- Update README, PyPI long description, FAQ, doctrine, and prompting guides with source-language / generated-artifact terminology.

## Verification
- git diff --check
- Parsed pypi_description.rst with docutils