### PR TITLE
feat(ci): rewrite release notes with Claude Code before Discord post

### DIFF
--- a/.github/workflows/backfill-release-notes.yml
+++ b/.github/workflows/backfill-release-notes.yml
@@ -1,0 +1,108 @@
+name: Backfill release notes with Claude Code
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to regenerate notes for (e.g. v0.0.249)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  rewrite-notes:
+    runs-on: ubuntu-latest
+    env:
+      HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' && 'true' || 'false' }}
+    steps:
+      - name: Fail if OAuth token missing
+        if: env.HAS_CLAUDE_OAUTH != 'true'
+        run: |
+          echo "::error::CLAUDE_CODE_OAUTH_TOKEN secret is not set."
+          exit 1
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Rewrite release notes with Claude Code
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="$TAG"
+          if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "::error::Tag ${tag} does not exist."
+            exit 1
+          fi
+          prev_tag=$(git describe --tags --abbrev=0 "${tag}^" 2>/dev/null || true)
+          if [ -z "$prev_tag" ]; then
+            echo "::error::No previous tag found before ${tag}."
+            exit 1
+          fi
+          echo "Summarizing ${prev_tag}..${tag} with Claude Code."
+
+          npm install -g @anthropic-ai/claude-code@2.1.150
+
+          commits=$(git log "${prev_tag}..${tag}" --pretty=format:'- %s (%h)')
+          stats=$(git diff --stat "${prev_tag}..${tag}")
+          diff=$(git diff "${prev_tag}..${tag}" \
+            -- ':(exclude)*.lock' ':(exclude)package-lock.json' \
+               ':(exclude)*test-durations.json' ':(exclude)dist/*' \
+               ':(exclude)*.min.js' ':(exclude)*.snap' \
+            | head -c 80000)
+
+          prompt_file=$(mktemp)
+          {
+            printf '%s\n' \
+              'Write concise, accurate, user-facing release notes for a CLI tool from the' \
+              'context below. Audience: developers using the `pdd` CLI.' \
+              '' \
+              'Format (markdown, no code fences around the whole thing):' \
+              '- One-line summary at the top.' \
+              '- Then sections "### Features", "### Fixes", "### Internal" — omit any' \
+              '  section that has no entries.' \
+              '- 1-7 bullets per section, each a single short sentence describing' \
+              '  user-visible behavior. Reference PR/issue numbers if shown in the' \
+              '  commit messages (e.g. "#1015"). Skip pure CI/test-infra churn unless' \
+              '  it changes observable behavior.' \
+              '' \
+              'Do not invent changes. If the diff is dominated by one theme, lead with' \
+              'it. Output only the release notes — no preamble, no sign-off.' \
+              '' \
+              'CONTEXT:'
+            printf '\nCommits:\n%s\n\nFiles changed:\n%s\n\nDiff (truncated):\n%s\n' \
+              "$commits" "$stats" "$diff"
+          } >"$prompt_file"
+
+          notes_file=$(mktemp --suffix=.md)
+          claude -p \
+              --model sonnet \
+              --tools "" \
+              --no-session-persistence \
+              --output-format text \
+              <"$prompt_file" >"$notes_file"
+
+          if [ ! -s "$notes_file" ]; then
+            echo "::error::Claude Code produced no output."
+            exit 1
+          fi
+
+          echo "--- New release notes ---"
+          cat "$notes_file"
+          echo "-------------------------"
+          gh release edit "$tag" --notes-file "$notes_file"
+          echo "Updated release notes for $tag."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    env:
+      HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -85,6 +87,82 @@ jobs:
           else
             gh release create "$tag" --generate-notes --verify-tag --target main
           fi
+
+      - name: Setup Node for Claude Code
+        if: env.HAS_CLAUDE_OAUTH == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Rewrite release notes with Claude Code
+        if: env.HAS_CLAUDE_OAUTH == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ github.ref_name }}"
+          prev_tag=$(git describe --tags --abbrev=0 "${tag}^" 2>/dev/null || true)
+          if [ -z "$prev_tag" ]; then
+            echo "No previous tag found; keeping auto-generated notes."
+            exit 0
+          fi
+          echo "Summarizing ${prev_tag}..${tag} with Claude Code."
+
+          npm install -g @anthropic-ai/claude-code@2.1.150
+
+          # Build context: commit log, diff stat, filtered/truncated diff.
+          commits=$(git log "${prev_tag}..${tag}" --pretty=format:'- %s (%h)')
+          stats=$(git diff --stat "${prev_tag}..${tag}")
+          diff=$(git diff "${prev_tag}..${tag}" \
+            -- ':(exclude)*.lock' ':(exclude)package-lock.json' \
+               ':(exclude)*test-durations.json' ':(exclude)dist/*' \
+               ':(exclude)*.min.js' ':(exclude)*.snap' \
+            | head -c 80000)
+
+          prompt_file=$(mktemp)
+          {
+            printf '%s\n' \
+              'Write concise, accurate, user-facing release notes for a CLI tool from the' \
+              'context below. Audience: developers using the `pdd` CLI.' \
+              '' \
+              'Format (markdown, no code fences around the whole thing):' \
+              '- One-line summary at the top.' \
+              '- Then sections "### Features", "### Fixes", "### Internal" — omit any' \
+              '  section that has no entries.' \
+              '- 1-7 bullets per section, each a single short sentence describing' \
+              '  user-visible behavior. Reference PR/issue numbers if shown in the' \
+              '  commit messages (e.g. "#1015"). Skip pure CI/test-infra churn unless' \
+              '  it changes observable behavior.' \
+              '' \
+              'Do not invent changes. If the diff is dominated by one theme, lead with' \
+              'it. Output only the release notes — no preamble, no sign-off.' \
+              '' \
+              'CONTEXT:'
+            printf '\nCommits:\n%s\n\nFiles changed:\n%s\n\nDiff (truncated):\n%s\n' \
+              "$commits" "$stats" "$diff"
+          } >"$prompt_file"
+
+          notes_file=$(mktemp --suffix=.md)
+          if ! claude -p \
+                --model sonnet \
+                --tools "" \
+                --no-session-persistence \
+                --output-format text \
+                <"$prompt_file" >"$notes_file"; then
+            echo "Claude Code failed; keeping auto-generated notes."
+            exit 0
+          fi
+          if [ ! -s "$notes_file" ]; then
+            echo "Claude Code produced no output; keeping auto-generated notes."
+            exit 0
+          fi
+
+          echo "--- New release notes ---"
+          cat "$notes_file"
+          echo "-------------------------"
+          gh release edit "$tag" --notes-file "$notes_file"
+          echo "Updated release notes for $tag."
 
       - name: Post release notes to Discord
         env:


### PR DESCRIPTION
## Summary
- The `release.yml` workflow now feeds the commit log + filtered diff to `claude -p` (OAuth-authenticated via `CLAUDE_CODE_OAUTH_TOKEN`) between the "create release" and "post to Discord" steps, and overwrites the auto-generated GitHub Release body with a categorized summary. Falls through to the auto-generated notes if the secret is absent or claude fails.
- Adds `backfill-release-notes.yml`, a `workflow_dispatch`-only workflow that re-summarizes any existing tag — both a validation surface and a one-off fix tool.

## Test plan
- [x] Local dry-run on `v0.0.248..v0.0.249` produced clean release notes summarizing the sync gates work in #1015 (Features/Fixes/Internal sections, PR references, no merge-title noise).
- [ ] After merge, trigger `Backfill release notes with Claude Code` against `v0.0.249` to validate the full CI path (npm install + OAuth + `claude -p` + `gh release edit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)