### PR TITLE
perf(agentic): avoid per-chunk transcript re-join in interactive PTY loop

### DIFF
--- a/.pdd/meta/agentic_common_python.json
+++ b/.pdd/meta/agentic_common_python.json
@@ -1,14 +1,14 @@
 {
-  "pdd_version": "0.0.236",
-  "timestamp": "2026-05-26T00:00:00.000000+00:00",
+  "pdd_version": "0.0.261.dev0",
+  "timestamp": "2026-06-02T23:54:15.886423+00:00",
   "command": "fix",
-  "prompt_hash": "631f9633021c0cb748efcc0a4e8b81c4e02cd15629a52b1d99e0a7bd4bc6712c",
-  "code_hash": "82e30c361de4d7b9a62928fe21d8f55df96691c461c73750b30595e3a04446f2",
+  "prompt_hash": "03d01db89847b3082824f427c16890f1c52ae11eb0e645f1f1fa589d0ed876be",
+  "code_hash": "a974cf3eb65e1d5e4410484e8192586f974a0a81e80cdc48bf2cc452771e551e",
   "example_hash": "113b5829cae3a9e38c362b74d5115ba09cab06c7be5831527d9829f97f7b3b7d",
-  "test_hash": "02ffedf502abf754bf81c21133fd6fc50b3a1ff53af55c5843e2b02244bcd671",
+  "test_hash": "5c3125467ff867e944b2c4de85eb62ab9141c5667930eb5ac8ada4b55b8fcf29",
   "test_files": {
-    "test_agentic_common.py": "02ffedf502abf754bf81c21133fd6fc50b3a1ff53af55c5843e2b02244bcd671",
-    "test_agentic_common_issue_813_anthropic_api_key_oauth_shadow.py": "1988f9b022bd4071f95aef13ba6a6a6681279711ad6f718744195b8e0b9dac9e",
+    "test_agentic_common.py": "5c3125467ff867e944b2c4de85eb62ab9141c5667930eb5ac8ada4b55b8fcf29",
+    "test_agentic_common_issue_813_anthropic_api_key_oauth_shadow.py": "4739f1445bbf7528c82eda7c78e52ff9341cfa03a167f351e4458115fd08d1f4",
     "test_agentic_common_worktree.py": "16fb52387d635f1bbccbac20d08ef5b5d878021b70fc1ad79e5d36664df2b9a9"
   },
   "include_deps": {
@@ -16,7 +16,7 @@
     "context/api_key_scanner_example.py": "4b9f880a30445f25edffc394857ae0c218097726c41ab996a03fcbc4350b5482",
     "context/auth_service_example.py": "4b6d2c8c9e13d1edc0d9805ee0c07657494cbf31dffe2bb0029b72975674a8cf",
     "context/python_preamble.prompt": "0388ed131bf986f8752e1bc4c81e4da0460cfe2908ec8c60b1314edbab768254",
-    "pdd/agentic_common.py": "82e30c361de4d7b9a62928fe21d8f55df96691c461c73750b30595e3a04446f2",
-    "pdd/llm_invoke.py": "c0cd59f42c2d096e0f9d85e280c6c96ed82834220f2a6952735a8195b0be0772"
+    "pdd/agentic_common.py": "a974cf3eb65e1d5e4410484e8192586f974a0a81e80cdc48bf2cc452771e551e",
+    "pdd/llm_invoke.py": "c7f13fe2b45b5aa6ba8d3870afce4de2f767d9596cb03563db8db3422af66f40"
   }
 }

--- a/.pdd/meta/agentic_common_python_run.json
+++ b/.pdd/meta/agentic_common_python_run.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-05-13T17:32:24+00:00",
+  "timestamp": "2026-06-02T23:54:15.886904+00:00",
   "exit_code": 0,
-  "tests_passed": 385,
+  "tests_passed": 467,
   "tests_failed": 0,
   "coverage": 90.0,
-  "test_hash": "02ffedf502abf754bf81c21133fd6fc50b3a1ff53af55c5843e2b02244bcd671",
+  "test_hash": "5c3125467ff867e944b2c4de85eb62ab9141c5667930eb5ac8ada4b55b8fcf29",
   "test_files": {
-    "test_agentic_common.py": "02ffedf502abf754bf81c21133fd6fc50b3a1ff53af55c5843e2b02244bcd671",
-    "test_agentic_common_issue_813_anthropic_api_key_oauth_shadow.py": "1988f9b022bd4071f95aef13ba6a6a6681279711ad6f718744195b8e0b9dac9e",
+    "test_agentic_common.py": "5c3125467ff867e944b2c4de85eb62ab9141c5667930eb5ac8ada4b55b8fcf29",
+    "test_agentic_common_issue_813_anthropic_api_key_oauth_shadow.py": "4739f1445bbf7528c82eda7c78e52ff9341cfa03a167f351e4458115fd08d1f4",
     "test_agentic_common_worktree.py": "16fb52387d635f1bbccbac20d08ef5b5d878021b70fc1ad79e5d36664df2b9a9"
   }
 }

--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -3362,7 +3362,13 @@ def _run_interactive_pty_until_reply(
         return False, "Claude Code interactive mode requires POSIX PTY support", 0.0, None
 
     master_fd, slave_fd = pty.openpty()
-    output_chunks: List[str] = []
+    # Bounded rolling output window, updated incrementally. Replaces an unbounded
+    # list of every PTY chunk that was re-joined on each read (for trust-prompt
+    # detection) and again on the error paths: detection is now O(window) per
+    # chunk and the buffer cannot grow with a long session. Sized to cover both
+    # the trust-detection window and the error-snippet length.
+    output_window_chars = max(4000, MAX_ERROR_SNIPPET_LENGTH)
+    output_tail = ""
     proc: Optional[subprocess.Popen] = None
     trust_confirmed = False
     try:
@@ -3398,7 +3404,7 @@ def _run_interactive_pty_until_reply(
             if remaining <= 0:
                 _terminate_process_group(proc, signal.SIGKILL)
                 proc.wait(timeout=5)
-                tail = "".join(output_chunks)[-MAX_ERROR_SNIPPET_LENGTH:]
+                tail = output_tail[-MAX_ERROR_SNIPPET_LENGTH:]
                 return False, f"Claude interactive mode timed out. Output tail: {tail}", 0.0, None
 
             readable, _, _ = select.select([master_fd], [], [], min(0.2, remaining))
@@ -3409,17 +3415,17 @@ def _run_interactive_pty_until_reply(
                     chunk = b""
                 if chunk:
                     decoded = chunk.decode("utf-8", errors="replace")
-                    output_chunks.append(decoded)
-                    if not trust_confirmed:
-                        output_tail = "".join(output_chunks)[-4000:]
-                        if _claude_interactive_needs_trust_confirmation(output_tail):
-                            os.write(master_fd, b"\r")
-                            trust_confirmed = True
+                    output_tail = (output_tail + decoded)[-output_window_chars:]
+                    if not trust_confirmed and _claude_interactive_needs_trust_confirmation(
+                        output_tail
+                    ):
+                        os.write(master_fd, b"\r")
+                        trust_confirmed = True
 
         if reply_path.exists():
             return _parse_claude_interactive_reply(reply_path, job_id)
 
-        tail = "".join(output_chunks)[-MAX_ERROR_SNIPPET_LENGTH:]
+        tail = output_tail[-MAX_ERROR_SNIPPET_LENGTH:]
         returncode = proc.returncode if proc is not None else None
         return (
             False,

--- a/tests/test_agentic_common.py
+++ b/tests/test_agentic_common.py
@@ -635,6 +635,71 @@ def test_interactive_pty_runner_waits_for_reply_file(tmp_path):
     assert model is None
 
 
+def test_interactive_pty_runner_detects_trust_prompt_across_chunks(tmp_path):
+    """The workspace-trust prompt can arrive split across several PTY reads; the
+    bounded rolling output_tail must accumulate it so the detector still fires and
+    the runner sends Enter. Verified end-to-end: the fake reports back whether it
+    received that Enter, so text=='TRUSTED' proves multi-chunk detection worked."""
+    reply_path = tmp_path / "reply.json"
+    job_id = "job-trust-chunks"
+    script_path = tmp_path / "fake_claude.py"
+    script_path.write_text(
+        "import sys, time, json, pathlib, select\n"
+        "reply = pathlib.Path(sys.argv[1])\n"
+        "job_id = sys.argv[2]\n"
+        # the trust prompt (all detector tokens) emitted in separate flushed chunks
+        "for part in ['Quick safety ', 'check\\n', 'I trust ', 'this folder\\n', "
+        "'Press Enter to ', 'confirm\\n']:\n"
+        "    sys.stdout.write(part); sys.stdout.flush(); time.sleep(0.05)\n"
+        # wait (bounded) for the runner's Enter on trust detection, then report it
+        "r, _, _ = select.select([sys.stdin], [], [], 4)\n"
+        "got = 'TRUSTED' if r else 'NO_ENTER'\n"
+        "reply.write_text(json.dumps({'job_id': job_id, 'success': True, 'text': got}), encoding='utf-8')\n"
+        "time.sleep(5)\n",
+        encoding="utf-8",
+    )
+
+    success, text, cost, model = _run_interactive_pty_until_reply(
+        [sys.executable, str(script_path), str(reply_path), job_id],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        timeout=10,
+        reply_path=reply_path,
+        job_id=job_id,
+    )
+
+    assert success is True, f"trust prompt split across chunks must still be detected; got {text!r}"
+    assert text == "TRUSTED"
+
+
+def test_interactive_pty_runner_timeout_tail_from_bounded_buffer(tmp_path):
+    """On timeout the error tail is sourced from the bounded rolling buffer (the
+    unbounded per-chunk output_chunks list is gone) and still carries recent
+    output."""
+    reply_path = tmp_path / "reply.json"
+    script_path = tmp_path / "fake_claude.py"
+    script_path.write_text(
+        "import sys, time\n"
+        "print('NEEDLE_OUTPUT_MARKER')\n"
+        "sys.stdout.flush()\n"
+        "time.sleep(30)\n",
+        encoding="utf-8",
+    )
+
+    success, text, cost, model = _run_interactive_pty_until_reply(
+        [sys.executable, str(script_path)],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        timeout=2,
+        reply_path=reply_path,
+        job_id="job-timeout",
+    )
+
+    assert success is False
+    assert "timed out" in text.lower()
+    assert "NEEDLE_OUTPUT_MARKER" in text
+
+
 def test_estimate_claude_interactive_session_cost_dedupes_request_ids(tmp_path):
     home = tmp_path / "home"
     session_id = "11111111-2222-4333-8444-555555555555"


### PR DESCRIPTION
## What this PR does now

`_run_interactive_pty_until_reply` (the `PDD_CLAUDE_CODE_MODE=interactive` PTY+MCP path) recomputed `"".join(output_chunks)[-4000:]` on **every** PTY read to feed the trust-prompt detector — O(n²) over a long interactive session. This replaces it with a bounded **rolling tail** updated incrementally (O(window) per chunk). Behaviour is unchanged — the 4000-char detection window is identical, only its construction is cheaper.

That is the **only** functional change: +4/-1 in `pdd/agentic_common.py`, plus the re-synced `agentic_common` fingerprint/run-report.

## Why the auth fast-fail was dropped (history)

This PR started as "fail fast on auth failures in interactive Claude Code": detect the `not logged in / please run /login` banner so a credential-rotating caller (the cloud OAuth waterfall) doesn't burn the full per-step timeout per dead key. Two mechanisms were attempted and **both withdrawn as unsound** under review:

1. **Reactive PTY banner scraping.** The banner is byte-identical to ordinary content a *working* session prints (editing auth code, quoting an issue, drafting docs), and a stuck session that prints any chrome line is byte-identical to a working one. No text/progress heuristic separates "revoked/stuck" from "working that printed the phrase" in *both* directions — every setting trades a false-positive (kill a healthy session, rotate away a **valid** credential) for a false-negative (miss a stuck one).

2. **Pre-launch credential check.** `claude auth status` does **not** validate the token, so it cannot detect the actual motivating case — an injected-but-**revoked** OAuth token in the waterfall (a "dead key" is present-but-revoked, not missing). It only catches *missing* credentials, and enumerating every Claude auth route to avoid false-failing local/enterprise setups (keychain OAuth, `apiKeyHelper`, Bedrock/Vertex/Foundry, …) is its own losing game.

## Deferred → #1365

A sound auth fast-fail needs a **post-launch structural signal** — e.g. a revoked session writes no assistant turns to the `~/.claude/projects/.../<session-id>.jsonl` transcript — plus real revoked-token data to validate against. Tracked in #1365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)