### PR TITLE
Guard PDS release-video configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,8 @@ jobs:
       #   vars.PDS_CLI_PACKAGE         install spec for the @promptdriven/pds
       #                                CLI, for example @promptdriven/pds@latest
       #                                or a pinned version.
-      #   vars.PDS_API_URL             PDS backend (default the CLI's built-in).
+      #   vars.PDS_API_URL             PDS backend. Defaults to production when
+      #                                the repo variable is unset.
       #   vars.RELEASE_VIDEO_PROJECT_ID  optional stable PDS project to reuse
       #                                across releases (else a per-release
       #                                "PDD <tag> release" project is created).
@@ -215,7 +216,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PDS_TOKEN: ${{ secrets.PDS_TOKEN }}
-          PDS_API_URL: ${{ vars.PDS_API_URL }}
+          PDS_API_URL: ${{ vars.PDS_API_URL || 'https://video.promptdriven.ai' }}
           PDS_CLI_PACKAGE: ${{ vars.PDS_CLI_PACKAGE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           RELEASE_VIDEO_PROJECT_ID: ${{ vars.RELEASE_VIDEO_PROJECT_ID }}

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ TEST_OUTPUTS := $(patsubst $(PDD_DIR)/%.py,$(TESTS_DIR)/test_%.py,$(PY_OUTPUTS))
 # All Example files in context directory (recursive)
 EXAMPLE_FILES := $(shell find $(CONTEXT_DIR) -name "*_example.py" 2>/dev/null)
 
-.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release release-video check-release-remote check-release-branch check-release-clean
+.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release release-video check-release-remote check-release-branch check-release-clean check-release-video-config
 
 all: $(PY_OUTPUTS) $(MAKEFILE_OUTPUT) $(CSV_OUTPUTS) $(EXAMPLE_OUTPUTS) $(TEST_OUTPUTS)
 
@@ -735,6 +735,12 @@ check-release-clean:
 		exit 1; \
 	fi
 
+check-release-video-config:
+	@python scripts/release_video.py \
+		--preflight \
+		--pds-cli "$(PDS_CLI)" \
+		--project-id "$(RELEASE_VIDEO_PROJECT_ID)"
+
 release-video:
 	@if [ "$(RELEASE_VIDEO)" = "0" ]; then \
 		echo "Skipping release video because RELEASE_VIDEO=0"; \
@@ -754,7 +760,7 @@ release-video:
 		--privacy "$(RELEASE_VIDEO_PRIVACY)" \
 		$$DRY_RUN_FLAG
 
-release: check-deps check-suspicious-files check-release-remote check-release-branch check-release-clean
+release: check-deps check-suspicious-files check-release-remote check-release-branch check-release-clean check-release-video-config
 	@echo "Preparing release"
 	@set -e; \
 	echo "Fetching tags from origin"; \

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -25,6 +25,9 @@ class ReleaseVideoError(RuntimeError):
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    if args.preflight:
+        return preflight_release_video(args)
+
     repo = Path(args.repo).resolve()
 
     try:
@@ -127,7 +130,79 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--privacy", default=os.environ.get("RELEASE_VIDEO_PRIVACY", "unlisted"))
     parser.add_argument("--idempotency-key", help="PDS idempotency key.")
     parser.add_argument("--dry-run", action="store_true", help="Plan without creating video or uploading.")
+    parser.add_argument(
+        "--preflight",
+        action="store_true",
+        help="Check local release-video configuration without creating artifacts.",
+    )
     return parser.parse_args(argv)
+
+
+def preflight_release_video(args: argparse.Namespace) -> int:
+    """Warn about local PDS profile shapes that are likely to fail a release."""
+    if os.environ.get("RELEASE_VIDEO", "").strip() == "0":
+        print("release-video preflight: skipped because RELEASE_VIDEO=0.")
+        return 0
+
+    project_id = str(args.project_id or "").strip()
+    if project_id:
+        print(f"release-video preflight: using explicit PDS project {project_id}.")
+        return 0
+
+    if os.environ.get("PDS_TOKEN", "").strip():
+        print("release-video preflight: PDS_TOKEN is set; token scopes cannot be verified locally.")
+        return 0
+
+    config_path = pds_config_path()
+    config = read_pds_config(config_path)
+    if not config:
+        print(
+            "release-video preflight: no local PDS profile found; set PDS_TOKEN "
+            "for CI-like release credentials."
+        )
+        return 0
+
+    profile_name = str(
+        os.environ.get("PDS_PROFILE", "").strip()
+        or config.get("currentProfile", "")
+        or "default"
+    )
+    profiles = config.get("profiles")
+    profile = profiles.get(profile_name, {}) if isinstance(profiles, dict) else {}
+    if not isinstance(profile, dict):
+        profile = {}
+    profile_project_id = str(profile.get("projectId") or "").strip()
+
+    if profile_project_id:
+        print(
+            "release-video preflight warning: active local PDS profile "
+            f"{profile_name!r} is pinned to project {profile_project_id!r}. "
+            "Normal releases create a new per-release project. The profile token "
+            "may fail with \"PDS agent token is not allowed for this project\". "
+            "Use a release-scoped PDS_TOKEN or PDS_PROFILE, set "
+            "RELEASE_VIDEO_PROJECT_ID for an authorized fixed project, or use "
+            "RELEASE_VIDEO=0 for recovery.",
+            file=sys.stderr,
+        )
+        return 0
+
+    print(f"release-video preflight: active local PDS profile {profile_name!r} has no fixed project id.")
+    return 0
+
+
+def pds_config_path() -> Path:
+    config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    if config_home:
+        return Path(config_home) / "pds" / "config.json"
+    return Path.home() / ".config" / "pds" / "config.json"
+
+
+def read_pds_config(path: Path) -> dict[str, Any]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 def run(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -173,6 +173,89 @@ def test_release_video_can_select_existing_pds_project(tmp_path: Path):
     assert "--project-name" not in pds_call
 
 
+def test_release_video_preflight_warns_for_project_scoped_profile(tmp_path: Path):
+    config_home = tmp_path / "config"
+    pds_config_dir = config_home / "pds"
+    pds_config_dir.mkdir(parents=True)
+    (pds_config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "currentProfile": "v18finish",
+                "profiles": {
+                    "v18finish": {
+                        "apiUrl": "https://video.promptdriven.ai",
+                        "projectId": "pdd-release-v0-0-260",
+                        "token": "local-secret-token",
+                    }
+                },
+            }
+        ),
+        encoding="utf8",
+    )
+    env = {**os.environ, "XDG_CONFIG_HOME": str(config_home)}
+    env.pop("PDS_TOKEN", None)
+    env.pop("PDS_PROFILE", None)
+    env.pop("RELEASE_VIDEO_PROJECT_ID", None)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--preflight"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "release-video preflight warning" in result.stderr
+    assert "v18finish" in result.stderr
+    assert "pdd-release-v0-0-260" in result.stderr
+    assert "PDS agent token is not allowed for this project" in result.stderr
+    assert "local-secret-token" not in result.stdout + result.stderr
+
+
+def test_release_video_preflight_allows_env_token_without_printing_it(tmp_path: Path):
+    config_home = tmp_path / "config"
+    pds_config_dir = config_home / "pds"
+    pds_config_dir.mkdir(parents=True)
+    (pds_config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "currentProfile": "v18finish",
+                "profiles": {
+                    "v18finish": {
+                        "projectId": "pdd-release-v0-0-260",
+                        "token": "local-secret-token",
+                    }
+                },
+            }
+        ),
+        encoding="utf8",
+    )
+    env = {
+        **os.environ,
+        "XDG_CONFIG_HOME": str(config_home),
+        "PDS_TOKEN": "env-secret-token",
+    }
+    env.pop("PDS_PROFILE", None)
+    env.pop("RELEASE_VIDEO_PROJECT_ID", None)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--preflight"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "PDS_TOKEN is set" in result.stdout
+    assert "release-video preflight warning" not in result.stderr
+    assert "env-secret-token" not in result.stdout + result.stderr
+    assert "local-secret-token" not in result.stdout + result.stderr
+
+
 def test_release_video_publish_requires_youtube_url(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     capture = tmp_path / "pds-capture.json"


### PR DESCRIPTION
## Summary
- default the release workflow PDS_API_URL to https://video.promptdriven.ai when the repo variable is unset or blank
- add a non-blocking release-video preflight that warns when the active local PDS profile is pinned to a fixed project
- add tests for project-scoped profile warnings and PDS_TOKEN override handling

## Tests
- conda run -n pdd --no-capture-output pytest tests/test_release_video.py -q
- SKIP_MAKEFILE_REGEN=1 make check-release-video-config RELEASE_VIDEO=0
- SKIP_MAKEFILE_REGEN=1 make check-release-video-config

Related: promptdriven/Generative-Video-Studio#708