### PR TITLE
fix(ci): avoid SIGPIPE in release-notes diff truncation

### DIFF
--- a/.github/workflows/backfill-release-notes.yml
+++ b/.github/workflows/backfill-release-notes.yml
@@ -57,13 +57,18 @@ jobs:
 
           npm install -g @anthropic-ai/claude-code@2.1.150
 
+          # Write full diff to a file then truncate via head-from-file to
+          # avoid SIGPIPE under `set -o pipefail` (git diff sees EPIPE when
+          # `head -c` closes stdin after 80KB).
           commits=$(git log "${prev_tag}..${tag}" --pretty=format:'- %s (%h)')
           stats=$(git diff --stat "${prev_tag}..${tag}")
-          diff=$(git diff "${prev_tag}..${tag}" \
+          diff_full=$(mktemp)
+          git diff "${prev_tag}..${tag}" \
             -- ':(exclude)*.lock' ':(exclude)package-lock.json' \
                ':(exclude)*test-durations.json' ':(exclude)dist/*' \
                ':(exclude)*.min.js' ':(exclude)*.snap' \
-            | head -c 80000)
+            >"$diff_full"
+          diff=$(head -c 80000 "$diff_full")
 
           prompt_file=$(mktemp)
           {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,13 +112,18 @@ jobs:
           npm install -g @anthropic-ai/claude-code@2.1.150
 
           # Build context: commit log, diff stat, filtered/truncated diff.
+          # Write full diff to a file then truncate via head-from-file to
+          # avoid SIGPIPE under `set -o pipefail` (git diff sees EPIPE when
+          # `head -c` closes stdin after 80KB).
           commits=$(git log "${prev_tag}..${tag}" --pretty=format:'- %s (%h)')
           stats=$(git diff --stat "${prev_tag}..${tag}")
-          diff=$(git diff "${prev_tag}..${tag}" \
+          diff_full=$(mktemp)
+          git diff "${prev_tag}..${tag}" \
             -- ':(exclude)*.lock' ':(exclude)package-lock.json' \
                ':(exclude)*test-durations.json' ':(exclude)dist/*' \
                ':(exclude)*.min.js' ':(exclude)*.snap' \
-            | head -c 80000)
+            >"$diff_full"
+          diff=$(head -c 80000 "$diff_full")
 
           prompt_file=$(mktemp)
           {


### PR DESCRIPTION
## Summary
- `git diff … | head -c 80000` under `set -o pipefail` makes `git diff` exit 141 (SIGPIPE) when `head` closes its stdin after 80KB. Repro: backfill run 26369862599 failed immediately after `npm install` with no other output.
- Fix: write the full filtered diff to a temp file, then `head -c 80000` from the file — no pipe involved. Applied to both `release.yml` and `backfill-release-notes.yml`.

## Test plan
- [ ] After merge, re-trigger `Backfill release notes with Claude Code` against `v0.0.249` to confirm the step now completes and `gh release edit` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)