### PR TITLE
feat(checkup): add interactive prompt checkup flags

### DIFF
--- a/pdd/checkup_interactive_main.py
+++ b/pdd/checkup_interactive_main.py
@@ -1,0 +1,100 @@
+"""Interactive checkup orchestration for .prompt file targets.
+
+Orchestrates: report → InteractiveRepairSession → optional apply.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from .checkup_prompt_main import SourceSetFinding, build_prompt_source_set_report
+
+
+class InteractiveRepairSession:
+    """Stub duck-typed protocol for the Block 1 InteractiveRepairSession.
+
+    Exposes ask(prompt: str) -> str and an iterable findings interface.
+    Replace with the real implementation once Block 1 is merged.
+    """
+
+    def __init__(self, findings: list[SourceSetFinding]) -> None:
+        self._findings = list(findings)
+
+    def ask(self, prompt: str) -> str:  # noqa: ARG002
+        """Return a clarification answer (stub: returns empty string)."""
+        return ""
+
+    def __iter__(self):  # type: ignore[override]
+        return iter(self._findings)
+
+
+def run_interactive_checkup(
+    target: str,
+    *,
+    apply: bool = False,
+    dry_run: bool = False,
+    project_root: Optional[Path] = None,
+    strict: bool = False,
+    quiet: bool = False,
+) -> Optional[tuple[str, float, str]]:
+    """Orchestrate report → session → optional apply for a .prompt target.
+
+    Guards (enforced by the CLI layer before this is called):
+    - --apply requires --interactive
+    - non-TTY + --interactive raises UsageError
+    - --dry-run: no writes (including no backup)
+    - --interactive without --apply: no writes
+    """
+    root = project_root if project_root is not None else Path.cwd()
+    report = build_prompt_source_set_report(
+        Path(target),
+        target=target,
+        project_root=root,
+        strict=strict,
+    )
+
+    if not quiet:
+        click.echo(f"Interactive checkup: {target}")
+        click.echo(f"Status: {report.status}  Findings: {len(report.findings)}")
+
+    session = InteractiveRepairSession(report.findings)
+
+    skipped = 0
+    for finding in session:
+        if not quiet:
+            click.echo(f"\n[{finding.finding_id}] ({finding.severity}) {finding.message}")
+            if finding.evidence:
+                click.echo(f"  Evidence: {finding.evidence[:200]}")
+
+        recommended = finding.recommended_action or "Apply automated fix"
+        click.echo(
+            f"\nChoose one:\n"
+            f"[1] {recommended}\n"
+            f"[2] Preview only\n"
+            f"[3] Write my own definition\n"
+            f"[4] Skip"
+        )
+        choice = click.prompt("Choice", type=click.IntRange(1, 4), default=4)
+
+        if choice == 4:
+            skipped += 1
+            continue
+        if choice == 3:
+            session.ask(f"Clarify finding {finding.finding_id}")
+            continue
+        if choice == 1 and apply and not dry_run:
+            # Block 3 applicator not yet merged — stub only.
+            if not quiet:
+                click.echo(f"  [stub] Would apply fix for {finding.finding_id} (Block 3 not merged).")
+
+    cost = 0.0
+    model = ""
+    message = (
+        f"Interactive checkup complete: {report.status} "
+        f"({len(report.findings)} findings, {skipped} skipped)"
+    )
+    if not quiet:
+        click.echo(f"\n{message}")
+    return message, cost, model

--- a/pdd/commands/checkup.py
+++ b/pdd/commands/checkup.py
@@ -3,6 +3,7 @@ Checkup command — GitHub issue-driven project health check, or local diagnosti
 """
 # pylint: disable=unknown-option-value
 import math
+import sys
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -385,6 +386,27 @@ def _forward_subcommand_json(
     help="Wall-clock timeout for the prompt repair loop in seconds (default: 120).",
 )
 @click.option(
+    "--interactive",
+    "interactive",
+    is_flag=True,
+    default=False,
+    help="With .prompt targets: enter interactive per-finding repair session.",
+)
+@click.option(
+    "--apply",
+    "apply",
+    is_flag=True,
+    default=False,
+    help="With --interactive: apply selected repairs. Requires --interactive.",
+)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="With --interactive --apply: preview changes without writing any files.",
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -415,6 +437,9 @@ def checkup(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     validate_arch_includes: bool,
     project_root: Optional[Path],
     strict: bool,
+    interactive: bool,
+    apply: bool,
+    dry_run: bool,
     as_json: bool,
     explain: bool,
     no_fix: bool,
@@ -566,6 +591,8 @@ def checkup(  # pylint: disable=too-many-arguments,too-many-positional-arguments
 
     if target == "simplify":
         simplify_args = list(ctx.args)
+        if apply:
+            simplify_args.insert(0, "--apply")
         if show_help:
             simplify_args.append("--help")
         exit_code = checkup_simplify.main(
@@ -671,6 +698,12 @@ def checkup(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     if ctx.args:
         raise click.UsageError(f"Got unexpected extra arguments ({' '.join(ctx.args)})")
 
+    if apply and not interactive:
+        raise click.UsageError("--apply requires --interactive.")
+
+    if interactive and not (sys.stdin.isatty() and sys.stdout.isatty()):
+        raise click.UsageError("--interactive requires a TTY (stdin and stdout must be a terminal).")
+
     if validate_arch_includes:
         if target is not None or pr_url is not None or issue_url_opt is not None:
             raise click.BadParameter(
@@ -687,6 +720,18 @@ def checkup(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         target,
         project_root=project_root,
     ):
+        if interactive and target.endswith(".prompt"):
+            from ..checkup_interactive_main import run_interactive_checkup  # pylint: disable=import-outside-toplevel
+
+            return run_interactive_checkup(
+                target,
+                apply=apply,
+                dry_run=dry_run,
+                project_root=project_root,
+                strict=strict,
+                quiet=ctx.obj.get("quiet", False),
+            )
+
         import json as _json  # pylint: disable=import-outside-toplevel
 
         quiet = ctx.obj.get("quiet", False)

--- a/tests/test_checkup_interactive.py
+++ b/tests/test_checkup_interactive.py
@@ -1,0 +1,194 @@
+"""Tests for interactive checkup flags and interaction policy.
+
+Covers:
+- non-TTY + --interactive → UsageError
+- --apply without --interactive → UsageError
+- --dry-run: no file writes (including no backup)
+- --interactive without --apply: no file writes
+- skip flow: choice 4 skips all findings
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from pdd.commands.checkup import checkup
+from pdd.checkup_interactive_main import InteractiveRepairSession, run_interactive_checkup
+from pdd.checkup_prompt_main import PromptSourceSetReport, SourceSetFinding
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_finding(finding_id: str = "F001") -> SourceSetFinding:
+    return SourceSetFinding(
+        finding_id=finding_id,
+        source_check="lint",
+        severity="warn",
+        file=Path("prompts/test.prompt"),
+        message="Test finding",
+        evidence="some evidence",
+        recommended_action="Fix the issue",
+    )
+
+
+def _make_report(tmp_path: Path, findings: list[SourceSetFinding] | None = None) -> PromptSourceSetReport:
+    prompt_path = tmp_path / "test.prompt"
+    return PromptSourceSetReport(
+        prompt_path=prompt_path,
+        project_root=tmp_path,
+        target=str(prompt_path),
+        findings=findings or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard: non-TTY + --interactive → UsageError
+# ---------------------------------------------------------------------------
+
+def test_interactive_requires_tty(tmp_path: Path) -> None:
+    """--interactive in a non-TTY context (CliRunner) must raise UsageError."""
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("test prompt content")
+
+    runner = CliRunner()
+    result = runner.invoke(checkup, [str(prompt_file), "--interactive"])
+
+    assert result.exit_code != 0
+    assert "TTY" in result.output or "tty" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Guard: --apply without --interactive → UsageError
+# ---------------------------------------------------------------------------
+
+def test_apply_requires_interactive(tmp_path: Path) -> None:
+    """--apply without --interactive must raise UsageError regardless of TTY."""
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("test prompt content")
+
+    runner = CliRunner()
+    result = runner.invoke(checkup, [str(prompt_file), "--apply"])
+
+    assert result.exit_code != 0
+    assert "--apply requires --interactive" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --dry-run: no writes including no backup
+# ---------------------------------------------------------------------------
+
+def test_dry_run_no_writes(tmp_path: Path) -> None:
+    """--dry-run must not modify any files or create backups."""
+    prompt_file = tmp_path / "test.prompt"
+    original_content = "original prompt content"
+    prompt_file.write_text(original_content)
+
+    finding = _make_finding("DRY-001")
+    report = _make_report(tmp_path, [finding])
+
+    with patch("pdd.checkup_interactive_main.build_prompt_source_set_report", return_value=report):
+        with patch("click.prompt", return_value=1):  # choose "apply" option
+            run_interactive_checkup(
+                str(prompt_file),
+                apply=True,
+                dry_run=True,
+                project_root=tmp_path,
+                quiet=True,
+            )
+
+    # File must be unchanged
+    assert prompt_file.read_text() == original_content
+    # No backup file created
+    backup_files = list(tmp_path.glob("*.bak")) + list(tmp_path.glob("*.prompt.bak"))
+    assert backup_files == [], f"Unexpected backup files: {backup_files}"
+
+
+# ---------------------------------------------------------------------------
+# --interactive without --apply: no writes
+# ---------------------------------------------------------------------------
+
+def test_interactive_no_writes(tmp_path: Path) -> None:
+    """--interactive without --apply must not modify any files."""
+    prompt_file = tmp_path / "test.prompt"
+    original_content = "original prompt content"
+    prompt_file.write_text(original_content)
+
+    finding = _make_finding("NW-001")
+    report = _make_report(tmp_path, [finding])
+
+    with patch("pdd.checkup_interactive_main.build_prompt_source_set_report", return_value=report):
+        with patch("click.prompt", return_value=1):  # choose "apply" option, but apply=False
+            run_interactive_checkup(
+                str(prompt_file),
+                apply=False,
+                dry_run=False,
+                project_root=tmp_path,
+                quiet=True,
+            )
+
+    assert prompt_file.read_text() == original_content
+    backup_files = list(tmp_path.glob("*.bak")) + list(tmp_path.glob("*.prompt.bak"))
+    assert backup_files == [], f"Unexpected backup files: {backup_files}"
+
+
+# ---------------------------------------------------------------------------
+# Skip flow: choice 4 skips finding
+# ---------------------------------------------------------------------------
+
+def test_skip_flow(tmp_path: Path) -> None:
+    """Choice 4 (Skip) must not apply any changes and count as skipped."""
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("prompt content")
+
+    findings = [_make_finding("SK-001"), _make_finding("SK-002")]
+    report = _make_report(tmp_path, findings)
+
+    with patch("pdd.checkup_interactive_main.build_prompt_source_set_report", return_value=report):
+        with patch("click.prompt", return_value=4):  # always skip
+            result = run_interactive_checkup(
+                str(prompt_file),
+                apply=True,
+                dry_run=False,
+                project_root=tmp_path,
+                quiet=True,
+            )
+
+    assert result is not None
+    message, cost, model = result
+    assert "skipped" in message
+    assert "2 skipped" in message
+
+
+# ---------------------------------------------------------------------------
+# InteractiveRepairSession stub interface
+# ---------------------------------------------------------------------------
+
+def test_interactive_repair_session_stub() -> None:
+    """InteractiveRepairSession stub exposes ask() and is iterable."""
+    finding = _make_finding("SES-001")
+    session = InteractiveRepairSession([finding])
+
+    # iterable
+    findings_list = list(session)
+    assert len(findings_list) == 1
+    assert findings_list[0].finding_id == "SES-001"
+
+    # ask returns a string
+    answer = session.ask("clarify this")
+    assert isinstance(answer, str)
+
+
+# ---------------------------------------------------------------------------
+# CLI param registration
+# ---------------------------------------------------------------------------
+
+def test_checkup_registers_interactive_flags() -> None:
+    """checkup command must have interactive, apply, and dry_run params."""
+    param_names = {p.name for p in checkup.params}
+    missing = {"interactive", "apply", "dry_run"} - param_names
+    assert not missing, f"Missing params: {missing}"


### PR DESCRIPTION
Closes #1436.\n\n## Summary\n- Register --interactive, --apply, and --dry-run on pdd checkup.\n- Route .prompt targets into a new interactive checkup orchestrator.\n- Add guard/menu/no-write tests for interactive checkup behavior.\n\n## Validation\n- .venv/bin/python -c "from pdd.commands.checkup import checkup; p={x.name for x in checkup.params}; assert all(f in p for f in ['interactive','apply','dry_run']), f'Missing: {p}'"\n- .venv/bin/python -m pytest tests/test_checkup_interactive.py -v\n- .venv/bin/python -m pytest tests/test_agentic_checkup.py tests/test_checkup_pr_mode.py tests/test_checkup_review_loop.py --no-header -q\n\n## Notes\n- Implemented in isolated temp clone from locked GoalSpec for issue #1436.\n