### PR TITLE
feat(checkup): CLI flags and interaction policy for interactive checkup (#1436)

### DIFF
--- a/pdd/change_main.py
+++ b/pdd/change_main.py
@@ -522,6 +522,7 @@ def change_main(
                 no_prompt_checkup=ctx.obj.get("no_prompt_checkup", False),
                 project_root=resolve_prompt_gate_project_root(saved_prompt_paths),
                 quiet=quiet,
+                interactive=ctx.obj.get("interactive", False),
             )
             if not should_continue:
                 msg = prompt_gate_block_message(gate_exit)

--- a/pdd/checkup_interactive_main.py
+++ b/pdd/checkup_interactive_main.py
@@ -1,0 +1,290 @@
+"""Interactive checkup orchestration for prompt-shaped ``pdd checkup`` targets."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Callable, Optional, Union
+
+import click
+
+from .checkup_interactive_session import (
+    ApprovedPatch,
+    InteractiveRepairSession,
+    NON_APPROVING_PATCH_KINDS,
+    RepairOption,
+)
+from .checkup_prompt_main import (
+    PromptSourceSetReport,
+    SourceSetFinding,
+    build_prompt_source_set_report,
+)
+
+_EVIDENCE_EXCERPT_LEN = 200
+_SessionType = Union[InteractiveRepairSession, "ClickInteractiveSession"]
+
+
+def _truncate_excerpt(text: str, max_len: int = _EVIDENCE_EXCERPT_LEN) -> str:
+    cleaned = " ".join(str(text).split())
+    if len(cleaned) <= max_len:
+        return cleaned
+    return cleaned[: max_len - 3] + "..."
+
+
+def filter_interactive_findings(
+    report: PromptSourceSetReport,
+    *,
+    explicit_interactive: bool,
+) -> list[SourceSetFinding]:
+    """Return findings that belong in an interactive repair session."""
+    if explicit_interactive:
+        return list(report.findings)
+    return [finding for finding in report.findings if finding.requires_clarification]
+
+
+def build_repair_options_for_finding(finding: SourceSetFinding) -> list[RepairOption]:
+    """Build up to two repair candidates from one structured finding."""
+    primary_action = finding.recommended_action or "Apply suggested repair"
+    primary_preview = _truncate_excerpt(finding.evidence or finding.message)
+    alternate_label = "Alternative repair"
+    alternate_preview = _truncate_excerpt(finding.message)
+    return [
+        RepairOption(
+            label=primary_action,
+            preview=primary_preview,
+            patch=ApprovedPatch(
+                kind="repair_candidate",
+                target=finding.file,
+                anchor={"finding_id": finding.finding_id, "line": finding.line},
+                replacement=primary_action,
+                finding_id=finding.finding_id,
+            ),
+        ),
+        RepairOption(
+            label=alternate_label,
+            preview=alternate_preview,
+            patch=ApprovedPatch(
+                kind="repair_candidate_alt",
+                target=finding.file,
+                anchor={"finding_id": finding.finding_id, "line": finding.line},
+                replacement=alternate_label,
+                finding_id=finding.finding_id,
+            ),
+        ),
+    ]
+
+
+class ClickInteractiveSession:
+    """Click-native ``InteractiveRepairSession`` backed by report findings."""
+
+    def __init__(self) -> None:
+        self.report: PromptSourceSetReport | None = None
+        self._options_by_finding: dict[str, list[RepairOption]] = {}
+        self.presented_options: dict[str, list[RepairOption]] = {}
+        self.recorded_choices: list[tuple[str, RepairOption]] = []
+
+    def seed(self, report: PromptSourceSetReport) -> None:
+        """Index repair options from a structured source-set report."""
+        self.report = report
+        self._options_by_finding = {
+            finding.finding_id: build_repair_options_for_finding(finding)
+            for finding in report.findings
+        }
+
+    def present_finding(self, finding_id: str) -> list[RepairOption]:
+        """Return repair candidates for one finding."""
+        options = list(self._options_by_finding.get(finding_id, []))
+        self.presented_options[finding_id] = options
+        return list(options)
+
+    def ask(self, question: str) -> str:
+        """Ask a free-form clarification question in the terminal."""
+        return click.prompt(question, type=str, default="", show_default=False)
+
+    def record_choice(self, finding_id: str, option: RepairOption) -> None:
+        """Record one validated menu choice for a finding."""
+        presented = self.presented_options.get(finding_id)
+        if presented is None or option not in presented:
+            raise ValueError(
+                f"repair option {option.label!r} was not presented for {finding_id!r}"
+            )
+        if any(existing_id == finding_id for existing_id, _ in self.recorded_choices):
+            raise ValueError(f"choice already recorded for {finding_id!r}")
+        self.recorded_choices.append((finding_id, option))
+
+    def approved_patches(self) -> list[ApprovedPatch]:
+        """Return approving patches from recorded menu choices."""
+        patches: list[ApprovedPatch] = []
+        for finding_id, option in self.recorded_choices:
+            patch = option.patch
+            if (
+                isinstance(patch, ApprovedPatch)
+                and patch.kind not in NON_APPROVING_PATCH_KINDS
+            ):
+                copied = deepcopy(patch)
+                if not copied.finding_id:
+                    copied.finding_id = finding_id
+                patches.append(copied)
+        return patches
+
+
+def _skip_option(finding: SourceSetFinding) -> RepairOption:
+    return RepairOption(
+        label="Skip",
+        preview="Skip this finding",
+        patch=ApprovedPatch(
+            kind="skip",
+            target=finding.file,
+            anchor={"finding_id": finding.finding_id},
+            replacement="",
+            finding_id=finding.finding_id,
+        ),
+    )
+
+
+def _custom_option(finding: SourceSetFinding, definition: str) -> RepairOption:
+    return RepairOption(
+        label="Write my own definition",
+        preview=_truncate_excerpt(definition),
+        patch=ApprovedPatch(
+            kind="custom_no_patch",
+            target=finding.file,
+            anchor={"finding_id": finding.finding_id},
+            replacement=definition,
+            finding_id=finding.finding_id,
+        ),
+    )
+
+
+def _append_presented_option(
+    session: ClickInteractiveSession,
+    finding_id: str,
+    option: RepairOption,
+) -> None:
+    presented = session.presented_options.get(finding_id)
+    if presented is None:
+        raise ValueError(f"finding {finding_id!r} was not presented")
+    if option not in presented:
+        session.presented_options[finding_id] = list(presented) + [option]
+
+
+def _prompt_menu_choice(
+    finding: SourceSetFinding,
+    options: list[RepairOption],
+) -> int:
+    click.echo(f"\n[{finding.finding_id}] {finding.message}")
+    if finding.evidence:
+        click.echo(f"  {_truncate_excerpt(finding.evidence)}")
+
+    label_a = options[0].label if options else "Option A"
+    preview_a = options[0].preview if options else "(unavailable)"
+    label_b = options[1].label if len(options) > 1 else "Option B"
+    preview_b = options[1].preview if len(options) > 1 else "(unavailable)"
+
+    click.echo("\nChoose one:")
+    click.echo(f"[1] {label_a} — {preview_a}")
+    click.echo(f"[2] {label_b} — {preview_b}")
+    click.echo("[3] Write my own definition")
+    click.echo("[4] Skip")
+    return click.prompt("Choice", type=click.IntRange(1, 4), default=4)
+
+
+def apply_approved_patches(
+    patches: list[ApprovedPatch],
+    *,
+    dry_run: bool,
+    quiet: bool,
+) -> None:
+    """Apply boundary for Block 3; v1 honors dry-run and leaves writes to Block 3."""
+    if dry_run or not patches:
+        return
+    for patch in patches:
+        if not quiet:
+            click.echo(
+                f"  [apply pending Block 3] {patch.finding_id}: {patch.kind} "
+                f"→ {patch.target}"
+            )
+
+
+def run_interactive_checkup(
+    target: str,
+    *,
+    apply: bool = False,
+    dry_run: bool = False,
+    project_root: Optional[Path] = None,
+    strict: bool = False,
+    quiet: bool = False,
+    explicit_interactive: bool = True,
+    session_factory: Optional[Callable[[], InteractiveRepairSession]] = None,
+) -> Optional[tuple[str, float, str]]:
+    """Orchestrate report → session → optional apply for one prompt target."""
+    root = project_root if project_root is not None else Path.cwd()
+    prompt_path = Path(target)
+    if not prompt_path.is_file():
+        raise click.UsageError(
+            f"--interactive requires a single .prompt file target, got {target!r}."
+        )
+
+    report = build_prompt_source_set_report(
+        prompt_path,
+        target=target,
+        project_root=root,
+        strict=strict,
+    )
+    findings = filter_interactive_findings(
+        report,
+        explicit_interactive=explicit_interactive,
+    )
+
+    if not quiet:
+        click.echo(f"Interactive checkup: {target}")
+        click.echo(
+            f"Status: {report.status}  Findings: {len(report.findings)}  "
+            f"In scope: {len(findings)}"
+        )
+
+    session: _SessionType
+    if session_factory is not None:
+        session = session_factory()
+    else:
+        session = ClickInteractiveSession()
+    session.seed(report)
+
+    skipped = 0
+    for finding in findings:
+        options = session.present_finding(finding.finding_id)
+        choice = _prompt_menu_choice(finding, options)
+
+        if choice == 4:
+            if isinstance(session, ClickInteractiveSession):
+                skip_option = _skip_option(finding)
+                _append_presented_option(session, finding.finding_id, skip_option)
+                session.record_choice(finding.finding_id, skip_option)
+            skipped += 1
+            continue
+
+        if choice == 3:
+            definition = session.ask("Enter your definition:")
+            if isinstance(session, ClickInteractiveSession):
+                custom_option = _custom_option(finding, definition)
+                _append_presented_option(session, finding.finding_id, custom_option)
+                session.record_choice(finding.finding_id, custom_option)
+            continue
+
+        index = choice - 1
+        if 0 <= index < len(options):
+            session.record_choice(finding.finding_id, options[index])
+
+    patches = session.approved_patches()
+    if apply:
+        apply_approved_patches(patches, dry_run=dry_run, quiet=quiet)
+
+    cost = 0.0
+    model = ""
+    message = (
+        f"Interactive checkup complete: {report.status} "
+        f"({len(findings)} findings, {skipped} skipped)"
+    )
+    if not quiet:
+        click.echo(f"\n{message}")
+    return message, cost, model

--- a/pdd/commands/checkup.py
+++ b/pdd/commands/checkup.py
@@ -3,6 +3,7 @@ Checkup command — GitHub issue-driven project health check, or local diagnosti
 """
 # pylint: disable=unknown-option-value
 import math
+import sys
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -30,6 +31,11 @@ from .coverage import coverage_cmd
 from .gate import gate_cmd
 from .drift import drift_cmd
 from .prompt import prompt_lint
+
+
+def _interactive_tty_available() -> bool:
+    """Return True when stdin and stdout are interactive terminals."""
+    return sys.stdin.isatty() and sys.stdout.isatty()
 
 
 def _forward_subcommand_json(
@@ -385,6 +391,27 @@ def _forward_subcommand_json(
     help="Wall-clock timeout for the prompt repair loop in seconds (default: 120).",
 )
 @click.option(
+    "--interactive",
+    "interactive",
+    is_flag=True,
+    default=False,
+    help="With .prompt targets: enter interactive per-finding repair session.",
+)
+@click.option(
+    "--apply",
+    "apply",
+    is_flag=True,
+    default=False,
+    help="With --interactive: apply selected repairs. Requires --interactive.",
+)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="With --interactive --apply: preview changes without writing any files.",
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -449,6 +476,9 @@ def checkup(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     max_prompt_repair_rounds: Optional[int],
     max_prompt_token_growth: Optional[int],
     max_prompt_repair_seconds: Optional[float],
+    interactive: bool,
+    apply: bool,
+    dry_run: bool,
 ) -> Optional[Tuple[str, float, str]]:
     """
     pdd checkup = verifier namespace
@@ -498,6 +528,17 @@ def checkup(  # pylint: disable=too-many-arguments,too-many-positional-arguments
       pdd checkup drift <DEVUNIT> [OPTIONS]
     """
     ctx.ensure_object(dict)
+
+    if apply and not interactive:
+        raise click.UsageError("--apply requires --interactive.")
+
+    if interactive and not _interactive_tty_available():
+        raise click.UsageError(
+            "--interactive requires a TTY (stdin and stdout must be a terminal)."
+        )
+
+    if interactive and as_json:
+        raise click.UsageError("--interactive cannot be combined with --json.")
 
     if show_help and target not in {
         "lint",
@@ -683,10 +724,31 @@ def checkup(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         run_validate_arch_includes_cli(root, strict=strict, quiet=ctx.obj.get("quiet", False))
         return "validate-arch-includes: ok", 0.0, ""
 
+    if interactive and target is not None and not is_prompt_shaped_target(
+        target,
+        project_root=project_root,
+    ):
+        raise click.UsageError(
+            "--interactive is only supported for prompt-shaped checkup targets."
+        )
+
     if pr_url is None and target is not None and is_prompt_shaped_target(
         target,
         project_root=project_root,
     ):
+        if interactive:
+            from ..checkup_interactive_main import run_interactive_checkup  # pylint: disable=import-outside-toplevel
+
+            return run_interactive_checkup(
+                target,
+                apply=apply,
+                dry_run=dry_run,
+                project_root=project_root,
+                strict=strict,
+                quiet=ctx.obj.get("quiet", False),
+                explicit_interactive=True,
+            )
+
         import json as _json  # pylint: disable=import-outside-toplevel
 
         quiet = ctx.obj.get("quiet", False)

--- a/pdd/commands/generate.py
+++ b/pdd/commands/generate.py
@@ -43,9 +43,10 @@ def _maybe_run_prompt_gate(
     project_root: Optional[str],
     quiet: bool,
     dry_run: bool = False,
+    interactive: bool = False,
 ) -> tuple[bool, int]:
     """Run the prompt gate; return ``(should_continue, exit_code)``."""
-    if dry_run:
+    if dry_run and not interactive:
         return True, 0
     root = Path(project_root or Path.cwd()).resolve()
     return maybe_run_workflow_prompt_gate(
@@ -54,6 +55,8 @@ def _maybe_run_prompt_gate(
         no_prompt_checkup=no_prompt_checkup,
         project_root=root,
         quiet=quiet,
+        interactive=interactive,
+        dry_run=dry_run,
     )
 
 
@@ -65,6 +68,7 @@ def _enforce_prompt_gate_or_exit(
     project_root: Optional[str],
     quiet: bool,
     dry_run: bool = False,
+    interactive: bool = False,
 ) -> None:
     """Raise ``click.Exit`` when strict prompt checkup blocks downstream work."""
     should_continue, exit_code = _maybe_run_prompt_gate(
@@ -74,6 +78,7 @@ def _enforce_prompt_gate_or_exit(
         project_root=project_root,
         quiet=quiet,
         dry_run=dry_run,
+        interactive=interactive,
     )
     if not should_continue:
         raise click.exceptions.Exit(exit_code)
@@ -181,6 +186,13 @@ class GenerateCommand(click.Command):
     default=False,
     help="Disable automatic prompt checkup for this run.",
 )
+@click.option(
+    "--interactive",
+    "interactive",
+    is_flag=True,
+    default=False,
+    help="With --prompt-checkup: run interactive per-finding repair on changed prompts.",
+)
 @click.pass_context
 @log_operation(operation="generate", clears_run_report=True, updates_fingerprint=True)
 @track_cost
@@ -206,6 +218,7 @@ def generate(
     compress: bool,
     prompt_checkup: Optional[str],
     no_prompt_checkup: bool,
+    interactive: bool,
 ) -> Optional[Tuple[str, float, str]]:
     """
     Create runnable code from a prompt file.
@@ -349,6 +362,7 @@ def generate(
                     project_root=project_root,
                     quiet=quiet,
                     dry_run=dry_run,
+                    interactive=interactive,
                 )
             return (message, cost, model) if success else None
 
@@ -396,6 +410,7 @@ def generate(
                     no_prompt_checkup=no_prompt_checkup,
                     project_root=project_root,
                     quiet=quiet,
+                    interactive=interactive,
                 )
             return (message, cost, model) if success else None
 

--- a/pdd/commands/modify.py
+++ b/pdd/commands/modify.py
@@ -222,6 +222,13 @@ def split(
     default=False,
     help="Disable automatic prompt checkup for this run.",
 )
+@click.option(
+    "--interactive",
+    "interactive",
+    is_flag=True,
+    default=False,
+    help="With --prompt-checkup: run interactive per-finding repair on changed prompts.",
+)
 @click.pass_context
 @track_cost
 def change(
@@ -237,6 +244,7 @@ def change(
     clean_restart: bool,
     prompt_checkup: Optional[str],
     no_prompt_checkup: bool,
+    interactive: bool,
 ) -> Optional[Tuple[Any, float, str]]:
     """
     Modify an input prompt file based on a change prompt or issue.
@@ -250,6 +258,7 @@ def change(
     ctx.ensure_object(dict)
     ctx.obj["prompt_checkup"] = prompt_checkup
     ctx.obj["no_prompt_checkup"] = no_prompt_checkup
+    ctx.obj["interactive"] = interactive
 
     if clean_restart and manual:
         raise click.UsageError(
@@ -384,6 +393,7 @@ def change(
                 no_prompt_checkup=no_prompt_checkup,
                 project_root=resolve_prompt_gate_project_root(changed_files or []),
                 quiet=quiet,
+                interactive=interactive,
             )
             if not should_continue:
                 raise click.exceptions.Exit(gate_exit)

--- a/pdd/prompt_gate.py
+++ b/pdd/prompt_gate.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 from typing import Optional, Sequence
 
@@ -204,6 +205,9 @@ def maybe_run_workflow_prompt_gate(
     no_prompt_checkup: bool,
     project_root: Path,
     quiet: bool = False,
+    interactive: bool = False,
+    apply: bool = False,
+    dry_run: bool = False,
 ) -> tuple[bool, int]:
     """Shared hook for generate/change workflows that touch ``.prompt`` files."""
     prompt_paths = [
@@ -212,6 +216,34 @@ def maybe_run_workflow_prompt_gate(
         if path.is_file()
     ]
     if not prompt_paths:
+        return True, 0
+
+    if apply and not interactive:
+        raise click.UsageError("--apply requires --interactive.")
+
+    if interactive:
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            raise click.UsageError(
+                "--interactive requires a TTY (stdin and stdout must be a terminal)."
+            )
+        from .checkup_interactive_main import run_interactive_checkup  # pylint: disable=import-outside-toplevel
+
+        gate_mode = resolve_prompt_gate_mode(
+            cli_prompt_checkup=cli_prompt_checkup,
+            no_prompt_checkup=no_prompt_checkup,
+            project_root=project_root,
+        )
+        strict = gate_mode == "strict"
+        for prompt_path in prompt_paths:
+            run_interactive_checkup(
+                str(prompt_path),
+                apply=apply,
+                dry_run=dry_run,
+                project_root=project_root,
+                strict=strict,
+                quiet=quiet,
+                explicit_interactive=True,
+            )
         return True, 0
 
     gate_mode = resolve_prompt_gate_mode(

--- a/tests/test_checkup_interactive.py
+++ b/tests/test_checkup_interactive.py
@@ -1,0 +1,262 @@
+"""Tests for interactive checkup flags and interaction policy (#1436)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from pdd.checkup_interactive_main import (
+    ClickInteractiveSession,
+    filter_interactive_findings,
+    run_interactive_checkup,
+)
+from pdd.checkup_interactive_session import FakeInteractiveSession, RepairOption
+from pdd.checkup_prompt_main import PromptSourceSetReport, SourceSetFinding
+from pdd.commands.checkup import checkup
+
+
+def _make_finding(
+    finding_id: str = "F001",
+    *,
+    requires_clarification: bool = False,
+    code: str = "",
+) -> SourceSetFinding:
+    return SourceSetFinding(
+        finding_id=finding_id,
+        source_check="lint",
+        severity="warn",
+        file=Path("prompts/test.prompt"),
+        message="Test finding",
+        evidence="some evidence",
+        recommended_action="Fix the issue",
+        code=code,
+        requires_clarification=requires_clarification,
+    )
+
+
+def _make_report(
+    tmp_path: Path,
+    findings: list[SourceSetFinding] | None = None,
+) -> PromptSourceSetReport:
+    prompt_path = tmp_path / "test.prompt"
+    return PromptSourceSetReport(
+        prompt_path=prompt_path,
+        project_root=tmp_path,
+        target=str(prompt_path),
+        findings=findings or [],
+    )
+
+
+def test_interactive_requires_tty(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("test prompt content")
+
+    runner = CliRunner()
+    result = runner.invoke(checkup, [str(prompt_file), "--interactive"])
+
+    assert result.exit_code != 0
+    assert "TTY" in result.output or "tty" in result.output.lower()
+
+
+def test_apply_requires_interactive(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("test prompt content")
+
+    runner = CliRunner()
+    result = runner.invoke(checkup, [str(prompt_file), "--apply"])
+
+    assert result.exit_code != 0
+    assert "--apply requires --interactive" in result.output
+
+
+def test_interactive_rejects_non_prompt_target() -> None:
+    runner = CliRunner()
+    with patch("pdd.commands.checkup._interactive_tty_available", return_value=True):
+        result = runner.invoke(
+            checkup,
+            ["https://github.com/promptdriven/pdd/issues/1", "--interactive"],
+        )
+
+    assert result.exit_code != 0
+    assert "prompt-shaped" in result.output
+
+
+def test_filter_interactive_findings_explicit_includes_all() -> None:
+    findings = [
+        _make_finding("A", requires_clarification=False),
+        _make_finding("B", requires_clarification=True),
+    ]
+    report = _make_report(Path("/tmp"), findings)
+
+    filtered = filter_interactive_findings(report, explicit_interactive=True)
+
+    assert len(filtered) == 2
+
+
+def test_filter_interactive_findings_auto_only_clarification() -> None:
+    findings = [
+        _make_finding("A", requires_clarification=False),
+        _make_finding("B", requires_clarification=True, code="VAGUE_TERM"),
+    ]
+    report = _make_report(Path("/tmp"), findings)
+
+    filtered = filter_interactive_findings(report, explicit_interactive=False)
+
+    assert [finding.finding_id for finding in filtered] == ["B"]
+
+
+def test_dry_run_no_writes(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "test.prompt"
+    original_content = "original prompt content"
+    prompt_file.write_text(original_content)
+
+    finding = _make_finding("DRY-001")
+    report = _make_report(tmp_path, [finding])
+
+    with patch(
+        "pdd.checkup_interactive_main.build_prompt_source_set_report",
+        return_value=report,
+    ):
+        with patch("pdd.checkup_interactive_main._prompt_menu_choice", return_value=1):
+            run_interactive_checkup(
+                str(prompt_file),
+                apply=True,
+                dry_run=True,
+                project_root=tmp_path,
+                quiet=True,
+            )
+
+    assert prompt_file.read_text() == original_content
+    backup_files = list(tmp_path.glob("*.bak")) + list(tmp_path.glob("*.prompt.bak"))
+    assert backup_files == []
+
+
+def test_interactive_no_writes(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "test.prompt"
+    original_content = "original prompt content"
+    prompt_file.write_text(original_content)
+
+    finding = _make_finding("NW-001")
+    report = _make_report(tmp_path, [finding])
+
+    with patch(
+        "pdd.checkup_interactive_main.build_prompt_source_set_report",
+        return_value=report,
+    ):
+        with patch("pdd.checkup_interactive_main._prompt_menu_choice", return_value=1):
+            run_interactive_checkup(
+                str(prompt_file),
+                apply=False,
+                dry_run=False,
+                project_root=tmp_path,
+                quiet=True,
+            )
+
+    assert prompt_file.read_text() == original_content
+    backup_files = list(tmp_path.glob("*.bak")) + list(tmp_path.glob("*.prompt.bak"))
+    assert backup_files == []
+
+
+def test_skip_flow(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("prompt content")
+
+    findings = [_make_finding("SK-001"), _make_finding("SK-002")]
+    report = _make_report(tmp_path, findings)
+
+    with patch(
+        "pdd.checkup_interactive_main.build_prompt_source_set_report",
+        return_value=report,
+    ):
+        with patch("pdd.checkup_interactive_main._prompt_menu_choice", return_value=4):
+            result = run_interactive_checkup(
+                str(prompt_file),
+                apply=True,
+                dry_run=False,
+                project_root=tmp_path,
+                quiet=True,
+            )
+
+    assert result is not None
+    message, _cost, _model = result
+    assert "skipped" in message
+    assert "2 skipped" in message
+
+
+def test_click_interactive_session_records_candidate_choice() -> None:
+    finding = _make_finding("SES-001")
+    report = _make_report(Path("/tmp"), [finding])
+    session = ClickInteractiveSession()
+    session.seed(report)
+
+    options = session.present_finding("SES-001")
+    assert len(options) == 2
+    session.record_choice("SES-001", options[0])
+
+    patches = session.approved_patches()
+    assert len(patches) == 1
+    assert patches[0].finding_id == "SES-001"
+
+
+def test_checkup_registers_interactive_flags() -> None:
+    param_names = {param.name for param in checkup.params}
+    missing = {"interactive", "apply", "dry_run"} - param_names
+    assert not missing, f"Missing params: {missing}"
+
+
+def test_cli_interactive_routes_with_tty(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("prompt content")
+    finding = _make_finding("CLI-001")
+    report = _make_report(tmp_path, [finding])
+
+    with patch("pdd.commands.checkup._interactive_tty_available", return_value=True):
+        with patch(
+            "pdd.checkup_interactive_main.build_prompt_source_set_report",
+            return_value=report,
+        ):
+            with patch("pdd.checkup_interactive_main._prompt_menu_choice", return_value=4):
+                runner = CliRunner()
+                result = runner.invoke(checkup, [str(prompt_file), "--interactive"])
+
+    assert result.exit_code == 0
+    assert "Interactive checkup complete" in result.output
+
+
+def test_fake_session_still_usable_via_factory(tmp_path: Path) -> None:
+    from pdd.checkup_interactive_session import ApprovedPatch
+
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("prompt content")
+    finding = _make_finding("FAKE-001")
+    report = _make_report(tmp_path, [finding])
+    repair_option = RepairOption(
+        label="Fix",
+        preview="preview",
+        patch=ApprovedPatch(
+            kind="repair_candidate",
+            target=prompt_file,
+            anchor={"finding_id": "FAKE-001"},
+            replacement="fix",
+            finding_id="FAKE-001",
+        ),
+    )
+    fake = FakeInteractiveSession({"FAKE-001": [repair_option, repair_option]})
+
+    with patch(
+        "pdd.checkup_interactive_main.build_prompt_source_set_report",
+        return_value=report,
+    ):
+        with patch("pdd.checkup_interactive_main._prompt_menu_choice", return_value=1):
+            run_interactive_checkup(
+                str(prompt_file),
+                apply=False,
+                project_root=tmp_path,
+                quiet=True,
+                session_factory=lambda: fake,
+            )
+
+    assert fake.recorded_choices == [("FAKE-001", repair_option)]


### PR DESCRIPTION
## Summary
- Register `--interactive`, `--apply`, and `--dry-run` on `pdd checkup` for prompt-shaped targets.
- Add `pdd/checkup_interactive_main.py` to orchestrate report → `InteractiveRepairSession` → numbered menus.
- Forward `--interactive` through generate/change prompt-gate hooks.

**Parent:** #1423 (Phase 3 — Block 2)
**Closes:** #1436

## Guard matrix (v1)
| Case | Behavior |
|------|----------|
| `--interactive` without `--apply` | Questions + preview, no writes |
| `--interactive --apply` | Delegates to Block 3 apply boundary (stub until #1437) |
| `--apply` without `--interactive` | Error |
| non-TTY + `--interactive` | Error |
| `--dry-run` | No file or backup writes |

## Test plan
- [x] `python -c "from pdd.commands.checkup import checkup; ..."` — flags registered
- [x] `python -m pytest tests/test_checkup_interactive.py -v` — 12 tests
- [x] `python -m pytest tests/test_agentic_checkup.py tests/test_checkup_pr_mode.py tests/test_checkup_review_loop.py tests/test_checkup_interactive_session.py -q` — no regressions
- [x] `pdd checkup --help` — new flags visible

## Notes
- Merges into `change/issue-1423` (interactive repair umbrella branch), not `main`.
- Block 3 deterministic patch apply (#1437) remains a separate follow-up.

Made with [Cursor](https://cursor.com)