### PR TITLE
fix(generate_test): section selectors for prompting_guide include

### DIFF
--- a/pdd/prompts/generate_test_LLM.prompt
+++ b/pdd/prompts/generate_test_LLM.prompt
@@ -31,7 +31,7 @@
     - Focus on testing functionality NOT already covered by existing tests
 
 % REPO PROMPTING GUIDE (optional; use it only to infer repo-specific filename, metadata tag, dependency, and include conventions when present):
-<include optional select="lines:299-307,lines:385-406">docs/prompting_guide.md</include>
+<include optional select="section:Best Practices,section:Relationship to Other Tags">docs/prompting_guide.md</include>
 
 % Follow these rules:
     - CRITICAL: You MUST analyze the actual code provided in code_under_test and generate tests for the EXACT public functions/classes defined in that code.


### PR DESCRIPTION
## Summary
- `docs/prompting_guide.md` is duplicated in two paths (top-level `docs/`, ~1817 lines; package-data `pdd/docs/`, ~914 lines). `PathResolver.resolve_include` falls through to the package copy whenever CWD has no local `docs/`, so `pdd test` invoked from a regression staging dir reads a different file than the unit tests do.
- Static `lines:N-M` ranges only fit one of the two files: the previous `lines:299-307,lines:385-406` hit unescaped `{`/`}` in the top-level copy (orphan `}` broke `str.format()` in `chunk_7`), and any line-number recalibration runs off the end of the package copy (regression `case_8` got an empty include → LLM returned no content).
- Switching to `section:Best Practices,section:Relationship to Other Tags` binds to headings present in both copies with brace-free bodies — robust to either resolution.

## Test plan
- [x] Local format-string diagnostic from both CWDs (repo root → top-level file; `/tmp` → package file): both preprocess and `prompt.format()` cleanly.
- [x] `make test-pdd-cli-release` (full Cloud Batch run, 77 tasks + llm-smoke): `cloud-test rc=0, llm-smoke rc=0`, both phases pass.
- [ ] Reviewer: confirm no other prompt files in `pdd/prompts/` depend on the old `lines:` ranges of `docs/prompting_guide.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)