### PR TITLE
fix(release): harden release video diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,13 @@ jobs:
       #                                artifact:read, distribution:package,
       #                                distribution:publish). A project-locked
       #                                token (e.g. an e2e profile) will NOT work.
+      #                                Local preflight can only confirm that a
+      #                                token is present; server-side preflight
+      #                                is required to verify scopes/project
+      #                                access. Normal create-mode needs a token
+      #                                that can keep accessing the project it
+      #                                just created, or a backend fix/wildcard
+      #                                token.
       #   vars.PDS_CLI_PACKAGE         install spec for the @promptdriven/pds
       #                                CLI, for example @promptdriven/pds@latest
       #                                or a pinned version.
@@ -210,6 +217,9 @@ jobs:
       #   vars.RELEASE_VIDEO_PROJECT_ID  optional stable PDS project to reuse
       #                                across releases (else a per-release
       #                                "PDD <tag> release" project is created).
+      #   vars.RELEASE_VIDEO_SCRIPT_PATH optional checked-out artifact path to
+      #                                reuse when Claude Code quota/auth blocks
+      #                                script generation.
       - name: Create release video and prepend link to notes (best-effort)
         if: env.HAS_PDS == 'true'
         continue-on-error: true
@@ -220,6 +230,7 @@ jobs:
           PDS_CLI_PACKAGE: ${{ vars.PDS_CLI_PACKAGE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           RELEASE_VIDEO_PROJECT_ID: ${{ vars.RELEASE_VIDEO_PROJECT_ID }}
+          RELEASE_VIDEO_SCRIPT_PATH: ${{ vars.RELEASE_VIDEO_SCRIPT_PATH }}
         run: |
           set -uo pipefail
           tag="${{ github.ref_name }}"
@@ -246,7 +257,7 @@ jobs:
               RELEASE_TAG="$tag" \
               RELEASE_GIT_SHA="${{ github.sha }}" \
               ${RELEASE_VIDEO_PROJECT_ID:+RELEASE_VIDEO_PROJECT_ID="$RELEASE_VIDEO_PROJECT_ID"}; then
-            echo "::warning::release video generation failed; release notes left unchanged."
+            echo "::warning::release video step failed; see diagnostics above for Claude script generation vs PDS publish. Release notes left unchanged."
             exit 0
           fi
           resp=".pdd/release-videos/${tag}/pds_response.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,9 @@ jobs:
       #                                access. Normal create-mode needs a token
       #                                that can keep accessing the project it
       #                                just created, or a backend fix/wildcard
-      #                                token.
+      #                                token. A project-locked token only works
+      #                                with vars.RELEASE_VIDEO_PROJECT_ID set to
+      #                                that same authorized fixed project.
       #   vars.PDS_CLI_PACKAGE         install spec for the @promptdriven/pds
       #                                CLI, for example @promptdriven/pds@latest
       #                                or a pinned version.

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ RELEASE_VIDEO_PLATFORM ?= youtube
 RELEASE_VIDEO_PRIVACY ?= unlisted
 RELEASE_VIDEO_DRY_RUN ?= 0
 RELEASE_VIDEO_PROJECT_ID ?=
+RELEASE_VIDEO_SCRIPT_PATH ?=
 CLAUDE_CLI ?= claude
 PDS_CLI ?= pds
 PDS_API_URL ?= https://video.promptdriven.ai
@@ -784,6 +785,7 @@ release-video:
 	python scripts/release_video.py \
 		--output-dir "$(RELEASE_VIDEO_OUTPUT_DIR)" \
 		--claude-cli "$(CLAUDE_CLI)" \
+		--script-path "$(RELEASE_VIDEO_SCRIPT_PATH)" \
 		--pds-cli "$(PDS_CLI)" \
 		--project-id "$(RELEASE_VIDEO_PROJECT_ID)" \
 		--preset "$(RELEASE_VIDEO_PRESET)" \

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -672,7 +672,14 @@ make release-local BUMP=minor  # minor bump
 make release-local BUMP=major  # major bump
 ```
 
-`make release-local` injects the local Infisical `PDS_RELEASE_TOKEN`, tags `HEAD` with the next `vX.Y.Z`, pushes the tag, then runs `make release-video`. The release-video step asks Claude Code to turn the release diff/notes into a short video script and calls the Prompt Driven Studio CLI (`pds release-video create --target publish --platform youtube --privacy unlisted --wait`) to create and upload an unlisted YouTube video. Set `PDS_CLI` if `pds` is not on `PATH`, and set `RELEASE_VIDEO_PROJECT_ID` only for emergency recovery with a fixed-project PDS token. Use `RELEASE_VIDEO=0` only for an emergency release that must skip paid video generation/upload. GitHub Actions then builds the wheel, waits for the `gltanaka` approval on the `pypi-publish` environment, publishes to PyPI via OIDC, and creates a GitHub Release with auto-generated notes.
+`make release-local` injects the local Infisical `PDS_RELEASE_TOKEN`, tags `HEAD` with the next `vX.Y.Z`, pushes the tag, then runs `make release-video`. The release-video step asks Claude Code to turn the release diff/notes into a short video script and calls the Prompt Driven Studio CLI (`pds release-video create --target publish --platform youtube --privacy unlisted --wait`) to create and upload an unlisted YouTube video. GitHub Actions then builds the wheel, waits for the `gltanaka` approval on the `pypi-publish` environment, publishes to PyPI via OIDC, and creates a GitHub Release with auto-generated notes.
+
+Release-video diagnostics and recovery:
+
+- Run `make check-release-video-config` before a local release. If `PDS_TOKEN` is set, local preflight can only confirm that a token exists; it cannot verify scopes or project access unless the PDS server preflight is run.
+- Normal create-mode creates a new per-release PDS project. The token must be able to create that project and continue accessing it afterward; otherwise use a backend fix/wildcard token or set `RELEASE_VIDEO_PROJECT_ID` for an authorized fixed project.
+- If Claude Code quota/auth blocks script generation, reuse a generated script artifact with `RELEASE_VIDEO_SCRIPT_PATH=.pdd/release-videos/<tag>/release_video_script.md make release-video RELEASE_TAG=<tag>`.
+- Set `PDS_CLI` if `pds` is not on `PATH`. Use `RELEASE_VIDEO=0` only for an emergency release that must skip paid video generation/upload.
 
 ### 9. Troubleshooting Development Setup
 

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -230,13 +230,22 @@ def preflight_release_video(args: argparse.Namespace) -> int:
         print(f"release-video preflight: using explicit PDS project {project_id}.")
 
     if os.environ.get("PDS_TOKEN", "").strip():
-        print(
-            "release-video preflight: PDS_TOKEN is set; local preflight cannot "
-            "verify token scopes or project access unless the PDS server "
-            "preflight is run. Normal create-mode creates a new per-release "
-            "project, so the token must create that project and continue "
-            "accessing it afterward (or use a backend fix/wildcard token)."
-        )
+        if project_id:
+            print(
+                "release-video preflight: PDS_TOKEN is set for explicit PDS "
+                f"project {project_id}; local preflight cannot verify token "
+                "scopes or access to that fixed project unless the PDS server "
+                "preflight is run."
+            )
+        else:
+            print(
+                "release-video preflight: PDS_TOKEN is set; local preflight "
+                "cannot verify token scopes or project access unless the PDS "
+                "server preflight is run. Normal create-mode creates a new "
+                "per-release project, so the token must create that project "
+                "and continue accessing it afterward (or use a backend "
+                "fix/wildcard token)."
+            )
         return 0
 
     if project_id:

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -20,6 +20,54 @@ YOUTUBE_URL_RE = re.compile(r"https?://(?:www\.)?(?:youtube\.com|youtu\.be)/[^\s
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_RELEASE_VIDEO_PROMPT = REPO_ROOT / "pdd" / "prompts" / "release_video_script_LLM.prompt"
 DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
+CLAUDE_FAILURE_CLASSES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "credential-limit",
+        (
+            r"hit\s+your\s+(?:session\s+|usage\s+|weekly\s+|monthly\s+)?limit"
+            r"[^\n]{0,80}?\bresets?\b",
+            r"weekly\s+(?:usage\s+)?limit",
+            r"usage\s+limit",
+            r"session\s+limit",
+        ),
+    ),
+    (
+        "quota",
+        (
+            r"quota\s+(?:exhausted|exceeded|reached)",
+            r"daily\s+quota",
+            r"terminal\s*quota\s*error",
+        ),
+    ),
+    (
+        "billing/credit-exhaustion",
+        (
+            r"credit\s+balance\s+is\s+too\s+low",
+            r"insufficient\s+(?:credit|balance|funds)",
+        ),
+    ),
+    (
+        "oauth/login",
+        (
+            r"not\s+logged\s+in",
+            r"please\s+run\s+/login",
+            r"claude\s+auth\s+login",
+        ),
+    ),
+    (
+        "auth",
+        (
+            r"authentication[_\s]error",
+            r"authentication\s+failed",
+            r"failed\s+to\s+authenticate",
+            r"invalid\s+(?:bearer|api\s+key|key)",
+            r"\b401\b",
+            r"unauthorized",
+            r"access\s+denied",
+            r"permission\s+denied",
+        ),
+    ),
+)
 
 
 class ReleaseVideoError(RuntimeError):
@@ -65,15 +113,22 @@ def main(argv: list[str] | None = None) -> int:
 
         context_path.write_text(context, encoding="utf8")
         release_notes_path.write_text(release_notes_from_context(context), encoding="utf8")
-        script_text = generate_script_with_claude(
-            context=context,
-            claude_cli=args.claude_cli,
-            claude_model=args.claude_model,
-            claude_tools=args.claude_tools,
-            prompt_template=Path(args.prompt_template),
-            timeout=args.claude_timeout,
-            cwd=repo,
-        )
+        if args.script_path:
+            script_text, source_script_path = load_release_video_script(
+                Path(args.script_path),
+                repo,
+            )
+            print(f"release-video: using prewritten script from {source_script_path}")
+        else:
+            script_text = generate_script_with_claude(
+                context=context,
+                claude_cli=args.claude_cli,
+                claude_model=args.claude_model,
+                claude_tools=args.claude_tools,
+                prompt_template=Path(args.prompt_template),
+                timeout=args.claude_timeout,
+                cwd=repo,
+            )
         script_path.write_text(script_text, encoding="utf8")
 
         response = create_release_video(
@@ -135,6 +190,14 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         default=os.environ.get("RELEASE_VIDEO_PROMPT_TEMPLATE", str(DEFAULT_RELEASE_VIDEO_PROMPT)),
         help="Prompt template used to generate the release-video script.",
     )
+    parser.add_argument(
+        "--script-path",
+        default=os.environ.get("RELEASE_VIDEO_SCRIPT_PATH", ""),
+        help=(
+            "Use an existing release-video script instead of invoking Claude Code. "
+            "Useful when reusing a generated artifact after Claude Code quota/auth failure."
+        ),
+    )
     parser.add_argument("--pds-cli", default=os.environ.get("PDS_CLI", "pds"))
     parser.add_argument(
         "--project-id",
@@ -165,10 +228,18 @@ def preflight_release_video(args: argparse.Namespace) -> int:
     project_id = str(args.project_id or "").strip()
     if project_id:
         print(f"release-video preflight: using explicit PDS project {project_id}.")
-        return 0
 
     if os.environ.get("PDS_TOKEN", "").strip():
-        print("release-video preflight: PDS_TOKEN is set; token scopes cannot be verified locally.")
+        print(
+            "release-video preflight: PDS_TOKEN is set; local preflight cannot "
+            "verify token scopes or project access unless the PDS server "
+            "preflight is run. Normal create-mode creates a new per-release "
+            "project, so the token must create that project and continue "
+            "accessing it afterward (or use a backend fix/wildcard token)."
+        )
+        return 0
+
+    if project_id:
         return 0
 
     config_path = pds_config_path()
@@ -195,16 +266,24 @@ def preflight_release_video(args: argparse.Namespace) -> int:
         print(
             "release-video preflight warning: active local PDS profile "
             f"{profile_name!r} is pinned to project {profile_project_id!r}. "
-            "Normal releases create a new per-release project. The profile token "
-            "may fail with \"PDS agent token is not allowed for this project\". "
-            "Use a release-scoped PDS_TOKEN or PDS_PROFILE, set "
-            "RELEASE_VIDEO_PROJECT_ID for an authorized fixed project, or use "
-            "RELEASE_VIDEO=0 for recovery.",
+            "Normal create-mode releases create a new per-release project and "
+            "require credentials that can create that project and continue "
+            "accessing it afterward. The profile token may fail with "
+            "\"PDS agent token is not allowed for this project\". Local "
+            "preflight cannot verify server-side scopes unless the PDS server "
+            "preflight is run. Use a release-scoped PDS_TOKEN/PDS_PROFILE, a "
+            "backend fix/wildcard token, RELEASE_VIDEO_PROJECT_ID for an "
+            "authorized fixed project, or RELEASE_VIDEO=0 for recovery.",
             file=sys.stderr,
         )
         return 0
 
-    print(f"release-video preflight: active local PDS profile {profile_name!r} has no fixed project id.")
+    print(
+        f"release-video preflight: active local PDS profile {profile_name!r} "
+        "has no fixed project id. Local preflight still cannot prove the "
+        "token can create and continue accessing a release project; run the "
+        "PDS server preflight for authoritative validation."
+    )
     return 0
 
 
@@ -457,11 +536,93 @@ def generate_script_with_claude(
     if claude_tools.strip():
         command.extend(["--allowedTools", claude_tools.strip()])
     prompt = render_release_video_prompt(context, prompt_template, cwd)
-    completed = run(command, cwd=cwd, input_text=prompt, timeout=timeout)
+    try:
+        completed = run(command, cwd=cwd, input_text=prompt, timeout=timeout, check=False)
+    except ReleaseVideoError as exc:
+        raise ReleaseVideoError(
+            "Claude Code script generation failed before PDS publish; "
+            f"PDS was not invoked. {exc}"
+        ) from exc
+    if completed.returncode != 0:
+        raise ReleaseVideoError(format_claude_script_generation_failure(command, completed))
     script = normalize_release_video_script(strip_markdown_fence(completed.stdout.strip()))
     if len(script) < 200:
         raise ReleaseVideoError("Claude Code produced an unexpectedly short release video script.")
     return script.rstrip() + "\n"
+
+
+def classify_claude_quota_auth_failure(output: str) -> str | None:
+    msg = output.lower()
+    for classification, patterns in CLAUDE_FAILURE_CLASSES:
+        if any(re.search(pattern, msg) for pattern in patterns):
+            return classification
+    return None
+
+
+def format_claude_script_generation_failure(
+    command: list[str],
+    completed: subprocess.CompletedProcess[str],
+) -> str:
+    combined_output = "\n".join(
+        text for text in (completed.stderr.strip(), completed.stdout.strip()) if text
+    )
+    classification = classify_claude_quota_auth_failure(combined_output)
+    message = (
+        "Claude Code script generation failed before PDS publish "
+        f"(exit {completed.returncode}); PDS was not invoked."
+    )
+    if classification:
+        message += (
+            f" Detected Claude Code quota/auth class {classification!r}; "
+            "check Claude Code auth/subscription state or retry with "
+            "RELEASE_VIDEO_SCRIPT_PATH pointing at a previously generated script."
+        )
+    else:
+        message += " This is a script-generation failure, not a PDS publish failure."
+    return f"{message} Command: {shlex.join(command)}. Details: {process_details(completed)}"
+
+
+def process_details(completed: subprocess.CompletedProcess[str]) -> str:
+    details: list[str] = []
+    stderr = completed.stderr.strip()
+    stdout = completed.stdout.strip()
+    if stderr:
+        details.append(f"stderr: {truncate(stderr, 1200)}")
+    if stdout:
+        details.append(f"stdout: {truncate(stdout, 1200)}")
+    if not details:
+        details.append(f"exit code {completed.returncode}")
+    return " | ".join(details)
+
+
+def load_release_video_script(script_path: Path, cwd: Path) -> tuple[str, Path]:
+    path = resolve_release_video_script_path(script_path, cwd)
+    try:
+        raw_script = path.read_text(encoding="utf8")
+    except OSError as exc:
+        raise ReleaseVideoError(f"Could not read release-video script {path}: {exc}") from exc
+    script = normalize_release_video_script(strip_markdown_fence(raw_script.strip()))
+    if len(script) < 200:
+        raise ReleaseVideoError(
+            f"Release-video script override {path} is unexpectedly short."
+        )
+    return script.rstrip() + "\n", path
+
+
+def resolve_release_video_script_path(script_path: Path, cwd: Path) -> Path:
+    if script_path.is_absolute():
+        if script_path.exists():
+            return script_path
+        raise ReleaseVideoError(f"Release-video script override not found: {script_path}")
+    candidates = [
+        cwd / script_path,
+        REPO_ROOT / script_path,
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate.resolve()
+    tried = "\n".join(str(candidate) for candidate in candidates)
+    raise ReleaseVideoError(f"Release-video script override not found. Tried:\n{tried}")
 
 
 def render_release_video_prompt(context: str, prompt_template: Path, cwd: Path) -> str:

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -508,6 +508,36 @@ def test_release_video_preflight_allows_env_token_without_printing_it(tmp_path: 
     assert "local-secret-token" not in result.stdout + result.stderr
 
 
+def test_release_video_preflight_with_env_token_and_project_reports_fixed_project(
+    tmp_path: Path,
+):
+    repo = init_release_repo(tmp_path)
+    env = release_video_env({"PDS_TOKEN": "env-secret-token"})
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--preflight",
+            "--project-id",
+            "fixed-project-123",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=True,
+    )
+
+    assert "using explicit PDS project fixed-project-123" in result.stdout
+    assert "PDS_TOKEN is set for explicit PDS project fixed-project-123" in result.stdout
+    assert "access to that fixed project" in result.stdout
+    assert "Normal create-mode creates a new per-release project" not in result.stdout
+    assert "env-secret-token" not in result.stdout + result.stderr
+
+
 def test_release_video_publish_requires_youtube_url(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     capture = tmp_path / "pds-capture.json"

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import os
 import subprocess
@@ -16,6 +17,7 @@ def release_video_env(extra: dict | None = None) -> dict:
         "CLAUDE_TIMEOUT",
         "RELEASE_VIDEO_CLAUDE_TOOLS",
         "RELEASE_VIDEO_PROMPT_TEMPLATE",
+        "RELEASE_VIDEO_SCRIPT_PATH",
     ):
         env.pop(key, None)
     if extra:
@@ -83,6 +85,46 @@ print("# PDD v1.1.0 Release Video\\n\\n"
       "Visual direction: show the changelog, a terminal running make release, and the uploaded YouTube receipt.")
 """,
     )
+
+
+def claude_failure_stub(tmp_path: Path, stderr: str, exit_code: int = 1) -> Path:
+    return write_executable(
+        tmp_path / "claude-failure-stub.py",
+        f"""#!/usr/bin/env python3
+import sys
+
+sys.stderr.write({stderr!r})
+raise SystemExit({exit_code})
+""",
+    )
+
+
+def reusable_script_text() -> str:
+    return """# PDD v1.1.0 Release Video
+
+## Opening
+
+NARRATOR:
+PDD v1.1.0 ships release video automation so maintainers can publish a clear story for every CLI release without changing the package publishing path.
+
+VISUAL: show the release tag, changelog excerpt, and terminal command side by side.
+
+## Details
+
+NARRATOR:
+The script highlights what changed, why it matters for developers, and how the generated release artifact flows into the PDS publish step for an unlisted YouTube video.
+
+VISUAL: show the PDS response with the YouTube URL ready for release notes.
+"""
+
+
+def load_release_video_module():
+    spec = importlib.util.spec_from_file_location("release_video", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 def pds_stub(tmp_path: Path, response: dict) -> Path:
@@ -233,6 +275,116 @@ def test_release_video_can_pass_custom_claude_tool_allowlist(tmp_path: Path):
     assert claude_argv[claude_argv.index("--allowedTools") + 1] == "Read,Grep,Bash(git show *)"
 
 
+def test_release_video_can_reuse_existing_script_without_invoking_claude(tmp_path: Path):
+    repo = init_release_repo(tmp_path)
+    capture = tmp_path / "pds-capture.json"
+    existing_script = tmp_path / "existing_release_video_script.md"
+    existing_script.write_text(reusable_script_text(), encoding="utf8")
+    env = release_video_env({"PDS_STUB_CAPTURE": str(capture)})
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--script-path",
+            str(existing_script),
+            "--claude-cli",
+            str(tmp_path / "missing-claude"),
+            "--pds-cli",
+            str(
+                pds_stub(
+                    tmp_path,
+                    {"ok": True, "summary": {"youtubeUrl": "https://youtu.be/reused"}},
+                )
+            ),
+            "--output-dir",
+            str(tmp_path / "videos"),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=True,
+    )
+
+    assert f"using prewritten script from {existing_script}" in result.stdout
+    assert "https://youtu.be/reused" in result.stdout
+    assert not (repo / "claude_prompt.txt").exists()
+    output_dir = tmp_path / "videos" / "v1.1.0"
+    script_text = (output_dir / "release_video_script.md").read_text(encoding="utf8")
+    assert "\n## Opening (0:00 - 0:30)" in script_text
+    assert "\n## Details (0:30 - 1:00)" in script_text
+    pds_call = json.loads(capture.read_text(encoding="utf8"))["argv"]
+    assert pds_call[pds_call.index("--script") + 1] == str(
+        output_dir / "release_video_script.md"
+    )
+
+
+def test_release_video_claude_quota_failure_is_script_generation_diagnostic(tmp_path: Path):
+    repo = init_release_repo(tmp_path)
+    capture = tmp_path / "pds-capture.json"
+    env = release_video_env({"PDS_STUB_CAPTURE": str(capture)})
+    claude = claude_failure_stub(
+        tmp_path,
+        "You've hit your weekly limit; resets on Jun 12, 2026 at 9am UTC\n",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--claude-cli",
+            str(claude),
+            "--pds-cli",
+            str(
+                pds_stub(
+                    tmp_path,
+                    {"ok": True, "summary": {"youtubeUrl": "https://youtu.be/quota"}},
+                )
+            ),
+            "--output-dir",
+            str(tmp_path / "videos"),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Claude Code script generation failed before PDS publish" in result.stderr
+    assert "PDS was not invoked" in result.stderr
+    assert "quota/auth class 'credential-limit'" in result.stderr
+    assert "RELEASE_VIDEO_SCRIPT_PATH" in result.stderr
+    assert not capture.exists()
+
+
+def test_release_video_claude_quota_auth_classifier():
+    release_video = load_release_video_module()
+
+    assert (
+        release_video.classify_claude_quota_auth_failure(
+            "You've hit your weekly limit; resets tomorrow."
+        )
+        == "credential-limit"
+    )
+    assert (
+        release_video.classify_claude_quota_auth_failure("please run /login")
+        == "oauth/login"
+    )
+    assert release_video.classify_claude_quota_auth_failure("401 unauthorized") == "auth"
+    assert release_video.classify_claude_quota_auth_failure("temporary network error") is None
+
+
 def test_release_video_fails_for_missing_prompt_template(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     missing_prompt = tmp_path / "missing_release_video_LLM.prompt"
@@ -348,6 +500,9 @@ def test_release_video_preflight_allows_env_token_without_printing_it(tmp_path: 
 
     assert result.returncode == 0
     assert "PDS_TOKEN is set" in result.stdout
+    assert "local preflight cannot verify token scopes or project access" in result.stdout
+    assert "PDS server preflight" in result.stdout
+    assert "continue accessing it afterward" in result.stdout
     assert "release-video preflight warning" not in result.stderr
     assert "env-secret-token" not in result.stdout + result.stderr
     assert "local-secret-token" not in result.stdout + result.stderr


### PR DESCRIPTION
## Summary

- classify Claude Code quota/auth failures during release-video script generation before PDS is invoked
- add `RELEASE_VIDEO_SCRIPT_PATH` / `--script-path` so a generated script artifact can be reused when Claude quota blocks regeneration
- clarify PDS token/preflight limitations in the release workflow comments and onboarding docs

## RCA Context

The v0.0.267 release-video path had two distinct failure modes: CI failed before PDS because Claude Code hit a weekly limit, while local/manual recovery reached PDS and then exposed a created-project access problem. This PR handles the PDD-side diagnostics and recovery path only; the PDS backend authorization fix is in a separate Generative-Video-Studio PR.

## TDD Evidence

The first commit adds regression coverage for script reuse, quota/auth classification, and stronger preflight wording. Against the previous code, the new tests fail because `--script-path` and the Claude failure classifier do not exist.

## Test Plan

- [x] `python -m pytest tests/test_release_video.py -q`
- [x] `python -m ruff check scripts/release_video.py tests/test_release_video.py`
- [x] `git diff --check`
