### PR TITLE
feat(release): auto-create release video and post it to Discord

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,8 @@ jobs:
             gh release create "$tag" --generate-notes --verify-tag --target main
           fi
 
-      - name: Setup Node for Claude Code / PDS
-        if: env.HAS_CLAUDE_OAUTH == 'true' || env.HAS_PDS == 'true'
+      - name: Setup Node for Claude Code
+        if: env.HAS_CLAUDE_OAUTH == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "20"
@@ -226,6 +226,12 @@ jobs:
             echo "vars.PDS_CLI_PACKAGE not set; skipping release video."
             exit 0
           fi
+          # Uses the runner's preinstalled Node (ubuntu-latest ships Node 20+);
+          # if it is ever absent, skip rather than fail the release.
+          if ! command -v npm >/dev/null 2>&1; then
+            echo "::warning::node/npm not available on runner; skipping release video."
+            exit 0
+          fi
           if ! npm install -g "$PDS_CLI_PACKAGE"; then
             echo "::warning::pds CLI install from PDS_CLI_PACKAGE failed; skipping release video."
             exit 0
@@ -251,13 +257,19 @@ jobs:
           echo "Release video: $youtube_url"
           # Prepend to the notes so it shows on the release page AND survives
           # the Discord post's tail-truncation below.
-          body=$(gh release view "$tag" --json body --jq .body)
+          if ! body=$(gh release view "$tag" --json body --jq .body); then
+            echo "::warning::could not read release notes; video link not added."
+            exit 0
+          fi
           case "$body" in
             *"$youtube_url"*) echo "Release notes already reference the video." ;;
             *)
-              printf '🎥 **Release video:** %s\n\n%s\n' "$youtube_url" "$body" \
-                | gh release edit "$tag" --notes-file -
-              echo "Prepended release video link to $tag notes." ;;
+              if printf '🎥 **Release video:** %s\n\n%s\n' "$youtube_url" "$body" \
+                  | gh release edit "$tag" --notes-file -; then
+                echo "Prepended release video link to $tag notes."
+              else
+                echo "::warning::failed to update release notes with video link."
+              fi ;;
           esac
 
       - name: Post release notes to Discord

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
       id-token: write
     env:
       HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' && 'true' || 'false' }}
+      HAS_PDS: ${{ secrets.PDS_TOKEN != '' && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -88,8 +89,8 @@ jobs:
             gh release create "$tag" --generate-notes --verify-tag --target main
           fi
 
-      - name: Setup Node for Claude Code
-        if: env.HAS_CLAUDE_OAUTH == 'true'
+      - name: Setup Node for Claude Code / PDS
+        if: env.HAS_CLAUDE_OAUTH == 'true' || env.HAS_PDS == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "20"
@@ -188,6 +189,76 @@ jobs:
           echo "-------------------------"
           gh release edit "$tag" --notes-file "$final_file"
           echo "Updated release notes for $tag."
+
+      # Best-effort release video: render via the PDS CLI, publish unlisted to
+      # YouTube, and prepend the link to the release notes so the Discord post
+      # below includes it. PyPI + the GitHub Release already shipped above, so
+      # this step never fails the release (continue-on-error + internal exit 0).
+      #
+      # Activation requires (all optional — no-op until provisioned):
+      #   secrets.PDS_TOKEN            PDS agent token authorized for release
+      #                                projects (scopes: project:create,
+      #                                project:read, project:write, pipeline:run,
+      #                                artifact:read, distribution:package,
+      #                                distribution:publish). A project-locked
+      #                                token (e.g. an e2e profile) will NOT work.
+      #   vars.PDS_CLI_PACKAGE         install spec for the private
+      #                                @promptdriven/pds CLI — an npm spec once
+      #                                published, or an https/tarball URL.
+      #   vars.PDS_API_URL             PDS backend (default the CLI's built-in).
+      #   vars.RELEASE_VIDEO_PROJECT_ID  optional stable PDS project to reuse
+      #                                across releases (else a per-release
+      #                                "PDD <tag> release" project is created).
+      - name: Create release video and prepend link to notes (best-effort)
+        if: env.HAS_PDS == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PDS_TOKEN: ${{ secrets.PDS_TOKEN }}
+          PDS_API_URL: ${{ vars.PDS_API_URL }}
+          PDS_CLI_PACKAGE: ${{ vars.PDS_CLI_PACKAGE }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          RELEASE_VIDEO_PROJECT_ID: ${{ vars.RELEASE_VIDEO_PROJECT_ID }}
+        run: |
+          set -uo pipefail
+          tag="${{ github.ref_name }}"
+          if [ -z "${PDS_CLI_PACKAGE:-}" ]; then
+            echo "vars.PDS_CLI_PACKAGE not set; skipping release video."
+            exit 0
+          fi
+          if ! npm install -g "$PDS_CLI_PACKAGE"; then
+            echo "::warning::pds CLI install from PDS_CLI_PACKAGE failed; skipping release video."
+            exit 0
+          fi
+          if ! command -v claude >/dev/null 2>&1; then
+            npm install -g @anthropic-ai/claude-code@2.1.150 \
+              || { echo "::warning::claude-code install failed; skipping release video."; exit 0; }
+          fi
+          # Render + publish (unlisted). Best-effort: swallow any failure.
+          if ! make release-video \
+              RELEASE_TAG="$tag" \
+              RELEASE_GIT_SHA="${{ github.sha }}" \
+              ${RELEASE_VIDEO_PROJECT_ID:+RELEASE_VIDEO_PROJECT_ID="$RELEASE_VIDEO_PROJECT_ID"}; then
+            echo "::warning::release video generation failed; release notes left unchanged."
+            exit 0
+          fi
+          resp=".pdd/release-videos/${tag}/pds_response.json"
+          youtube_url=$(grep -oE 'https?://(www\.)?(youtube\.com|youtu\.be)/[^"]+' "$resp" 2>/dev/null | head -1 || true)
+          if [ -z "$youtube_url" ]; then
+            echo "No YouTube URL in PDS response ($resp); release notes unchanged."
+            exit 0
+          fi
+          echo "Release video: $youtube_url"
+          # Prepend to the notes so it shows on the release page AND survives
+          # the Discord post's tail-truncation below.
+          body=$(gh release view "$tag" --json body --jq .body)
+          case "$body" in
+            *"$youtube_url"*) echo "Release notes already reference the video." ;;
+            *)
+              printf '🎥 **Release video:** %s\n\n%s\n' "$youtube_url" "$body" \
+                | gh release edit "$tag" --notes-file -
+              echo "Prepended release video link to $tag notes." ;;
+          esac
 
       - name: Post release notes to Discord
         env:


### PR DESCRIPTION
## Summary

Makes the release video happen **automatically on every release** and surfaces it in the Discord **Updates** post — no manual `make release-video` step.

Today the video is created only by a local `make release-video` step, while the Discord post is a separate CI step in `release.yml` that posts **release notes only** (no video link) and runs decoupled from the local video. This PR closes that gap by moving video creation into the tag-triggered workflow and feeding the YouTube link into the existing Discord post.

## What it does

In the `publish-pypi` job, after the GitHub Release is created and notes are rewritten, a new step:
1. Installs the PDS CLI (from `vars.PDS_CLI_PACKAGE`) and `claude-code` (if needed).
2. Runs `make release-video` → renders the video and publishes it **unlisted to YouTube**.
3. Extracts the YouTube URL from the PDS response and **prepends it to the release notes**, so:
   - the release page shows it, and
   - the existing **"Post release notes to Discord"** step (which posts the release body) includes it — prepended so it survives that step's 4000-char tail-truncation.

No change to the Discord step itself was needed.

## Safety — best-effort, fully gated, absent-safe

- Runs **only** when `secrets.PDS_TOKEN` is present (`HAS_PDS` job env, same pattern as `HAS_CLAUDE_OAUTH`).
- **Skips cleanly** if `vars.PDS_CLI_PACKAGE` is unset, or if the pds/claude install fails.
- `continue-on-error: true` **+** internal `exit 0` on every failure path: PyPI publish and the GitHub Release already happened earlier in the job, so a video failure **can never fail a release**.
- **Until you provision the secret/var below, this is a no-op** — existing releases are unaffected.

## Activation (provision when ready)

| Type | Name | Purpose |
|---|---|---|
| secret | `PDS_TOKEN` | Release-authorized PDS agent token (scopes: `project:create,project:read,project:write,pipeline:run,artifact:read,distribution:package,distribution:publish`). A **project-locked** token (e.g. an e2e profile token) will not work. |
| var | `PDS_CLI_PACKAGE` | Install spec for the private `@promptdriven/pds` CLI — an npm spec once published, or an https/tarball URL. |
| var | `PDS_API_URL` | Optional PDS backend override. |
| var | `RELEASE_VIDEO_PROJECT_ID` | Optional stable PDS project to reuse across releases (otherwise a per-release `PDD <tag> release` project is created). |

> Note: `@promptdriven/pds` is currently `private: true` and not on npm, so CI needs an install source (`PDS_CLI_PACKAGE`). Options: publish it, stage a tarball (e.g. GCS, like the auto-heal pattern), or point at a release artifact.

## Test plan

- [x] `release.yml` parses as valid YAML; step order verified (video step sits between notes-rewrite and the Discord post).
- [x] Gating verified: with no `PDS_TOKEN` secret, `HAS_PDS=false` → step does not run (no behavior change to current releases).
- [ ] End-to-end (after provisioning `PDS_TOKEN` + `PDS_CLI_PACKAGE`): tag a release, confirm the video publishes and the YouTube link appears in the GitHub release notes + Discord post.

## Out of scope

- Provisioning the `PDS_TOKEN` / `PDS_CLI_PACKAGE` (requires a release-authorized PDS credential + deciding the CLI install source).
- Whether every release (incl. patch bumps) should publish a video vs. only minor/major — currently every release; easy to gate later on `github.ref_name`.