### PR TITLE
docs(ci): update SHA-pin comment to v3.2.0 in auto-heal

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Mint pdd_cloud App token
         if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
         id: app_token
-        # SHA-pinned to v3.1.1 (https://github.com/actions/create-github-app-token/releases/tag/v3.1.1)
+        # SHA-pinned to v3.2.0 (https://github.com/actions/create-github-app-token/releases/tag/v3.2.0)
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           app-id: ${{ secrets.PDD_CLOUD_APP_ID }}


### PR DESCRIPTION
## Summary
- PR #1166 (Dependabot) bumped the `actions/create-github-app-token` SHA from v3.1.1's commit to v3.2.0's commit, but Dependabot can't update freeform comments. The inline `# SHA-pinned to v3.1.1` on `auto-heal.yml:186` was left stale.
- This PR realigns the comment with the actual SHA (`bcd2ba49…` is v3.2.0's commit). Pure documentation, no behavior change.

## Test plan
- [x] Comment URL points to a real `actions/create-github-app-token` release page.
- [ ] `auto-heal` passes (the same workflow being edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)