### PR TITLE
Implement #1437 on top of change/issue-1423

### DIFF
--- a/pdd/change_main.py
+++ b/pdd/change_main.py
@@ -522,6 +522,7 @@ def change_main(
                 no_prompt_checkup=ctx.obj.get("no_prompt_checkup", False),
                 project_root=resolve_prompt_gate_project_root(saved_prompt_paths),
                 quiet=quiet,
+                interactive=ctx.obj.get("interactive", False),
             )
             if not should_continue:
                 msg = prompt_gate_block_message(gate_exit)

--- a/pdd/checkup_interactive_main.py
+++ b/pdd/checkup_interactive_main.py
@@ -14,6 +14,7 @@ from .checkup_interactive_session import (
     NON_APPROVING_PATCH_KINDS,
     RepairOption,
 )
+from .checkup_prompt_apply import apply_approved_patches as run_patch_apply
 from .checkup_prompt_main import (
     PromptSourceSetReport,
     SourceSetFinding,
@@ -21,6 +22,13 @@ from .checkup_prompt_main import (
 )
 
 _EVIDENCE_EXCERPT_LEN = 200
+_PRIMARY_KIND_BY_SOURCE = {
+    "lint": "vocab_definition",
+    "contract": "contract_rule",
+    "coverage": "coverage_line",
+    "gate": "waiver",
+    "snapshot": "contract_rule",
+}
 _SessionType = Union[InteractiveRepairSession, "ClickInteractiveSession"]
 
 
@@ -48,12 +56,18 @@ def build_repair_options_for_finding(finding: SourceSetFinding) -> list[RepairOp
     primary_preview = _truncate_excerpt(finding.evidence or finding.message)
     alternate_label = "Alternative repair"
     alternate_preview = _truncate_excerpt(finding.message)
+    primary_kind = _PRIMARY_KIND_BY_SOURCE.get(finding.source_check, "vocab_definition")
+    alternate_kind = (
+        "story_template"
+        if finding.file.suffix.lower() == ".md"
+        else "append_covers"
+    )
     return [
         RepairOption(
             label=primary_action,
             preview=primary_preview,
             patch=ApprovedPatch(
-                kind="repair_candidate",
+                kind=primary_kind,
                 target=finding.file,
                 anchor={"finding_id": finding.finding_id, "line": finding.line},
                 replacement=primary_action,
@@ -64,10 +78,10 @@ def build_repair_options_for_finding(finding: SourceSetFinding) -> list[RepairOp
             label=alternate_label,
             preview=alternate_preview,
             patch=ApprovedPatch(
-                kind="repair_candidate_alt",
+                kind=alternate_kind,
                 target=finding.file,
                 anchor={"finding_id": finding.finding_id, "line": finding.line},
-                replacement=alternate_label,
+                replacement=alternate_preview,
                 finding_id=finding.finding_id,
             ),
         ),
@@ -194,16 +208,30 @@ def apply_approved_patches(
     *,
     dry_run: bool,
     quiet: bool,
-) -> None:
-    """Apply boundary for Block 3; v1 honors dry-run and leaves writes to Block 3."""
-    if dry_run or not patches:
-        return
-    for patch in patches:
-        if not quiet:
-            click.echo(
-                f"  [apply pending Block 3] {patch.finding_id}: {patch.kind} "
-                f"→ {patch.target}"
-            )
+    project_root: Path,
+    original_target: str,
+    strict: bool,
+    choices_by_finding: dict[str, int],
+) -> int:
+    """Delegate to the deterministic patch applicator and return postflight exit code."""
+    if not patches:
+        return 0
+    result = run_patch_apply(
+        patches,
+        repo_root=project_root,
+        original_target=original_target,
+        dry_run=dry_run,
+        interactive=True,
+        strict=strict,
+        choices_by_finding=choices_by_finding,
+    )
+    if not quiet:
+        if result.log_path is not None:
+            click.echo(f"Apply log: {result.log_path}")
+        if result.backup_root is not None:
+            click.echo(f"Backups: {result.backup_root}")
+        click.echo(f"Postflight: {result.postflight_status}")
+    return result.exit_code
 
 
 def run_interactive_checkup(
@@ -251,9 +279,11 @@ def run_interactive_checkup(
     session.seed(report)
 
     skipped = 0
+    choices_by_finding: dict[str, int] = {}
     for finding in findings:
         options = session.present_finding(finding.finding_id)
         choice = _prompt_menu_choice(finding, options)
+        choices_by_finding[finding.finding_id] = choice
 
         if choice == 4:
             if isinstance(session, ClickInteractiveSession):
@@ -276,8 +306,17 @@ def run_interactive_checkup(
             session.record_choice(finding.finding_id, options[index])
 
     patches = session.approved_patches()
+    postflight_exit = 0
     if apply:
-        apply_approved_patches(patches, dry_run=dry_run, quiet=quiet)
+        postflight_exit = apply_approved_patches(
+            patches,
+            dry_run=dry_run,
+            quiet=quiet,
+            project_root=root,
+            original_target=target,
+            strict=strict,
+            choices_by_finding=choices_by_finding,
+        )
 
     cost = 0.0
     model = ""
@@ -287,4 +326,6 @@ def run_interactive_checkup(
     )
     if not quiet:
         click.echo(f"\n{message}")
+    if postflight_exit:
+        raise click.exceptions.Exit(postflight_exit)
     return message, cost, model

--- a/pdd/checkup_interactive_main.py
+++ b/pdd/checkup_interactive_main.py
@@ -1,0 +1,290 @@
+"""Interactive checkup orchestration for prompt-shaped ``pdd checkup`` targets."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Callable, Optional, Union
+
+import click
+
+from .checkup_interactive_session import (
+    ApprovedPatch,
+    InteractiveRepairSession,
+    NON_APPROVING_PATCH_KINDS,
+    RepairOption,
+)
+from .checkup_prompt_main import (
+    PromptSourceSetReport,
+    SourceSetFinding,
+    build_prompt_source_set_report,
+)
+
+_EVIDENCE_EXCERPT_LEN = 200
+_SessionType = Union[InteractiveRepairSession, "ClickInteractiveSession"]
+
+
+def _truncate_excerpt(text: str, max_len: int = _EVIDENCE_EXCERPT_LEN) -> str:
+    cleaned = " ".join(str(text).split())
+    if len(cleaned) <= max_len:
+        return cleaned
+    return cleaned[: max_len - 3] + "..."
+
+
+def filter_interactive_findings(
+    report: PromptSourceSetReport,
+    *,
+    explicit_interactive: bool,
+) -> list[SourceSetFinding]:
+    """Return findings that belong in an interactive repair session."""
+    if explicit_interactive:
+        return list(report.findings)
+    return [finding for finding in report.findings if finding.requires_clarification]
+
+
+def build_repair_options_for_finding(finding: SourceSetFinding) -> list[RepairOption]:
+    """Build up to two repair candidates from one structured finding."""
+    primary_action = finding.recommended_action or "Apply suggested repair"
+    primary_preview = _truncate_excerpt(finding.evidence or finding.message)
+    alternate_label = "Alternative repair"
+    alternate_preview = _truncate_excerpt(finding.message)
+    return [
+        RepairOption(
+            label=primary_action,
+            preview=primary_preview,
+            patch=ApprovedPatch(
+                kind="repair_candidate",
+                target=finding.file,
+                anchor={"finding_id": finding.finding_id, "line": finding.line},
+                replacement=primary_action,
+                finding_id=finding.finding_id,
+            ),
+        ),
+        RepairOption(
+            label=alternate_label,
+            preview=alternate_preview,
+            patch=ApprovedPatch(
+                kind="repair_candidate_alt",
+                target=finding.file,
+                anchor={"finding_id": finding.finding_id, "line": finding.line},
+                replacement=alternate_label,
+                finding_id=finding.finding_id,
+            ),
+        ),
+    ]
+
+
+class ClickInteractiveSession:
+    """Click-native ``InteractiveRepairSession`` backed by report findings."""
+
+    def __init__(self) -> None:
+        self.report: PromptSourceSetReport | None = None
+        self._options_by_finding: dict[str, list[RepairOption]] = {}
+        self.presented_options: dict[str, list[RepairOption]] = {}
+        self.recorded_choices: list[tuple[str, RepairOption]] = []
+
+    def seed(self, report: PromptSourceSetReport) -> None:
+        """Index repair options from a structured source-set report."""
+        self.report = report
+        self._options_by_finding = {
+            finding.finding_id: build_repair_options_for_finding(finding)
+            for finding in report.findings
+        }
+
+    def present_finding(self, finding_id: str) -> list[RepairOption]:
+        """Return repair candidates for one finding."""
+        options = list(self._options_by_finding.get(finding_id, []))
+        self.presented_options[finding_id] = options
+        return list(options)
+
+    def ask(self, question: str) -> str:
+        """Ask a free-form clarification question in the terminal."""
+        return click.prompt(question, type=str, default="", show_default=False)
+
+    def record_choice(self, finding_id: str, option: RepairOption) -> None:
+        """Record one validated menu choice for a finding."""
+        presented = self.presented_options.get(finding_id)
+        if presented is None or option not in presented:
+            raise ValueError(
+                f"repair option {option.label!r} was not presented for {finding_id!r}"
+            )
+        if any(existing_id == finding_id for existing_id, _ in self.recorded_choices):
+            raise ValueError(f"choice already recorded for {finding_id!r}")
+        self.recorded_choices.append((finding_id, option))
+
+    def approved_patches(self) -> list[ApprovedPatch]:
+        """Return approving patches from recorded menu choices."""
+        patches: list[ApprovedPatch] = []
+        for finding_id, option in self.recorded_choices:
+            patch = option.patch
+            if (
+                isinstance(patch, ApprovedPatch)
+                and patch.kind not in NON_APPROVING_PATCH_KINDS
+            ):
+                copied = deepcopy(patch)
+                if not copied.finding_id:
+                    copied.finding_id = finding_id
+                patches.append(copied)
+        return patches
+
+
+def _skip_option(finding: SourceSetFinding) -> RepairOption:
+    return RepairOption(
+        label="Skip",
+        preview="Skip this finding",
+        patch=ApprovedPatch(
+            kind="skip",
+            target=finding.file,
+            anchor={"finding_id": finding.finding_id},
+            replacement="",
+            finding_id=finding.finding_id,
+        ),
+    )
+
+
+def _custom_option(finding: SourceSetFinding, definition: str) -> RepairOption:
+    return RepairOption(
+        label="Write my own definition",
+        preview=_truncate_excerpt(definition),
+        patch=ApprovedPatch(
+            kind="custom_no_patch",
+            target=finding.file,
+            anchor={"finding_id": finding.finding_id},
+            replacement=definition,
+            finding_id=finding.finding_id,
+        ),
+    )
+
+
+def _append_presented_option(
+    session: ClickInteractiveSession,
+    finding_id: str,
+    option: RepairOption,
+) -> None:
+    presented = session.presented_options.get(finding_id)
+    if presented is None:
+        raise ValueError(f"finding {finding_id!r} was not presented")
+    if option not in presented:
+        session.presented_options[finding_id] = list(presented) + [option]
+
+
+def _prompt_menu_choice(
+    finding: SourceSetFinding,
+    options: list[RepairOption],
+) -> int:
+    click.echo(f"\n[{finding.finding_id}] {finding.message}")
+    if finding.evidence:
+        click.echo(f"  {_truncate_excerpt(finding.evidence)}")
+
+    label_a = options[0].label if options else "Option A"
+    preview_a = options[0].preview if options else "(unavailable)"
+    label_b = options[1].label if len(options) > 1 else "Option B"
+    preview_b = options[1].preview if len(options) > 1 else "(unavailable)"
+
+    click.echo("\nChoose one:")
+    click.echo(f"[1] {label_a} — {preview_a}")
+    click.echo(f"[2] {label_b} — {preview_b}")
+    click.echo("[3] Write my own definition")
+    click.echo("[4] Skip")
+    return click.prompt("Choice", type=click.IntRange(1, 4), default=4)
+
+
+def apply_approved_patches(
+    patches: list[ApprovedPatch],
+    *,
+    dry_run: bool,
+    quiet: bool,
+) -> None:
+    """Apply boundary for Block 3; v1 honors dry-run and leaves writes to Block 3."""
+    if dry_run or not patches:
+        return
+    for patch in patches:
+        if not quiet:
+            click.echo(
+                f"  [apply pending Block 3] {patch.finding_id}: {patch.kind} "
+                f"→ {patch.target}"
+            )
+
+
+def run_interactive_checkup(
+    target: str,
+    *,
+    apply: bool = False,
+    dry_run: bool = False,
+    project_root: Optional[Path] = None,
+    strict: bool = False,
+    quiet: bool = False,
+    explicit_interactive: bool = True,
+    session_factory: Optional[Callable[[], InteractiveRepairSession]] = None,
+) -> Optional[tuple[str, float, str]]:
+    """Orchestrate report → session → optional apply for one prompt target."""
+    root = project_root if project_root is not None else Path.cwd()
+    prompt_path = Path(target)
+    if not prompt_path.is_file():
+        raise click.UsageError(
+            f"--interactive requires a single .prompt file target, got {target!r}."
+        )
+
+    report = build_prompt_source_set_report(
+        prompt_path,
+        target=target,
+        project_root=root,
+        strict=strict,
+    )
+    findings = filter_interactive_findings(
+        report,
+        explicit_interactive=explicit_interactive,
+    )
+
+    if not quiet:
+        click.echo(f"Interactive checkup: {target}")
+        click.echo(
+            f"Status: {report.status}  Findings: {len(report.findings)}  "
+            f"In scope: {len(findings)}"
+        )
+
+    session: _SessionType
+    if session_factory is not None:
+        session = session_factory()
+    else:
+        session = ClickInteractiveSession()
+    session.seed(report)
+
+    skipped = 0
+    for finding in findings:
+        options = session.present_finding(finding.finding_id)
+        choice = _prompt_menu_choice(finding, options)
+
+        if choice == 4:
+            if isinstance(session, ClickInteractiveSession):
+                skip_option = _skip_option(finding)
+                _append_presented_option(session, finding.finding_id, skip_option)
+                session.record_choice(finding.finding_id, skip_option)
+            skipped += 1
+            continue
+
+        if choice == 3:
+            definition = session.ask("Enter your definition:")
+            if isinstance(session, ClickInteractiveSession):
+                custom_option = _custom_option(finding, definition)
+                _append_presented_option(session, finding.finding_id, custom_option)
+                session.record_choice(finding.finding_id, custom_option)
+            continue
+
+        index = choice - 1
+        if 0 <= index < len(options):
+            session.record_choice(finding.finding_id, options[index])
+
+    patches = session.approved_patches()
+    if apply:
+        apply_approved_patches(patches, dry_run=dry_run, quiet=quiet)
+
+    cost = 0.0
+    model = ""
+    message = (
+        f"Interactive checkup complete: {report.status} "
+        f"({len(findings)} findings, {skipped} skipped)"
+    )
+    if not quiet:
+        click.echo(f"\n{message}")
+    return message, cost, model

--- a/pdd/checkup_prompt_apply.py
+++ b/pdd/checkup_prompt_apply.py
@@ -1,0 +1,304 @@
+"""Deterministic apply path for interactive prompt repair ``ApprovedPatch`` objects."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .checkup_interactive_session import ApprovedPatch
+from .checkup_prompt_main import run_checkup_prompt
+
+ALLOWED_PATCH_KINDS = frozenset(
+    {
+        "vocab_definition",
+        "contract_rule",
+        "coverage_line",
+        "waiver",
+        "story_template",
+        "append_covers",
+    }
+)
+
+_FORBIDDEN_REL_PREFIXES = (
+    "tests/",
+    "pdd/",
+    "dist/",
+    ".git/",
+    "context/",
+)
+
+
+@dataclass
+class ApplyFindingRecord:
+    """One row in the interactive apply log."""
+
+    id: str
+    choice: int
+    patch_kind: str
+    target_path: str
+    status: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "choice": self.choice,
+            "patch_kind": self.patch_kind,
+            "target_path": self.target_path,
+            "status": self.status,
+        }
+
+
+@dataclass
+class ApplyRunResult:
+    """Outcome of one interactive apply run."""
+
+    run_id: str
+    findings: list[ApplyFindingRecord] = field(default_factory=list)
+    postflight_status: str = "pass"
+    exit_code: int = 0
+    log_path: Path | None = None
+    backup_root: Path | None = None
+
+
+def _new_run_id() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S-%fZ")
+
+
+def _relative_posix_path(path: Path, repo_root: Path) -> str:
+    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+
+
+def _is_writable_relative_path(rel: Path) -> bool:
+    if rel.suffix.lower() == ".prompt" and not rel.name.lower().endswith("_llm.prompt"):
+        return True
+    if (
+        len(rel.parts) >= 2
+        and rel.parts[0] == "user_stories"
+        and rel.name.startswith("story__")
+        and rel.suffix.lower() == ".md"
+    ):
+        return True
+    return False
+
+
+def _validate_patch(patch: ApprovedPatch, repo_root: Path) -> Path:
+    """Validate patch kind and target path; return the resolved writable path."""
+    if patch.kind not in ALLOWED_PATCH_KINDS:
+        raise ValueError(f"patch kind {patch.kind!r} is not allowlisted")
+
+    target = Path(patch.target)
+    if target.is_absolute():
+        raise ValueError("absolute patch targets are not allowed")
+
+    repo_root = repo_root.resolve()
+    resolved = (repo_root / target).resolve()
+    try:
+        rel = resolved.relative_to(repo_root)
+    except ValueError as exc:
+        raise ValueError("patch target escapes repository root") from exc
+
+    rel_posix = rel.as_posix()
+    if ".." in rel.parts:
+        raise ValueError("path traversal is not allowed")
+
+    for prefix in _FORBIDDEN_REL_PREFIXES:
+        if rel_posix == prefix.rstrip("/") or rel_posix.startswith(prefix):
+            raise ValueError(f"patch target {rel_posix!r} is not writable")
+
+    if not _is_writable_relative_path(rel):
+        raise ValueError(
+            "patch target must be a .prompt file (excluding *_LLM.prompt) "
+            "or user_stories/story__*.md"
+        )
+
+    if not resolved.is_file():
+        raise ValueError(f"patch target does not exist: {rel_posix}")
+
+    return resolved
+
+
+def _apply_patch_content(path: Path, patch: ApprovedPatch) -> str:
+    """Return updated file contents for one validated patch."""
+    original = path.read_text(encoding="utf-8")
+    if patch.kind == "append_covers":
+        suffix = "" if original.endswith("\n") or not original else "\n"
+        replacement = patch.replacement
+        if replacement and not replacement.endswith("\n"):
+            replacement += "\n"
+        return original + suffix + replacement
+
+    lines = original.splitlines(keepends=True)
+    replacement = patch.replacement
+    if replacement and not replacement.endswith("\n"):
+        replacement += "\n"
+
+    anchor_line = patch.anchor.get("line")
+    insert_at = len(lines)
+    if anchor_line not in (None, ""):
+        try:
+            insert_at = max(0, int(anchor_line) - 1)
+        except (TypeError, ValueError):
+            insert_at = len(lines)
+
+    if 0 <= insert_at <= len(lines):
+        lines.insert(insert_at, replacement)
+    else:
+        lines.append(replacement)
+    return "".join(lines)
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        delete=False,
+    ) as handle:
+        handle.write(content)
+        temp_path = Path(handle.name)
+    os.replace(temp_path, path)
+
+
+def _backup_file(path: Path, repo_root: Path, run_id: str) -> Path:
+    rel = path.resolve().relative_to(repo_root.resolve())
+    backup_root = repo_root / ".pdd" / "evidence" / "checkups" / "backups" / run_id
+    dest = backup_root / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(path, dest)
+    return dest
+
+
+def _write_apply_log(
+    repo_root: Path,
+    *,
+    run_id: str,
+    interactive: bool,
+    dry_run: bool,
+    findings: Sequence[ApplyFindingRecord],
+    postflight_status: str,
+) -> Path:
+    evidence_dir = repo_root / ".pdd" / "evidence" / "checkups"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    log_path = evidence_dir / f"apply-{run_id}.json"
+    payload = {
+        "run_id": run_id,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "interactive": interactive,
+        "dry_run": dry_run,
+        "findings": [record.as_dict() for record in findings],
+        "postflight_status": postflight_status,
+    }
+    log_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return log_path
+
+
+def apply_approved_patches(
+    patches: Sequence[ApprovedPatch],
+    *,
+    repo_root: Path,
+    original_target: str,
+    dry_run: bool = False,
+    interactive: bool = True,
+    strict: bool = False,
+    choices_by_finding: Mapping[str, int] | None = None,
+) -> ApplyRunResult:
+    """Validate, backup, atomically apply patches, log, and postflight check."""
+    run_id = _new_run_id()
+    repo_root = repo_root.resolve()
+    choices = dict(choices_by_finding or {})
+    records: list[ApplyFindingRecord] = []
+    backup_root: Path | None = None
+    applied_any = False
+
+    for patch in patches:
+        finding_id = patch.finding_id or str(patch.anchor.get("finding_id", ""))
+        choice = choices.get(finding_id, 0)
+        try:
+            target_path = _validate_patch(patch, repo_root)
+            rel_target = _relative_posix_path(target_path, repo_root)
+        except ValueError:
+            records.append(
+                ApplyFindingRecord(
+                    id=finding_id,
+                    choice=choice,
+                    patch_kind=patch.kind,
+                    target_path=str(patch.target),
+                    status="rejected",
+                )
+            )
+            continue
+
+        if dry_run:
+            records.append(
+                ApplyFindingRecord(
+                    id=finding_id,
+                    choice=choice,
+                    patch_kind=patch.kind,
+                    target_path=rel_target,
+                    status="accepted",
+                )
+            )
+            continue
+
+        if backup_root is None:
+            backup_root = repo_root / ".pdd" / "evidence" / "checkups" / "backups" / run_id
+        _backup_file(target_path, repo_root, run_id)
+        new_content = _apply_patch_content(target_path, patch)
+        _atomic_write(target_path, new_content)
+        applied_any = True
+        records.append(
+            ApplyFindingRecord(
+                id=finding_id,
+                choice=choice,
+                patch_kind=patch.kind,
+                target_path=rel_target,
+                status="accepted",
+            )
+        )
+
+    postflight_status = "pass"
+    exit_code = 0
+    if not dry_run and applied_any:
+        try:
+            passed, _message, _cost, _model, exit_code = run_checkup_prompt(
+                original_target,
+                quiet=True,
+                strict=strict,
+                project_root=repo_root,
+            )
+            if exit_code == 0 and passed:
+                postflight_status = "pass"
+            elif exit_code == 0:
+                postflight_status = "warn"
+            else:
+                postflight_status = "fail"
+        except Exception:  # pylint: disable=broad-except
+            postflight_status = "error"
+            exit_code = 2
+
+    log_path: Path | None = None
+    if interactive and (records or dry_run):
+        log_path = _write_apply_log(
+            repo_root,
+            run_id=run_id,
+            interactive=interactive,
+            dry_run=dry_run,
+            findings=records,
+            postflight_status=postflight_status,
+        )
+
+    return ApplyRunResult(
+        run_id=run_id,
+        findings=records,
+        postflight_status=postflight_status,
+        exit_code=exit_code,
+        log_path=log_path,
+        backup_root=backup_root,
+    )

--- a/pdd/commands/checkup.py
+++ b/pdd/commands/checkup.py
@@ -3,6 +3,7 @@ Checkup command — GitHub issue-driven project health check, or local diagnosti
 """
 # pylint: disable=unknown-option-value
 import math
+import sys
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -30,6 +31,11 @@ from .coverage import coverage_cmd
 from .gate import gate_cmd
 from .drift import drift_cmd
 from .prompt import prompt_lint
+
+
+def _interactive_tty_available() -> bool:
+    """Return True when stdin and stdout are interactive terminals."""
+    return sys.stdin.isatty() and sys.stdout.isatty()
 
 
 def _forward_subcommand_json(
@@ -385,6 +391,27 @@ def _forward_subcommand_json(
     help="Wall-clock timeout for the prompt repair loop in seconds (default: 120).",
 )
 @click.option(
+    "--interactive",
+    "interactive",
+    is_flag=True,
+    default=False,
+    help="With .prompt targets: enter interactive per-finding repair session.",
+)
+@click.option(
+    "--apply",
+    "apply",
+    is_flag=True,
+    default=False,
+    help="With --interactive: apply selected repairs. Requires --interactive.",
+)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="With --interactive --apply: preview changes without writing any files.",
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -449,6 +476,9 @@ def checkup(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     max_prompt_repair_rounds: Optional[int],
     max_prompt_token_growth: Optional[int],
     max_prompt_repair_seconds: Optional[float],
+    interactive: bool,
+    apply: bool,
+    dry_run: bool,
 ) -> Optional[Tuple[str, float, str]]:
     """
     pdd checkup = verifier namespace
@@ -498,6 +528,17 @@ def checkup(  # pylint: disable=too-many-arguments,too-many-positional-arguments
       pdd checkup drift <DEVUNIT> [OPTIONS]
     """
     ctx.ensure_object(dict)
+
+    if apply and not interactive:
+        raise click.UsageError("--apply requires --interactive.")
+
+    if interactive and not _interactive_tty_available():
+        raise click.UsageError(
+            "--interactive requires a TTY (stdin and stdout must be a terminal)."
+        )
+
+    if interactive and as_json:
+        raise click.UsageError("--interactive cannot be combined with --json.")
 
     if show_help and target not in {
         "lint",
@@ -683,10 +724,31 @@ def checkup(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         run_validate_arch_includes_cli(root, strict=strict, quiet=ctx.obj.get("quiet", False))
         return "validate-arch-includes: ok", 0.0, ""
 
+    if interactive and target is not None and not is_prompt_shaped_target(
+        target,
+        project_root=project_root,
+    ):
+        raise click.UsageError(
+            "--interactive is only supported for prompt-shaped checkup targets."
+        )
+
     if pr_url is None and target is not None and is_prompt_shaped_target(
         target,
         project_root=project_root,
     ):
+        if interactive:
+            from ..checkup_interactive_main import run_interactive_checkup  # pylint: disable=import-outside-toplevel
+
+            return run_interactive_checkup(
+                target,
+                apply=apply,
+                dry_run=dry_run,
+                project_root=project_root,
+                strict=strict,
+                quiet=ctx.obj.get("quiet", False),
+                explicit_interactive=True,
+            )
+
         import json as _json  # pylint: disable=import-outside-toplevel
 
         quiet = ctx.obj.get("quiet", False)

--- a/pdd/commands/generate.py
+++ b/pdd/commands/generate.py
@@ -43,9 +43,10 @@ def _maybe_run_prompt_gate(
     project_root: Optional[str],
     quiet: bool,
     dry_run: bool = False,
+    interactive: bool = False,
 ) -> tuple[bool, int]:
     """Run the prompt gate; return ``(should_continue, exit_code)``."""
-    if dry_run:
+    if dry_run and not interactive:
         return True, 0
     root = Path(project_root or Path.cwd()).resolve()
     return maybe_run_workflow_prompt_gate(
@@ -54,6 +55,8 @@ def _maybe_run_prompt_gate(
         no_prompt_checkup=no_prompt_checkup,
         project_root=root,
         quiet=quiet,
+        interactive=interactive,
+        dry_run=dry_run,
     )
 
 
@@ -65,6 +68,7 @@ def _enforce_prompt_gate_or_exit(
     project_root: Optional[str],
     quiet: bool,
     dry_run: bool = False,
+    interactive: bool = False,
 ) -> None:
     """Raise ``click.Exit`` when strict prompt checkup blocks downstream work."""
     should_continue, exit_code = _maybe_run_prompt_gate(
@@ -74,6 +78,7 @@ def _enforce_prompt_gate_or_exit(
         project_root=project_root,
         quiet=quiet,
         dry_run=dry_run,
+        interactive=interactive,
     )
     if not should_continue:
         raise click.exceptions.Exit(exit_code)
@@ -181,6 +186,13 @@ class GenerateCommand(click.Command):
     default=False,
     help="Disable automatic prompt checkup for this run.",
 )
+@click.option(
+    "--interactive",
+    "interactive",
+    is_flag=True,
+    default=False,
+    help="With --prompt-checkup: run interactive per-finding repair on changed prompts.",
+)
 @click.pass_context
 @log_operation(operation="generate", clears_run_report=True, updates_fingerprint=True)
 @track_cost
@@ -206,6 +218,7 @@ def generate(
     compress: bool,
     prompt_checkup: Optional[str],
     no_prompt_checkup: bool,
+    interactive: bool,
 ) -> Optional[Tuple[str, float, str]]:
     """
     Create runnable code from a prompt file.
@@ -349,6 +362,7 @@ def generate(
                     project_root=project_root,
                     quiet=quiet,
                     dry_run=dry_run,
+                    interactive=interactive,
                 )
             return (message, cost, model) if success else None
 
@@ -396,6 +410,7 @@ def generate(
                     no_prompt_checkup=no_prompt_checkup,
                     project_root=project_root,
                     quiet=quiet,
+                    interactive=interactive,
                 )
             return (message, cost, model) if success else None
 

--- a/pdd/commands/modify.py
+++ b/pdd/commands/modify.py
@@ -222,6 +222,13 @@ def split(
     default=False,
     help="Disable automatic prompt checkup for this run.",
 )
+@click.option(
+    "--interactive",
+    "interactive",
+    is_flag=True,
+    default=False,
+    help="With --prompt-checkup: run interactive per-finding repair on changed prompts.",
+)
 @click.pass_context
 @track_cost
 def change(
@@ -237,6 +244,7 @@ def change(
     clean_restart: bool,
     prompt_checkup: Optional[str],
     no_prompt_checkup: bool,
+    interactive: bool,
 ) -> Optional[Tuple[Any, float, str]]:
     """
     Modify an input prompt file based on a change prompt or issue.
@@ -250,6 +258,7 @@ def change(
     ctx.ensure_object(dict)
     ctx.obj["prompt_checkup"] = prompt_checkup
     ctx.obj["no_prompt_checkup"] = no_prompt_checkup
+    ctx.obj["interactive"] = interactive
 
     if clean_restart and manual:
         raise click.UsageError(
@@ -384,6 +393,7 @@ def change(
                 no_prompt_checkup=no_prompt_checkup,
                 project_root=resolve_prompt_gate_project_root(changed_files or []),
                 quiet=quiet,
+                interactive=interactive,
             )
             if not should_continue:
                 raise click.exceptions.Exit(gate_exit)

--- a/pdd/prompt_gate.py
+++ b/pdd/prompt_gate.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 from typing import Optional, Sequence
 
@@ -204,6 +205,9 @@ def maybe_run_workflow_prompt_gate(
     no_prompt_checkup: bool,
     project_root: Path,
     quiet: bool = False,
+    interactive: bool = False,
+    apply: bool = False,
+    dry_run: bool = False,
 ) -> tuple[bool, int]:
     """Shared hook for generate/change workflows that touch ``.prompt`` files."""
     prompt_paths = [
@@ -212,6 +216,34 @@ def maybe_run_workflow_prompt_gate(
         if path.is_file()
     ]
     if not prompt_paths:
+        return True, 0
+
+    if apply and not interactive:
+        raise click.UsageError("--apply requires --interactive.")
+
+    if interactive:
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            raise click.UsageError(
+                "--interactive requires a TTY (stdin and stdout must be a terminal)."
+            )
+        from .checkup_interactive_main import run_interactive_checkup  # pylint: disable=import-outside-toplevel
+
+        gate_mode = resolve_prompt_gate_mode(
+            cli_prompt_checkup=cli_prompt_checkup,
+            no_prompt_checkup=no_prompt_checkup,
+            project_root=project_root,
+        )
+        strict = gate_mode == "strict"
+        for prompt_path in prompt_paths:
+            run_interactive_checkup(
+                str(prompt_path),
+                apply=apply,
+                dry_run=dry_run,
+                project_root=project_root,
+                strict=strict,
+                quiet=quiet,
+                explicit_interactive=True,
+            )
         return True, 0
 
     gate_mode = resolve_prompt_gate_mode(

--- a/tests/test_checkup_interactive.py
+++ b/tests/test_checkup_interactive.py
@@ -1,0 +1,262 @@
+"""Tests for interactive checkup flags and interaction policy (#1436)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from pdd.checkup_interactive_main import (
+    ClickInteractiveSession,
+    filter_interactive_findings,
+    run_interactive_checkup,
+)
+from pdd.checkup_interactive_session import FakeInteractiveSession, RepairOption
+from pdd.checkup_prompt_main import PromptSourceSetReport, SourceSetFinding
+from pdd.commands.checkup import checkup
+
+
+def _make_finding(
+    finding_id: str = "F001",
+    *,
+    requires_clarification: bool = False,
+    code: str = "",
+) -> SourceSetFinding:
+    return SourceSetFinding(
+        finding_id=finding_id,
+        source_check="lint",
+        severity="warn",
+        file=Path("prompts/test.prompt"),
+        message="Test finding",
+        evidence="some evidence",
+        recommended_action="Fix the issue",
+        code=code,
+        requires_clarification=requires_clarification,
+    )
+
+
+def _make_report(
+    tmp_path: Path,
+    findings: list[SourceSetFinding] | None = None,
+) -> PromptSourceSetReport:
+    prompt_path = tmp_path / "test.prompt"
+    return PromptSourceSetReport(
+        prompt_path=prompt_path,
+        project_root=tmp_path,
+        target=str(prompt_path),
+        findings=findings or [],
+    )
+
+
+def test_interactive_requires_tty(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("test prompt content")
+
+    runner = CliRunner()
+    result = runner.invoke(checkup, [str(prompt_file), "--interactive"])
+
+    assert result.exit_code != 0
+    assert "TTY" in result.output or "tty" in result.output.lower()
+
+
+def test_apply_requires_interactive(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("test prompt content")
+
+    runner = CliRunner()
+    result = runner.invoke(checkup, [str(prompt_file), "--apply"])
+
+    assert result.exit_code != 0
+    assert "--apply requires --interactive" in result.output
+
+
+def test_interactive_rejects_non_prompt_target() -> None:
+    runner = CliRunner()
+    with patch("pdd.commands.checkup._interactive_tty_available", return_value=True):
+        result = runner.invoke(
+            checkup,
+            ["https://github.com/promptdriven/pdd/issues/1", "--interactive"],
+        )
+
+    assert result.exit_code != 0
+    assert "prompt-shaped" in result.output
+
+
+def test_filter_interactive_findings_explicit_includes_all() -> None:
+    findings = [
+        _make_finding("A", requires_clarification=False),
+        _make_finding("B", requires_clarification=True),
+    ]
+    report = _make_report(Path("/tmp"), findings)
+
+    filtered = filter_interactive_findings(report, explicit_interactive=True)
+
+    assert len(filtered) == 2
+
+
+def test_filter_interactive_findings_auto_only_clarification() -> None:
+    findings = [
+        _make_finding("A", requires_clarification=False),
+        _make_finding("B", requires_clarification=True, code="VAGUE_TERM"),
+    ]
+    report = _make_report(Path("/tmp"), findings)
+
+    filtered = filter_interactive_findings(report, explicit_interactive=False)
+
+    assert [finding.finding_id for finding in filtered] == ["B"]
+
+
+def test_dry_run_no_writes(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "test.prompt"
+    original_content = "original prompt content"
+    prompt_file.write_text(original_content)
+
+    finding = _make_finding("DRY-001")
+    report = _make_report(tmp_path, [finding])
+
+    with patch(
+        "pdd.checkup_interactive_main.build_prompt_source_set_report",
+        return_value=report,
+    ):
+        with patch("pdd.checkup_interactive_main._prompt_menu_choice", return_value=1):
+            run_interactive_checkup(
+                str(prompt_file),
+                apply=True,
+                dry_run=True,
+                project_root=tmp_path,
+                quiet=True,
+            )
+
+    assert prompt_file.read_text() == original_content
+    backup_files = list(tmp_path.glob("*.bak")) + list(tmp_path.glob("*.prompt.bak"))
+    assert backup_files == []
+
+
+def test_interactive_no_writes(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "test.prompt"
+    original_content = "original prompt content"
+    prompt_file.write_text(original_content)
+
+    finding = _make_finding("NW-001")
+    report = _make_report(tmp_path, [finding])
+
+    with patch(
+        "pdd.checkup_interactive_main.build_prompt_source_set_report",
+        return_value=report,
+    ):
+        with patch("pdd.checkup_interactive_main._prompt_menu_choice", return_value=1):
+            run_interactive_checkup(
+                str(prompt_file),
+                apply=False,
+                dry_run=False,
+                project_root=tmp_path,
+                quiet=True,
+            )
+
+    assert prompt_file.read_text() == original_content
+    backup_files = list(tmp_path.glob("*.bak")) + list(tmp_path.glob("*.prompt.bak"))
+    assert backup_files == []
+
+
+def test_skip_flow(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("prompt content")
+
+    findings = [_make_finding("SK-001"), _make_finding("SK-002")]
+    report = _make_report(tmp_path, findings)
+
+    with patch(
+        "pdd.checkup_interactive_main.build_prompt_source_set_report",
+        return_value=report,
+    ):
+        with patch("pdd.checkup_interactive_main._prompt_menu_choice", return_value=4):
+            result = run_interactive_checkup(
+                str(prompt_file),
+                apply=True,
+                dry_run=False,
+                project_root=tmp_path,
+                quiet=True,
+            )
+
+    assert result is not None
+    message, _cost, _model = result
+    assert "skipped" in message
+    assert "2 skipped" in message
+
+
+def test_click_interactive_session_records_candidate_choice() -> None:
+    finding = _make_finding("SES-001")
+    report = _make_report(Path("/tmp"), [finding])
+    session = ClickInteractiveSession()
+    session.seed(report)
+
+    options = session.present_finding("SES-001")
+    assert len(options) == 2
+    session.record_choice("SES-001", options[0])
+
+    patches = session.approved_patches()
+    assert len(patches) == 1
+    assert patches[0].finding_id == "SES-001"
+
+
+def test_checkup_registers_interactive_flags() -> None:
+    param_names = {param.name for param in checkup.params}
+    missing = {"interactive", "apply", "dry_run"} - param_names
+    assert not missing, f"Missing params: {missing}"
+
+
+def test_cli_interactive_routes_with_tty(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("prompt content")
+    finding = _make_finding("CLI-001")
+    report = _make_report(tmp_path, [finding])
+
+    with patch("pdd.commands.checkup._interactive_tty_available", return_value=True):
+        with patch(
+            "pdd.checkup_interactive_main.build_prompt_source_set_report",
+            return_value=report,
+        ):
+            with patch("pdd.checkup_interactive_main._prompt_menu_choice", return_value=4):
+                runner = CliRunner()
+                result = runner.invoke(checkup, [str(prompt_file), "--interactive"])
+
+    assert result.exit_code == 0
+    assert "Interactive checkup complete" in result.output
+
+
+def test_fake_session_still_usable_via_factory(tmp_path: Path) -> None:
+    from pdd.checkup_interactive_session import ApprovedPatch
+
+    prompt_file = tmp_path / "test.prompt"
+    prompt_file.write_text("prompt content")
+    finding = _make_finding("FAKE-001")
+    report = _make_report(tmp_path, [finding])
+    repair_option = RepairOption(
+        label="Fix",
+        preview="preview",
+        patch=ApprovedPatch(
+            kind="repair_candidate",
+            target=prompt_file,
+            anchor={"finding_id": "FAKE-001"},
+            replacement="fix",
+            finding_id="FAKE-001",
+        ),
+    )
+    fake = FakeInteractiveSession({"FAKE-001": [repair_option, repair_option]})
+
+    with patch(
+        "pdd.checkup_interactive_main.build_prompt_source_set_report",
+        return_value=report,
+    ):
+        with patch("pdd.checkup_interactive_main._prompt_menu_choice", return_value=1):
+            run_interactive_checkup(
+                str(prompt_file),
+                apply=False,
+                project_root=tmp_path,
+                quiet=True,
+                session_factory=lambda: fake,
+            )
+
+    assert fake.recorded_choices == [("FAKE-001", repair_option)]

--- a/tests/test_checkup_interactive.py
+++ b/tests/test_checkup_interactive.py
@@ -237,7 +237,7 @@ def test_fake_session_still_usable_via_factory(tmp_path: Path) -> None:
         label="Fix",
         preview="preview",
         patch=ApprovedPatch(
-            kind="repair_candidate",
+            kind="vocab_definition",
             target=prompt_file,
             anchor={"finding_id": "FAKE-001"},
             replacement="fix",

--- a/tests/test_checkup_prompt_apply.py
+++ b/tests/test_checkup_prompt_apply.py
@@ -1,0 +1,167 @@
+"""Tests for deterministic interactive prompt patch apply (#1437)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pdd.checkup_interactive_session import ApprovedPatch
+from pdd.checkup_prompt_apply import (
+    _validate_patch,
+    apply_approved_patches,
+)
+
+
+def _patch(
+    *,
+    kind: str = "vocab_definition",
+    target: str = "prompts/test_python.prompt",
+    finding_id: str = "lint:test:1:VAGUE",
+    replacement: str = "- Defined term: explicit meaning.",
+    line: int = 1,
+) -> ApprovedPatch:
+    return ApprovedPatch(
+        kind=kind,
+        target=Path(target),
+        anchor={"finding_id": finding_id, "line": line},
+        replacement=replacement,
+        finding_id=finding_id,
+    )
+
+
+def _write_prompt(repo: Path, rel: str = "prompts/test_python.prompt", content: str = "line one\n") -> Path:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_validate_patch_accepts_prompt_and_story(tmp_path: Path) -> None:
+    prompt = _write_prompt(tmp_path)
+    story = tmp_path / "user_stories" / "story__refund.md"
+    story.parent.mkdir(parents=True)
+    story.write_text("# Story\n", encoding="utf-8")
+
+    _validate_patch(_patch(target="prompts/test_python.prompt"), tmp_path)
+    _validate_patch(
+        _patch(kind="story_template", target="user_stories/story__refund.md"),
+        tmp_path,
+    )
+    assert prompt.is_file()
+    assert story.is_file()
+
+
+@pytest.mark.parametrize(
+    ("target", "kind", "message"),
+    [
+        ("../../../etc/passwd", "vocab_definition", "escapes"),
+        ("tests/test_x.prompt", "vocab_definition", "not writable"),
+        ("prompts/secret_LLM.prompt", "vocab_definition", "_LLM.prompt"),
+        ("README.md", "vocab_definition", "must be"),
+        ("prompts/test_python.prompt", "repair_candidate", "allowlisted"),
+    ],
+)
+def test_validate_patch_rejects_invalid_targets(
+    tmp_path: Path,
+    target: str,
+    kind: str,
+    message: str,
+) -> None:
+    if target.endswith(".prompt"):
+        _write_prompt(tmp_path, target)
+    elif target == "README.md":
+        (tmp_path / "README.md").write_text("docs\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        _validate_patch(_patch(kind=kind, target=target), tmp_path)
+
+
+def test_dry_run_writes_no_bytes_and_still_logs(tmp_path: Path) -> None:
+    prompt = _write_prompt(tmp_path, content="original\n")
+    original = prompt.read_text(encoding="utf-8")
+
+    result = apply_approved_patches(
+        [_patch()],
+        repo_root=tmp_path,
+        original_target=str(prompt),
+        dry_run=True,
+        choices_by_finding={"lint:test:1:VAGUE": 1},
+    )
+
+    assert prompt.read_text(encoding="utf-8") == original
+    assert result.log_path is not None
+    assert result.log_path.is_file()
+    payload = json.loads(result.log_path.read_text(encoding="utf-8"))
+    assert payload["dry_run"] is True
+    assert payload["findings"][0]["status"] == "accepted"
+    assert not list((tmp_path / ".pdd" / "evidence" / "checkups" / "backups").glob("**/*"))
+
+
+def test_apply_creates_backup_and_mutates_prompt(tmp_path: Path) -> None:
+    prompt = _write_prompt(tmp_path, content="before\n")
+
+    with patch("pdd.checkup_prompt_apply.run_checkup_prompt", return_value=(True, "ok", 0.0, "", 0)):
+        result = apply_approved_patches(
+            [_patch(replacement="- Defined term: explicit meaning.\n")],
+            repo_root=tmp_path,
+            original_target=str(prompt),
+            choices_by_finding={"lint:test:1:VAGUE": 1},
+        )
+
+    assert result.backup_root is not None
+    backup_file = result.backup_root / "prompts" / "test_python.prompt"
+    assert backup_file.read_text(encoding="utf-8") == "before\n"
+    assert "- Defined term" in prompt.read_text(encoding="utf-8")
+    assert result.log_path is not None
+    assert result.postflight_status == "pass"
+
+
+def test_apply_rejects_invalid_patch_kind_in_log(tmp_path: Path) -> None:
+    prompt = _write_prompt(tmp_path, content="unchanged\n")
+    bad = _patch(kind="repair_candidate")
+
+    result = apply_approved_patches(
+        [bad],
+        repo_root=tmp_path,
+        original_target=str(prompt),
+        choices_by_finding={"lint:test:1:VAGUE": 1},
+    )
+
+    assert result.findings[0].status == "rejected"
+    assert prompt.read_text(encoding="utf-8") == "unchanged\n"
+    assert result.backup_root is None
+
+
+def test_postflight_failure_propagates_exit_code(tmp_path: Path) -> None:
+    prompt = _write_prompt(tmp_path)
+
+    with patch(
+        "pdd.checkup_prompt_apply.run_checkup_prompt",
+        return_value=(False, "fail", 0.0, "", 2),
+    ):
+        result = apply_approved_patches(
+            [_patch()],
+            repo_root=tmp_path,
+            original_target=str(prompt),
+            choices_by_finding={"lint:test:1:VAGUE": 1},
+        )
+
+    assert result.postflight_status == "fail"
+    assert result.exit_code == 2
+
+
+def test_append_covers_appends_to_file_end(tmp_path: Path) -> None:
+    prompt = _write_prompt(tmp_path, content="header\n")
+
+    with patch("pdd.checkup_prompt_apply.run_checkup_prompt", return_value=(True, "ok", 0.0, "", 0)):
+        apply_approved_patches(
+            [_patch(kind="append_covers", replacement="covers: extra")],
+            repo_root=tmp_path,
+            original_target=str(prompt),
+            choices_by_finding={"lint:test:1:VAGUE": 2},
+        )
+
+    assert prompt.read_text(encoding="utf-8").endswith("covers: extra\n")


### PR DESCRIPTION
## Summary

Implements #1437 on a dedicated branch based on the parent PR branch `change/issue-1423`.

Adds the deterministic interactive prompt patch applicator (`pdd/checkup_prompt_apply.py`) and wires it into the Block 2 interactive orchestrator from #1436.

**Closes:** #1437

## Relationship to Parent PR

This PR targets `change/issue-1423`, **not** `main`.

It is intended to merge into the interactive repair umbrella branch after review, alongside #1513 (#1436), #1514 (#1438), and #1515 (#1434).

## Issue Contract

* **Required behavior:**
  * Validate structured `ApprovedPatch` objects (kind + path allowlist)
  * Backup to `.pdd/evidence/checkups/backups/<run_id>/`
  * Atomic writes via tempfile + `os.replace`
  * Apply log at `.pdd/evidence/checkups/apply-<run_id>.json`
  * Postflight unified prompt checkup via `run_checkup_prompt`
  * `--dry-run` short-circuits before backup/write
* **Preserved behavior:** non-interactive checkup, #1436 guards/menus, `InteractiveRepairSession` protocol
* **Out of scope:** non-interactive repair (#1422), generated code edits, auto-apply by confidence

## Implementation

* **Added** `pdd/checkup_prompt_apply.py` — validate → backup → atomic apply → log → postflight
* **Updated** `pdd/checkup_interactive_main.py` — replace Block 3 stub; map repair options to allowlisted patch kinds; propagate postflight exit codes
* **Added** `tests/test_checkup_prompt_apply.py` — validation, dry-run, backup, log, postflight failure

## Tests

* Added `tests/test_checkup_prompt_apply.py` (11 tests)
* Updated `tests/test_checkup_interactive.py` for allowlisted patch kinds

## Verification

```bash
git branch --show-current
# DianaTao/issue-1437-from-change-issue-1423

git diff --stat change/issue-1423...HEAD
# 4 files changed, 527 insertions(+), 15 deletions(-)

python -m pytest tests/test_checkup_prompt_apply.py tests/test_checkup_interactive.py -v
# 23 passed

python -m pytest tests/test_checkup_interactive_session.py -q
# 26 passed

python -m py_compile pdd/checkup_prompt_apply.py pdd/checkup_interactive_main.py
# ok
```

## pdd Bot / Reviewer Comments Addressed

* **Validate patch kinds + writable paths only** → `_validate_patch()` with allowlist and repo containment tests
* **`--dry-run` before backup/write** → early return records log entries without `copy2`/`os.replace`
* **Apply log schema** → `apply-<run_id>.json` with findings + `postflight_status`
* **Postflight uses #1420 authority** → `run_checkup_prompt()` after apply; failure propagates exit code
* **LLM layer never calls apply with raw text** → only typed `ApprovedPatch` accepted

## Unrelated Diff Check

No unrelated changes. Diff is limited to Block 3 apply module, interactive orchestrator wiring, and focused tests.

## Risks

* Patch content application is line-insert/append heuristic (v1); complex anchor semantics may need refinement per patch kind.
* `custom_no_patch` / `skip` choices remain non-approving (by design).
* Parent branch `change/issue-1423` on origin is still pre-#1436 until stacked PRs land; this branch includes #1436 commit `cb494344e` as its base.


Made with [Cursor](https://cursor.com)