### PR TITLE
fix(ci): allow sync_tui auto-heal metadata staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,6 +263,7 @@ yarn.lock
 !.pdd/meta/preprocess_python.json
 !.pdd/meta/summarize_directory_python.json
 !.pdd/meta/sync_determine_operation_python.json
+!.pdd/meta/sync_tui_python.json
 .pdd/meta/*_run.json
 # Issue #1006 follow-up: these two modules' tests pass quickly but
 # `pdd sync` runs >20 minutes on them in CI, hitting the auto-heal


### PR DESCRIPTION
## Summary
- Fixes the PR #1314 auto-heal Cloud Build failure by allowlisting `.pdd/meta/sync_tui_python.json` for staging.
- Keeps the change scoped to the existing auto-heal metadata allowlist pattern in `.gitignore`.

## Investigation
Cloud Build `b4ac1d5a-1392-4c92-a20c-6f4451174caa` successfully healed `sync_tui`, finalized metadata, then failed during commit staging:

```text
ci-heal: skipping gitignored paths during stage:
['.pdd/meta/sync_tui_python.json']
metadata staging verification failed: missing .pdd/meta/sync_tui_python.json
```

Before this fix, `git check-ignore -v .pdd/meta/sync_tui_python.json` matched the `.pdd/meta/*.json` catch-all. Existing precedent in this file is to add per-module `!.pdd/meta/<module>_python.json` allowlist entries for auto-heal-managed fingerprints.

Sibling check:
- PR #1314 auto-heal detects `sync_tui,thread_safe_redirector`.
- `thread_safe_redirector` has no prompt-managed module and was skipped by `ci_drift_heal`; the failing finalized module is `sync_tui`.

Prior fixes referenced:
- `8008bbfa7` allowlisted `preprocess_python.json` for the same staging-verifier failure class.
- `a3fecca05` used the same allowlist shape for other finalized metadata files.

## Validation
- `git check-ignore -q -- .pdd/meta/sync_tui_python.json` now returns non-ignored (`sync_tui metadata is stageable`).
- `python /Users/gregtanaka/Documents/pdd_cloud/scripts/ci/detect_pdd_cli_auto_heal_modules.py --diff-base origin/main...origin/fix/issue-255-sync-ansi` -> `sync_tui,thread_safe_redirector`.
- `pytest -q tests/test_ci_drift_heal.py::TestMetadataFinalizationBoundary tests/test_issue_1021_reproduction.py::TestIssue1021StageSkipsGitignoredRunReports tests/test_issue_1021_reproduction.py::TestIssue1021AutoHealMetadataLeak tests/test_issue_1021_reproduction.py::TestIssue1021StageGeneratedExampleAfterUpdateHeal` -> `15 passed`.
- `git diff --check` passed.

## Notes
After this lands, PR #1314 will still need to incorporate `main` and rerun `auto-heal` so the generated `sync_tui` fingerprint can be staged by the Cloud Build job.