### PR TITLE
chore(ci): bump GitHub Actions to Node-24 majors (clear deprecation warning)

### DIFF
--- a/.github/workflows/backfill-release-notes.yml
+++ b/.github/workflows/backfill-release-notes.yml
@@ -27,12 +27,12 @@ jobs:
           echo "::error::CLAUDE_CODE_OAUTH_TOKEN secret is not set."
           exit 1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/pdd-secrets-dispatch.yml
+++ b/.github/workflows/pdd-secrets-dispatch.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -55,11 +55,11 @@ jobs:
     env:
       HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' && 'true' || 'false' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Setup Node for Claude Code
         if: env.HAS_CLAUDE_OAUTH == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,12 +36,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -87,12 +87,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -120,12 +120,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'


### PR DESCRIPTION
## Summary
- Pin first-party JS actions to their latest major (v6), which declares `using: 'node24'` in `action.yml` and clears the *"Node.js 20 actions are deprecated"* annotation surfaced on every recent workflow run.
- Inputs in use (`python-version`, `node-version`, `fetch-depth`, `cache`) are unchanged across v4/v5 → v6, so this is a drop-in upgrade.
- SHA-pinned `actions/create-github-app-token` in `auto-heal.yml` is intentionally left alone (security pinning).

### Bumps
| Action | From | To | Files |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | release, backfill-release-notes, unit-tests |
| `actions/setup-node` | `@v4` | `@v6` | release, backfill-release-notes |
| `actions/setup-python` | `@v5` | `@v6` | release, unit-tests, pdd-secrets-dispatch |

## Test plan
- [ ] `auto-heal`, `Analyze`, `Public CLI Regression`, `Run Unit Tests`, `Package Preprocess Smoke` all green on this PR.
- [ ] No Node-20 deprecation annotation in the PR's check logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)