### PR TITLE
feat(checkup): merge InteractiveRepairSession protocol into #1423 (#1435)

### DIFF
--- a/architecture.json
+++ b/architecture.json
@@ -10005,20 +10005,13 @@
     "interface": {
       "type": "module",
       "module": {
+        "dataclasses": [
+          "ApprovedPatch",
+          "RepairOption"
+        ],
         "functions": [
           {
-            "name": "ApprovedPatch",
-            "signature": "(kind: str, target: Path, anchor: dict, replacement: str, finding_id: str = '')",
-            "returns": "ApprovedPatch"
-          },
-          {
-            "name": "RepairOption",
-            "signature": "(label: str, preview: str, patch: ApprovedPatch)",
-            "returns": "RepairOption"
-          },
-          {
             "name": "InteractiveRepairSession",
-            "signature": "(seed(report: PromptSourceSetReport) -> None, present_finding(finding_id: str) -> list[RepairOption], ask(question: str) -> str, record_choice(finding_id: str, option: RepairOption) -> None, approved_patches() -> list[ApprovedPatch])",
             "returns": "Protocol"
           },
           {

--- a/pdd/prompts/checkup_interactive_session_python.prompt
+++ b/pdd/prompts/checkup_interactive_session_python.prompt
@@ -4,10 +4,28 @@
 {
   "type": "module",
   "module": {
+    "dataclasses": [
+      {
+        "name": "ApprovedPatch",
+        "fields": [
+          {"name": "kind", "type": "str"},
+          {"name": "target", "type": "Path"},
+          {"name": "anchor", "type": "dict"},
+          {"name": "replacement", "type": "str"},
+          {"name": "finding_id", "type": "str", "default": "''"}
+        ]
+      },
+      {
+        "name": "RepairOption",
+        "fields": [
+          {"name": "label", "type": "str"},
+          {"name": "preview", "type": "str"},
+          {"name": "patch", "type": "ApprovedPatch"}
+        ]
+      }
+    ],
     "functions": [
-      {"name": "ApprovedPatch", "signature": "(kind: str, target: Path, anchor: dict, replacement: str, finding_id: str = '')", "returns": "ApprovedPatch"},
-      {"name": "RepairOption", "signature": "(label: str, preview: str, patch: ApprovedPatch)", "returns": "RepairOption"},
-      {"name": "InteractiveRepairSession", "signature": "(seed(report: PromptSourceSetReport) -> None, present_finding(finding_id: str) -> list[RepairOption], ask(question: str) -> str, record_choice(finding_id: str, option: RepairOption) -> None, approved_patches() -> list[ApprovedPatch])", "returns": "Protocol"},
+      {"name": "InteractiveRepairSession", "returns": "Protocol"},
       {"name": "FakeInteractiveSession", "signature": "(options_by_finding=None, answers=None)", "returns": "FakeInteractiveSession"}
     ]
   }

--- a/tests/test_checkup_interactive_session.py
+++ b/tests/test_checkup_interactive_session.py
@@ -379,3 +379,36 @@ def test_prompt_forbids_tty_pi_and_provider_calls() -> None:
     assert "MUST NOT prompt on TTY or Pi backends in this module." in prompt
     assert "MUST NOT call external providers." in prompt
     assert "implement Pi/TTY backends" in prompt
+    assert "RepairOption.patch` must be non-optional" in prompt
+
+
+def test_pdd_interface_conformance_allows_dataclass_exports() -> None:
+    """Dataclass types must not be declared as functions with paren signatures."""
+    import json
+    import re
+    from pathlib import Path
+
+    from pdd.code_generator_main import _verify_pdd_interface_signatures
+
+    prompt = Path("pdd/prompts/checkup_interactive_session_python.prompt").read_text(
+        encoding="utf-8"
+    )
+    code = Path("pdd/checkup_interactive_session.py").read_text(encoding="utf-8")
+    match = re.search(r"<pdd-interface>\s*(\{.*?\})\s*</pdd-interface>", prompt, re.S)
+    assert match is not None
+    interface = json.loads(match.group(1))
+    function_names = {
+        item["name"]
+        for item in interface.get("module", {}).get("functions", [])
+        if isinstance(item, dict) and item.get("name")
+    }
+    assert "ApprovedPatch" not in function_names
+    assert "RepairOption" not in function_names
+
+    _verify_pdd_interface_signatures(
+        generated_code=code,
+        prompt_content=prompt,
+        prompt_name="checkup_interactive_session_python.prompt",
+        output_path="pdd/checkup_interactive_session.py",
+        architecture_entry={},
+    )


### PR DESCRIPTION
## Summary

Stacks Block 1 (#1435) into the parent epic branch `change/issue-1423`.

`change/issue-1423` already contains the Hybrid-aligned `InteractiveRepairSession` protocol, `FakeInteractiveSession`, docs, and contract tests from #1435. This PR adds the remaining delta:

- Move `ApprovedPatch` / `RepairOption` from `<pdd-interface>` `functions` to `dataclasses` (repo convention) so `pdd sync` conformance no longer treats `@dataclass` types as missing functions
- Regression test for `_verify_pdd_interface_signatures` against the real module + prompt

Related: #1435, parent #1423

## Test plan

- [x] `python -m pytest tests/test_checkup_interactive_session.py -q` (27 passed)
- [ ] `pdd sync checkup_interactive_session` conformance passes after merge
- [ ] Parent epic branch CI green after stacking


Made with [Cursor](https://cursor.com)