### PR TITLE
fix(change): rehydrate direct edit candidates on resume

### DIFF
--- a/pdd/agentic_change_orchestrator.py
+++ b/pdd/agentic_change_orchestrator.py
@@ -1633,6 +1633,16 @@ def run_agentic_change_orchestrator(
     for s_num, s_out in step_outputs.items():
         context[f"step{s_num}_output"] = s_out
 
+    cached_step6_output = str(context.get("step6_output", ""))
+    if (
+        last_completed_step >= 6
+        and cached_step6_output
+        and not cached_step6_output.startswith("FAILED:")
+    ):
+        context["direct_edit_candidates"] = _parse_direct_edit_candidates(
+            cached_step6_output
+        )
+
     changed_files = []
     
     if "step9_output" in context:

--- a/pdd/prompts/agentic_change_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_change_orchestrator_python.prompt
@@ -226,6 +226,7 @@ After Step 9 parses FILES_CREATED/FILES_MODIFIED/DIRECT_EDITS, pass the extracte
 After Step 6 completes, parse the "Direct Edit Candidates" table from the output:
 - Extract file paths from rows in the table
 - Store in `context["direct_edit_candidates"]` as a list
+- On resume from cached Step 6 output, rehydrate `context["direct_edit_candidates"]` before the step loop begins
 - Pass to Step 9 so it knows which files can be directly edited
 - Step 9 can only directly edit files that appear in this list
 

--- a/tests/test_agentic_change_orchestrator.py
+++ b/tests/test_agentic_change_orchestrator.py
@@ -2028,6 +2028,96 @@ def test_step9_worktree_fallback_filters_prompt_files(tmp_path):
     assert "notes.txt" not in files
 
 
+def test_resume_to_step9_rehydrates_direct_edit_candidates_for_fallback(
+    mock_dependencies, temp_cwd
+):
+    """
+    On resume after cached Step 6/8, Step 9 may omit DIRECT_EDITS/FILES_*
+    markers and rely on worktree fallback. The fallback must still receive
+    direct-edit candidates parsed from cached Step 6 output.
+    """
+    mocks = mock_dependencies
+
+    step6_output = """
+## Step 6: Dev Units Identified
+
+**Status:** No Dev Units Found
+
+### Direct Edit Candidates (No Prompt)
+| File | Edit Type | Description |
+|------|-----------|-------------|
+| `lib/agent-api/auth.ts` | logic fix | Remove allowlist gate |
+"""
+    existing_state = {
+        "last_completed_step": 8,
+        "step_outputs": {
+            **{str(i): f"out{i}" for i in range(1, 9)},
+            "6": step6_output,
+            "8": "**Status:** No Changes Required",
+        },
+        "worktree_path": str(temp_cwd),
+        "total_cost": 0.5,
+        "model_used": "gpt-4",
+    }
+    mocks["load_state"].return_value = (existing_state, None)
+
+    def side_effect_run(**kwargs):
+        label = kwargs.get("label", "")
+        if label == "step9":
+            return (
+                True,
+                "Applied the scoped authentication change.",
+                0.1,
+                "gpt-4",
+            )
+        if label == "step10":
+            return (True, "Architecture updated.", 0.1, "gpt-4")
+        if label.startswith("step11"):
+            return (True, "No Issues Found", 0.1, "gpt-4")
+        if label == "step13":
+            return (
+                True,
+                "PR Created: https://github.com/owner/repo/pull/607",
+                0.1,
+                "gpt-4",
+            )
+        return (True, f"Output for {label}", 0.1, "gpt-4")
+
+    observed_candidates = []
+
+    def fake_detect(worktree_path, direct_edit_candidates=None):
+        observed_candidates.extend(direct_edit_candidates or [])
+        return ["lib/agent-api/auth.ts"]
+
+    mocks["run"].side_effect = side_effect_run
+
+    with patch(
+        "pdd.agentic_change_orchestrator._preflight_drift_heal",
+        return_value=([], [], []),
+    ), patch(
+        "pdd.agentic_change_orchestrator._detect_worktree_changes",
+        side_effect=fake_detect,
+    ):
+        success, msg, _, _, files = run_agentic_change_orchestrator(
+            issue_url="http://url",
+            issue_content="content",
+            repo_owner="owner",
+            repo_name="repo",
+            issue_number=607,
+            issue_author="me",
+            issue_title="Direct edit resume",
+            cwd=temp_cwd,
+            quiet=True,
+        )
+
+    assert success is True
+    assert "lib/agent-api/auth.ts" in files
+    assert observed_candidates == ["lib/agent-api/auth.ts"], (
+        "Step 9 fallback must receive direct-edit candidates rehydrated from "
+        f"cached Step 6 output; got {observed_candidates!r}. msg={msg!r}"
+    )
+
+
 def test_step9_output_saved_on_failure(mock_dependencies, temp_cwd):
     """
     When step 9 fails (no files from either regex or worktree fallback),


### PR DESCRIPTION
## Summary

- Rehydrate `context["direct_edit_candidates"]` from cached Step 6 output before the step loop starts.
- Preserves Step 9 worktree fallback behavior when resuming after Step 8 and the Step 9 LLM omits `FILES_*` / `DIRECT_EDITS` markers.
- Updates the packaged orchestrator prompt contract so regenerated code keeps the resume invariant.

## Repro / red test

On `upstream/main` plus the test-only commit:

```text
pytest tests/test_agentic_change_orchestrator.py::test_resume_to_step9_rehydrates_direct_edit_candidates_for_fallback -q
FAILED ... Step 9 fallback must receive direct-edit candidates rehydrated from cached Step 6 output; got []
```

## Investigation

- Sibling audit: searched `direct_edit_candidates`, `_detect_worktree_changes`, `step_outputs`, `last_completed_step`, and resume context setup. The fresh Step 6 path populated `context["direct_edit_candidates"]`; the cached-state path only populated `context["step6_output"]`.
- Prior related fix: #1374 made Step 8 no-prompt analysis continue to Step 9 and passed direct-edit candidates through the fresh-run Step 9 fallback. This PR closes the remaining resume-only gap after that change.
- Scope decision: no broader refactor; this only reconstructs a derived context value from already-trusted cached Step 6 output.

## Test plan

- [x] `pytest tests/test_agentic_change_orchestrator.py::test_resume_to_step9_rehydrates_direct_edit_candidates_for_fallback -q`
- [x] `pytest tests/test_agentic_change_orchestrator.py -q -k "direct_edit or direct_edits or step8_no_prompt or worktree_fallback"`
- [x] `pytest tests/test_agentic_change_orchestrator.py -q` (178 passed)
- [x] `python -m py_compile pdd/agentic_change_orchestrator.py`
- [x] `git diff --check`

## Risk / out of scope

- Risk is low: the new value is derived from cached Step 6 text and only expands the Step 9 fallback allowlist to the same candidate set used in a fresh run.
- Does not change direct-edit parsing rules or Step 9 file marker parsing.