### PR TITLE
fix(sync): hide Rich-highlighted ANSI fragments

### DIFF
--- a/.pdd/meta/sync_tui_python.json
+++ b/.pdd/meta/sync_tui_python.json
@@ -1,0 +1,15 @@
+{
+  "pdd_version": "0.0.257.dev0",
+  "timestamp": "2026-06-01T18:19:03.939345+00:00",
+  "command": "update",
+  "prompt_hash": "5eb3bb0151fa49a4f51f87c06051545bfa07a3bdf27718f23616a6a301deefa2",
+  "code_hash": "941cbbd6026742784188c66b97d64479daa733ffe1ff2d3d11f464e8a0e10992",
+  "example_hash": "1d25354296c98967b94a5290f3db52d112bf6d160110056e4cdc88ae7db2297a",
+  "test_hash": "3d787dd8211c3ed4361df33c382b5ae2ef366aa9b0757d53a1fc103142b160fe",
+  "test_files": {
+    "test_sync_tui.py": "3d787dd8211c3ed4361df33c382b5ae2ef366aa9b0757d53a1fc103142b160fe"
+  },
+  "include_deps": {
+    "context/python_preamble.prompt": "0388ed131bf986f8752e1bc4c81e4da0460cfe2908ec8c60b1314edbab768254"
+  }
+}

--- a/.pdd/meta/sync_tui_python_run.json
+++ b/.pdd/meta/sync_tui_python_run.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2026-06-01T18:19:03.938322+00:00",
+  "exit_code": 0,
+  "tests_passed": 25,
+  "tests_failed": 0,
+  "coverage": 100.0,
+  "test_hash": "3d787dd8211c3ed4361df33c382b5ae2ef366aa9b0757d53a1fc103142b160fe",
+  "test_files": {
+    "test_sync_tui.py": "3d787dd8211c3ed4361df33c382b5ae2ef366aa9b0757d53a1fc103142b160fe"
+  }
+}

--- a/context/sync_tui_example.py
+++ b/context/sync_tui_example.py
@@ -1,0 +1,63 @@
+"""Example: capture Rich/ANSI worker output in the sync Textual TUI.
+
+Run this from a real terminal. The worker emits ANSI sequences that Rich may
+highlight before they reach the TUI redirector; SyncApp captures the output
+without showing raw escape fragments in the RichLog.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from typing import Any
+
+from rich.console import Console
+
+from pdd.sync_tui import SyncApp
+
+
+def worker() -> dict[str, Any]:
+    """Emit representative worker output and return a sync-like result."""
+    console = Console(
+        file=sys.stdout,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+    console.print("\x1b[90mchecking prompt drift\x1b[0m")
+    console.print("pre\x1b]0;hidden-title\x1b[31mRED\x1b[0mpost")
+    console.print("done")
+    return {
+        "success": True,
+        "total_cost": 0.0,
+        "model_name": "example",
+        "operations_completed": ["example"],
+        "errors": [],
+    }
+
+
+def main() -> dict[str, Any]:
+    """Run the TUI with a small worker that writes ANSI-rich output."""
+    app = SyncApp(
+        basename="sync_tui_example",
+        budget=0.01,
+        worker_func=worker,
+        function_name_ref=["example"],
+        cost_ref=[0.0],
+        prompt_path_ref=["prompts/sync_tui_python.prompt"],
+        code_path_ref=["pdd/sync_tui.py"],
+        example_path_ref=["context/sync_tui_example.py"],
+        tests_path_ref=["tests/test_sync_tui.py"],
+        prompt_color_ref=["blue"],
+        code_color_ref=["cyan"],
+        example_color_ref=["green"],
+        tests_color_ref=["yellow"],
+        stop_event=threading.Event(),
+        no_steer=True,
+    )
+    return app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pdd/prompts/sync_tui_python.prompt
+++ b/pdd/prompts/sync_tui_python.prompt
@@ -31,6 +31,26 @@ providing animated feedback, log output, and modal dialogs for user interaction.
    - Buffer writes, flush on newlines
    - Handle carriage returns for progress bar updates (keep content after last \r)
    - Convert ANSI codes to Rich Text via Text.from_ansi()
+   - Repair Rich-highlighted escape sequences before ANSI parsing so Rich
+     syntax highlighting does not surface fragments like `[90m`, `]0;title`,
+     or `39;49;00m` as visible sync output
+   - Preserve existing Rich Text spans around ANSI output when reparsing, so
+     outer styles such as bold/dim and OSC hyperlink styles survive nested
+     ANSI color resets
+   - Strip ECMA-48 control payloads that should not be visible in the log,
+     including CSI, OSC, DCS, SOS, PM, APC, C1 controls, standalone C0
+     controls, and DEL
+   - Treat CAN/SUB and interrupting ESC bytes as string-control cancellation
+     boundaries, hiding accumulated control payload while preserving following
+     visible text
+   - Split buffered output only on visible newlines outside ANSI string-control
+     payloads; newline and carriage-return bytes inside OSC/DCS/SOS/PM/APC
+     payloads must remain hidden and must not flush or compact visible log
+     lines
+   - Terminate malformed CSI parsing at C0/newline/carriage-return boundaries
+     so invalid escape fragments do not merge adjacent visible lines
+   - Keep ANSI restoration and fallback scanning linear in the input length to
+     avoid pathological rescans on malformed or unterminated escape fragments
    - Dim lines matching log timestamp pattern (YYYY-MM-DD HH:MM:SS)
    - Use app.call_from_thread() for thread-safe widget updates
 

--- a/pdd/sync_tui.py
+++ b/pdd/sync_tui.py
@@ -19,6 +19,7 @@ from rich.align import Align
 from rich.text import Text
 import time
 import re
+from rich.ansi import re_ansi as RICH_ANSI_RE
 
 # Reuse existing animation logic
 from .sync_animation import AnimationState, _render_animation_frame, DEEP_NAVY, ELECTRIC_CYAN
@@ -29,7 +30,6 @@ from rich.style import Style
 
 # Default steering timeout (seconds).
 DEFAULT_STEER_TIMEOUT_S = 8.0
-ANSI_CSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def _debug_swallow(context: str, exc: Exception) -> None:
@@ -70,11 +70,122 @@ def _is_headless_environment() -> bool:
 
 def _text_from_ansi_output(text: str) -> Text:
     """Parse ANSI text, including ANSI that Rich highlighted before capture."""
+    text = _restore_rich_highlighted_ansi(text)
     rendered = Text.from_ansi(text)
-    if "\x1b[" in rendered.plain:
+    if RICH_ANSI_RE.search(rendered.plain):
         reparsed = Text.from_ansi(rendered.plain)
         return _merge_reparsed_ansi_spans(rendered, reparsed)
     return rendered
+
+
+def _restore_rich_highlighted_ansi(text: str) -> str:
+    """Repair ANSI escape sequences split by Rich's syntax highlighter."""
+    if "\x1b\x1b[" not in text:
+        return text
+
+    restored_parts: List[str] = []
+    index = 0
+    while index < len(text):
+        restored = _try_restore_highlighted_escape(text, index)
+        if restored is not None:
+            sequence, index = restored
+            restored_parts.append(sequence)
+            continue
+
+        restored_parts.append(text[index])
+        index += 1
+
+    return "".join(restored_parts)
+
+
+def _try_restore_highlighted_escape(
+    text: str, start: int
+) -> Optional[tuple[str, int]]:
+    """Restore one highlighted ANSI escape sequence starting at ``start``."""
+    if start >= len(text) or text[start] != "\x1b":
+        return None
+
+    index = _skip_sgr_sequences(text, start + 1)
+    if index == start + 1 or index >= len(text):
+        return None
+
+    marker = text[index]
+    if marker == "[":
+        return _restore_highlighted_csi(text, index + 1)
+    if marker == "]":
+        return _restore_highlighted_osc(text, index + 1)
+    if marker in "(@-Z\\-_":
+        return _restore_highlighted_single_escape(text, marker, index + 1)
+    return None
+
+
+def _restore_highlighted_csi(text: str, start: int) -> Optional[tuple[str, int]]:
+    """Restore a highlighted CSI sequence body."""
+    index = start
+    body: List[str] = []
+    while index < len(text):
+        skipped = _skip_sgr_sequences(text, index)
+        if skipped != index:
+            index = skipped
+            continue
+
+        char = text[index]
+        body.append(char)
+        index += 1
+        if "@" <= char <= "~":
+            return "\x1b[" + "".join(body), index
+    return None
+
+
+def _restore_highlighted_osc(text: str, start: int) -> Optional[tuple[str, int]]:
+    """Restore a highlighted OSC sequence body."""
+    index = start
+    body: List[str] = []
+    while index < len(text):
+        skipped = _skip_sgr_sequences(text, index)
+        if skipped != index:
+            index = skipped
+            continue
+        if text.startswith("\x1b\\", index):
+            return "\x1b]" + "".join(body) + "\x1b\\", index + 2
+
+        body.append(text[index])
+        index += 1
+    return None
+
+
+def _restore_highlighted_single_escape(
+    text: str, marker: str, start: int
+) -> tuple[str, int]:
+    """Restore a highlighted non-CSI/non-OSC escape sequence."""
+    index = _skip_sgr_sequences(text, start)
+    if marker == "(" and index < len(text):
+        return "\x1b" + marker + text[index], index + 1
+    return "\x1b" + marker, index
+
+
+def _skip_sgr_sequences(text: str, start: int) -> int:
+    """Skip Rich highlighter SGR sequences at ``start``."""
+    index = start
+    while True:
+        next_index = _consume_sgr_sequence(text, index)
+        if next_index is None:
+            return index
+        index = next_index
+
+
+def _consume_sgr_sequence(text: str, start: int) -> Optional[int]:
+    """Return the index after a CSI SGR sequence, if present."""
+    if not text.startswith("\x1b[", start):
+        return None
+
+    index = start + 2
+    while index < len(text):
+        char = text[index]
+        index += 1
+        if "@" <= char <= "~":
+            return index if char == "m" else None
+    return None
 
 
 def _merge_reparsed_ansi_spans(original: Text, reparsed: Text) -> Text:
@@ -83,12 +194,18 @@ def _merge_reparsed_ansi_spans(original: Text, reparsed: Text) -> Text:
     position_map: List[Optional[int]] = [None] * len(plain_text)
     clean_chars: List[str] = []
     index = 0
-    for match in ANSI_CSI_RE.finditer(plain_text):
+    for match in RICH_ANSI_RE.finditer(plain_text):
+        start, end = match.span()
+        if start < index:
+            continue
+        _osc, sgr = match.groups()
+        if sgr == "(" and end < len(plain_text):
+            end += 1
         while index < match.start():
             position_map[index] = len(clean_chars)
             clean_chars.append(plain_text[index])
             index += 1
-        index = match.end()
+        index = end
     while index < len(plain_text):
         position_map[index] = len(clean_chars)
         clean_chars.append(plain_text[index])

--- a/pdd/sync_tui.py
+++ b/pdd/sync_tui.py
@@ -36,6 +36,12 @@ C1_CSI = "\x9b"
 C1_OSC = "\x9d"
 C1_ST = "\x9c"
 C1_CONTROL_STARTERS = "".join(chr(value) for value in range(0x80, 0xA0))
+C0_CONTROL_CHARS = "".join(
+    chr(value) for value in range(0x20)
+    if value not in {0x09, 0x0A, 0x0D, 0x1B}
+)
+CAN = "\x18"
+SUB = "\x1a"
 BEL = "\x07"
 ST = "\x1b\\"
 
@@ -105,7 +111,11 @@ def _prepare_ansi_text(
     has_ansi = False
     index = 0
     while index < len(text):
-        if text[index] != "\x1b" and text[index] not in C1_CONTROL_STARTERS:
+        if (
+            text[index] != "\x1b"
+            and text[index] not in C1_CONTROL_STARTERS
+            and text[index] not in C0_CONTROL_CHARS
+        ):
             position_map[index] = len(clean_chars)
             rich_parts.append(text[index])
             clean_chars.append(text[index])
@@ -138,6 +148,8 @@ def _scan_ansi_token(
     if start >= len(text):
         return None, start + 1, "", ""
 
+    if text[start] in C0_CONTROL_CHARS:
+        return start + 1, start + 1, "single", ""
     if text[start] in C1_STRING_CONTROL_MARKERS:
         return _scan_string_control_token(text, start + 1)
     if text[start] == C1_CSI:
@@ -184,6 +196,8 @@ def _scan_csi_token(text: str, start: int) -> tuple[Optional[int], int, str, str
         char = text[index]
         if char == "\x1b":
             return None, index, "", ""
+        if _is_csi_cancel_char(char):
+            return index + 1, index + 1, "csi_cancel", char
         index += 1
         if "@" <= char <= "~":
             return index, index, "csi", ""
@@ -214,6 +228,8 @@ def _scan_osc_end(text: str, start: int) -> tuple[Optional[int], str, int]:
     index = start
     while index < len(text):
         char = text[index]
+        if char in {CAN, SUB}:
+            return index + 1, char, index + 1
         if char == BEL:
             return index + 1, BEL, index + 1
         if char == C1_ST:
@@ -226,6 +242,11 @@ def _scan_osc_end(text: str, start: int) -> tuple[Optional[int], str, int]:
     return None, "", index
 
 
+def _is_csi_cancel_char(char: str) -> bool:
+    """Return True when a C0 character cancels a CSI sequence."""
+    return char in {"\n", "\r", CAN, SUB} or char in C0_CONTROL_CHARS
+
+
 def _scan_string_control_end(
     text: str,
     start: int,
@@ -234,6 +255,8 @@ def _scan_string_control_end(
     index = start
     while index < len(text):
         char = text[index]
+        if char in {CAN, SUB}:
+            return index + 1, char, index + 1
         if char == C1_ST:
             return index + 1, C1_ST, index + 1
         if char == "\x1b":
@@ -256,6 +279,8 @@ def _rich_ansi_token(
         if text[start] == C1_CSI:
             return "\x1b[" + text[start + 1:end]
         return text[start:end]
+    if token_kind == "csi_cancel":
+        return ""
     if token_kind == "osc":
         body_start = start + 2 if text[start] == "\x1b" else start + 1
         body_end = end - len(terminator)
@@ -467,13 +492,13 @@ def _is_sgr_reset(sequence: str) -> bool:
 
 
 def _is_full_reset_csi(body: str) -> bool:
-    """Return True when a CSI SGR body ends by fully resetting terminal style."""
+    """Return True when a CSI SGR body fully resets terminal style."""
     if not body.endswith("m"):
         return False
     params = body[:-1].replace(":", ";").split(";")
     if not params:
         return True
-    return params[-1] in {"", "0", "00"}
+    return any(param in {"", "0", "00"} for param in params)
 
 
 def _merge_reparsed_ansi_spans(
@@ -518,14 +543,14 @@ def _map_visible_span(
 
 def _split_complete_ansi_line(text: str) -> Optional[tuple[str, str]]:
     """Split at the first newline that is not inside a string control."""
-    newline_index = _find_visible_newline(text)
-    if newline_index is None:
+    split_index = _find_visible_line_split(text)
+    if split_index is None:
         return None
-    return text[:newline_index], text[newline_index + 1:]
+    return text[:split_index], text[split_index + 1:]
 
 
-def _find_visible_newline(text: str) -> Optional[int]:
-    """Return the first newline outside ANSI string-control payloads."""
+def _find_visible_line_split(text: str) -> Optional[int]:
+    """Return the first line split outside ANSI string-control payloads."""
     index = 0
     while index < len(text):
         char = text[index]
@@ -536,6 +561,11 @@ def _find_visible_newline(text: str) -> Optional[int]:
                 text,
                 index,
             )
+            if (
+                _token_kind == "csi_cancel"
+                and _terminator in {"\n", "\r", CAN, SUB}
+            ):
+                return token_end - 1
             if _is_string_control_start(text, index):
                 if token_end is not None:
                     index = token_end
@@ -550,9 +580,41 @@ def _find_visible_newline(text: str) -> Optional[int]:
     return None
 
 
+def _trim_to_after_last_visible_carriage_return(text: str) -> str:
+    """Apply carriage-return compaction outside ANSI string controls."""
+    carriage_return_index = _find_last_visible_carriage_return(text)
+    if carriage_return_index is None:
+        return text
+    return text[carriage_return_index + 1:]
+
+
+def _find_last_visible_carriage_return(text: str) -> Optional[int]:
+    """Return the last CR outside ANSI controls."""
+    last_carriage_return: Optional[int] = None
+    index = 0
+    while index < len(text):
+        if text[index] == "\r":
+            last_carriage_return = index
+            index += 1
+            continue
+        if _is_ansi_control_start(text, index):
+            token_end, next_index, _token_kind, _terminator = _scan_ansi_token(
+                text,
+                index,
+            )
+            index = token_end if token_end is not None else max(next_index, index + 1)
+            continue
+        index += 1
+    return last_carriage_return
+
+
 def _is_ansi_control_start(text: str, index: int) -> bool:
     """Return True when ``text[index]`` can begin an ANSI control sequence."""
-    return text[index] == "\x1b" or text[index] in C1_CONTROL_STARTERS
+    return (
+        text[index] == "\x1b"
+        or text[index] in C1_CONTROL_STARTERS
+        or text[index] in C0_CONTROL_CHARS
+    )
 
 
 def _is_string_control_start(text: str, index: int) -> bool:
@@ -953,8 +1015,11 @@ class ThreadSafeRedirector(io.TextIOBase):
         # Handle carriage return for in-place updates (progress bars)
         # When buffer has \r but no \n, it's an intermediate progress update
         # Keep only content after the last \r (ready for next update or final \n)
-        if '\r' in self.buffer and '\n' not in self.buffer:
-            self.buffer = self.buffer.rsplit('\r', 1)[-1]
+        if (
+            '\r' in self.buffer
+            and _split_complete_ansi_line(self.buffer) is None
+        ):
+            self.buffer = _trim_to_after_last_visible_carriage_return(self.buffer)
             return len(s)
 
         # Process complete lines. ANSI string-control payloads may contain
@@ -966,7 +1031,7 @@ class ThreadSafeRedirector(io.TextIOBase):
             line, self.buffer = split_line
             # Handle \r within line: keep only content after last \r
             if '\r' in line:
-                line = line.rsplit('\r', 1)[-1]
+                line = _trim_to_after_last_visible_carriage_return(line)
 
             # Convert ANSI codes to Rich Text
             text = _text_from_ansi_output(line)

--- a/pdd/sync_tui.py
+++ b/pdd/sync_tui.py
@@ -67,6 +67,13 @@ def _is_headless_environment() -> bool:
         return True
 
 
+def _text_from_ansi_output(text: str) -> Text:
+    """Parse ANSI text, including ANSI that Rich highlighted before capture."""
+    rendered = Text.from_ansi(text)
+    if "\x1b[" in rendered.plain:
+        return Text.from_ansi(rendered.plain)
+    return rendered
+
 
 class ChoiceScreen(ModalScreen[str]):
     """Modal choice picker with a default selection after a short timeout."""
@@ -465,10 +472,10 @@ class ThreadSafeRedirector(io.TextIOBase):
             # Handle \r within line: keep only content after last \r
             if '\r' in line:
                 line = line.rsplit('\r', 1)[-1]
-            self.captured_logs.append(line)  # Capture processed line
 
             # Convert ANSI codes to Rich Text
-            text = Text.from_ansi(line)
+            text = _text_from_ansi_output(line)
+            self.captured_logs.append(text.plain)  # Capture processed line
 
             # Check if the line looks like a log message and dim it
             # We strip ANSI codes for pattern matching to ensure the regex works
@@ -485,7 +492,7 @@ class ThreadSafeRedirector(io.TextIOBase):
     def flush(self):
         # Write any remaining content in buffer
         if self.buffer:
-            text = Text.from_ansi(self.buffer)
+            text = _text_from_ansi_output(self.buffer)
             if self.log_pattern.match(text.plain):
                 text.style = Style(dim=True)
             self.app.call_from_thread(self.log_widget.write, text)

--- a/pdd/sync_tui.py
+++ b/pdd/sync_tui.py
@@ -19,7 +19,6 @@ from rich.align import Align
 from rich.text import Text
 import time
 import re
-from rich.ansi import re_ansi as RICH_ANSI_RE
 
 # Reuse existing animation logic
 from .sync_animation import AnimationState, _render_animation_frame, DEEP_NAVY, ELECTRIC_CYAN
@@ -30,6 +29,18 @@ from rich.style import Style
 
 # Default steering timeout (seconds).
 DEFAULT_STEER_TIMEOUT_S = 8.0
+CHARSET_SELECTOR_MARKERS = "()*+-./"
+CHARSET_SELECTOR_RE = re.compile(r"\x1b[()*+\-./].")
+ANSI_ESCAPE_RE = re.compile(
+    r"""
+    (?:\x1b[()*+\-./].)|
+    (?:\x1b[0-?])|
+    (?:\x1b\].*?\x1b\\)|
+    (?:\x1b\[[0-?]*[ -/]*[@-~])|
+    (?:\x1b[@-Z\\-_])
+    """,
+    re.VERBOSE,
+)
 
 
 def _debug_swallow(context: str, exc: Exception) -> None:
@@ -72,8 +83,9 @@ def _text_from_ansi_output(text: str) -> Text:
     """Parse ANSI text, including ANSI that Rich highlighted before capture."""
     text = _restore_rich_highlighted_ansi(text)
     rendered = Text.from_ansi(text)
-    if RICH_ANSI_RE.search(rendered.plain):
-        reparsed = Text.from_ansi(rendered.plain)
+    if ANSI_ESCAPE_RE.search(rendered.plain):
+        reparsed_plain = CHARSET_SELECTOR_RE.sub("", rendered.plain)
+        reparsed = Text.from_ansi(reparsed_plain)
         return _merge_reparsed_ansi_spans(rendered, reparsed)
     return rendered
 
@@ -86,72 +98,80 @@ def _restore_rich_highlighted_ansi(text: str) -> str:
     restored_parts: List[str] = []
     index = 0
     while index < len(text):
-        restored = _try_restore_highlighted_escape(text, index)
-        if restored is not None:
-            sequence, index = restored
+        if text[index] != "\x1b":
+            restored_parts.append(text[index])
+            index += 1
+            continue
+
+        sequence, next_index = _try_restore_highlighted_escape(text, index)
+        if sequence is not None:
+            index = next_index
             restored_parts.append(sequence)
             continue
 
-        restored_parts.append(text[index])
-        index += 1
+        restored_parts.append(text[index:next_index])
+        index = next_index
 
     return "".join(restored_parts)
 
 
 def _try_restore_highlighted_escape(
     text: str, start: int
-) -> Optional[tuple[str, int]]:
+) -> tuple[Optional[str], int]:
     """Restore one highlighted ANSI escape sequence starting at ``start``."""
     if start >= len(text) or text[start] != "\x1b":
-        return None
+        return None, start + 1
 
     index = _skip_sgr_sequences(text, start + 1)
     if index == start + 1 or index >= len(text):
-        return None
+        return None, start + 1
 
     marker = text[index]
     if marker == "[":
         return _restore_highlighted_csi(text, index + 1)
     if marker == "]":
         return _restore_highlighted_osc(text, index + 1)
-    if marker in "(@-Z\\-_":
+    if _is_single_escape_marker(marker):
         return _restore_highlighted_single_escape(text, marker, index + 1)
-    return None
+    return None, start + 1
 
 
-def _restore_highlighted_csi(text: str, start: int) -> Optional[tuple[str, int]]:
+def _restore_highlighted_csi(text: str, start: int) -> tuple[Optional[str], int]:
     """Restore a highlighted CSI sequence body."""
     index = start
     body: List[str] = []
     while index < len(text):
-        skipped = _skip_sgr_sequences(text, index)
-        if skipped != index:
-            index = skipped
-            continue
-
         char = text[index]
+        if char == "\x1b":
+            skipped = _skip_sgr_sequences(text, index)
+            if skipped != index:
+                index = skipped
+                continue
+            return None, index
         body.append(char)
         index += 1
         if "@" <= char <= "~":
             return "\x1b[" + "".join(body), index
-    return None
+    return None, index
 
 
-def _restore_highlighted_osc(text: str, start: int) -> Optional[tuple[str, int]]:
+def _restore_highlighted_osc(text: str, start: int) -> tuple[Optional[str], int]:
     """Restore a highlighted OSC sequence body."""
     index = start
     body: List[str] = []
     while index < len(text):
-        skipped = _skip_sgr_sequences(text, index)
-        if skipped != index:
-            index = skipped
-            continue
         if text.startswith("\x1b\\", index):
             return "\x1b]" + "".join(body) + "\x1b\\", index + 2
+        if text[index] == "\x1b":
+            skipped = _skip_sgr_sequences(text, index)
+            if skipped != index:
+                index = skipped
+                continue
+            return None, index
 
         body.append(text[index])
         index += 1
-    return None
+    return None, index
 
 
 def _restore_highlighted_single_escape(
@@ -159,9 +179,18 @@ def _restore_highlighted_single_escape(
 ) -> tuple[str, int]:
     """Restore a highlighted non-CSI/non-OSC escape sequence."""
     index = _skip_sgr_sequences(text, start)
-    if marker == "(" and index < len(text):
+    if marker in CHARSET_SELECTOR_MARKERS and index < len(text):
         return "\x1b" + marker + text[index], index + 1
     return "\x1b" + marker, index
+
+
+def _is_single_escape_marker(marker: str) -> bool:
+    """Return True when ``marker`` is a Rich-compatible single escape marker."""
+    return (
+        marker in CHARSET_SELECTOR_MARKERS
+        or "@" <= marker <= "Z"
+        or "\\" <= marker <= "_"
+    )
 
 
 def _skip_sgr_sequences(text: str, start: int) -> int:
@@ -194,13 +223,10 @@ def _merge_reparsed_ansi_spans(original: Text, reparsed: Text) -> Text:
     position_map: List[Optional[int]] = [None] * len(plain_text)
     clean_chars: List[str] = []
     index = 0
-    for match in RICH_ANSI_RE.finditer(plain_text):
+    for match in ANSI_ESCAPE_RE.finditer(plain_text):
         start, end = match.span()
         if start < index:
             continue
-        _osc, sgr = match.groups()
-        if sgr == "(" and end < len(plain_text):
-            end += 1
         while index < match.start():
             position_map[index] = len(clean_chars)
             clean_chars.append(plain_text[index])

--- a/pdd/sync_tui.py
+++ b/pdd/sync_tui.py
@@ -30,6 +30,11 @@ from rich.style import Style
 # Default steering timeout (seconds).
 DEFAULT_STEER_TIMEOUT_S = 8.0
 CHARSET_SELECTOR_MARKERS = "()*+-./"
+STRING_CONTROL_MARKERS = "PX^_"
+C1_STRING_CONTROL_MARKERS = "\x90\x98\x9e\x9f"
+C1_OSC = "\x9d"
+C1_CONTROL_STARTERS = C1_STRING_CONTROL_MARKERS + C1_OSC
+C1_ST = "\x9c"
 BEL = "\x07"
 ST = "\x1b\\"
 
@@ -99,7 +104,7 @@ def _prepare_ansi_text(
     has_ansi = False
     index = 0
     while index < len(text):
-        if text[index] != "\x1b":
+        if text[index] != "\x1b" and text[index] not in C1_CONTROL_STARTERS:
             position_map[index] = len(clean_chars)
             rich_parts.append(text[index])
             clean_chars.append(text[index])
@@ -132,9 +137,15 @@ def _scan_ansi_token(
     start: int,
 ) -> tuple[Optional[int], int, str, str]:
     """Scan one ANSI escape token without rescanning malformed suffixes."""
-    if start >= len(text) or text[start] != "\x1b":
+    if start >= len(text):
         return None, start + 1, "", ""
-    if start + 1 >= len(text):
+
+    if text[start] in C1_STRING_CONTROL_MARKERS:
+        return _scan_string_control_token(text, start + 1)
+    if text[start] == C1_OSC:
+        return _scan_osc_token(text, start + 1)
+
+    if text[start] != "\x1b" or start + 1 >= len(text):
         return None, start + 1, "", ""
 
     marker = text[start + 1]
@@ -142,6 +153,8 @@ def _scan_ansi_token(
         return _scan_csi_token(text, start + 2)
     if marker == "]":
         return _scan_osc_token(text, start + 2)
+    if marker in STRING_CONTROL_MARKERS:
+        return _scan_string_control_token(text, start + 2)
     if marker in CHARSET_SELECTOR_MARKERS:
         if start + 2 < len(text):
             return start + 3, start + 3, "single", ""
@@ -172,6 +185,17 @@ def _scan_osc_token(text: str, start: int) -> tuple[Optional[int], int, str, str
     return token_end, token_end, "osc", terminator
 
 
+def _scan_string_control_token(
+    text: str,
+    start: int,
+) -> tuple[Optional[int], int, str, str]:
+    """Scan a string-control token body terminated by ST."""
+    token_end, terminator, next_index = _scan_string_control_end(text, start)
+    if token_end is None:
+        return None, next_index, "", ""
+    return token_end, token_end, "string", terminator
+
+
 def _scan_osc_end(text: str, start: int) -> tuple[Optional[int], str, int]:
     """Return an OSC token end, terminator, and next index."""
     index = start
@@ -179,6 +203,26 @@ def _scan_osc_end(text: str, start: int) -> tuple[Optional[int], str, int]:
         char = text[index]
         if char == BEL:
             return index + 1, BEL, index + 1
+        if char == C1_ST:
+            return index + 1, C1_ST, index + 1
+        if char == "\x1b":
+            if text.startswith(ST, index):
+                return index + len(ST), ST, index + len(ST)
+            return None, "", index
+        index += 1
+    return None, "", index
+
+
+def _scan_string_control_end(
+    text: str,
+    start: int,
+) -> tuple[Optional[int], str, int]:
+    """Return a string-control token end, terminator, and next index."""
+    index = start
+    while index < len(text):
+        char = text[index]
+        if char == C1_ST:
+            return index + 1, C1_ST, index + 1
         if char == "\x1b":
             if text.startswith(ST, index):
                 return index + len(ST), ST, index + len(ST)
@@ -198,9 +242,9 @@ def _rich_ansi_token(
     if token_kind == "csi":
         return text[start:end]
     if token_kind == "osc":
-        if terminator == BEL:
-            return text[start:end - 1] + ST
-        return text[start:end]
+        body_start = start + 2 if text[start] == "\x1b" else start + 1
+        body_end = end - len(terminator)
+        return "\x1b]" + text[body_start:body_end] + ST
     return ""
 
 
@@ -211,16 +255,29 @@ def _restore_rich_highlighted_ansi(text: str) -> str:
 
     restored_parts: List[str] = []
     index = 0
+    active_sgr = ""
     while index < len(text):
         if text[index] != "\x1b":
             restored_parts.append(text[index])
             index += 1
             continue
 
-        sequence, next_index = _try_restore_highlighted_escape(text, index)
+        sequence, next_index = _try_restore_highlighted_escape(
+            text,
+            index,
+            active_sgr,
+        )
         if sequence is not None:
             index = next_index
             restored_parts.append(sequence)
+            continue
+
+        sgr_end = _consume_sgr_sequence(text, index)
+        if sgr_end is not None:
+            sequence = text[index:sgr_end]
+            active_sgr = _update_active_sgr(active_sgr, sequence)
+            restored_parts.append(sequence)
+            index = sgr_end
             continue
 
         restored_parts.append(text[index:next_index])
@@ -230,7 +287,7 @@ def _restore_rich_highlighted_ansi(text: str) -> str:
 
 
 def _try_restore_highlighted_escape(
-    text: str, start: int
+    text: str, start: int, active_sgr: str
 ) -> tuple[Optional[str], int]:
     """Restore one highlighted ANSI escape sequence starting at ``start``."""
     if start >= len(text) or text[start] != "\x1b":
@@ -242,29 +299,29 @@ def _try_restore_highlighted_escape(
 
     marker = text[index]
     if marker == "[":
-        return _restore_highlighted_csi(text, index + 1)
+        return _restore_highlighted_csi(text, index + 1, active_sgr)
     if marker == "]":
         return _restore_highlighted_osc(text, index + 1)
+    if marker in STRING_CONTROL_MARKERS:
+        return _restore_highlighted_string_control(text, marker, index + 1)
     if _is_single_escape_marker(marker):
         return _restore_highlighted_single_escape(text, marker, index + 1)
     return None, start + 1
 
 
-def _restore_highlighted_csi(text: str, start: int) -> tuple[Optional[str], int]:
+def _restore_highlighted_csi(
+    text: str,
+    start: int,
+    active_sgr: str,
+) -> tuple[Optional[str], int]:
     """Restore a highlighted CSI sequence body."""
     index = start
     body: List[str] = []
-    preserved_sgr: List[str] = []
     while index < len(text):
         char = text[index]
         if char == "\x1b":
-            skipped, sequences = _consume_sgr_sequences(text, index)
+            skipped = _skip_sgr_sequences(text, index)
             if skipped != index:
-                preserved_sgr.extend(
-                    sequence
-                    for sequence in sequences
-                    if not _is_sgr_reset(sequence)
-                )
                 index = skipped
                 continue
             return None, index
@@ -272,10 +329,9 @@ def _restore_highlighted_csi(text: str, start: int) -> tuple[Optional[str], int]
         index += 1
         if "@" <= char <= "~":
             csi_sequence = "\x1b[" + "".join(body)
-            outer_style = "".join(preserved_sgr)
             if _is_full_reset_csi("".join(body)):
-                return csi_sequence + outer_style, index
-            return outer_style + csi_sequence, index
+                return csi_sequence + active_sgr, index
+            return csi_sequence, index
     return None, index
 
 
@@ -283,23 +339,41 @@ def _restore_highlighted_osc(text: str, start: int) -> tuple[Optional[str], int]
     """Restore a highlighted OSC sequence body."""
     index = start
     body: List[str] = []
-    preserved_sgr: List[str] = []
     while index < len(text):
         if text[index] == BEL:
-            return "\x1b]" + "".join(body) + BEL + "".join(preserved_sgr), index + 1
+            return "\x1b]" + "".join(body) + BEL, index + 1
+        if text[index] == C1_ST:
+            return "\x1b]" + "".join(body) + C1_ST, index + 1
         if text.startswith("\x1b\\", index):
-            return (
-                "\x1b]" + "".join(body) + "\x1b\\" + "".join(preserved_sgr),
-                index + 2,
-            )
+            return "\x1b]" + "".join(body) + "\x1b\\", index + 2
         if text[index] == "\x1b":
-            skipped, sequences = _consume_sgr_sequences(text, index)
+            skipped = _skip_sgr_sequences(text, index)
             if skipped != index:
-                preserved_sgr.extend(
-                    sequence
-                    for sequence in sequences
-                    if not _is_sgr_reset(sequence)
-                )
+                index = skipped
+                continue
+            return None, index
+
+        body.append(text[index])
+        index += 1
+    return None, index
+
+
+def _restore_highlighted_string_control(
+    text: str,
+    marker: str,
+    start: int,
+) -> tuple[Optional[str], int]:
+    """Restore a highlighted DCS/SOS/PM/APC string-control sequence."""
+    index = start
+    body: List[str] = []
+    while index < len(text):
+        if text[index] == C1_ST:
+            return "\x1b" + marker + "".join(body) + C1_ST, index + 1
+        if text.startswith(ST, index):
+            return "\x1b" + marker + "".join(body) + ST, index + len(ST)
+        if text[index] == "\x1b":
+            skipped = _skip_sgr_sequences(text, index)
+            if skipped != index:
                 index = skipped
                 continue
             return None, index
@@ -313,13 +387,10 @@ def _restore_highlighted_single_escape(
     text: str, marker: str, start: int
 ) -> tuple[str, int]:
     """Restore a highlighted non-CSI/non-OSC escape sequence."""
-    index, sequences = _consume_sgr_sequences(text, start)
-    preserved_sgr = "".join(
-        sequence for sequence in sequences if not _is_sgr_reset(sequence)
-    )
+    index = _skip_sgr_sequences(text, start)
     if marker in CHARSET_SELECTOR_MARKERS and index < len(text):
-        return "\x1b" + marker + text[index] + preserved_sgr, index + 1
-    return "\x1b" + marker + preserved_sgr, index
+        return "\x1b" + marker + text[index], index + 1
+    return "\x1b" + marker, index
 
 
 def _is_single_escape_marker(marker: str) -> bool:
@@ -361,6 +432,13 @@ def _consume_sgr_sequence(text: str, start: int) -> Optional[int]:
         if "@" <= char <= "~":
             return index if char == "m" else None
     return None
+
+
+def _update_active_sgr(active_sgr: str, sequence: str) -> str:
+    """Update active Rich outer-style SGR state with one direct SGR sequence."""
+    if _is_sgr_reset(sequence):
+        return ""
+    return active_sgr + sequence
 
 
 def _is_sgr_reset(sequence: str) -> bool:

--- a/pdd/sync_tui.py
+++ b/pdd/sync_tui.py
@@ -29,6 +29,7 @@ from rich.style import Style
 
 # Default steering timeout (seconds).
 DEFAULT_STEER_TIMEOUT_S = 8.0
+ANSI_CSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def _debug_swallow(context: str, exc: Exception) -> None:
@@ -71,8 +72,55 @@ def _text_from_ansi_output(text: str) -> Text:
     """Parse ANSI text, including ANSI that Rich highlighted before capture."""
     rendered = Text.from_ansi(text)
     if "\x1b[" in rendered.plain:
-        return Text.from_ansi(rendered.plain)
+        reparsed = Text.from_ansi(rendered.plain)
+        return _merge_reparsed_ansi_spans(rendered, reparsed)
     return rendered
+
+
+def _merge_reparsed_ansi_spans(original: Text, reparsed: Text) -> Text:
+    """Merge ANSI reparsing spans without dropping existing non-ANSI spans."""
+    plain_text = original.plain
+    position_map: List[Optional[int]] = [None] * len(plain_text)
+    clean_chars: List[str] = []
+    index = 0
+    for match in ANSI_CSI_RE.finditer(plain_text):
+        while index < match.start():
+            position_map[index] = len(clean_chars)
+            clean_chars.append(plain_text[index])
+            index += 1
+        index = match.end()
+    while index < len(plain_text):
+        position_map[index] = len(clean_chars)
+        clean_chars.append(plain_text[index])
+        index += 1
+
+    clean_plain = "".join(clean_chars)
+    if clean_plain != reparsed.plain:
+        return reparsed
+
+    merged = Text(clean_plain, style=original.style)
+    for span in original.spans:
+        mapped = _map_visible_span(span.start, span.end, position_map)
+        if mapped is not None:
+            merged.stylize(span.style, *mapped)
+    for span in reparsed.spans:
+        merged.stylize(span.style, span.start, span.end)
+
+    return merged
+
+
+def _map_visible_span(
+    start: int, end: int, position_map: List[Optional[int]]
+) -> Optional[tuple[int, int]]:
+    """Map a span from ANSI-bearing text to visible text coordinates."""
+    mapped_positions = [
+        mapped
+        for mapped in position_map[start:end]
+        if mapped is not None
+    ]
+    if not mapped_positions:
+        return None
+    return min(mapped_positions), max(mapped_positions) + 1
 
 
 class ChoiceScreen(ModalScreen[str]):

--- a/pdd/sync_tui.py
+++ b/pdd/sync_tui.py
@@ -254,18 +254,28 @@ def _restore_highlighted_csi(text: str, start: int) -> tuple[Optional[str], int]
     """Restore a highlighted CSI sequence body."""
     index = start
     body: List[str] = []
+    preserved_sgr: List[str] = []
     while index < len(text):
         char = text[index]
         if char == "\x1b":
-            skipped = _skip_sgr_sequences(text, index)
+            skipped, sequences = _consume_sgr_sequences(text, index)
             if skipped != index:
+                preserved_sgr.extend(
+                    sequence
+                    for sequence in sequences
+                    if not _is_sgr_reset(sequence)
+                )
                 index = skipped
                 continue
             return None, index
         body.append(char)
         index += 1
         if "@" <= char <= "~":
-            return "\x1b[" + "".join(body), index
+            csi_sequence = "\x1b[" + "".join(body)
+            outer_style = "".join(preserved_sgr)
+            if _is_full_reset_csi("".join(body)):
+                return csi_sequence + outer_style, index
+            return outer_style + csi_sequence, index
     return None, index
 
 
@@ -273,14 +283,23 @@ def _restore_highlighted_osc(text: str, start: int) -> tuple[Optional[str], int]
     """Restore a highlighted OSC sequence body."""
     index = start
     body: List[str] = []
+    preserved_sgr: List[str] = []
     while index < len(text):
         if text[index] == BEL:
-            return "\x1b]" + "".join(body) + BEL, index + 1
+            return "\x1b]" + "".join(body) + BEL + "".join(preserved_sgr), index + 1
         if text.startswith("\x1b\\", index):
-            return "\x1b]" + "".join(body) + "\x1b\\", index + 2
+            return (
+                "\x1b]" + "".join(body) + "\x1b\\" + "".join(preserved_sgr),
+                index + 2,
+            )
         if text[index] == "\x1b":
-            skipped = _skip_sgr_sequences(text, index)
+            skipped, sequences = _consume_sgr_sequences(text, index)
             if skipped != index:
+                preserved_sgr.extend(
+                    sequence
+                    for sequence in sequences
+                    if not _is_sgr_reset(sequence)
+                )
                 index = skipped
                 continue
             return None, index
@@ -294,10 +313,13 @@ def _restore_highlighted_single_escape(
     text: str, marker: str, start: int
 ) -> tuple[str, int]:
     """Restore a highlighted non-CSI/non-OSC escape sequence."""
-    index = _skip_sgr_sequences(text, start)
+    index, sequences = _consume_sgr_sequences(text, start)
+    preserved_sgr = "".join(
+        sequence for sequence in sequences if not _is_sgr_reset(sequence)
+    )
     if marker in CHARSET_SELECTOR_MARKERS and index < len(text):
-        return "\x1b" + marker + text[index], index + 1
-    return "\x1b" + marker, index
+        return "\x1b" + marker + text[index] + preserved_sgr, index + 1
+    return "\x1b" + marker + preserved_sgr, index
 
 
 def _is_single_escape_marker(marker: str) -> bool:
@@ -311,11 +333,19 @@ def _is_single_escape_marker(marker: str) -> bool:
 
 def _skip_sgr_sequences(text: str, start: int) -> int:
     """Skip Rich highlighter SGR sequences at ``start``."""
+    index, _sequences = _consume_sgr_sequences(text, start)
+    return index
+
+
+def _consume_sgr_sequences(text: str, start: int) -> tuple[int, List[str]]:
+    """Return the index after a run of SGR sequences and the consumed strings."""
     index = start
+    sequences: List[str] = []
     while True:
         next_index = _consume_sgr_sequence(text, index)
         if next_index is None:
-            return index
+            return index, sequences
+        sequences.append(text[index:next_index])
         index = next_index
 
 
@@ -331,6 +361,23 @@ def _consume_sgr_sequence(text: str, start: int) -> Optional[int]:
         if "@" <= char <= "~":
             return index if char == "m" else None
     return None
+
+
+def _is_sgr_reset(sequence: str) -> bool:
+    """Return True when an SGR sequence resets the active terminal style."""
+    if not sequence.startswith("\x1b[") or not sequence.endswith("m"):
+        return False
+    return _is_full_reset_csi(sequence[2:])
+
+
+def _is_full_reset_csi(body: str) -> bool:
+    """Return True when a CSI SGR body ends by fully resetting terminal style."""
+    if not body.endswith("m"):
+        return False
+    params = body[:-1].replace(":", ";").split(";")
+    if not params:
+        return True
+    return params[-1] in {"", "0", "00"}
 
 
 def _merge_reparsed_ansi_spans(

--- a/pdd/sync_tui.py
+++ b/pdd/sync_tui.py
@@ -1,6 +1,7 @@
 import threading
 import sys
 import os
+import re
 from typing import List, Optional, Callable, Any
 import io
 import asyncio
@@ -18,7 +19,6 @@ from rich.panel import Panel
 from rich.align import Align
 from rich.text import Text
 import time
-import re
 
 # Reuse existing animation logic
 from .sync_animation import AnimationState, _render_animation_frame, DEEP_NAVY, ELECTRIC_CYAN
@@ -30,17 +30,8 @@ from rich.style import Style
 # Default steering timeout (seconds).
 DEFAULT_STEER_TIMEOUT_S = 8.0
 CHARSET_SELECTOR_MARKERS = "()*+-./"
-CHARSET_SELECTOR_RE = re.compile(r"\x1b[()*+\-./].")
-ANSI_ESCAPE_RE = re.compile(
-    r"""
-    (?:\x1b[()*+\-./].)|
-    (?:\x1b[0-?])|
-    (?:\x1b\].*?\x1b\\)|
-    (?:\x1b\[[0-?]*[ -/]*[@-~])|
-    (?:\x1b[@-Z\\-_])
-    """,
-    re.VERBOSE,
-)
+BEL = "\x07"
+ST = "\x1b\\"
 
 
 def _debug_swallow(context: str, exc: Exception) -> None:
@@ -82,12 +73,135 @@ def _is_headless_environment() -> bool:
 def _text_from_ansi_output(text: str) -> Text:
     """Parse ANSI text, including ANSI that Rich highlighted before capture."""
     text = _restore_rich_highlighted_ansi(text)
+    text, _clean_text, _position_map, _has_ansi = _prepare_ansi_text(text)
     rendered = Text.from_ansi(text)
-    if ANSI_ESCAPE_RE.search(rendered.plain):
-        reparsed_plain = CHARSET_SELECTOR_RE.sub("", rendered.plain)
-        reparsed = Text.from_ansi(reparsed_plain)
-        return _merge_reparsed_ansi_spans(rendered, reparsed)
+    reparse_text, clean_text, position_map, has_ansi = _prepare_ansi_text(
+        rendered.plain
+    )
+    if has_ansi:
+        reparsed = Text.from_ansi(reparse_text)
+        return _merge_reparsed_ansi_spans(
+            rendered,
+            reparsed,
+            clean_text,
+            position_map,
+        )
     return rendered
+
+
+def _prepare_ansi_text(
+    text: str,
+) -> tuple[str, str, List[Optional[int]], bool]:
+    """Return Rich-compatible ANSI text, visible text, position map, and status."""
+    rich_parts: List[str] = []
+    clean_chars: List[str] = []
+    position_map: List[Optional[int]] = [None] * len(text)
+    has_ansi = False
+    index = 0
+    while index < len(text):
+        if text[index] != "\x1b":
+            position_map[index] = len(clean_chars)
+            rich_parts.append(text[index])
+            clean_chars.append(text[index])
+            index += 1
+            continue
+
+        token_end, next_index, token_kind, terminator = _scan_ansi_token(
+            text,
+            index,
+        )
+        if token_end is not None:
+            has_ansi = True
+            rich_parts.append(
+                _rich_ansi_token(text, index, token_end, token_kind, terminator)
+            )
+            index = token_end
+            continue
+
+        while index < next_index:
+            position_map[index] = len(clean_chars)
+            rich_parts.append(text[index])
+            clean_chars.append(text[index])
+            index += 1
+
+    return "".join(rich_parts), "".join(clean_chars), position_map, has_ansi
+
+
+def _scan_ansi_token(
+    text: str,
+    start: int,
+) -> tuple[Optional[int], int, str, str]:
+    """Scan one ANSI escape token without rescanning malformed suffixes."""
+    if start >= len(text) or text[start] != "\x1b":
+        return None, start + 1, "", ""
+    if start + 1 >= len(text):
+        return None, start + 1, "", ""
+
+    marker = text[start + 1]
+    if marker == "[":
+        return _scan_csi_token(text, start + 2)
+    if marker == "]":
+        return _scan_osc_token(text, start + 2)
+    if marker in CHARSET_SELECTOR_MARKERS:
+        if start + 2 < len(text):
+            return start + 3, start + 3, "single", ""
+        return None, start + 2, "", ""
+    if "0" <= marker <= "?" or "@" <= marker <= "Z" or "\\" <= marker <= "_":
+        return start + 2, start + 2, "single", ""
+    return None, start + 1, "", ""
+
+
+def _scan_csi_token(text: str, start: int) -> tuple[Optional[int], int, str, str]:
+    """Scan a CSI token body."""
+    index = start
+    while index < len(text):
+        char = text[index]
+        if char == "\x1b":
+            return None, index, "", ""
+        index += 1
+        if "@" <= char <= "~":
+            return index, index, "csi", ""
+    return None, index, "", ""
+
+
+def _scan_osc_token(text: str, start: int) -> tuple[Optional[int], int, str, str]:
+    """Scan an OSC token body terminated by ST or BEL."""
+    token_end, terminator, next_index = _scan_osc_end(text, start)
+    if token_end is None:
+        return None, next_index, "", ""
+    return token_end, token_end, "osc", terminator
+
+
+def _scan_osc_end(text: str, start: int) -> tuple[Optional[int], str, int]:
+    """Return an OSC token end, terminator, and next index."""
+    index = start
+    while index < len(text):
+        char = text[index]
+        if char == BEL:
+            return index + 1, BEL, index + 1
+        if char == "\x1b":
+            if text.startswith(ST, index):
+                return index + len(ST), ST, index + len(ST)
+            return None, "", index
+        index += 1
+    return None, "", index
+
+
+def _rich_ansi_token(
+    text: str,
+    start: int,
+    end: int,
+    token_kind: str,
+    terminator: str,
+) -> str:
+    """Return the token form Rich can parse without exposing control payloads."""
+    if token_kind == "csi":
+        return text[start:end]
+    if token_kind == "osc":
+        if terminator == BEL:
+            return text[start:end - 1] + ST
+        return text[start:end]
+    return ""
 
 
 def _restore_rich_highlighted_ansi(text: str) -> str:
@@ -160,6 +274,8 @@ def _restore_highlighted_osc(text: str, start: int) -> tuple[Optional[str], int]
     index = start
     body: List[str] = []
     while index < len(text):
+        if text[index] == BEL:
+            return "\x1b]" + "".join(body) + BEL, index + 1
         if text.startswith("\x1b\\", index):
             return "\x1b]" + "".join(body) + "\x1b\\", index + 2
         if text[index] == "\x1b":
@@ -217,27 +333,18 @@ def _consume_sgr_sequence(text: str, start: int) -> Optional[int]:
     return None
 
 
-def _merge_reparsed_ansi_spans(original: Text, reparsed: Text) -> Text:
+def _merge_reparsed_ansi_spans(
+    original: Text,
+    reparsed: Text,
+    clean_plain: Optional[str] = None,
+    position_map: Optional[List[Optional[int]]] = None,
+) -> Text:
     """Merge ANSI reparsing spans without dropping existing non-ANSI spans."""
     plain_text = original.plain
-    position_map: List[Optional[int]] = [None] * len(plain_text)
-    clean_chars: List[str] = []
-    index = 0
-    for match in ANSI_ESCAPE_RE.finditer(plain_text):
-        start, end = match.span()
-        if start < index:
-            continue
-        while index < match.start():
-            position_map[index] = len(clean_chars)
-            clean_chars.append(plain_text[index])
-            index += 1
-        index = end
-    while index < len(plain_text):
-        position_map[index] = len(clean_chars)
-        clean_chars.append(plain_text[index])
-        index += 1
-
-    clean_plain = "".join(clean_chars)
+    if clean_plain is None or position_map is None:
+        _reparse_text, clean_plain, position_map, _has_ansi = _prepare_ansi_text(
+            plain_text
+        )
     if clean_plain != reparsed.plain:
         return reparsed
 

--- a/pdd/sync_tui.py
+++ b/pdd/sync_tui.py
@@ -32,9 +32,10 @@ DEFAULT_STEER_TIMEOUT_S = 8.0
 CHARSET_SELECTOR_MARKERS = "()*+-./"
 STRING_CONTROL_MARKERS = "PX^_"
 C1_STRING_CONTROL_MARKERS = "\x90\x98\x9e\x9f"
+C1_CSI = "\x9b"
 C1_OSC = "\x9d"
-C1_CONTROL_STARTERS = C1_STRING_CONTROL_MARKERS + C1_OSC
 C1_ST = "\x9c"
+C1_CONTROL_STARTERS = "".join(chr(value) for value in range(0x80, 0xA0))
 BEL = "\x07"
 ST = "\x1b\\"
 
@@ -123,11 +124,8 @@ def _prepare_ansi_text(
             index = token_end
             continue
 
-        while index < next_index:
-            position_map[index] = len(clean_chars)
-            rich_parts.append(text[index])
-            clean_chars.append(text[index])
-            index += 1
+        has_ansi = True
+        index = max(next_index, index + 1)
 
     return "".join(rich_parts), "".join(clean_chars), position_map, has_ansi
 
@@ -142,11 +140,15 @@ def _scan_ansi_token(
 
     if text[start] in C1_STRING_CONTROL_MARKERS:
         return _scan_string_control_token(text, start + 1)
+    if text[start] == C1_CSI:
+        return _scan_csi_token(text, start + 1)
     if text[start] == C1_OSC:
         return _scan_osc_token(text, start + 1)
+    if text[start] in C1_CONTROL_STARTERS:
+        return start + 1, start + 1, "single", ""
 
     if text[start] != "\x1b" or start + 1 >= len(text):
-        return None, start + 1, "", ""
+        return start + 1, start + 1, "single", ""
 
     marker = text[start + 1]
     if marker == "[":
@@ -159,9 +161,20 @@ def _scan_ansi_token(
         if start + 2 < len(text):
             return start + 3, start + 3, "single", ""
         return None, start + 2, "", ""
-    if "0" <= marker <= "?" or "@" <= marker <= "Z" or "\\" <= marker <= "_":
-        return start + 2, start + 2, "single", ""
-    return None, start + 1, "", ""
+    return _scan_escape_sequence_token(text, start + 1)
+
+
+def _scan_escape_sequence_token(
+    text: str,
+    start: int,
+) -> tuple[Optional[int], int, str, str]:
+    """Scan a non-CSI/non-string ESC sequence with optional intermediates."""
+    index = start
+    while index < len(text) and " " <= text[index] <= "/":
+        index += 1
+    if index < len(text) and "0" <= text[index] <= "~":
+        return index + 1, index + 1, "single", ""
+    return None, index, "", ""
 
 
 def _scan_csi_token(text: str, start: int) -> tuple[Optional[int], int, str, str]:
@@ -240,11 +253,16 @@ def _rich_ansi_token(
 ) -> str:
     """Return the token form Rich can parse without exposing control payloads."""
     if token_kind == "csi":
+        if text[start] == C1_CSI:
+            return "\x1b[" + text[start + 1:end]
         return text[start:end]
     if token_kind == "osc":
         body_start = start + 2 if text[start] == "\x1b" else start + 1
         body_end = end - len(terminator)
-        return "\x1b]" + text[body_start:body_end] + ST
+        body = text[body_start:body_end]
+        if "\n" in body or "\r" in body:
+            return ""
+        return "\x1b]" + body + ST
     return ""
 
 
@@ -496,6 +514,56 @@ def _map_visible_span(
     if not mapped_positions:
         return None
     return min(mapped_positions), max(mapped_positions) + 1
+
+
+def _split_complete_ansi_line(text: str) -> Optional[tuple[str, str]]:
+    """Split at the first newline that is not inside a string control."""
+    newline_index = _find_visible_newline(text)
+    if newline_index is None:
+        return None
+    return text[:newline_index], text[newline_index + 1:]
+
+
+def _find_visible_newline(text: str) -> Optional[int]:
+    """Return the first newline outside ANSI string-control payloads."""
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "\n":
+            return index
+        if _is_ansi_control_start(text, index):
+            token_end, next_index, _token_kind, _terminator = _scan_ansi_token(
+                text,
+                index,
+            )
+            if _is_string_control_start(text, index):
+                if token_end is not None:
+                    index = token_end
+                    continue
+                if next_index >= len(text):
+                    return None
+                index = next_index
+                continue
+            index = token_end if token_end is not None else max(next_index, index + 1)
+            continue
+        index += 1
+    return None
+
+
+def _is_ansi_control_start(text: str, index: int) -> bool:
+    """Return True when ``text[index]`` can begin an ANSI control sequence."""
+    return text[index] == "\x1b" or text[index] in C1_CONTROL_STARTERS
+
+
+def _is_string_control_start(text: str, index: int) -> bool:
+    """Return True when ``text[index]`` begins OSC/DCS/SOS/PM/APC payload."""
+    if text[index] in C1_STRING_CONTROL_MARKERS + C1_OSC:
+        return True
+    return (
+        text[index] == "\x1b"
+        and index + 1 < len(text)
+        and text[index + 1] in STRING_CONTROL_MARKERS + "]"
+    )
 
 
 class ChoiceScreen(ModalScreen[str]):
@@ -889,9 +957,13 @@ class ThreadSafeRedirector(io.TextIOBase):
             self.buffer = self.buffer.rsplit('\r', 1)[-1]
             return len(s)
 
-        # Process complete lines
-        while '\n' in self.buffer:
-            line, self.buffer = self.buffer.split('\n', 1)
+        # Process complete lines. ANSI string-control payloads may contain
+        # newlines, so only split on visible newlines outside those controls.
+        while True:
+            split_line = _split_complete_ansi_line(self.buffer)
+            if split_line is None:
+                break
+            line, self.buffer = split_line
             # Handle \r within line: keep only content after last \r
             if '\r' in line:
                 line = line.rsplit('\r', 1)[-1]

--- a/pdd/sync_tui.py
+++ b/pdd/sync_tui.py
@@ -42,6 +42,8 @@ C0_CONTROL_CHARS = "".join(
 )
 CAN = "\x18"
 SUB = "\x1a"
+DEL = "\x7f"
+CONTROL_CHARS = C0_CONTROL_CHARS + DEL
 BEL = "\x07"
 ST = "\x1b\\"
 
@@ -114,7 +116,7 @@ def _prepare_ansi_text(
         if (
             text[index] != "\x1b"
             and text[index] not in C1_CONTROL_STARTERS
-            and text[index] not in C0_CONTROL_CHARS
+            and text[index] not in CONTROL_CHARS
         ):
             position_map[index] = len(clean_chars)
             rich_parts.append(text[index])
@@ -148,7 +150,7 @@ def _scan_ansi_token(
     if start >= len(text):
         return None, start + 1, "", ""
 
-    if text[start] in C0_CONTROL_CHARS:
+    if text[start] in CONTROL_CHARS:
         return start + 1, start + 1, "single", ""
     if text[start] in C1_STRING_CONTROL_MARKERS:
         return _scan_string_control_token(text, start + 1)
@@ -383,6 +385,8 @@ def _restore_highlighted_osc(text: str, start: int) -> tuple[Optional[str], int]
     index = start
     body: List[str] = []
     while index < len(text):
+        if text[index] in {CAN, SUB}:
+            return "\x1b]" + "".join(body) + text[index], index + 1
         if text[index] == BEL:
             return "\x1b]" + "".join(body) + BEL, index + 1
         if text[index] == C1_ST:
@@ -394,7 +398,7 @@ def _restore_highlighted_osc(text: str, start: int) -> tuple[Optional[str], int]
             if skipped != index:
                 index = skipped
                 continue
-            return None, index
+            return "\x1b]" + "".join(body) + CAN, index
 
         body.append(text[index])
         index += 1
@@ -410,6 +414,8 @@ def _restore_highlighted_string_control(
     index = start
     body: List[str] = []
     while index < len(text):
+        if text[index] in {CAN, SUB}:
+            return "\x1b" + marker + "".join(body) + text[index], index + 1
         if text[index] == C1_ST:
             return "\x1b" + marker + "".join(body) + C1_ST, index + 1
         if text.startswith(ST, index):
@@ -419,7 +425,7 @@ def _restore_highlighted_string_control(
             if skipped != index:
                 index = skipped
                 continue
-            return None, index
+            return "\x1b" + marker + "".join(body) + CAN, index
 
         body.append(text[index])
         index += 1
@@ -556,6 +562,10 @@ def _find_visible_line_split(text: str) -> Optional[int]:
         char = text[index]
         if char == "\n":
             return index
+        highlighted_end = _highlighted_string_control_end(text, index)
+        if highlighted_end is not None:
+            index = highlighted_end
+            continue
         if _is_ansi_control_start(text, index):
             token_end, next_index, _token_kind, _terminator = _scan_ansi_token(
                 text,
@@ -597,6 +607,10 @@ def _find_last_visible_carriage_return(text: str) -> Optional[int]:
             last_carriage_return = index
             index += 1
             continue
+        highlighted_end = _highlighted_string_control_end(text, index)
+        if highlighted_end is not None:
+            index = highlighted_end
+            continue
         if _is_ansi_control_start(text, index):
             token_end, next_index, _token_kind, _terminator = _scan_ansi_token(
                 text,
@@ -613,7 +627,30 @@ def _is_ansi_control_start(text: str, index: int) -> bool:
     return (
         text[index] == "\x1b"
         or text[index] in C1_CONTROL_STARTERS
-        or text[index] in C0_CONTROL_CHARS
+        or text[index] in CONTROL_CHARS
+    )
+
+
+def _highlighted_string_control_end(text: str, index: int) -> Optional[int]:
+    """Return end index for a Rich-highlighted string control, if present."""
+    if index >= len(text) or text[index] != "\x1b":
+        return None
+    sequence, next_index = _try_restore_highlighted_escape(text, index, "")
+    if sequence is None or not _restored_sequence_is_string_control(sequence):
+        return None
+    return next_index
+
+
+def _restored_sequence_is_string_control(sequence: str) -> bool:
+    """Return True when a restored sequence is OSC/DCS/SOS/PM/APC."""
+    if not sequence:
+        return False
+    if sequence[0] in C1_STRING_CONTROL_MARKERS + C1_OSC:
+        return True
+    return (
+        sequence[0] == "\x1b"
+        and len(sequence) > 1
+        and sequence[1] in STRING_CONTROL_MARKERS + "]"
     )
 
 

--- a/tests/test_thread_safe_redirector.py
+++ b/tests/test_thread_safe_redirector.py
@@ -278,6 +278,56 @@ def test_rich_printed_ansi_reset_preserves_outer_suffix_style(
     )
 
 
+def test_rich_highlighter_style_not_replayed_for_256_color_csi(
+    redirector,
+    captured_texts,
+):
+    """Rich highlighter SGR should not become part of restored CSI style."""
+    console = Console(
+        file=redirector,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+
+    console.print("\x1b[38;5;196mRED\x1b[0m after")
+
+    text = captured_texts[0]
+    assert text.plain == "RED after"
+    assert any(
+        span.start <= 0 and span.end >= len("RED")
+        and getattr(span.style.color, "number", None) == 196
+        for span in text.spans
+    )
+    assert not any(span.style.bold for span in text.spans)
+
+
+def test_rich_highlighter_style_not_replayed_after_osc_title(
+    redirector,
+    captured_texts,
+):
+    """Restoring highlighted OSC should not style following visible text."""
+    console = Console(
+        file=redirector,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+
+    console.print("pre\x1b]0;title\x1b\\post after")
+
+    text = captured_texts[0]
+    assert text.plain == "prepost after"
+    assert not any(
+        span.start < len("prepost after")
+        and span.end > len("pre")
+        and (span.style.bold or span.style.underline)
+        for span in text.spans
+    )
+
+
 def test_rich_printed_osc_and_csi_preserve_styles(redirector, captured_texts):
     """OSC hyperlinks and CSI color should not leak or drop existing Rich styles."""
     console = Console(
@@ -312,6 +362,30 @@ def test_rich_printed_osc_and_csi_preserve_styles(redirector, captured_texts):
 def test_direct_bel_terminated_osc_does_not_leak_payload(redirector, captured_lines):
     """BEL-terminated OSC sequences should be stripped from direct output."""
     redirector.write("pre\x1b]0;mytitle\x07post\n")
+
+    assert captured_lines == ["prepost"]
+
+
+@pytest.mark.parametrize(
+    "sequence",
+    [
+        "pre\x1bP1;payload\x1b\\post",
+        "pre\x1bXpayload\x1b\\post",
+        "pre\x1b^payload\x1b\\post",
+        "pre\x1b_payload\x1b\\post",
+        "pre\x90payload\x9cpost",
+    ],
+    ids=[
+        "esc-dcs",
+        "esc-sos",
+        "esc-pm",
+        "esc-apc",
+        "c1-dcs",
+    ],
+)
+def test_string_control_payloads_do_not_leak(sequence, redirector, captured_lines):
+    """DCS/SOS/PM/APC and C1 string-control payloads should be stripped."""
+    redirector.write(sequence + "\n")
 
     assert captured_lines == ["prepost"]
 

--- a/tests/test_thread_safe_redirector.py
+++ b/tests/test_thread_safe_redirector.py
@@ -6,13 +6,13 @@ These tests verify:
 2. ThreadSafeRedirector properly handles \r for progress bar suppression
 3. Normal newline behavior is preserved
 """
-import pytest
-from unittest.mock import MagicMock, patch
 from typing import List
+from unittest.mock import MagicMock
 
+import pytest
 from rich.console import Console
 
-from pdd.sync_tui import ThreadSafeRedirector, TUIStdoutWrapper, TUIStdinRedirector
+from pdd.sync_tui import ThreadSafeRedirector, TUIStdoutWrapper
 
 
 class MockRichLog:
@@ -215,5 +215,6 @@ def test_rich_printed_ansi_output_does_not_show_escape_fragments(redirector, cap
     )
 
     console.print("\x1b[90mhello\x1b[0m")
+    console.print("\x1b[36m\x1b[1mcyan-bold\x1b[39;49;00m")
 
-    assert captured_lines == ["hello"]
+    assert captured_lines == ["hello", "cyan-bold"]

--- a/tests/test_thread_safe_redirector.py
+++ b/tests/test_thread_safe_redirector.py
@@ -254,6 +254,30 @@ def test_rich_printed_ansi_preserves_existing_rich_styles(redirector, captured_t
     )
 
 
+def test_rich_printed_ansi_reset_preserves_outer_suffix_style(
+    redirector,
+    captured_texts,
+):
+    """Nested ANSI reset should not truncate an outer Rich style span."""
+    console = Console(
+        file=redirector,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+
+    console.print("[dim]\x1b[31mFAIL\x1b[0m after[/dim]")
+
+    text = captured_texts[0]
+    assert text.plain == "FAIL after"
+    assert any(
+        span.start <= len("FAIL ") and span.end >= len("FAIL after")
+        and span.style.dim
+        for span in text.spans
+    )
+
+
 def test_rich_printed_osc_and_csi_preserve_styles(redirector, captured_texts):
     """OSC hyperlinks and CSI color should not leak or drop existing Rich styles."""
     console = Console(

--- a/tests/test_thread_safe_redirector.py
+++ b/tests/test_thread_safe_redirector.py
@@ -390,6 +390,75 @@ def test_string_control_payloads_do_not_leak(sequence, redirector, captured_line
     assert captured_lines == ["prepost"]
 
 
+@pytest.mark.parametrize(
+    "sequence",
+    [
+        "pre\x1bcpost",
+        "pre\x1b#8post",
+        "pre\x1b%Gpost",
+        "pre\x1b Fpost",
+        "pre\x1b Gpost",
+        "pre\x9b?25lpost",
+    ],
+    ids=[
+        "esc-ris",
+        "esc-screen-alignment",
+        "esc-utf8-designate",
+        "esc-sp-f",
+        "esc-sp-g",
+        "c1-csi",
+    ],
+)
+def test_ecma48_controls_do_not_leak(sequence, redirector, captured_lines):
+    """Valid ESC/C1 controls should not reach the log as raw text."""
+    redirector.write(sequence + "\n")
+
+    assert captured_lines == ["prepost"]
+
+
+@pytest.mark.parametrize(
+    "sequence",
+    [
+        "pre\x1b]0;payload\x1b[31mRED\x1b[0mpost",
+        "pre\x1bPpayload\x1b[31mRED\x1b[0mpost",
+    ],
+    ids=["osc-interrupted-by-csi", "dcs-interrupted-by-csi"],
+)
+def test_interrupted_string_control_payloads_do_not_leak(
+    sequence,
+    redirector,
+    captured_lines,
+):
+    """String-control payload before an interrupting ESC should be stripped."""
+    redirector.write(sequence + "\n")
+
+    assert captured_lines == ["preREDpost"]
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        ("\x1b]0;title", "\x1b\\"),
+        ("\x1bPpayload", "\x1b\\"),
+        ("\x90payload", "\x9c"),
+    ],
+    ids=["osc-st", "dcs-st", "c1-dcs-st"],
+)
+def test_string_control_payloads_can_span_newlines(
+    start,
+    end,
+    redirector,
+    captured_lines,
+):
+    """Newlines inside string controls should not flush hidden payload."""
+    redirector.write("pre" + start + "\n")
+    assert captured_lines == []
+
+    redirector.write("more" + end + "post\n")
+
+    assert captured_lines == ["prepost"]
+
+
 def test_rich_printed_non_csi_escape_preserves_styles(redirector, captured_texts):
     """Non-CSI escape controls should be stripped without dropping Rich styles."""
     console = Console(

--- a/tests/test_thread_safe_redirector.py
+++ b/tests/test_thread_safe_redirector.py
@@ -20,10 +20,12 @@ class MockRichLog:
 
     def __init__(self):
         self.written_lines: List[str] = []
+        self.written_texts: List[object] = []
 
     def write(self, text):
         """Capture the plain text content."""
         if hasattr(text, 'plain'):
+            self.written_texts.append(text)
             self.written_lines.append(text.plain)
         else:
             self.written_lines.append(str(text))
@@ -59,6 +61,12 @@ def redirector(mock_app, mock_log):
 def captured_lines(mock_log):
     """Return the captured lines from the mock log."""
     return mock_log.written_lines
+
+
+@pytest.fixture
+def captured_texts(mock_log):
+    """Return the captured Rich Text objects from the mock log."""
+    return mock_log.written_texts
 
 
 # =============================================================================
@@ -218,3 +226,28 @@ def test_rich_printed_ansi_output_does_not_show_escape_fragments(redirector, cap
     console.print("\x1b[36m\x1b[1mcyan-bold\x1b[39;49;00m")
 
     assert captured_lines == ["hello", "cyan-bold"]
+
+
+def test_rich_printed_ansi_preserves_existing_rich_styles(redirector, captured_texts):
+    """Reparsing highlighted ANSI should keep non-ANSI Rich styles on the line."""
+    console = Console(
+        file=redirector,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+
+    console.print("[bold]prefix[/bold] \x1b[90mhello\x1b[0m")
+
+    text = captured_texts[0]
+    assert text.plain == "prefix hello"
+    assert any(
+        span.start <= 0 and span.end >= len("prefix") and span.style.bold
+        for span in text.spans
+    )
+    assert any(
+        span.start <= len("prefix ") and span.end >= len("prefix hello")
+        and getattr(span.style.color, "number", None) == 8
+        for span in text.spans
+    )

--- a/tests/test_thread_safe_redirector.py
+++ b/tests/test_thread_safe_redirector.py
@@ -285,6 +285,13 @@ def test_rich_printed_osc_and_csi_preserve_styles(redirector, captured_texts):
     )
 
 
+def test_direct_bel_terminated_osc_does_not_leak_payload(redirector, captured_lines):
+    """BEL-terminated OSC sequences should be stripped from direct output."""
+    redirector.write("pre\x1b]0;mytitle\x07post\n")
+
+    assert captured_lines == ["prepost"]
+
+
 def test_rich_printed_non_csi_escape_preserves_styles(redirector, captured_texts):
     """Non-CSI escape controls should be stripped without dropping Rich styles."""
     console = Console(
@@ -344,3 +351,23 @@ def test_malformed_highlighted_ansi_restore_advances_linearly(monkeypatch):
     sync_tui._restore_rich_highlighted_ansi(malformed)
 
     assert calls <= repeat_count * 20
+
+
+def test_malformed_osc_span_mapping_avoids_regex_rescan(monkeypatch):
+    """Fallback span mapping should not use suffix-scanning regex matching."""
+    malformed = "\x1b]8;;unterminated"
+    plain = "prefix " + malformed * 20 + " suffix"
+    original = sync_tui.Text(plain)
+    reparsed = sync_tui.Text(plain)
+
+    class SuffixScanningRegex:
+        """Detect accidental use of the regex fallback in span mapping."""
+
+        def finditer(self, text):
+            raise AssertionError(f"regex finditer called for {len(text)} chars")
+
+    monkeypatch.setattr(sync_tui, "ANSI_ESCAPE_RE", SuffixScanningRegex())
+
+    merged = sync_tui._merge_reparsed_ansi_spans(original, reparsed)
+
+    assert merged.plain == plain

--- a/tests/test_thread_safe_redirector.py
+++ b/tests/test_thread_safe_redirector.py
@@ -278,6 +278,30 @@ def test_rich_printed_ansi_reset_preserves_outer_suffix_style(
     )
 
 
+def test_rich_printed_composite_ansi_reset_preserves_outer_suffix_style(
+    redirector,
+    captured_texts,
+):
+    """Composite SGR reset should restore an outer Rich style afterward."""
+    console = Console(
+        file=redirector,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+
+    console.print("[dim]\x1b[31mFAIL\x1b[0;39m after[/dim]")
+
+    text = captured_texts[0]
+    assert text.plain == "FAIL after"
+    assert any(
+        span.start <= len("FAIL ") and span.end >= len("FAIL after")
+        and span.style.dim
+        for span in text.spans
+    )
+
+
 def test_rich_highlighter_style_not_replayed_for_256_color_csi(
     redirector,
     captured_texts,
@@ -455,6 +479,98 @@ def test_string_control_payloads_can_span_newlines(
     assert captured_lines == []
 
     redirector.write("more" + end + "post\n")
+
+    assert captured_lines == ["prepost"]
+
+
+@pytest.mark.parametrize(
+    "sequence",
+    [
+        "pre\x1b]0;ti\rtle\x1b\\post\n",
+        "pre\x1bPpay\rload\x1b\\post\n",
+    ],
+    ids=["osc-cr", "dcs-cr"],
+)
+def test_string_control_carriage_returns_do_not_leak_or_drop_prefix(
+    sequence,
+    redirector,
+    captured_lines,
+):
+    """CR inside string controls should not trigger progress-line compaction."""
+    redirector.write(sequence)
+
+    assert captured_lines == ["prepost"]
+
+
+def test_split_string_control_carriage_return_stays_hidden(
+    redirector,
+    captured_lines,
+):
+    """CR in a partial string-control payload should remain buffered."""
+    redirector.write("pre\x1bPpay\r")
+    assert captured_lines == []
+
+    redirector.write("load\x1b\\post\n")
+
+    assert captured_lines == ["prepost"]
+
+
+@pytest.mark.parametrize(
+    "sequence",
+    [
+        "pre\x1b[?25\npost\n",
+        "pre\x1b[?25\rpost\n",
+        "pre\x1b[?25\x18post\n",
+        "pre\x1b[?25\x1apost\n",
+        "pre\x9b?25\npost\n",
+    ],
+    ids=["newline", "carriage-return", "can", "sub", "c1-newline"],
+)
+def test_malformed_csi_c0_terminators_do_not_leak_or_merge_lines(
+    sequence,
+    redirector,
+    captured_lines,
+):
+    """Malformed CSI should stop at C0/newline boundaries."""
+    redirector.write(sequence)
+
+    assert captured_lines == ["pre", "post"]
+
+
+@pytest.mark.parametrize(
+    "sequence",
+    [
+        "pre\x00post",
+        "pre\x08post",
+        "pre\x0bpost",
+        "pre\x0cpost",
+        "pre\x18post",
+        "pre\x1apost",
+    ],
+    ids=["nul", "bs", "vt", "ff", "can", "sub"],
+)
+def test_standalone_c0_controls_do_not_leak(sequence, redirector, captured_lines):
+    """Standalone C0 controls should be stripped from sync output."""
+    redirector.write(sequence + "\n")
+
+    assert captured_lines == ["prepost"]
+
+
+@pytest.mark.parametrize(
+    "sequence",
+    [
+        "pre\x1b]0;payload\x18post\n",
+        "pre\x1bPpayload\x1apost\n",
+    ],
+    ids=["osc-can", "dcs-sub"],
+)
+def test_can_sub_cancel_string_control_payloads(
+    sequence,
+    redirector,
+    captured_lines,
+):
+    """CAN/SUB should cancel string controls and hide accumulated payload."""
+    redirector.write(sequence)
 
     assert captured_lines == ["prepost"]
 

--- a/tests/test_thread_safe_redirector.py
+++ b/tests/test_thread_safe_redirector.py
@@ -251,3 +251,54 @@ def test_rich_printed_ansi_preserves_existing_rich_styles(redirector, captured_t
         and getattr(span.style.color, "number", None) == 8
         for span in text.spans
     )
+
+
+def test_rich_printed_osc_and_csi_preserve_styles(redirector, captured_texts):
+    """OSC hyperlinks and CSI color should not leak or drop existing Rich styles."""
+    console = Console(
+        file=redirector,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+    osc_link = "\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\"
+
+    console.print("[bold]prefix[/bold] " + osc_link + " \x1b[90mhello\x1b[0m")
+
+    text = captured_texts[0]
+    assert text.plain == "prefix link hello"
+    assert any(
+        span.start <= 0 and span.end >= len("prefix") and span.style.bold
+        for span in text.spans
+    )
+    assert any(
+        span.start <= len("prefix ") and span.end >= len("prefix link")
+        and span.style.link == "https://example.com"
+        for span in text.spans
+    )
+    assert any(
+        span.start <= len("prefix link ") and span.end >= len("prefix link hello")
+        and getattr(span.style.color, "number", None) == 8
+        for span in text.spans
+    )
+
+
+def test_rich_printed_non_csi_escape_preserves_styles(redirector, captured_texts):
+    """Non-CSI escape controls should be stripped without dropping Rich styles."""
+    console = Console(
+        file=redirector,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+
+    console.print("[bold]prefix[/bold] \x1b(Btail")
+
+    text = captured_texts[0]
+    assert text.plain == "prefix tail"
+    assert any(
+        span.start <= 0 and span.end >= len("prefix") and span.style.bold
+        for span in text.spans
+    )

--- a/tests/test_thread_safe_redirector.py
+++ b/tests/test_thread_safe_redirector.py
@@ -10,6 +10,8 @@ import pytest
 from unittest.mock import MagicMock, patch
 from typing import List
 
+from rich.console import Console
+
 from pdd.sync_tui import ThreadSafeRedirector, TUIStdoutWrapper, TUIStdinRedirector
 
 
@@ -200,3 +202,18 @@ def test_ansi_codes_preserved(redirector, captured_lines):
     assert len(captured_lines) == 1
     # The ANSI codes get converted to Rich Text, plain text should be just "Green text"
     assert "Green text" in captured_lines[0]
+
+
+def test_rich_printed_ansi_output_does_not_show_escape_fragments(redirector, captured_lines):
+    """ANSI output printed through Rich should not display raw escape fragments."""
+    console = Console(
+        file=redirector,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+
+    console.print("\x1b[90mhello\x1b[0m")
+
+    assert captured_lines == ["hello"]

--- a/tests/test_thread_safe_redirector.py
+++ b/tests/test_thread_safe_redirector.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 import pytest
 from rich.console import Console
 
+import pdd.sync_tui as sync_tui
 from pdd.sync_tui import ThreadSafeRedirector, TUIStdoutWrapper
 
 
@@ -302,3 +303,44 @@ def test_rich_printed_non_csi_escape_preserves_styles(redirector, captured_texts
         span.start <= 0 and span.end >= len("prefix") and span.style.bold
         for span in text.spans
     )
+
+
+def test_rich_printed_charset_selector_sibling_preserves_styles(redirector, captured_texts):
+    """Charset selector siblings such as ESC)0 should not leak raw escape text."""
+    console = Console(
+        file=redirector,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+
+    console.print("[bold]prefix[/bold] \x1b)0tail")
+
+    text = captured_texts[0]
+    assert text.plain == "prefix tail"
+    assert any(
+        span.start <= 0 and span.end >= len("prefix") and span.style.bold
+        for span in text.spans
+    )
+
+
+def test_malformed_highlighted_ansi_restore_advances_linearly(monkeypatch):
+    """Malformed highlighted OSC/CSI candidates should not rescan suffixes."""
+    malformed_osc = "\x1b\x1b[1m]\x1b[0m8;;unterminated"
+    malformed_csi = "\x1b\x1b[1m[\x1b[0m999"
+    repeat_count = 20
+    malformed = (malformed_osc + malformed_csi) * repeat_count
+    calls = 0
+    original_skip = sync_tui._skip_sgr_sequences
+
+    def counting_skip(text, start):
+        nonlocal calls
+        calls += 1
+        return original_skip(text, start)
+
+    monkeypatch.setattr(sync_tui, "_skip_sgr_sequences", counting_skip)
+
+    sync_tui._restore_rich_highlighted_ansi(malformed)
+
+    assert calls <= repeat_count * 20

--- a/tests/test_thread_safe_redirector.py
+++ b/tests/test_thread_safe_redirector.py
@@ -352,6 +352,60 @@ def test_rich_highlighter_style_not_replayed_after_osc_title(
     )
 
 
+def test_rich_highlighted_osc_interruption_does_not_leak_payload(
+    redirector,
+    captured_lines,
+):
+    """Rich-highlighted OSC payload should be hidden when interrupted by CSI."""
+    console = Console(
+        file=redirector,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+
+    console.print("pre\x1b]0;payload\x1b[31mRED\x1b[0mpost")
+
+    assert captured_lines == ["preREDpost"]
+
+
+def test_rich_highlighted_osc_cancellation_does_not_leak_payload(
+    redirector,
+    captured_lines,
+):
+    """Rich-highlighted OSC payload should be hidden when canceled by CAN."""
+    console = Console(
+        file=redirector,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+
+    console.print("pre\x1b]0;payload\x18post")
+
+    assert captured_lines == ["prepost"]
+
+
+def test_rich_highlighted_osc_newline_payload_stays_hidden(
+    redirector,
+    captured_lines,
+):
+    """Rich-highlighted multiline OSC payload should not split visible logs."""
+    console = Console(
+        file=redirector,
+        force_terminal=True,
+        color_system="standard",
+        highlight=True,
+        width=80,
+    )
+
+    console.print("pre\x1b]0;ti\nmore\x1b\\post")
+
+    assert captured_lines == ["prepost"]
+
+
 def test_rich_printed_osc_and_csi_preserve_styles(redirector, captured_texts):
     """OSC hyperlinks and CSI color should not leak or drop existing Rich styles."""
     console = Console(
@@ -552,6 +606,13 @@ def test_malformed_csi_c0_terminators_do_not_leak_or_merge_lines(
 def test_standalone_c0_controls_do_not_leak(sequence, redirector, captured_lines):
     """Standalone C0 controls should be stripped from sync output."""
     redirector.write(sequence + "\n")
+
+    assert captured_lines == ["prepost"]
+
+
+def test_del_control_does_not_leak(redirector, captured_lines):
+    """DEL should be stripped alongside raw C0 controls."""
+    redirector.write("pre\x7fpost\n")
 
     assert captured_lines == ["prepost"]
 

--- a/tests/test_thread_safe_redirector.py
+++ b/tests/test_thread_safe_redirector.py
@@ -354,20 +354,23 @@ def test_malformed_highlighted_ansi_restore_advances_linearly(monkeypatch):
 
 
 def test_malformed_osc_span_mapping_avoids_regex_rescan(monkeypatch):
-    """Fallback span mapping should not use suffix-scanning regex matching."""
+    """Fallback span mapping should scan malformed OSC fragments once."""
     malformed = "\x1b]8;;unterminated"
-    plain = "prefix " + malformed * 20 + " suffix"
+    repeat_count = 20
+    plain = "prefix " + malformed * repeat_count + " suffix"
     original = sync_tui.Text(plain)
     reparsed = sync_tui.Text(plain)
+    calls = 0
+    original_scan = sync_tui._scan_ansi_token
 
-    class SuffixScanningRegex:
-        """Detect accidental use of the regex fallback in span mapping."""
+    def counting_scan(text, start):
+        nonlocal calls
+        calls += 1
+        return original_scan(text, start)
 
-        def finditer(self, text):
-            raise AssertionError(f"regex finditer called for {len(text)} chars")
-
-    monkeypatch.setattr(sync_tui, "ANSI_ESCAPE_RE", SuffixScanningRegex())
+    monkeypatch.setattr(sync_tui, "_scan_ansi_token", counting_scan)
 
     merged = sync_tui._merge_reparsed_ansi_spans(original, reparsed)
 
     assert merged.plain == plain
+    assert calls <= repeat_count * 2


### PR DESCRIPTION
## Summary
- Adds regression coverage for ANSI-colored output that is printed through Rich before reaching the sync TUI redirector.
- Parses Rich-highlighted ANSI output robustly in `ThreadSafeRedirector`, preserving direct ANSI styling while preventing raw `[90m` / `[39;49;00m` fragments from appearing in the Textual log.

Fixes #255.

## Verification
- `pytest -q tests/test_thread_safe_redirector.py tests/test_sync_tui.py`
- `pylint pdd/sync_tui.py tests/test_thread_safe_redirector.py` (direct command still reports pre-existing lint debt in these files; no pylint errors with `--errors-only`)
- `pylint --errors-only pdd/sync_tui.py tests/test_thread_safe_redirector.py`