### PR TITLE
fix(core-dump): include active llm model csv

### DIFF
--- a/pdd/core/dump.py
+++ b/pdd/core/dump.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 import click
 import requests
+from pdd.path_resolution import get_default_resolver
 
 try:
     from .. import __version__
@@ -19,6 +20,8 @@ except ImportError:
     # Fallback for environments where `pdd` resolves as a namespace package.
     __version__ = "unknown"
 from .errors import console, get_core_dump_errors
+
+_PATH_RESOLUTION_ERRORS = (OSError, RuntimeError, ValueError)
 
 
 def _extract_sync_steps_from_file_contents(file_contents: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -100,6 +103,67 @@ def garbage_collect_core_dumps(keep: int = 10) -> int:
             pass
 
     return deleted
+
+
+def _detect_project_root_from_cwd_for_model_csv(max_levels: int = 5) -> Path:
+    """Search upward from CWD using the model CSV project-root markers."""
+    try:
+        current_dir = Path.cwd().resolve()
+        for _ in range(max_levels):
+            if (
+                (current_dir / ".git").exists()
+                or (current_dir / "pyproject.toml").exists()
+                or (current_dir / "data").is_dir()
+                or (current_dir / ".env").exists()
+            ):
+                return current_dir
+            parent = current_dir.parent
+            if parent == current_dir:
+                break
+            current_dir = parent
+    except _PATH_RESOLUTION_ERRORS:
+        pass
+    return Path.cwd().resolve()
+
+
+def _resolve_active_llm_model_csv() -> Optional[Path]:
+    """Return the active llm_model.csv path using llm_invoke's precedence."""
+    try:
+        user_model_csv_path = Path.home() / ".pdd" / "llm_model.csv"
+        if user_model_csv_path.is_file():
+            return user_model_csv_path.resolve()
+    except _PATH_RESOLUTION_ERRORS:
+        pass
+
+    try:
+        resolver = get_default_resolver()
+        project_root = resolver.resolve_project_root()
+        project_root_from_env = (
+            resolver.pdd_path_env is not None
+            and project_root == resolver.pdd_path_env
+        )
+        project_csv_from_env = project_root / ".pdd" / "llm_model.csv"
+        if project_root_from_env and project_csv_from_env.is_file():
+            return project_csv_from_env.resolve()
+    except _PATH_RESOLUTION_ERRORS:
+        pass
+
+    try:
+        project_root_from_cwd = _detect_project_root_from_cwd_for_model_csv()
+        project_csv_from_cwd = project_root_from_cwd / ".pdd" / "llm_model.csv"
+        if project_csv_from_cwd.is_file():
+            return project_csv_from_cwd.resolve()
+    except _PATH_RESOLUTION_ERRORS:
+        pass
+
+    try:
+        package_csv = Path(__file__).resolve().parents[1] / "data" / "llm_model.csv"
+        if package_csv.is_file():
+            return package_csv.resolve()
+    except (IndexError, OSError, RuntimeError, ValueError):
+        pass
+
+    return None
 
 
 def _write_core_dump(
@@ -189,6 +253,10 @@ def _write_core_dump(
         for config_file in config_files:
             if config_file.exists() and config_file.is_file():
                 core_dump_files.add(str(config_file.resolve()))
+
+        llm_model_csv = _resolve_active_llm_model_csv()
+        if llm_model_csv is not None:
+            core_dump_files.add(str(llm_model_csv))
 
         for file_path in core_dump_files:
             try:

--- a/pdd/prompts/core/dump_python.prompt
+++ b/pdd/prompts/core/dump_python.prompt
@@ -20,7 +20,7 @@
      - Signature: `_write_core_dump(ctx: click.Context, normalized_results: List[Any], invoked_subcommands: List[str], total_cost: float, terminal_output: Optional[str] = None) -> None`
      - Payload structure: `schema_version` (integer, currently 1), `pdd_version`, `timestamp_utc`, `argv` (without binary name), `cwd`, `platform` dict, `global_options` dict, `invoked_subcommands`, `total_cost`, `steps` list, `errors`, `environment`, `file_contents`, `terminal_output`.
      - File collection: reads from `ctx.obj["core_dump_files"]` set; 50KB size limit per file; marks binary as `<binary>`, oversized as `<too large>`, errors as `<error reading file: ...>`.
-     - Auto-includes: meta files from `.pdd/meta/` matching invoked commands; config files (`.pdd/config.json`, `.pddconfig`, `pdd.json`).
+     - Auto-includes: meta files from `.pdd/meta/` matching invoked commands; config files (`.pdd/config.json`, `.pddconfig`, `pdd.json`); the active LLM model CSV (`~/.pdd/llm_model.csv`, explicit real `$PDD_PATH/.pdd/llm_model.csv`, CWD project `.pdd/llm_model.csv`, or packaged `pdd/data/llm_model.csv`, in that order).
      - Environment filtering: only `PDD_*` vars and `VIRTUAL_ENV`, `PYTHONPATH`, `PATH`; redacts vars containing KEY, TOKEN, SECRET, PASSWORD.
 
   2. **`_get_github_token` function**:

--- a/tests/test_core_dump.py
+++ b/tests/test_core_dump.py
@@ -240,6 +240,100 @@ def test_core_dump_auto_includes_operation_log_and_run_report(tmp_path, monkeypa
     assert sync_steps[0].get("source_log")
 
 
+def test_core_dump_auto_includes_user_llm_model_csv_with_precedence(tmp_path, monkeypatch):
+    """Core dump should include the active user llm_model.csv when it exists."""
+    import json
+    from pdd.core.dump import _write_core_dump
+
+    fake_home = tmp_path / "home"
+    user_pdd_dir = fake_home / ".pdd"
+    user_pdd_dir.mkdir(parents=True)
+    user_csv = user_pdd_dir / "llm_model.csv"
+    user_csv.write_text(
+        "provider,model,input,output,coding_arena_elo,api_key\n"
+        "UserProvider,user-model,1,2,3,USER_API_KEY\n",
+        encoding="utf-8",
+    )
+
+    env_project = tmp_path / "env_project"
+    env_project_pdd = env_project / ".pdd"
+    env_project_pdd.mkdir(parents=True)
+    (env_project_pdd / "llm_model.csv").write_text("env csv should not win", encoding="utf-8")
+
+    cwd_project = tmp_path / "cwd_project"
+    cwd_project_pdd = cwd_project / ".pdd"
+    cwd_project_pdd.mkdir(parents=True)
+    (cwd_project_pdd / "llm_model.csv").write_text("cwd csv should not win", encoding="utf-8")
+
+    mock_ctx = MagicMock()
+    mock_ctx.obj = {
+        "core_dump": True,
+        "core_dump_files": set(),
+        "force": False,
+        "strength": 0.75,
+        "temperature": 0.0,
+        "time": 0.25,
+        "verbose": False,
+        "quiet": True,
+        "local": False,
+        "context": None,
+        "output_cost": None,
+        "review_examples": False,
+    }
+
+    monkeypatch.chdir(cwd_project)
+    monkeypatch.setenv("PDD_PATH", str(env_project))
+    with patch("pdd.core.dump.Path.home", return_value=fake_home):
+        _write_core_dump(mock_ctx, [("ok", 0.0, "")], ["generate"], 0.0)
+
+    core_dumps = list((cwd_project / ".pdd" / "core_dumps").glob("pdd-core-*.json"))
+    core_dump_data = json.loads(core_dumps[0].read_text(encoding="utf-8"))
+    file_contents = core_dump_data.get("file_contents", {})
+
+    assert str(user_csv) in file_contents
+    assert "UserProvider,user-model" in file_contents[str(user_csv)]
+    assert not any("env csv should not win" in content for content in file_contents.values())
+    assert not any("cwd csv should not win" in content for content in file_contents.values())
+
+
+def test_core_dump_auto_includes_packaged_llm_model_csv_fallback(tmp_path, monkeypatch):
+    """Core dump should include packaged llm_model.csv when no override exists."""
+    import json
+    from pdd.core.dump import _write_core_dump
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    mock_ctx = MagicMock()
+    mock_ctx.obj = {
+        "core_dump": True,
+        "core_dump_files": set(),
+        "force": False,
+        "strength": 0.75,
+        "temperature": 0.0,
+        "time": 0.25,
+        "verbose": False,
+        "quiet": True,
+        "local": False,
+        "context": None,
+        "output_cost": None,
+        "review_examples": False,
+    }
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PDD_PATH", raising=False)
+    with patch("pdd.core.dump.Path.home", return_value=fake_home):
+        _write_core_dump(mock_ctx, [("ok", 0.0, "")], ["generate"], 0.0)
+
+    core_dumps = list((tmp_path / ".pdd" / "core_dumps").glob("pdd-core-*.json"))
+    core_dump_data = json.loads(core_dumps[0].read_text(encoding="utf-8"))
+    file_contents = core_dump_data.get("file_contents", {})
+
+    csv_keys = [key for key in file_contents if key.endswith("pdd/data/llm_model.csv")]
+    assert csv_keys, f"Packaged llm_model.csv missing from file_contents: {list(file_contents.keys())}"
+    assert "provider,model,input,output" in file_contents[csv_keys[0]]
+
+
 def test_core_dump_steps_model_default_unknown(tmp_path, monkeypatch):
     """If results omit model or results are missing, core dump should store model='unknown'."""
     import json

--- a/tests/test_core_dump.py
+++ b/tests/test_core_dump.py
@@ -296,6 +296,59 @@ def test_core_dump_auto_includes_user_llm_model_csv_with_precedence(tmp_path, mo
     assert not any("cwd csv should not win" in content for content in file_contents.values())
 
 
+def test_core_dump_auto_includes_pdd_path_llm_model_csv_before_cwd(tmp_path, monkeypatch):
+    """Core dump should prefer explicit real PDD_PATH llm_model.csv over CWD."""
+    import json
+    from pdd.core.dump import _write_core_dump
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    env_project = tmp_path / "env_project"
+    env_project_pdd = env_project / ".pdd"
+    env_project_pdd.mkdir(parents=True)
+    env_csv = env_project_pdd / "llm_model.csv"
+    env_csv.write_text(
+        "provider,model,input,output,coding_arena_elo,api_key\n"
+        "EnvProvider,env-model,1,2,3,ENV_API_KEY\n",
+        encoding="utf-8",
+    )
+
+    cwd_project = tmp_path / "cwd_project"
+    cwd_project_pdd = cwd_project / ".pdd"
+    cwd_project_pdd.mkdir(parents=True)
+    (cwd_project_pdd / "llm_model.csv").write_text("cwd csv should not win", encoding="utf-8")
+
+    mock_ctx = MagicMock()
+    mock_ctx.obj = {
+        "core_dump": True,
+        "core_dump_files": set(),
+        "force": False,
+        "strength": 0.75,
+        "temperature": 0.0,
+        "time": 0.25,
+        "verbose": False,
+        "quiet": True,
+        "local": False,
+        "context": None,
+        "output_cost": None,
+        "review_examples": False,
+    }
+
+    monkeypatch.chdir(cwd_project)
+    monkeypatch.setenv("PDD_PATH", str(env_project))
+    with patch("pdd.core.dump.Path.home", return_value=fake_home):
+        _write_core_dump(mock_ctx, [("ok", 0.0, "")], ["generate"], 0.0)
+
+    core_dumps = list((cwd_project / ".pdd" / "core_dumps").glob("pdd-core-*.json"))
+    core_dump_data = json.loads(core_dumps[0].read_text(encoding="utf-8"))
+    file_contents = core_dump_data.get("file_contents", {})
+
+    assert str(env_csv) in file_contents
+    assert "EnvProvider,env-model" in file_contents[str(env_csv)]
+    assert not any("cwd csv should not win" in content for content in file_contents.values())
+
+
 def test_core_dump_auto_includes_packaged_llm_model_csv_fallback(tmp_path, monkeypatch):
     """Core dump should include packaged llm_model.csv when no override exists."""
     import json
@@ -330,7 +383,9 @@ def test_core_dump_auto_includes_packaged_llm_model_csv_fallback(tmp_path, monke
     file_contents = core_dump_data.get("file_contents", {})
 
     csv_keys = [key for key in file_contents if key.endswith("pdd/data/llm_model.csv")]
-    assert csv_keys, f"Packaged llm_model.csv missing from file_contents: {list(file_contents.keys())}"
+    assert csv_keys, (
+        f"Packaged llm_model.csv missing from file_contents: {list(file_contents.keys())}"
+    )
     assert "provider,model,input,output" in file_contents[csv_keys[0]]
 
 


### PR DESCRIPTION
## Summary
- Fixes #230.
- Include the active LLM model CSV in core dump file_contents using the same precedence intent as llm_invoke: user ~/.pdd, explicit real PDD_PATH project, CWD project, then packaged pdd/data.
- Keep collection best-effort by resolving candidates defensively and handing the selected file to the existing size/binary/error-gated dump file reader.
- Update core dump prompt spec and add regression coverage for user precedence, PDD_PATH-over-CWD precedence, and packaged fallback.

## Investigation
- Sibling bug hunt: _write_core_dump already auto-included tracked files, .pdd/meta JSON/log/report files, and config files (.pdd/config.json, .pddconfig, pdd.json), but no llm_model.csv path was added. I did not find other core dump auto-include categories with the same missing-file pattern in this scope.
- Model CSV ownership: pdd/llm_invoke.py resolves ~/.pdd/llm_model.csv first, then explicit real PDD_PATH project .pdd/llm_model.csv, then CWD project .pdd/llm_model.csv, then packaged pdd/data/llm_model.csv. The fix follows that selection intent without importing llm_invoke.
- Prior commits checked: issue #231 core dump GC/default-on work (1fa1f9971) established best-effort dump behavior and post-write cleanup; report-core/core dump work (ff1421544 lineage) established file_contents attachment flow; recent CSV-shadow diagnostic work (99d7ec090) confirmed user/project CSV shadowing is meaningful runtime context.

## Tests
- Red before fix: pytest -q tests/test_core_dump.py::test_core_dump_auto_includes_user_llm_model_csv_with_precedence tests/test_core_dump.py::test_core_dump_auto_includes_packaged_llm_model_csv_fallback -> 2 failed.
- Green after fix: pytest -q tests/test_core_dump.py -> 31 passed.
- python -m py_compile pdd/core/dump.py tests/test_core_dump.py -> passed.
- git diff --check -> passed.
- pylint pdd/core/dump.py tests/test_core_dump.py -> exits 30 due existing lint debt in these files (line length, broad exceptions, complexity, test-module import style, etc.).