### PR TITLE
fix(ci): skip tests/fixtures in cloud-batch chunking + isolate PDD_QUIET leak

### DIFF
--- a/ci/cloud-batch/balance-chunks.py
+++ b/ci/cloud-batch/balance-chunks.py
@@ -37,14 +37,16 @@ HEAVY_FILE_THRESHOLD_DEFAULT = 300.0
 
 
 def _should_include_test_file(path: Path) -> bool:
-    """Exclude fixture-only test trees that are not part of the runnable suite."""
-    parts = path.parts
-    if "fixtures" in parts:
-        fixtures_idx = parts.index("fixtures")
-        fixture_subtree = parts[fixtures_idx + 1 :]
-        if fixture_subtree[:1] == ("one_session_eval",):
-            return False
-    return True
+    """Exclude fixture-only test trees that are not part of the runnable suite.
+
+    Everything under a ``fixtures/`` directory is scenario data for higher-level
+    tests (one-session eval, coverage contracts, etc.) and is excluded from
+    pytest collection by ``tests/fixtures/conftest.py``. Such files must never be
+    packed into a chunk: an explicit path on the pytest command line bypasses
+    ``collect_ignore_glob``, and some fixtures are intentionally broken (e.g.
+    syntax-error files used to exercise failed-state handling).
+    """
+    return "fixtures" not in path.parts
 
 
 def discover_test_files(test_dir: str) -> list[str]:

--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -383,7 +383,7 @@ if [ "${TASK_INDEX}" -ge "${PYTEST_START}" ] && [ "${TASK_INDEX}" -le "${PYTEST_
             mapfile -t CHUNK_TESTS < "${ASSIGN_OUTPUT}"
         else
             echo "=== balance-chunks.py failed, falling back to alphabetical split ==="
-            mapfile -t ALL_TESTS < <(find tests/ -name 'test_*.py' ! -path 'tests/fixtures/one_session_eval/*' | sort)
+            mapfile -t ALL_TESTS < <(find tests/ -name 'test_*.py' ! -path 'tests/fixtures/*' | sort)
             TOTAL=${#ALL_TESTS[@]}
             CHUNK_SIZE=$(( (TOTAL + PYTEST_CHUNKS - 1) / PYTEST_CHUNKS ))
             START_IDX=$(( CHUNK_INDEX * CHUNK_SIZE ))
@@ -393,7 +393,7 @@ if [ "${TASK_INDEX}" -ge "${PYTEST_START}" ] && [ "${TASK_INDEX}" -le "${PYTEST_
     else
         # Fallback: alphabetical split
         echo "=== No durations file, using alphabetical split ==="
-        mapfile -t ALL_TESTS < <(find tests/ -name 'test_*.py' ! -path 'tests/fixtures/one_session_eval/*' | sort)
+        mapfile -t ALL_TESTS < <(find tests/ -name 'test_*.py' ! -path 'tests/fixtures/*' | sort)
         TOTAL=${#ALL_TESTS[@]}
         CHUNK_SIZE=$(( (TOTAL + PYTEST_CHUNKS - 1) / PYTEST_CHUNKS ))
         START_IDX=$(( CHUNK_INDEX * CHUNK_SIZE ))
@@ -407,7 +407,7 @@ if [ "${TASK_INDEX}" -ge "${PYTEST_START}" ] && [ "${TASK_INDEX}" -le "${PYTEST_
         exit 0
     fi
 
-    TOTAL_FILES=$(find tests/ -name 'test_*.py' ! -path 'tests/fixtures/one_session_eval/*' | wc -l)
+    TOTAL_FILES=$(find tests/ -name 'test_*.py' ! -path 'tests/fixtures/*' | wc -l)
     echo "=== Pytest chunk ${CHUNK_INDEX}: ${#CHUNK_TESTS[@]} files (of ${TOTAL_FILES} total) ==="
     printf '  %s\n' "${CHUNK_TESTS[@]}"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,26 @@ def _enforce_isolated_home(monkeypatch):
     monkeypatch.setenv("CODEX_HOME", os.path.join(_PYTEST_FAKE_HOME, ".codex"))
 
 
+@pytest.fixture(autouse=True)
+def _isolate_pdd_quiet():
+    """Restore PDD_QUIET after each test so ``--quiet`` CLI runs don't leak.
+
+    The CLI group callback writes ``os.environ["PDD_QUIET"] = "1"`` directly
+    when ``--quiet`` is passed (pdd/core/cli.py). In-process ``CliRunner``
+    tests therefore mutate the global environment and never undo it. Without
+    cleanup the flag leaks into later tests in the same process and silences
+    the Rich console output they assert on (e.g. test_preprocess.py's
+    unresolved-include warnings), producing order-dependent failures once
+    cloud-batch packs the leaking test into the same chunk.
+    """
+    saved = os.environ.get("PDD_QUIET")
+    yield
+    if saved is None:
+        os.environ.pop("PDD_QUIET", None)
+    else:
+        os.environ["PDD_QUIET"] = saved
+
+
 @pytest.fixture(scope="session")
 def sandbox_home() -> Path:
     """Expose the session-scoped fake HOME pinned at conftest import time.


### PR DESCRIPTION
## Summary

Fixes the two failures the cloud-batch release suite (`make test-pdd-cli-release`) hit on `main` — both in the cloud-batch chunked runner, neither reproducible under a plain `pytest tests/`.

**1. Broken fixture crashed chunk collection.** Chunk file discovery (`balance-chunks.py`, and the `entrypoint.sh` fallbacks) hands pytest **explicit file paths**, which bypass `collect_ignore_glob`. The exclusion only skipped `tests/fixtures/one_session_eval/`, so the intentionally broken-syntax `tests/fixtures/coverage_contracts/fake_tests/test_receipt_failed.py` got packed into a chunk and aborted collection with a `SyntaxError`. Now the entire `tests/fixtures/` subtree is excluded from discovery, matching `tests/fixtures/conftest.py`'s `collect_ignore_glob = ["*"]` intent. `tests/test_739_fixtures.py` (a real top-level test, no `fixtures/` path component) is unaffected.

**2. `PDD_QUIET` leaked across tests.** In-process `CliRunner` tests that pass `--quiet` trigger the CLI group callback's `os.environ["PDD_QUIET"] = "1"` write (`pdd/core/cli.py`), which is never undone. Once cloud-batch packed such a test (`test_e2e_issue_1205_example_output_extension.py`) ahead of `test_preprocess.py` in the same chunk, quiet mode silenced the Rich console warning that 4 `test_unresolved_include_*` tests assert on `capsys.out`. Added an autouse `_isolate_pdd_quiet` fixture that snapshots/restores `PDD_QUIET` per test — same pattern as the existing `_enforce_isolated_home` / `preserve_cwd` isolation fixtures. Fixes the whole class (9 test files do in-process `--quiet` CLI calls).

## Test plan

- [x] `make test-pdd-cli-release` (cloud-batch, 77 tasks): **77 passed, 0 failed** (was 75/77).
- [x] Leaker file + all 4 `test_unresolved_include_*` in one process: 9 passed (failed before the fix).
- [x] `test_preprocess.py` + `test_quiet_flag.py`: 138 passed (quiet-mode tests not regressed).
- [x] `balance-chunks.py` discovery excludes all `tests/fixtures/*`, keeps `test_739_fixtures.py`.
- [x] `bash -n entrypoint.sh` + `py_compile balance-chunks.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)