### PR TITLE
feat(checkup): add requires_clarification to prompt source-set report (#1438)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ For a rule-to-story/test coverage matrix (`pdd checkup coverage`), see [docs/cov
 
 For non-interactive bounded prompt repair after a failed prompt source-set checkup, see [docs/prompt_repair.md](docs/prompt_repair.md).
 
+For the deterministic prompt source-set quality gate and its `pdd.prompt_source_set_report.v1` JSON schema (including the per-finding `requires_clarification` / `clarification_reason` clarification signal), see [docs/checkup_prompt_quality_gate.md](docs/checkup_prompt_quality_gate.md).
+
 ## Installation
 
 ### Prerequisites for macOS

--- a/architecture.json
+++ b/architecture.json
@@ -9989,5 +9989,74 @@
         ]
       }
     }
+  },
+  {
+    "reason": "Owns the normalized pdd.prompt_source_set_report.v1 report and the deterministic per-engine clarification heuristics that route findings to interactive vs. automated repair.",
+    "description": "Single owner of the pdd.prompt_source_set_report.v1 report consumed by `pdd checkup` prompt targets and downstream interactive/non-interactive prompt repair. Orchestrates the deterministic lint, contract, coverage, gate, snapshot, and drift engines, aggregates their results into one PromptSourceSetReport of SourceSetFinding objects, owns as_dict() serialization, and applies code/status-driven heuristics that set requires_clarification and a compact clarification_reason without calling an LLM or mutating source.",
+    "dependencies": [
+      "prompt_lint_python.prompt",
+      "contract_check_python.prompt",
+      "coverage_contracts_python.prompt",
+      "gate_python.prompt",
+      "construct_paths_python.prompt",
+      "user_story_tests_python.prompt",
+      "evidence_store_python.prompt"
+    ],
+    "priority": 245,
+    "filename": "checkup_prompt_main_python.prompt",
+    "filepath": "pdd/checkup_prompt_main.py",
+    "tags": [
+      "checkup",
+      "module",
+      "python"
+    ],
+    "interface": {
+      "type": "module",
+      "module": {
+        "constants": [
+          {
+            "name": "REPORT_SCHEMA",
+            "value": "pdd.prompt_source_set_report.v1"
+          }
+        ],
+        "classes": [
+          {
+            "name": "SourceSetFinding",
+            "kind": "dataclass"
+          },
+          {
+            "name": "PromptSourceSetReport",
+            "kind": "dataclass"
+          }
+        ],
+        "functions": [
+          {
+            "name": "build_prompt_source_set_report",
+            "signature": "(prompt_path: Path, *, target: str, project_root: Optional[Path] = None, strict: bool = False, stories_dir: Optional[Path] = None, tests_dir: Optional[Path] = None) -> PromptSourceSetReport",
+            "returns": "PromptSourceSetReport"
+          },
+          {
+            "name": "run_checkup_prompt",
+            "signature": "(target: str, *, explain: bool = False, as_json: bool = False, quiet: bool = False, strict: bool = False, project_root: Optional[Path] = None) -> tuple[bool, str, float, str, int]",
+            "returns": "tuple[bool, str, float, str, int]"
+          },
+          {
+            "name": "run_checkup_prompt_paths",
+            "signature": "(prompt_paths: Sequence[Path], *, target: str = '', project_root: Optional[Path] = None, strict: bool = False) -> tuple[list[PromptSourceSetReport], int]",
+            "returns": "tuple[list[PromptSourceSetReport], int]"
+          },
+          {
+            "name": "render_prompt_source_set_report",
+            "signature": "(report: PromptSourceSetReport, *, quiet: bool = False) -> None",
+            "returns": "None"
+          },
+          {
+            "name": "render_automatic_gate_summary",
+            "signature": "(reports: Sequence[PromptSourceSetReport], *, mode: str, quiet: bool = False) -> None",
+            "returns": "None"
+          }
+        ]
+      }
+    }
   }
 ]

--- a/context/checkup_prompt_main_example.py
+++ b/context/checkup_prompt_main_example.py
@@ -1,0 +1,130 @@
+"""
+Example demonstrating how to programmatically execute prompt checkups,
+generate a unified prompt source-set report, and render findings.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from rich.console import Console
+
+# Import the orchestrator and report models from the pdd package
+from pdd.checkup_prompt_main import (
+    build_prompt_source_set_report,
+    render_prompt_source_set_report,
+    PromptSourceSetReport,
+)
+
+# Initialize a rich console for beautifully formatted terminal outputs
+console = Console()
+
+
+def setup_mock_project(project_root: Path) -> tuple[Path, Path, Path]:
+    """
+    Sets up a mock prompt project with contract rules, a user story, and test coverage
+    to simulate a real-world repository state.
+    
+    Parameters:
+        project_root: The Path to the directory where mock files should be written.
+        
+    Returns:
+        A tuple of (prompt_path, stories_dir, tests_dir).
+    """
+    stories_dir = project_root / "user_stories"
+    tests_dir = project_root / "tests"
+    
+    # Ensure fresh directory structures
+    stories_dir.mkdir(parents=True, exist_ok=True)
+    tests_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1. Create a prompt file containing structural sections and contract rules
+    prompt_path = project_root / "translate_python.prompt"
+    prompt_content = """<system>
+You are an expert translator.
+</system>
+
+<contract_rules>
+R1: Output MUST be valid, well-formed JSON.
+R2: Do NOT include conversational filler before or after the JSON payload.
+</contract_rules>
+
+<coverage>
+R1: story__translation.md, test_R1_json_format
+R2: story__translation.md
+</coverage>
+"""
+    prompt_path.write_text(prompt_content, encoding="utf-8")
+
+    # 2. Create a user story markdown file that covers both R1 and R2
+    story_path = stories_dir / "story__translation.md"
+    story_content = """# Story: High Quality Translation
+
+<!-- pdd-story-prompts: translate_python.prompt -->
+
+## Covers
+- translate_python.prompt#R1
+- translate_python.prompt#R2
+
+## Acceptance Criteria
+- Ensure output is valid JSON.
+- Ensure no conversational filler.
+"""
+    story_path.write_text(story_content, encoding="utf-8")
+
+    # 3. Create a python test file checking R1 (leaving R2 story-only)
+    test_path = tests_dir / "test_translation.py"
+    test_content = """# R1: Verify that output is valid JSON
+def test_R1_json_format():
+    assert True
+"""
+    test_path.write_text(test_content, encoding="utf-8")
+
+    return prompt_path, stories_dir, tests_dir
+
+
+def main() -> None:
+    # Anchor all created output files to the local './output' directory
+    project_root = Path("./output").resolve()
+    
+    console.print(f"[bold blue]Setting up mock project at {project_root}...[/bold blue]")
+    prompt_path, stories_dir, tests_dir = setup_mock_project(project_root)
+
+    console.print("\n[bold green]Running deterministic source-set checkup...[/bold green]")
+    
+    # Orchestrate the checkup engines (lint, contract, coverage, snapshot, gate)
+    # to yield a unified PromptSourceSetReport.
+    report: PromptSourceSetReport = build_prompt_source_set_report(
+        prompt_path=prompt_path,
+        target="translate_python",
+        project_root=project_root,
+        stories_dir=stories_dir,
+        tests_dir=tests_dir,
+        strict=False,
+    )
+
+    console.print("\n[bold yellow]--- Rendered Human Readable Report ---[/bold yellow]")
+    # Use the built-in click renderer to output the overview
+    render_prompt_source_set_report(report, quiet=False)
+
+    console.print("\n[bold yellow]--- Programmatic Report Metadata ---[/bold yellow]")
+    console.print(f"Report Schema: [cyan]{report.as_dict()['schema']}[/cyan]")
+    console.print(f"Overall Status: [bold]{report.status.upper()}[/bold]")
+    console.print(f"Has Contract Rules: [green]{report.coverage.has_contract_rules if report.coverage else False}[/green]")
+    console.print(f"Deterministic Exit Code: [red]{report.deterministic_exit_code()}[/red]")
+
+    # Inspect parsed coverage rules and print their identified status
+    if report.coverage:
+        console.print("\n[bold yellow]--- Rule Coverage Summary ---[/bold yellow]")
+        for rule in report.coverage.rules:
+            console.print(
+                f"Rule [bold cyan]{rule.rule_id}[/bold cyan]: "
+                f"Status=[magenta]{rule.status}[/magenta], "
+                f"Stories={rule.stories}, "
+                f"Tests={rule.tests}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/checkup_prompt_quality_gate.md
+++ b/docs/checkup_prompt_quality_gate.md
@@ -51,13 +51,40 @@ Machine-readable output uses `--json` and conforms to
 - `target`: the CLI target string
 - `checks[]`: per-engine status summary
 - `findings[]`: deterministic findings with `id`, `source_check`, `severity`,
-  `file`, `line`, `message`, `recommended_action`, and `fix_command`
+  `file`, `line`, `message`, `recommended_action`, `fix_command`,
+  `requires_clarification`, and `clarification_reason`
 - `actions[]`: suggested next commands
 - `deterministic_exit_code`: 0 clean, 1 warnings, 2 errors (or strict warnings)
 
 `--strict` affects deterministic exit codes only (warnings become failures in
 strict mode, including automatic `--prompt-checkup strict`). `--explain` prints a
 read-only finding summary and never changes the exit code.
+
+### Clarification signal
+
+Every finding carries two paired fields so downstream tooling can decide which
+findings need a human decision before automatic repair:
+
+- `requires_clarification` (boolean, always present, defaults to `false`):
+  `true` only when a deterministic, per-engine heuristic detects genuine
+  ambiguity that a human must resolve. There is no LLM classification.
+- `clarification_reason` (string, always present, empty `""` when
+  `requires_clarification` is `false`): a compact, machine-parseable reason
+  containing only metadata (term, rule ID, status, path, line) — never prompt
+  excerpts or sensitive prose.
+
+Heuristics are conservative and code/status-driven:
+
+| Engine   | Marks `requires_clarification: true` when |
+|----------|-------------------------------------------|
+| lint     | vague/ambiguous vocabulary with multiple plausible definitions |
+| contract | rule-ID collision (`DUPLICATE_ID`) or a vague obligation code (`VAGUE*`) |
+| coverage | a `story-only` rule matches more than one candidate story target |
+| gate     | a waiver/policy decision is required but policy metadata is ambiguous |
+
+The fields are additive and backward-compatible: consumers that ignore them are
+unaffected, and `requires_clarification` is always emitted as a real JSON boolean
+(never a string or `0/1`).
 
 ## Workflow hook interface
 

--- a/pdd/prompts/checkup_prompt_main_python.prompt
+++ b/pdd/prompts/checkup_prompt_main_python.prompt
@@ -1,0 +1,185 @@
+<include>context/python_preamble.prompt</include>
+<pdd-reason>Owns the normalized pdd.prompt_source_set_report.v1 report and the deterministic per-engine clarification heuristics that route findings to interactive vs. automated repair.</pdd-reason>
+<pdd-interface>
+{
+  "type": "module",
+  "module": {
+    "constants": [
+      {"name": "REPORT_SCHEMA", "value": "pdd.prompt_source_set_report.v1"}
+    ],
+    "classes": [
+      {"name": "SourceSetFinding", "kind": "dataclass"},
+      {"name": "PromptSourceSetReport", "kind": "dataclass"}
+    ],
+    "functions": [
+      {"name": "build_prompt_source_set_report", "signature": "(prompt_path: Path, *, target: str, project_root: Optional[Path] = None, strict: bool = False, stories_dir: Optional[Path] = None, tests_dir: Optional[Path] = None) -> PromptSourceSetReport", "returns": "PromptSourceSetReport"},
+      {"name": "run_checkup_prompt", "signature": "(target: str, *, explain: bool = False, as_json: bool = False, quiet: bool = False, strict: bool = False, project_root: Optional[Path] = None) -> tuple[bool, str, float, str, int]", "returns": "tuple[bool, str, float, str, int]"},
+      {"name": "run_checkup_prompt_paths", "signature": "(prompt_paths: Sequence[Path], *, target: str = '', project_root: Optional[Path] = None, strict: bool = False) -> tuple[list[PromptSourceSetReport], int]", "returns": "tuple[list[PromptSourceSetReport], int]"},
+      {"name": "render_prompt_source_set_report", "signature": "(report: PromptSourceSetReport, *, quiet: bool = False) -> None", "returns": "None"},
+      {"name": "render_automatic_gate_summary", "signature": "(reports: Sequence[PromptSourceSetReport], *, mode: str, quiet: bool = False) -> None", "returns": "None"}
+    ]
+  }
+}
+</pdd-interface>
+<pdd-dependency>prompt_lint_python.prompt</pdd-dependency>
+<pdd-dependency>contract_check_python.prompt</pdd-dependency>
+<pdd-dependency>coverage_contracts_python.prompt</pdd-dependency>
+<pdd-dependency>gate_python.prompt</pdd-dependency>
+<pdd-dependency>construct_paths_python.prompt</pdd-dependency>
+<pdd-dependency>user_story_tests_python.prompt</pdd-dependency>
+<pdd-dependency>evidence_store_python.prompt</pdd-dependency>
+
+% Goal
+Write `pdd/checkup_prompt_main.py`.
+
+% Role & Scope
+This module is the single owner of the normalized `pdd.prompt_source_set_report.v1`
+report consumed by `pdd checkup` prompt targets and by downstream interactive
+(#1423) and non-interactive (#1422) prompt repair. It orchestrates the existing
+deterministic engines (lint, contract, coverage, gate, snapshot, drift), aggregates
+their results into one `PromptSourceSetReport` of `SourceSetFinding` objects, and
+owns the `as_dict()` serialization point. It reuses the engine modules and MUST NOT
+re-implement lint / contract / coverage / gate logic, call an LLM, or mutate source
+files.
+
+% Vocabulary
+- `requires_clarification` finding: a finding a human must resolve before automated
+  repair, detected by a deterministic, code/status-driven heuristic — never by LLM
+  classification.
+- `clarification_reason`: a compact, machine-parseable string holding only metadata
+  (term, rule ID, status, path, line) that explains why clarification is required.
+
+% Requirements
+1. Expose the public API: `REPORT_SCHEMA = "pdd.prompt_source_set_report.v1"`,
+   the `SourceSetFinding` and `PromptSourceSetReport` dataclasses, and the functions
+   `build_prompt_source_set_report`, `run_checkup_prompt`, `run_checkup_prompt_paths`,
+   `render_prompt_source_set_report`, and `render_automatic_gate_summary`.
+2. `build_prompt_source_set_report` runs each engine for one prompt and collects
+   `SourceSetFinding` objects plus a per-engine `checks[]` status summary:
+   - lint via `scan_prompt`; contract via `check_prompt`; coverage via `build_coverage`;
+     gate via `run_gate_policy` only when an evidence manifest exists for the dev unit;
+     snapshot via `check_snapshot_policy`; an informational drift readiness note when a
+     manifest is present.
+   - Resolve `stories_dir` (honoring `PDD_USER_STORIES_DIR` via `_resolve_stories_dir`)
+     and `tests_dir` against the resolved `project_root` so the report is correct when
+     `pdd checkup` is invoked from outside the project.
+3. `SourceSetFinding` carries: `finding_id`, `source_check`, `severity`, `file`,
+   `line`, `message`, `evidence`, `recommended_action`, `fix_command`, `code`,
+   `rule_id`, `requires_clarification`, `clarification_reason`, and optional
+   `confidence`. `as_dict()` emits keys `id` (from `finding_id`), `source_check`,
+   `severity`, `file` (as `str`), `line`, `message`, `evidence`, `recommended_action`,
+   `fix_command`, `code`, `rule_id`, `requires_clarification`, and
+   `clarification_reason`; `confidence` is included only when not `None`.
+
+% Contract rules
+R1 — `requires_clarification` default & type
+For every finding emitted by `as_dict()`, `requires_clarification` MUST default to
+`False` and MUST serialize as a real JSON boolean.
+This rule is violated if the key is missing or serialized as `"true"`/`0`/`1`.
+
+R2 — `clarification_reason` always present
+For every finding, `clarification_reason` is a `str` defaulting to `""` and MUST
+always be serialized as a string key in `as_dict()` (empty `""` when no clarification
+is required), matching the module's always-emit-string convention.
+This rule is violated if the key is absent or non-string for any finding.
+
+R3 — reason non-empty when flagged
+For every finding where `requires_clarification` is `True`, `clarification_reason`
+MUST be non-empty; when no explicit reason was supplied, the dataclass MUST derive a
+compact code-based reason in `__post_init__`.
+This rule is violated if a flagged finding serializes an empty `clarification_reason`.
+
+R4 — lint vague-term heuristic
+For every lint finding whose `code` contains `VAGUE`, the module MUST set
+`requires_clarification=True`; when `term` metadata is available the reason MUST name
+the term and only compact metadata.
+This rule is violated if a `VAGUE` lint finding is left unflagged.
+
+R5 — contract `DUPLICATE_ID` heuristic
+For every contract finding with code `DUPLICATE_ID` (rule-ID collision), the module
+MUST set `requires_clarification=True` for all colliding findings, with a reason
+naming the `rule_id` when available.
+This rule is violated if any `DUPLICATE_ID` finding is left unflagged.
+
+R6 — contract vague-term heuristic
+For every contract finding whose `code` contains `VAGUE`, the module MUST set
+`requires_clarification=True`, with a term-based reason when `term` metadata exists.
+This rule is violated if a `VAGUE` contract finding is left unflagged.
+
+R7 — coverage story-only multi-target heuristic
+For every coverage rule with status `story-only` (`STATUS_STORY_ONLY`) that matched
+more than one story (`len(rule.stories) > 1`), the module MUST emit a `warn`-level
+finding with `code="story_only_ambiguous"` and `requires_clarification=True`; rules
+with one or zero matched stories MUST remain unflagged.
+This rule is violated if a single-target story-only rule is flagged, or a multi-target
+one is not.
+
+R8 — gate ambiguous-waiver heuristic
+For every gate finding whose waiver/policy decision is ambiguous (e.g. an
+unknown-rule or malformed waiver, code containing `UNKNOWN`, `MALFORMED`, or
+`AMBIGUOUS`), the module MUST set `requires_clarification=True` with a reason naming
+the gate `code`; unambiguous gate failures (missing/expired evidence) MUST remain
+unflagged.
+This rule is violated if an ambiguous waiver/policy gate finding is left unflagged.
+
+R9 — privacy of reasons
+For every finding, `clarification_reason` MUST contain only compact metadata (term,
+rule ID, status, path, line) and MUST NOT embed prompt excerpts or sensitive prose.
+This rule is violated if a reason contains raw prompt body text.
+
+R10 — deterministic, no LLM, no mutation
+The module MUST NOT call an LLM, preprocess or execute prompt directives, or modify
+any source file; every clarification decision MUST be derived from engine codes and
+status values.
+This rule is violated if any heuristic depends on a model call or writes to disk.
+
+R11 — additive compatibility
+The change is additive: all existing report and finding keys and the per-engine
+schemas are unchanged, and consumers that ignore the new fields MUST be unaffected.
+This rule is violated if any pre-existing report key is removed or renamed.
+
+% Report and rendering behavior
+- `PromptSourceSetReport` exposes `error_count`, `warn_count`, `passed`, `status`
+  (`pass`/`warn`/`fail`), `recommended_actions()`, `deterministic_exit_code(*, strict=False)`
+  (0 clean, 1 warnings, 2 errors or strict warnings), and `as_dict(*, strict=False)`
+  emitting `schema`, `status`, `target`, `prompt`, `checks`, `findings`, `actions`,
+  and `deterministic_exit_code`.
+- `run_checkup_prompt` resolves targets with `resolve_prompt_targets`, builds a report
+  per prompt, prints human-readable output unless `as_json`, supports a read-only
+  `--explain` listing, and on `--json` prints a `sort_keys=True` payload with `schema`,
+  `target`, `status`, `reports[]`, and `deterministic_exit_code`. It returns
+  `(passed, message, 0.0, "", exit_code)`.
+- `run_checkup_prompt_paths` builds reports for explicit prompt paths and returns the
+  reports plus the aggregate deterministic exit code.
+
+% Dependencies
+<pdd.prompt_lint>
+    <include select="def:scan_prompt,class:LintResult,class:LintIssue" mode="interface">pdd/prompt_lint.py</include>
+</pdd.prompt_lint>
+<pdd.contract_check>
+    <include select="def:check_prompt,class:ContractResult,class:ContractIssue" mode="interface">pdd/contract_check.py</include>
+</pdd.contract_check>
+<pdd.coverage_contracts>
+    <include select="def:build_coverage,class:CoverageResult,class:RuleCoverage,const:STATUS_STORY_ONLY,const:STATUS_FAILED,const:STATUS_UNCHECKED" mode="interface">pdd/coverage_contracts.py</include>
+</pdd.coverage_contracts>
+<pdd.gate_main>
+    <include select="def:run_gate_policy,class:GateResult,class:GateFailure" mode="interface">pdd/gate_main.py</include>
+</pdd.gate_main>
+<pdd.source_set_model>
+    <include select="def:resolve_prompt_targets" mode="interface">pdd/source_set_model.py</include>
+</pdd.source_set_model>
+<pdd.context_snapshot_policy>
+    <include select="def:check_snapshot_policy" mode="interface">pdd/context_snapshot_policy.py</include>
+</pdd.context_snapshot_policy>
+<pdd.construct_paths>
+    <include select="def:_strip_language_suffix" mode="interface">pdd/construct_paths.py</include>
+</pdd.construct_paths>
+<pdd.user_story_tests>
+    <include select="def:_resolve_stories_dir" mode="interface">pdd/user_story_tests.py</include>
+</pdd.user_story_tests>
+<pdd.evidence_store>
+    <include select="def:devunits_dir,def:resolve_prompt_path" mode="interface">pdd/evidence_store.py</include>
+</pdd.evidence_store>
+
+% Deliverables
+- Code: `pdd/checkup_prompt_main.py`


### PR DESCRIPTION
## Summary
- Add `requires_clarification` routing to the #1420 prompt source-set report so interactive repair (#1423) can filter findings reliably.
- Align prompt spec, example context, architecture registry, and docs for `checkup_prompt_main`.

**Parent:** #1423 (umbrella integration branch)
**Closes:** #1438

## Behavior
- Finding objects in `pdd.prompt_source_set_report.v1` expose `requires_clarification: true` for vague/semantic issues that need human clarification before automated repair.
- Block 2 (#1436) uses this field when not running with explicit `--interactive`.

## Test plan
- [x] Existing `tests/test_checkup_prompt_main.py` coverage for `requires_clarification`
- [ ] Verify PR diff against `change/issue-1423` is limited to report schema / spec alignment

## Notes
- Targets `change/issue-1423`, not `main` — part of the stacked interactive checkup workflow.
- Related open PR against `main`: #1511

Made with [Cursor](https://cursor.com)