### PR TITLE
Update PDS CLI package release comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,9 +202,9 @@ jobs:
       #                                artifact:read, distribution:package,
       #                                distribution:publish). A project-locked
       #                                token (e.g. an e2e profile) will NOT work.
-      #   vars.PDS_CLI_PACKAGE         install spec for the private
-      #                                @promptdriven/pds CLI — an npm spec once
-      #                                published, or an https/tarball URL.
+      #   vars.PDS_CLI_PACKAGE         install spec for the @promptdriven/pds
+      #                                CLI, for example @promptdriven/pds@latest
+      #                                or a pinned version.
       #   vars.PDS_API_URL             PDS backend (default the CLI's built-in).
       #   vars.RELEASE_VIDEO_PROJECT_ID  optional stable PDS project to reuse
       #                                across releases (else a per-release


### PR DESCRIPTION
## Summary
- update the release workflow comment now that @promptdriven/pds is published on npm
- document @promptdriven/pds@latest as the expected PDS_CLI_PACKAGE value

## Test plan
- not run; comment-only workflow metadata update