### PR TITLE
Improve release-video script generation

### DIFF
--- a/pdd/prompts/release_video_script_LLM.prompt
+++ b/pdd/prompts/release_video_script_LLM.prompt
@@ -1,0 +1,59 @@
+<pdd-reason>LLM template: writes a PDS-compatible release-video narration script from GitHub release context and repo research.</pdd-reason>
+
+You are an expert technical product marketer, developer educator, and video scriptwriter.
+Write the narration script for a short YouTube release video about this PDD CLI release.
+
+Audience:
+- Developers who use Prompt-Driven Development today.
+- Developers evaluating whether PDD will save them time, reduce release risk, or improve prompt/code quality.
+- Technical leads who care about concrete workflow value, not generic feature announcements.
+
+Target length:
+- 60-90 seconds.
+
+Style:
+- Clear, concrete, technical, and demo-friendly.
+- Explain what changed, why it matters, and the practical business value.
+- Avoid hype, filler, and vague benefit language.
+- Do not invent claims. Every claim must be grounded in the release context or additional research.
+
+Research requirement:
+- Before writing the final script, use available Claude Code tools to research the release enough to understand the product story.
+- Start from the release context below, then inspect relevant release notes, commits, PRs, issues, changelog entries, docs, tests, and changed files when tools are available.
+- Prefer authoritative local or GitHub sources: the checked-out repo, `git log`, `git show`, `git diff`, `gh release view`, `gh pr view`, and linked issue/PR text.
+- Identify the primary user problem solved by the release, the workflow before and after the change, and the concrete business value.
+- Do not inspect secrets, tokens, credentials, private user config, `.env*` files, or unrelated local files.
+- If tool access is unavailable, use the provided release context only and say nothing about unavailable research in the final script.
+
+Business-value requirements:
+- Lead with the highest-value user outcome, not the implementation detail.
+- For each major feature or fix, connect it to a user/business result, such as faster repair loops, fewer blocked releases, lower review burden, safer automation, clearer failure recovery, or reduced manual work.
+- Explain the "before" pain and the "after" improvement when that helps the story.
+- Mention the release tag naturally.
+- Include at least one concrete example workflow or command when the release context supports it.
+- Keep the message useful for people deciding whether to upgrade.
+
+Visual requirements:
+- Use the PDS script format exactly:
+  - Every spoken narration block starts with `NARRATOR:` on its own line.
+  - Every non-spoken visual cue starts with `VISUAL:` on its own line.
+- Visual cues must be detailed enough for an automated video generator to create relevant scenes.
+- For every `VISUAL:` cue, include specific screen/UI/content direction, not generic phrases.
+- Prefer visuals that reveal the product and workflow: terminal commands, before/after output, GitHub release page, changelog snippets, failing/passing checks, audit files, config snippets, PR/issue references, diagrams of the workflow, and short code/doc excerpts.
+- When showing text on screen, specify the exact or representative text to display.
+- Include motion/composition direction when useful: split-screen before/after, highlighted lines, zoom into terminal output, progress ticks, callout labels, timeline arrows, or overlay badges.
+- Do not use purely atmospheric visuals. Avoid vague cues like "show developers coding" unless tied to a concrete PDD workflow on screen.
+
+Structure requirements:
+- Use plain Markdown.
+- Start with a concise title.
+- Structure the script with 3-5 timestamped level-2 Markdown section headings,
+  exactly like `## Release hook (0:00 - 0:12)`.
+- The automated video pipeline parses headings that start with `## `.
+- Include a short hook, narration beats, and visual direction cues.
+- Keep it suitable for an automated video pipeline: no tables, no footnotes, no citations, no code fences.
+- Output only the script. Do not include research notes, analysis, citations, or preamble.
+
+RELEASE CONTEXT:
+
+{release_context}

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -17,6 +17,27 @@ from typing import Any
 
 SEMVER_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
 YOUTUBE_URL_RE = re.compile(r"https?://(?:www\.)?(?:youtube\.com|youtu\.be)/[^\s\"'<>]+")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_RELEASE_VIDEO_PROMPT = REPO_ROOT / "pdd" / "prompts" / "release_video_script_LLM.prompt"
+DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
+DEFAULT_CLAUDE_TOOLS = ",".join(
+    [
+        "Read",
+        "Grep",
+        "Glob",
+        "Bash(git log *)",
+        "Bash(git show *)",
+        "Bash(git diff *)",
+        "Bash(git status *)",
+        "Bash(git tag *)",
+        "Bash(git describe *)",
+        "Bash(git rev-list *)",
+        "Bash(git remote *)",
+        "Bash(gh release view *)",
+        "Bash(gh pr view *)",
+        "Bash(gh issue view *)",
+    ]
+)
 
 
 class ReleaseVideoError(RuntimeError):
@@ -66,6 +87,8 @@ def main(argv: list[str] | None = None) -> int:
             context=context,
             claude_cli=args.claude_cli,
             claude_model=args.claude_model,
+            claude_tools=args.claude_tools,
+            prompt_template=Path(args.prompt_template),
             timeout=args.claude_timeout,
             cwd=repo,
         )
@@ -115,8 +138,21 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         help="Directory for generated release-video artifacts.",
     )
     parser.add_argument("--claude-cli", default=os.environ.get("CLAUDE_CLI", "claude"))
-    parser.add_argument("--claude-model", default=os.environ.get("CLAUDE_MODEL", "sonnet"))
-    parser.add_argument("--claude-timeout", type=float, default=300.0)
+    parser.add_argument("--claude-model", default=os.environ.get("CLAUDE_MODEL", DEFAULT_CLAUDE_MODEL))
+    parser.add_argument(
+        "--claude-tools",
+        default=os.environ.get("RELEASE_VIDEO_CLAUDE_TOOLS", DEFAULT_CLAUDE_TOOLS),
+        help=(
+            "Claude Code tools allowed while researching the release. "
+            "Set RELEASE_VIDEO_CLAUDE_TOOLS='' to use Claude Code defaults."
+        ),
+    )
+    parser.add_argument("--claude-timeout", type=float, default=float(os.environ.get("CLAUDE_TIMEOUT", "900")))
+    parser.add_argument(
+        "--prompt-template",
+        default=os.environ.get("RELEASE_VIDEO_PROMPT_TEMPLATE", str(DEFAULT_RELEASE_VIDEO_PROMPT)),
+        help="Prompt template used to generate the release-video script.",
+    )
     parser.add_argument("--pds-cli", default=os.environ.get("PDS_CLI", "pds"))
     parser.add_argument(
         "--project-id",
@@ -419,6 +455,8 @@ def generate_script_with_claude(
     context: str,
     claude_cli: str,
     claude_model: str,
+    claude_tools: str,
+    prompt_template: Path,
     timeout: float,
     cwd: Path,
 ) -> str:
@@ -429,14 +467,14 @@ def generate_script_with_claude(
             "-p",
             "--model",
             claude_model,
-            "--tools",
-            "",
             "--no-session-persistence",
             "--output-format",
             "text",
         ]
     )
-    prompt = build_claude_prompt(context)
+    if claude_tools.strip():
+        command.extend(["--allowedTools", claude_tools.strip()])
+    prompt = render_release_video_prompt(context, prompt_template, cwd)
     completed = run(command, cwd=cwd, input_text=prompt, timeout=timeout)
     script = normalize_release_video_script(strip_markdown_fence(completed.stdout.strip()))
     if len(script) < 200:
@@ -444,32 +482,33 @@ def generate_script_with_claude(
     return script.rstrip() + "\n"
 
 
-def build_claude_prompt(context: str) -> str:
-    return f"""Write the narration script for a short YouTube release video about this PDD CLI release.
+def render_release_video_prompt(context: str, prompt_template: Path, cwd: Path) -> str:
+    path = resolve_prompt_template_path(prompt_template, cwd)
+    try:
+        template = path.read_text(encoding="utf8")
+    except OSError as exc:
+        raise ReleaseVideoError(f"Could not read release-video prompt template {path}: {exc}") from exc
+    if "{release_context}" not in template:
+        raise ReleaseVideoError(
+            f"Release-video prompt template {path} must contain {{release_context}}."
+        )
+    return template.replace("{release_context}", context)
 
-Audience: developers who use or may adopt Prompt-Driven Development.
-Length: 60-90 seconds.
-Style: concise, concrete, technical, and demo-friendly.
 
-Requirements:
-- Base every claim on the release context below; do not invent features.
-- Lead with the most user-visible change.
-- Mention the release tag.
-- Use plain Markdown.
-- Structure the script with 3-5 timestamped level-2 Markdown section headings,
-  exactly like "## Release hook (0:00 - 0:12)"; the automated video pipeline
-  parses those "## " headings.
-- Use the PDS script format: every spoken narration block starts with
-  "NARRATOR:" on its own line, and every non-spoken visual cue starts with
-  "VISUAL:" on its own line.
-- Include a title, a short hook, narration beats, and visual direction cues.
-- Keep it suitable for an automated video pipeline: no tables, no footnotes, no citations, no code fences.
-- Output only the script.
-
-RELEASE CONTEXT:
-
-{context}
-"""
+def resolve_prompt_template_path(prompt_template: Path, cwd: Path) -> Path:
+    if prompt_template.is_absolute():
+        if prompt_template.exists():
+            return prompt_template
+        raise ReleaseVideoError(f"Release-video prompt template not found: {prompt_template}")
+    candidates = [
+        cwd / prompt_template,
+        REPO_ROOT / prompt_template,
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate.resolve()
+    tried = "\n".join(str(candidate) for candidate in candidates)
+    raise ReleaseVideoError(f"Release-video prompt template not found. Tried:\n{tried}")
 
 
 def create_release_video(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -9,6 +9,20 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "release_video.py"
 
 
+def release_video_env(extra: dict | None = None) -> dict:
+    env = {**os.environ}
+    for key in (
+        "CLAUDE_MODEL",
+        "CLAUDE_TIMEOUT",
+        "RELEASE_VIDEO_CLAUDE_TOOLS",
+        "RELEASE_VIDEO_PROMPT_TEMPLATE",
+    ):
+        env.pop(key, None)
+    if extra:
+        env.update(extra)
+    return env
+
+
 def run(command, cwd: Path, **kwargs):
     return subprocess.run(
         command,
@@ -54,11 +68,13 @@ def claude_stub(tmp_path: Path) -> Path:
     return write_executable(
         tmp_path / "claude-stub.py",
         """#!/usr/bin/env python3
+import json
 import pathlib
 import sys
 
 prompt = sys.stdin.read()
 pathlib.Path("claude_prompt.txt").write_text(prompt, encoding="utf8")
+pathlib.Path("claude_argv.json").write_text(json.dumps(sys.argv[1:], indent=2), encoding="utf8")
 print("# PDD v1.1.0 Release Video\\n\\n"
       "Hook: This release turns the PDD release process into a publishable video story.\\n\\n"
       "Narration: PDD v1.1.0 adds release video automation, using release context to create a concise update for developers. "
@@ -89,7 +105,7 @@ print(json.dumps({response_literal}))
 def test_release_video_generates_script_and_invokes_pds_publish(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     capture = tmp_path / "pds-capture.json"
-    env = {**os.environ, "PDS_STUB_CAPTURE": str(capture)}
+    env = release_video_env({"PDS_STUB_CAPTURE": str(capture)})
     pds = pds_stub(
         tmp_path,
         {"ok": True, "summary": {"youtubeUrl": "https://youtu.be/pdd-release"}},
@@ -125,8 +141,19 @@ def test_release_video_generates_script_and_invokes_pds_publish(tmp_path: Path):
     assert "\nNARRATOR:\n" in script_text
     assert "\nVISUAL: show the changelog" in script_text
     claude_prompt = (repo / "claude_prompt.txt").read_text(encoding="utf8")
-    assert 'exactly like "## Release hook (0:00 - 0:12)"' in claude_prompt
-    assert '"NARRATOR:" on its own line' in claude_prompt
+    assert "Research requirement:" in claude_prompt
+    assert "Business-value requirements:" in claude_prompt
+    assert "Visual requirements:" in claude_prompt
+    assert "what changed, why it matters, and the practical business value" in claude_prompt
+    assert "## Release hook (0:00 - 0:12)" in claude_prompt
+    assert "Every spoken narration block starts with `NARRATOR:` on its own line." in claude_prompt
+    assert "release video automation" in claude_prompt
+    claude_argv = json.loads((repo / "claude_argv.json").read_text(encoding="utf8"))
+    assert claude_argv[claude_argv.index("--model") + 1] == "claude-opus-4-8"
+    allowed_tools = claude_argv[claude_argv.index("--allowedTools") + 1]
+    assert "Read" in allowed_tools
+    assert "Bash(git show *)" in allowed_tools
+    assert "Bash(gh release view *)" in allowed_tools
     pds_call = json.loads(capture.read_text(encoding="utf8"))["argv"]
     assert pds_call[:2] == ["release-video", "create"]
     assert pds_call[pds_call.index("--target") + 1] == "publish"
@@ -141,7 +168,7 @@ def test_release_video_generates_script_and_invokes_pds_publish(tmp_path: Path):
 def test_release_video_can_select_existing_pds_project(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     capture = tmp_path / "pds-capture.json"
-    env = {**os.environ, "PDS_STUB_CAPTURE": str(capture)}
+    env = release_video_env({"PDS_STUB_CAPTURE": str(capture)})
 
     subprocess.run(
         [
@@ -173,6 +200,43 @@ def test_release_video_can_select_existing_pds_project(tmp_path: Path):
     assert "--project-name" not in pds_call
 
 
+def test_release_video_fails_for_missing_prompt_template(tmp_path: Path):
+    repo = init_release_repo(tmp_path)
+    missing_prompt = tmp_path / "missing_release_video_LLM.prompt"
+    env = release_video_env(
+        {
+            "PDS_STUB_CAPTURE": str(tmp_path / "pds-capture.json"),
+            "RELEASE_VIDEO_PROMPT_TEMPLATE": str(missing_prompt),
+        }
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--claude-cli",
+            str(claude_stub(tmp_path)),
+            "--pds-cli",
+            str(pds_stub(tmp_path, {"ok": True, "summary": {"youtubeUrl": "https://youtu.be/prompt"}})),
+            "--output-dir",
+            str(tmp_path / "videos"),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert f"Release-video prompt template not found: {missing_prompt}" in result.stderr
+    assert not (repo / "claude_prompt.txt").exists()
+
+
 def test_release_video_preflight_warns_for_project_scoped_profile(tmp_path: Path):
     config_home = tmp_path / "config"
     pds_config_dir = config_home / "pds"
@@ -192,7 +256,7 @@ def test_release_video_preflight_warns_for_project_scoped_profile(tmp_path: Path
         ),
         encoding="utf8",
     )
-    env = {**os.environ, "XDG_CONFIG_HOME": str(config_home)}
+    env = release_video_env({"XDG_CONFIG_HOME": str(config_home)})
     env.pop("PDS_TOKEN", None)
     env.pop("PDS_PROFILE", None)
     env.pop("RELEASE_VIDEO_PROJECT_ID", None)
@@ -233,7 +297,7 @@ def test_release_video_preflight_allows_env_token_without_printing_it(tmp_path: 
         encoding="utf8",
     )
     env = {
-        **os.environ,
+        **release_video_env(),
         "XDG_CONFIG_HOME": str(config_home),
         "PDS_TOKEN": "env-secret-token",
     }
@@ -259,7 +323,7 @@ def test_release_video_preflight_allows_env_token_without_printing_it(tmp_path: 
 def test_release_video_publish_requires_youtube_url(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     capture = tmp_path / "pds-capture.json"
-    env = {**os.environ, "PDS_STUB_CAPTURE": str(capture)}
+    env = release_video_env({"PDS_STUB_CAPTURE": str(capture)})
 
     result = subprocess.run(
         [
@@ -290,7 +354,7 @@ def test_release_video_publish_requires_youtube_url(tmp_path: Path):
 def test_release_video_dry_run_does_not_require_youtube_url(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     capture = tmp_path / "pds-capture.json"
-    env = {**os.environ, "PDS_STUB_CAPTURE": str(capture)}
+    env = release_video_env({"PDS_STUB_CAPTURE": str(capture)})
 
     subprocess.run(
         [


### PR DESCRIPTION
## Summary
- switch release-video script generation to Claude Opus 4.8 by default
- move the release-video script prompt into pdd/prompts/release_video_script_LLM.prompt
- expand the prompt to require release research, concrete business value, and detailed visual direction while avoiding secrets
- allow constrained Claude Code read/git/gh tools during release research and add prompt-template validation

## Test plan
- conda run -n pdd --no-capture-output pytest tests/test_release_video.py -q
- git diff --check
- conda run -n pdd --no-capture-output python -m py_compile scripts/release_video.py