### PR TITLE
fix(ci): preserve contributor attribution in release notes

### DIFF
--- a/.github/workflows/backfill-release-notes.yml
+++ b/.github/workflows/backfill-release-notes.yml
@@ -53,6 +53,11 @@ jobs:
             echo "::error::No previous tag found before ${tag}."
             exit 1
           fi
+          # Compute GitHub's auto-generated notes (What's Changed / PR authors /
+          # New Contributors) for this range so we can append their contributor
+          # attribution below the AI summary.
+          auto_notes=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="$tag" -f previous_tag_name="$prev_tag" --jq .body 2>/dev/null || true)
           echo "Summarizing ${prev_tag}..${tag} with Claude Code."
 
           npm install -g @anthropic-ai/claude-code@2.1.150
@@ -106,8 +111,19 @@ jobs:
             exit 1
           fi
 
+          # Append GitHub's auto-generated attribution (What's Changed /
+          # New Contributors / Full Changelog) below the AI summary so
+          # contributor credit is preserved.
+          final_file=$(mktemp --suffix=.md)
+          {
+            cat "$notes_file"
+            if [ -n "$auto_notes" ]; then
+              printf '\n\n---\n\n%s\n' "$auto_notes"
+            fi
+          } >"$final_file"
+
           echo "--- New release notes ---"
-          cat "$notes_file"
+          cat "$final_file"
           echo "-------------------------"
-          gh release edit "$tag" --notes-file "$notes_file"
+          gh release edit "$tag" --notes-file "$final_file"
           echo "Updated release notes for $tag."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,11 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ github.ref_name }}"
+          # Preserve GitHub's auto-generated notes (created by the previous
+          # step) so we can append their contributor attribution
+          # ("What's Changed", PR authors, "New Contributors") below the AI
+          # summary instead of discarding it.
+          auto_notes=$(gh release view "$tag" --json body --jq .body 2>/dev/null || true)
           prev_tag=$(git describe --tags --abbrev=0 "${tag}^" 2>/dev/null || true)
           if [ -z "$prev_tag" ]; then
             echo "No previous tag found; keeping auto-generated notes."
@@ -163,10 +168,21 @@ jobs:
             exit 0
           fi
 
+          # Append GitHub's auto-generated attribution (What's Changed /
+          # New Contributors / Full Changelog) below the AI summary so
+          # contributor credit is preserved.
+          final_file=$(mktemp --suffix=.md)
+          {
+            cat "$notes_file"
+            if [ -n "$auto_notes" ]; then
+              printf '\n\n---\n\n%s\n' "$auto_notes"
+            fi
+          } >"$final_file"
+
           echo "--- New release notes ---"
-          cat "$notes_file"
+          cat "$final_file"
           echo "-------------------------"
-          gh release edit "$tag" --notes-file "$notes_file"
+          gh release edit "$tag" --notes-file "$final_file"
           echo "Updated release notes for $tag."
 
       - name: Post release notes to Discord

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,16 +102,20 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ github.ref_name }}"
-          # Preserve GitHub's auto-generated notes (created by the previous
-          # step) so we can append their contributor attribution
-          # ("What's Changed", PR authors, "New Contributors") below the AI
-          # summary instead of discarding it.
-          auto_notes=$(gh release view "$tag" --json body --jq .body 2>/dev/null || true)
           prev_tag=$(git describe --tags --abbrev=0 "${tag}^" 2>/dev/null || true)
           if [ -z "$prev_tag" ]; then
             echo "No previous tag found; keeping auto-generated notes."
             exit 0
           fi
+          # Regenerate GitHub's auto-generated notes (What's Changed / PR
+          # authors / New Contributors) fresh from the tag range so we can
+          # append their contributor attribution below the AI summary.
+          # We deliberately do NOT read the existing release body: on a
+          # workflow re-run it may already be "AI summary + appended
+          # auto-notes", and re-appending it would duplicate the notes and
+          # break the idempotent release path. Matches backfill-release-notes.yml.
+          auto_notes=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="$tag" -f previous_tag_name="$prev_tag" --jq .body 2>/dev/null || true)
           echo "Summarizing ${prev_tag}..${tag} with Claude Code."
 
           npm install -g @anthropic-ai/claude-code@2.1.150


### PR DESCRIPTION
## Problem

Published GitHub Releases lost all contributor attribution. Root cause is in the release pipeline:

1. **`release.yml` → "Create GitHub Release with auto-notes"** runs `gh release create "$tag" --generate-notes`, which produces a body with `## What's Changed` (`* … by @user in #PR`) and a `## New Contributors` section.
2. **`release.yml` → "Rewrite release notes with Claude Code"** then **overwrote** that body via `gh release edit --notes-file`, replacing it with a Claude summary built only from `git log --pretty=format:'- %s (%h)'` (subject + short hash, **no author**) + a truncated diff. The prompt never asks for contributors and the context contains no author/handle data — so attribution was silently dropped.

`backfill-release-notes.yml` shares the same prompt/logic and had the same bug.

## Fix

Keep the Claude summary on top and **append** GitHub's auto-generated attribution below a `---` divider instead of discarding it:

- **`release.yml`** — capture the auto-notes from the preceding `gh release create --generate-notes` step (`gh release view "$tag" --json body`) and append them after the AI summary.
- **`backfill-release-notes.yml`** — there is no `create` step, so compute attribution fresh via `gh api repos/$GITHUB_REPOSITORY/releases/generate-notes` and append the same way.

Result on the next release:

```
## Summary / ### Features / ### Fixes      ← Claude summary
---
## What's Changed
* … by @alice in #1015
## New Contributors
* @bob made their first contribution
**Full Changelog**: v0.0.248...v0.0.249
```

Attribution now uses real GitHub `@handles`/PR links, so the model can't drop it. If `CLAUDE_CODE_OAUTH_TOKEN` is unset, the rewrite step is skipped and GitHub's attributed notes are kept as-is (already correct).

## Sibling-bug check

The "overwrite auto-notes → drop attribution" pattern existed in **both** release workflows; both are fixed in this PR. No other workflow calls `gh release edit`/`--notes-file`.

## Verification

There is no pytest harness for GitHub Actions workflow logic in this repo, so the runbook's "failing test first" step is replaced by:
- `python -c "yaml.safe_load(...)"` passes for both files.
- No trailing-whitespace / structural changes outside the two steps.
- Codex adversarial review (posted as a PR comment) as the correctness gate.
- `gh api .../releases/generate-notes` requires `contents: write`; `backfill-release-notes.yml` already declares it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
