### PR TITLE
feat: add CLI tagline positioning

### DIFF
--- a/architecture.json
+++ b/architecture.json
@@ -1130,6 +1130,43 @@
     }
   },
   {
+    "reason": "Centralizes concise user-facing CLI branding strings for orientation surfaces.",
+    "description": "Defines shared tagline and positioning constants used by root help, setup onboarding, and connect startup output.",
+    "dependencies": [],
+    "priority": 31,
+    "filename": "cli_branding_python.prompt",
+    "filepath": "pdd/cli_branding.py",
+    "tags": [
+      "module",
+      "python",
+      "cli",
+      "branding"
+    ],
+    "interface": {
+      "type": "module",
+      "module": {
+        "constants": [
+          {
+            "name": "PDD_TAGLINE",
+            "type": "str"
+          },
+          {
+            "name": "PDD_FULL_TAGLINE",
+            "type": "str"
+          },
+          {
+            "name": "PDD_POSITIONING",
+            "type": "str"
+          }
+        ]
+      }
+    },
+    "position": {
+      "x": 14960,
+      "y": 220
+    }
+  },
+  {
     "reason": "LLM prompt template for sync analysis operations.",
     "description": "Defines the prompt structure for sync analysis. Invoked by the corresponding Python module to format LLM requests.",
     "dependencies": [],
@@ -4418,7 +4455,8 @@
     "reason": "Orchestrates pdd setup with OpenCode-aware CLI bootstrap and deterministic model configuration.",
     "description": "Runs the interactive pdd setup flow with agentic CLI bootstrapping, API-key discovery, model configuration, .pddrc initialization, and summary output.",
     "dependencies": [
-      "cli_detector_python.prompt"
+      "cli_detector_python.prompt",
+      "cli_branding_python.prompt"
     ],
     "priority": 129,
     "filename": "setup_tool_python.prompt",
@@ -8645,7 +8683,8 @@
       "duplicate_cli_guard_python.prompt",
       "agentic_common_python.prompt",
       "auto_update_python.prompt",
-      "track_cost_python.prompt"
+      "track_cost_python.prompt",
+      "cli_branding_python.prompt"
     ],
     "priority": 5,
     "filename": "core/cli_python.prompt",

--- a/pdd/cli_branding.py
+++ b/pdd/cli_branding.py
@@ -1,0 +1,7 @@
+"""Shared user-facing CLI branding strings."""
+
+PDD_TAGLINE = "The Last Programming Language™"
+PDD_FULL_TAGLINE = f"PDD: {PDD_TAGLINE}"
+PDD_POSITIONING = "Prompt files are source; code is generated output."
+
+__all__ = ["PDD_TAGLINE", "PDD_FULL_TAGLINE", "PDD_POSITIONING"]

--- a/pdd/commands/connect.py
+++ b/pdd/commands/connect.py
@@ -17,6 +17,8 @@ from typing import Optional
 
 import click
 
+from ..cli_branding import PDD_POSITIONING
+
 
 # Default port and range for auto-assignment
 DEFAULT_PORT = 9876
@@ -308,6 +310,7 @@ def connect(
         ctx.exit(1)
 
     # 6. Print Status Messages
+    click.echo(click.style(PDD_POSITIONING, fg="cyan"))
     click.echo(click.style(f"Starting PDD server on {server_url}", fg="green", bold=True))
     click.echo(f"Project Root: {click.style(str(project_root), fg='blue')}")
     click.echo(f"API Documentation: {click.style(f'{server_url}/docs', underline=True)}")

--- a/pdd/core/cli.py
+++ b/pdd/core/cli.py
@@ -16,6 +16,7 @@ except ImportError:
     DEFAULT_TIME = 0.25
     __version__ = "unknown"
 from ..auto_update import auto_update
+from ..cli_branding import PDD_FULL_TAGLINE, PDD_POSITIONING
 from ..construct_paths import list_available_contexts
 from ..install_completion import get_local_pdd_path
 from .errors import console, handle_error, clear_core_dump_errors
@@ -97,6 +98,9 @@ class PDDCLI(click.Group):
 
     def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         self.format_usage(ctx, formatter)
+        formatter.write_text(PDD_FULL_TAGLINE)
+        formatter.write_text(PDD_POSITIONING)
+        formatter.write_paragraph()
         with formatter.section("Generate Suite (related commands)"):
             formatter.write_dl([
                 ("generate", "Create runnable code from a prompt file."),
@@ -245,7 +249,7 @@ class PDDCLI(click.Group):
 @click.group(
     cls=PDDCLI,
     invoke_without_command=True,
-    help="PDD (Prompt-Driven Development) Command Line Interface.",
+    help="PDD prompt-native programming system.",
 )
 @click.option(
     "--force",

--- a/pdd/prompts/cli_branding_python.prompt
+++ b/pdd/prompts/cli_branding_python.prompt
@@ -1,0 +1,31 @@
+<pdd-reason>Centralizes concise user-facing CLI branding strings for orientation surfaces.</pdd-reason>
+
+<pdd-interface>
+{
+  "type": "module",
+  "module": {
+    "constants": [
+      {"name": "PDD_TAGLINE", "type": "str"},
+      {"name": "PDD_FULL_TAGLINE", "type": "str"},
+      {"name": "PDD_POSITIONING", "type": "str"}
+    ]
+  }
+}
+</pdd-interface>
+
+% You are an expert Python engineer. Your goal is to write `pdd/cli_branding.py`.
+
+% Role & Scope
+  This module centralizes short, user-facing CLI branding strings used only on
+  orientation surfaces such as root help, setup onboarding, and connect startup.
+  It must not print anything or import heavy dependencies.
+
+% Requirements
+  1. Define `PDD_TAGLINE = "The Last Programming Language™"`.
+  2. Define `PDD_FULL_TAGLINE` as `"PDD: {PDD_TAGLINE}"`.
+  3. Define `PDD_POSITIONING = "Prompt files are source; code is generated output."`.
+  4. Define `__all__` with the three public constants.
+  5. Do not add functions, side effects, environment access, or runtime imports.
+
+% Deliverables
+  - Code: `pdd/cli_branding.py`

--- a/pdd/prompts/commands/connect_python.prompt
+++ b/pdd/prompts/commands/connect_python.prompt
@@ -66,6 +66,7 @@
      - Use webbrowser.open()
 
   6. **Output messages**:
+     - Print `PDD_POSITIONING` from `pdd.cli_branding` before the server details.
      - "Starting PDD server on http://{host}:{port}"
      - "API Documentation: http://{host}:{port}/docs"
      - "Frontend: http://{host}:{port}" (or custom URL)
@@ -103,6 +104,7 @@
   - NO @track_cost decorator (no LLM calls)
   - Use click.echo() for output
   - Use click.style() for colored output
+  - Import `PDD_POSITIONING` from `pdd.cli_branding`
   - click.confirm() for security warning
   - Determine project_root from current working directory
   - Pass click context for potential future use

--- a/pdd/prompts/core/cli_python.prompt
+++ b/pdd/prompts/core/cli_python.prompt
@@ -22,6 +22,7 @@
 <pdd-dependency>agentic_common_python.prompt</pdd-dependency>
 <pdd-dependency>auto_update_python.prompt</pdd-dependency>
 <pdd-dependency>track_cost_python.prompt</pdd-dependency>
+<pdd-dependency>cli_branding_python.prompt</pdd-dependency>
 
 % You are an expert Python engineer. Your goal is to write the core CLI logic for PDD in `pdd/core/cli.py`.
 
@@ -37,7 +38,7 @@
      - `_strip_ansi_codes(text)`: Remove ANSI sequences via `r'\x1b\[[0-9;]*m'`.
 
   2. **PDDCLI (click.Group)**:
-     - `format_help`: Add a "Generate Suite" section for `generate`, `test`, and `example` commands as described in README.
+     - `format_help`: After usage, print `PDD_FULL_TAGLINE` and `PDD_POSITIONING` from `pdd.cli_branding`, then add a "Generate Suite" section for `generate`, `test`, and `example` commands as described in README.
      - `invoke`: Centralized exception handling.
        - `click.Abort`: Exit code 1, silent (no error report).
        - `KeyboardInterrupt`, `Exception`: Pass to `handle_error`.
@@ -79,7 +80,7 @@
   </pdd.agentic_common>
 
 % Instructions
-  - Imports: `os`, `sys`, `io`, `re`, `click`, `typing`. From package/submodules: `DEFAULT_STRENGTH`, `__version__`, `DEFAULT_TIME`, `auto_update`, `list_available_contexts`, `get_local_pdd_path`, `handle_error`, `clear_core_dump_errors`, `_first_pending_command`, `_should_show_onboarding_reminder`, `_write_core_dump`, `garbage_collect_core_dumps`.
+  - Imports: `os`, `sys`, `io`, `re`, `click`, `typing`. From package/submodules: `DEFAULT_STRENGTH`, `__version__`, `DEFAULT_TIME`, `auto_update`, `PDD_FULL_TAGLINE`, `PDD_POSITIONING`, `list_available_contexts`, `get_local_pdd_path`, `handle_error`, `clear_core_dump_errors`, `_first_pending_command`, `_should_show_onboarding_reminder`, `_write_core_dump`, `garbage_collect_core_dumps`.
   - Use `click.version_option(version=__version__, package_name="pdd-cli")`.
 
 % Deliverables

--- a/pdd/prompts/setup_tool_python.prompt
+++ b/pdd/prompts/setup_tool_python.prompt
@@ -12,6 +12,7 @@
 </pdd-interface>
 
 <pdd-dependency>cli_detector_python.prompt</pdd-dependency>
+<pdd-dependency>cli_branding_python.prompt</pdd-dependency>
 
 % You are an expert Python engineer. Your goal is to write the pdd/setup_tool.py module.
 
@@ -23,7 +24,7 @@ Main orchestrator for `pdd setup`. Implements a two-phase flow designed for mini
 1. Function: `run_setup()` — main entry point. Two-phase flow:
 
    **Banner:**
-   Print the PDD ASCII art logo in cyan via `_print_pdd_logo()`, followed by bold white tagline: "Let's get set up quickly with a solid basic configuration!" Use ANSI escape codes (CYAN="\033[36m", WHITE="\033[37m", BOLD="\033[1m", RESET="\033[0m").
+   Print the PDD ASCII art logo in cyan via `_print_pdd_logo()`. The logo should replace the old "COMMAND LINE INTERFACE" wording with "THE LAST" and "PROGRAMMING LANGUAGE". After the logo, print `PDD_FULL_TAGLINE` in bold white, then `PDD_POSITIONING` in white, then the existing bold white setup line: "Let's get set up quickly with a solid basic configuration!" Use ANSI escape codes (CYAN="\033[36m", WHITE="\033[37m", BOLD="\033[1m", RESET="\033[0m").
 
    **Phase 1 — CLI Bootstrap (interactive, 0–2 user inputs):**
    a. Call `cli_detector.detect_and_bootstrap_cli()` which returns `List[CliBootstrapResult]`.
@@ -98,7 +99,7 @@ Main orchestrator for `pdd setup`. Implements a two-phase flow designed for mini
    - From `pdd.provider_manager`: `_read_csv`, `_write_csv_atomic`, `_get_user_csv_path`, `_save_key_to_api_env`, `_get_shell_rc_path`, `parse_api_key_vars`, `add_provider_from_registry`
    - From `pdd.pddrc_initializer`: `_detect_language`, `_build_pddrc_content`
    - From `pdd.model_tester`: `_run_test`, `test_model_interactive`
-   - Top-level: `getpass`, `os`, `sys`, `pathlib.Path`, `threading`
+   - Top-level: `getpass`, `os`, `sys`, `pathlib.Path`, `threading`, `PDD_FULL_TAGLINE`, `PDD_POSITIONING` from `pdd.cli_branding`
    - Optional: `litellm` (import-guarded), `dotenv` (import-guarded)
 
 % Dependencies

--- a/pdd/setup_tool.py
+++ b/pdd/setup_tool.py
@@ -14,6 +14,9 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from rich.console import Console as _RichConsole
+
+from pdd.cli_branding import PDD_FULL_TAGLINE, PDD_POSITIONING
+
 _console = _RichConsole(highlight=False)
 
 # ANSI escape codes for coloring (works without rich)
@@ -42,8 +45,8 @@ def _print_pdd_logo() -> None:
             "xxx      x+           xx+           DRIVEN",
             "xxx        x+         xxx           DEVELOPMENT\u00a9",
             "xxx         x+        xx+",
-            "xxx        x+         xx+           COMMAND LINE INTERFACE",
-            "xxx      x+          xxx",
+            "xxx        x+         xx+           THE LAST",
+            "xxx      x+          xxx            PROGRAMMING LANGUAGE",
             "xxx                +xx+ ",
             "xxx     +xxxxxxxxxxx+",
             "xxx   +xx+",
@@ -54,6 +57,9 @@ def _print_pdd_logo() -> None:
         ]
     )
     print(f"{CYAN}{logo}{RESET}")
+    print()
+    print(f"{BOLD}{WHITE}{PDD_FULL_TAGLINE}{RESET}")
+    print(f"{WHITE}{PDD_POSITIONING}{RESET}")
     print()
     print(f"{BOLD}{WHITE}Let's get set up quickly with a solid basic configuration!{RESET}")
     print()

--- a/tests/commands/test_connect.py
+++ b/tests/commands/test_connect.py
@@ -39,6 +39,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from pdd.cli_branding import PDD_POSITIONING
+
 # Import the command under test
 # We assume the package structure allows this import based on the file path provided
 from pdd.commands.connect import connect
@@ -108,6 +110,7 @@ def test_connect_defaults(mock_dependencies):
             result = runner.invoke(connect)
 
             assert result.exit_code == 0
+            assert PDD_POSITIONING in result.output
             assert "Starting PDD server on http://127.0.0.1:9876" in result.output
 
             # Verify create_app called with current directory

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 import click
 
 from pdd import __version__, DEFAULT_STRENGTH, DEFAULT_TEMPERATURE, DEFAULT_TIME
+from pdd.cli_branding import PDD_FULL_TAGLINE, PDD_POSITIONING
 # Import necessary components from pdd.core.cli for testing
 from pdd.core.cli import _strip_ansi_codes, OutputCapture, PDDCLI, cli as cli_command, process_commands
 import pdd.core.cli as core_cli_module
@@ -179,6 +180,8 @@ def test_cli_help(runner):
     result = runner.invoke(cli_command, ["--help"])
     assert result.exit_code == 0
     assert "Usage: cli [OPTIONS] COMMAND" in result.output
+    assert PDD_FULL_TAGLINE in result.output
+    assert PDD_POSITIONING in result.output
     assert "generate" in result.output
     assert "fix" in result.output
     assert "install-completion" in result.output
@@ -555,6 +558,8 @@ def test_pddcli_format_help_includes_suite():
     formatter = click.HelpFormatter()
     group.format_help(ctx, formatter)
     output = formatter.getvalue()
+    assert PDD_FULL_TAGLINE in output
+    assert PDD_POSITIONING in output
     assert "Generate Suite (related commands)" in output
     assert "generate" in output
 

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -68,11 +68,13 @@
 
 import csv
 import os
-import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from pdd import setup_tool
+from pdd.cli_branding import PDD_FULL_TAGLINE, PDD_POSITIONING
 
 
 # ---------------------------------------------------------------------------
@@ -130,6 +132,17 @@ _ENV_VARS_TO_CLEAN = [
     "VERTEXAI_LOCATION", "AZURE_API_KEY", "AZURE_API_BASE",
     "AZURE_API_VERSION",
 ]
+
+
+def test_print_pdd_logo_includes_positioning(capsys):
+    """Setup onboarding banner should include the repositioning line."""
+    setup_tool._print_pdd_logo()
+
+    output = capsys.readouterr().out
+    assert PDD_FULL_TAGLINE in output
+    assert PDD_POSITIONING in output
+    assert "THE LAST" in output
+    assert "PROGRAMMING LANGUAGE" in output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add shared CLI branding constants for the PDD tagline and short positioning line.
- Surface the tagline in root help and setup onboarding, and add the concise positioning line to connect startup.
- Update PDD prompt specs and architecture metadata for the new branding module and changed output surfaces.

## Verification
- pytest tests/core/test_cli.py tests/commands/test_connect.py tests/test_setup_tool.py
- git diff --check HEAD~1..HEAD
- python -m py_compile pdd/cli_branding.py pdd/core/cli.py pdd/setup_tool.py pdd/commands/connect.py
- python -m json.tool architecture.json