### PR TITLE
fix(opus-4-7): force adaptive shape on Vertex transform_request for ALL opus-4-7 calls

### DIFF
--- a/.pdd/meta/llm_invoke_python.json
+++ b/.pdd/meta/llm_invoke_python.json
@@ -1,10 +1,10 @@
 {
   "pdd_version": "0.0.250",
-  "timestamp": "2026-05-26T06:29:38.979243+00:00",
+  "timestamp": "2026-05-26T07:25:25.605027+00:00",
   "command": "example",
   "prompt_hash": "b409c7b353bbce6bbe8c0d2e6badaf35acdc80b33eb22846844903caf9bf6b53",
-  "code_hash": "80ae4817086ba6c47c9179a0c890bc2afd95781b7363b40d354c596fa9cdf2a2",
-  "example_hash": "147548be677fcfddb4eadcf9fe12c27a277d83cb96492e9735076b3a438d8b2f",
+  "code_hash": "645840f41232e02bee8ab97959bccfda335ce962b07873365cac712228e746c0",
+  "example_hash": "675909d758ad7b5e49a7700f30eaa46fcff91981fe518e8c9b9c97b4831f5251",
   "test_hash": "cfddf7abd6c630e26764efe03d1c4d62c75973b1f60d7c04e87264fb86d0ca7a",
   "test_files": {
     "test_llm_invoke.py": "cfddf7abd6c630e26764efe03d1c4d62c75973b1f60d7c04e87264fb86d0ca7a",

--- a/context/llm_invoke_example.py
+++ b/context/llm_invoke_example.py
@@ -1,45 +1,86 @@
 import os
 import sys
-from typing import Dict, Any
-from pdd.llm_invoke import llm_invoke
+from pydantic import BaseModel
 
-def main() -> None:
-    """Example script demonstrating how to use llm_invoke."""
-    # Check for a required API key to avoid interactive prompts in headless mode
+# Import the llm_invoke function and logging utility from the pdd package
+from pdd.llm_invoke import llm_invoke, set_quiet_logging
+
+
+def main():
+    """
+    Demonstrate the usage of llm_invoke for basic generation, 
+    structured output, and batch processing.
+    """
+    # Check for required API key before attempting LLM calls.
+    # The specific key required depends on your PDD_MODEL_DEFAULT or local llm_model.csv
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         print("OPENAI_API_KEY not set. Set it to run this example.")
         sys.exit(0)
 
-    print("--- Basic LLM Invocation ---")
-    
-    # Define the prompt template and the input variables
-    prompt_template = "Write a one-sentence greeting for a user named {name} from a {role}."
-    input_vars = {
-        "name": "Alice",
-        "role": "friendly robot"
-    }
-    
-    # Call llm_invoke with standard parameters
-    # - strength (0.0 to 1.0): Determines model selection (0=cheapest, 0.5=base, 1=highest ELO)
-    # - temperature: Controls randomness of the output
-    # - time: Controls reasoning effort/budget (0.0 to 1.0)
-    response: Dict[str, Any] = llm_invoke(
-        prompt=prompt_template,
-        input_json=input_vars,
-        strength=0.5,
-        temperature=0.7,
-        time=0.25,
-        verbose=True
+    # Optionally suppress noisy logs from LiteLLM
+    set_quiet_logging()
+
+    print("--- Example 1: Basic Text Generation ---")
+    # Uses string formatting based on input_json dictionary
+    response = llm_invoke(
+        prompt="Write a one-sentence fun fact about {topic}.",
+        input_json={"topic": "space"},
+        strength=0.5,       # 0.0 = cheapest, 0.5 = base model, 1.0 = highest ELO
+        temperature=0.7,    # Creativity parameter
+        verbose=False
     )
     
-    # Extract and display the outputs
-    print("\n--- Output Results ---")
-    print(f"Result Content: {response.get('result')}")
+    print(f"Result: {response.get('result')}")
     print(f"Model Used: {response.get('model_name')}")
-    print(f"Estimated Cost: ${response.get('cost'):.6f}")
-    print(f"Finish Reason: {response.get('finish_reason')}")
-    print(f"Models Attempted: {response.get('attempted_models')}")
+    print(f"Cost: ${response.get('cost', 0):.6f}")
+
+
+    print("\n--- Example 2: Structured Output (Pydantic) ---")
+    # Define a Pydantic model for the expected output structure
+    class AnimalFact(BaseModel):
+        animal_name: str
+        lifespan_years: int
+        is_mammal: bool
+
+    # The LLM will be instructed to return a JSON matching this schema
+    response_structured = llm_invoke(
+        prompt="Give me a fact about a {animal}.",
+        input_json={"animal": "kangaroo"},
+        strength=0.5,
+        temperature=0.1,    # Lower temperature for structured data is recommended
+        output_pydantic=AnimalFact
+    )
+
+    result_obj = response_structured.get('result')
+    if isinstance(result_obj, AnimalFact):
+        print(f"Name: {result_obj.animal_name}")
+        print(f"Lifespan: {result_obj.lifespan_years} years")
+        print(f"Mammal: {result_obj.is_mammal}")
+    else:
+        print("Failed to parse into Pydantic model:", result_obj)
+
+
+    print("\n--- Example 3: Batch Processing ---")
+    # Pass a list of dictionaries to process multiple prompts concurrently
+    batch_inputs = [
+        {"word": "happy"},
+        {"word": "sad"},
+        {"word": "angry"}
+    ]
+    
+    response_batch = llm_invoke(
+        prompt="What is a common synonym for {word}? Reply with just one word.",
+        input_json=batch_inputs,
+        use_batch_mode=True,
+        strength=0.1,       # Opt for a cheaper/faster model for bulk tasks
+        temperature=0.3
+    )
+    
+    print("Batch Results (list of strings):")
+    for idx, res in enumerate(response_batch.get('result', [])):
+        print(f"  Input '{batch_inputs[idx]['word']}': {res.strip()}")
+
 
 if __name__ == "__main__":
     main()

--- a/pdd/llm_invoke.py
+++ b/pdd/llm_invoke.py
@@ -284,18 +284,73 @@ try:
     if not getattr(_existing_vertex_transform, "_pdd_opus_4_7_vertex_patched", False):
         _orig_vertex_transform = _existing_vertex_transform
         _VERTEX_OPUS_47_ALIASES = ("opus-4-7", "opus_4_7", "opus-4.7", "opus_4.7")
+        # Map LiteLLM "low/medium/high/max" reasoning_effort levels back to a
+        # default `output_config.effort` value when none is present on the
+        # incoming request. This mirrors what LiteLLM's map_openai_params
+        # does — we replicate it here so retry-path calls that bypass
+        # map_openai_params still get a sensible effort hint.
+        def _effort_from_budget_tokens(budget_tokens):
+            try:
+                bt = int(budget_tokens or 0)
+            except Exception:  # pylint: disable=broad-except
+                return "high"
+            # Anthropic's documented buckets:
+            #   minimal/low: 1024, medium: 4096, high: 8192, max: 16384+
+            if bt >= 16384:
+                return "max"
+            if bt >= 8192:
+                return "high"
+            if bt >= 4096:
+                return "medium"
+            return "low"
+
         def _patched_vertex_transform(self, model, messages, optional_params, litellm_params, headers):  # pylint: disable=function-redefined
             data = _orig_vertex_transform(self, model, messages, optional_params, litellm_params, headers)
             m = model.lower() if isinstance(model, str) else ""
             if not any(a in m for a in _VERTEX_OPUS_47_ALIASES):
                 return data
-            # The original transform_request popped output_config from `data`;
-            # restore it from optional_params so Vertex receives the
-            # thinking.type.adaptive + output_config.effort pair Opus 4.7
-            # actually requires.
-            oc = optional_params.get("output_config") if isinstance(optional_params, dict) else None
-            if isinstance(oc, dict) and "output_config" not in data:
-                data["output_config"] = oc
+            # Vertex AI Opus 4.7 rejects the legacy `thinking.type.enabled`
+            # shape entirely; the API instructs callers to use
+            # `thinking.type.adaptive` + `output_config.effort`. Force this
+            # shape unconditionally for opus-4-7 because:
+            #
+            #   * map_openai_params produces the right shape on the first
+            #     call (predicate + restore-output_config patches both fire),
+            #     but LiteLLM's `num_retries` retry path re-enters
+            #     transform_request with a stale `optional_params` dict that
+            #     carries `thinking={type:enabled,budget_tokens:N}` and no
+            #     output_config. Without unconditional rewrite here, the
+            #     retry call goes out with the legacy shape and Vertex 400s.
+            #
+            #   * Other code paths (compact-mode retry, fallback budget
+            #     calculation, anything that calls litellm.completion()
+            #     directly with thinking={"type":"enabled",...}) hit the
+            #     same wire if not normalized here.
+            current_thinking = data.get("thinking")
+            budget_tokens = None
+            if isinstance(current_thinking, dict):
+                if current_thinking.get("type") == "enabled":
+                    budget_tokens = current_thinking.get("budget_tokens")
+                    data["thinking"] = {"type": "adaptive"}
+            else:
+                data["thinking"] = {"type": "adaptive"}
+            # output_config: prefer caller's value, else derive from
+            # reasoning_effort/budget_tokens, else default to "high".
+            if "output_config" not in data:
+                oc = optional_params.get("output_config") if isinstance(optional_params, dict) else None
+                if isinstance(oc, dict):
+                    data["output_config"] = oc
+                else:
+                    effort = None
+                    if isinstance(optional_params, dict):
+                        re_effort = optional_params.get("reasoning_effort")
+                        if isinstance(re_effort, str):
+                            effort = re_effort
+                    if effort is None and budget_tokens is not None:
+                        effort = _effort_from_budget_tokens(budget_tokens)
+                    if effort is None:
+                        effort = "high"
+                    data["output_config"] = {"effort": effort}
             return data
         _patched_vertex_transform._pdd_opus_4_7_vertex_patched = True
         _VertexAIAnthropicConfigOpus47.transform_request = _patched_vertex_transform


### PR DESCRIPTION
## Summary

- PR #1195 fixed the **first** transform_request call but missed the retry path.
- LiteLLM's `num_retries` retries re-enter transform_request with a stale `optional_params` dict — `thinking={type:enabled,budget_tokens:N}` and no `output_config`. PR #1195's conditional restore couldn't help because `optional_params.output_config` was also gone.
- Verified locally: first call succeeds, retries 400 with same Vertex error → release-gate smoke keeps failing.
- This PR makes the wrap **unconditionally normalize** the wire body for opus-4-7: enabled→adaptive, derive output_config.effort from any available signal.

## Repro

Traced via `pdd --local --force sync hello` (real staging Vertex SA, dev6 with PRs #1193+#1194+#1195 merged):

```
CALL 1: thinking={type:adaptive}, output_config={effort:low}   → SUCCESS
CALL 2: optional_params.thinking={type:enabled,budget_tokens:1024}
        optional_params.output_config=null
        → body.thinking={type:enabled,budget_tokens:1024}
        → body.output_config=null
        → Vertex 400 "thinking.type.enabled is not supported"
```

CALLs 3, 4: identical to CALL 2. The retry path enters transform_request bypassing the patched `map_openai_params`.

## What changed

The Vertex `transform_request` wrap (added in PR #1195) now unconditionally rewrites for opus-4-7:

1. **Thinking shape**: if `data["thinking"]` is `{type:enabled,...}`, replace with `{type:adaptive}`. Capture `budget_tokens` for effort derivation.
2. **Output config**: if `data["output_config"]` is missing, pick the best available effort hint:
   - `optional_params["output_config"]` (PR #1195's path)
   - `optional_params["reasoning_effort"]` (string)
   - Effort derived from `budget_tokens` via Anthropic's standard bucket mapping (1024→low, 4096→medium, 8192→high, 16384+→max)
   - Fallback `"high"`

Non-opus-4-7 models pass through LiteLLM's native behavior untouched (sonnet-4-6 confirmed).

## Verified

End-to-end local smoke against real staging Vertex:

```
INFO: [SUCCESS] Invocation successful for vertex_ai/claude-opus-4-7 (took 5.78s)
INFO: [SUCCESS] Invocation successful for vertex_ai/claude-opus-4-7 (took 2.78s)
INFO: [SUCCESS] Invocation successful for vertex_ai/claude-opus-4-7 (took 5.49s)
SUCCESS: generated hello module runs correctly
```

3 sequential Opus 4.7 invocations (generate + example + test phases) all succeed; the hello module is generated and runs.

## Test plan

- [x] direct unit-style: retry-path scenario (enabled+null → adaptive+effort), first-call scenario (preserved), sonnet-4-6 (unchanged)
- [x] end-to-end local smoke against real staging Vertex API: all 3 Opus 4.7 calls succeed
- [ ] downstream: pdd_cloud `make test-pdd-cli-release` rerun once merged — expected to be the round where smoke finally goes green

## Risks / out-of-scope

- Same Azure caveat as #1193 / #1194 / #1195 (out of scope — AzureAIStudioConfig doesn't inherit from AnthropicConfig).
- The wrap is purely additive — only normalizes when model is opus-4-7. Non-opus traffic unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)