### PR TITLE
Use Claude Code default tools for release-video research

### DIFF
--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -20,24 +20,6 @@ YOUTUBE_URL_RE = re.compile(r"https?://(?:www\.)?(?:youtube\.com|youtu\.be)/[^\s
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_RELEASE_VIDEO_PROMPT = REPO_ROOT / "pdd" / "prompts" / "release_video_script_LLM.prompt"
 DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
-DEFAULT_CLAUDE_TOOLS = ",".join(
-    [
-        "Read",
-        "Grep",
-        "Glob",
-        "Bash(git log *)",
-        "Bash(git show *)",
-        "Bash(git diff *)",
-        "Bash(git status *)",
-        "Bash(git tag *)",
-        "Bash(git describe *)",
-        "Bash(git rev-list *)",
-        "Bash(git remote *)",
-        "Bash(gh release view *)",
-        "Bash(gh pr view *)",
-        "Bash(gh issue view *)",
-    ]
-)
 
 
 class ReleaseVideoError(RuntimeError):
@@ -141,10 +123,10 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--claude-model", default=os.environ.get("CLAUDE_MODEL", DEFAULT_CLAUDE_MODEL))
     parser.add_argument(
         "--claude-tools",
-        default=os.environ.get("RELEASE_VIDEO_CLAUDE_TOOLS", DEFAULT_CLAUDE_TOOLS),
+        default=os.environ.get("RELEASE_VIDEO_CLAUDE_TOOLS", ""),
         help=(
-            "Claude Code tools allowed while researching the release. "
-            "Set RELEASE_VIDEO_CLAUDE_TOOLS='' to use Claude Code defaults."
+            "Optional Claude Code tool allowlist for locked-down environments. "
+            "Defaults to Claude Code's normal tool permissions."
         ),
     )
     parser.add_argument("--claude-timeout", type=float, default=float(os.environ.get("CLAUDE_TIMEOUT", "900")))

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -150,10 +150,7 @@ def test_release_video_generates_script_and_invokes_pds_publish(tmp_path: Path):
     assert "release video automation" in claude_prompt
     claude_argv = json.loads((repo / "claude_argv.json").read_text(encoding="utf8"))
     assert claude_argv[claude_argv.index("--model") + 1] == "claude-opus-4-8"
-    allowed_tools = claude_argv[claude_argv.index("--allowedTools") + 1]
-    assert "Read" in allowed_tools
-    assert "Bash(git show *)" in allowed_tools
-    assert "Bash(gh release view *)" in allowed_tools
+    assert "--allowedTools" not in claude_argv
     pds_call = json.loads(capture.read_text(encoding="utf8"))["argv"]
     assert pds_call[:2] == ["release-video", "create"]
     assert pds_call[pds_call.index("--target") + 1] == "publish"
@@ -198,6 +195,42 @@ def test_release_video_can_select_existing_pds_project(tmp_path: Path):
     assert pds_call[:2] == ["--project", "release-project"]
     assert pds_call[2:4] == ["release-video", "create"]
     assert "--project-name" not in pds_call
+
+
+def test_release_video_can_pass_custom_claude_tool_allowlist(tmp_path: Path):
+    repo = init_release_repo(tmp_path)
+    capture = tmp_path / "pds-capture.json"
+    env = release_video_env(
+        {
+            "PDS_STUB_CAPTURE": str(capture),
+            "RELEASE_VIDEO_CLAUDE_TOOLS": "Read,Grep,Bash(git show *)",
+        }
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--claude-cli",
+            str(claude_stub(tmp_path)),
+            "--pds-cli",
+            str(pds_stub(tmp_path, {"ok": True, "summary": {"youtubeUrl": "https://youtu.be/tools"}})),
+            "--output-dir",
+            str(tmp_path / "videos"),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=True,
+    )
+
+    claude_argv = json.loads((repo / "claude_argv.json").read_text(encoding="utf8"))
+    assert claude_argv[claude_argv.index("--allowedTools") + 1] == "Read,Grep,Bash(git show *)"
 
 
 def test_release_video_fails_for_missing_prompt_template(tmp_path: Path):


### PR DESCRIPTION
## Summary
- stop passing a default --allowedTools allowlist to Claude Code during release-video script generation
- keep --claude-tools / RELEASE_VIDEO_CLAUDE_TOOLS as an explicit opt-in for locked-down environments
- update tests to assert the default path uses Claude Code's normal tool permissions

## Test plan
- conda run -n pdd --no-capture-output pytest tests/test_release_video.py -q
- git diff --check
- conda run -n pdd --no-capture-output python -m py_compile scripts/release_video.py