### PR TITLE
Command color system: one brand-derived palette for commands, tags & states

### DIFF
--- a/docs/design/color-system.md
+++ b/docs/design/color-system.md
@@ -1,0 +1,89 @@
+# PDD CLI color system
+
+Part of [EPIC #1540](EPIC-1540-design-refresh.md) — workstream 1, "Command color
+system."
+
+The PDD CLI uses **one** color system, defined in [`pdd/cli_theme.py`](../../pdd/cli_theme.py)
+and derived from the PromptDriven.ai Brand Guidelines v1.4 (§3 Color Palette,
+§7 ASCII & Terminal Assets). Color communicates *meaning*, not decoration:
+commands always look like commands, tags always look like tags, and states
+(success / warning / error) are unmistakable.
+
+## Why centralize
+
+Before this, ~20 color names were used ad-hoc across the package (516 `[yellow]`,
+239 `[red]`, 205 `[bold red]`, …) and four modules each defined their own inline
+Rich `Theme`. The same idea (an error, a path, a tag) could appear in different
+colors depending on which file printed it. A single theme fixes that and gives
+every future command a ready-made, on-brand palette to build on.
+
+## Brand palette
+
+| Brand name      | Hex       | Role in the brand |
+|-----------------|-----------|-------------------|
+| Electric-Cyan   | `#00D8FF` | Primary           |
+| Deep-Navy       | `#0A0A23` | Ink / Fill        |
+| Lumen-Purple    | `#8C47FF` | Accent 1          |
+| Prompt-Magenta  | `#FF2AA6` | Accent 2          |
+| Light-Sleet     | `#F5F7FA` | Surface-Light     |
+| Graphite-900    | `#1A1B26` | Surface-Dark      |
+| Build-Green     | `#18C07A` | Success           |
+| Build-Green-700 | `#0FA86A` | Success tint      |
+| Diff-Yellow     | `#FBBB35` | Warning           |
+| Break-Red       | `#F34842` | Error             |
+
+## Semantic roles
+
+Style output by **role**, never by raw color. The mapping below is the contract;
+the colors behind it can evolve (e.g. adaptive theming, workstream 4) without
+touching call sites.
+
+| Role(s)                                   | Color           | When to use |
+|-------------------------------------------|-----------------|-------------|
+| `command`, `command.strong`, `heading`, `info`, `value` | Electric-Cyan | Subcommands, headings, primary info — the hero color |
+| `tag`, `tag.strong`, `label`              | Lumen-Purple    | PDD/XML tags, labels, keys — distinct from commands |
+| `accent`, `selector`                      | Prompt-Magenta  | Selections, highlights, CTAs — use sparingly |
+| `success`, `success.strong`               | Build-Green     | Completed operations |
+| `version`                                 | Build-Green-700 | Version line (per §7) |
+| `warning`, `warning.strong`               | Diff-Yellow     | Recoverable problems, cautions |
+| `error`                                   | bold Break-Red  | Failures |
+| `danger`                                  | Break-Red       | Destructive prompts / emphasis |
+| `path`                                    | dim Electric-Cyan | File paths, values |
+| `muted`                                   | dim             | De-emphasized text |
+
+The legacy role names `info`, `warning`, `error`, `success`, `path`, and
+`selector` are kept resolvable so existing modules keep working as they migrate.
+
+## Usage
+
+```python
+from pdd.cli_theme import get_console, style
+
+console = get_console()                 # themed Rich Console (forwards kwargs)
+console.print("[command]pdd sync[/command] [path]auth.prompt[/path]")
+console.print("[success]✔ build succeeded[/success]")
+console.print("[error]✗ generation failed[/error]")
+
+# Build a styled fragment for a console that already carries the theme:
+msg = style("warning", "no API key found")   # -> "[warning]no API key found[/warning]"
+
+# Route to stderr while keeping the palette:
+err = get_console(stderr=True)
+```
+
+For raw colors (charts, banners), import the palette constants
+(`ELECTRIC_CYAN`, `BUILD_GREEN`, …) or `BRAND_PALETTE` rather than hardcoding hex.
+
+## Terminal compatibility
+
+Hex styles are emitted as truecolor and downgraded automatically by Rich to the
+nearest 256/16-color value on limited terminals, and dropped entirely when output
+is not a TTY (e.g. CI logs), matching the branding fallback guidance in §7.
+
+## Adoption status
+
+- ✅ `pdd/cli_theme.py` — the system itself.
+- ✅ `pdd/content_selector.py` — first module migrated onto `get_console()`.
+- ⬜ `construct_paths.py`, `metadata_sync.py`, `update_main.py` and the remaining
+  inline `[color]` markup across the package — these are prompt-driven modules;
+  they migrate via their prompts in follow-on PRs under this EPIC.

--- a/pdd/cli_theme.py
+++ b/pdd/cli_theme.py
@@ -1,0 +1,136 @@
+"""Central CLI color system for PDD.
+
+Single source of truth for color across the PDD command-line interface. Every
+command should obtain its console from :func:`get_console` (or import the shared
+:data:`console`) and style output by *semantic role* — ``command``, ``tag``,
+``success``, ``warning``, ``error`` — rather than picking raw colors. Color is
+used to communicate meaning, not for decoration.
+
+All values are taken from the PromptDriven.ai Brand Guidelines v1.4, §3 (Color
+Palette) and §7 (ASCII & Terminal Assets). See ``docs/design/color-system.md``
+for the role -> color mapping and rationale.
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.theme import Theme
+
+# ---------------------------------------------------------------------------
+# Brand palette — Brand Guidelines v1.4 §3. Hex values are authoritative; do not
+# introduce colors outside this palette.
+# ---------------------------------------------------------------------------
+ELECTRIC_CYAN = "#00D8FF"      # Primary
+DEEP_NAVY = "#0A0A23"          # Ink / Fill
+LUMEN_PURPLE = "#8C47FF"       # Accent 1
+PROMPT_MAGENTA = "#FF2AA6"     # Accent 2
+LIGHT_SLEET = "#F5F7FA"        # Surface-Light
+GRAPHITE_900 = "#1A1B26"       # Surface-Dark
+BUILD_GREEN = "#18C07A"        # Success
+BUILD_GREEN_700 = "#0FA86A"    # Success tint
+DIFF_YELLOW = "#FBBB35"        # Warning
+BREAK_RED = "#F34842"          # Error
+
+# Human brand name -> hex, for tooling, docs, and round-trip validation.
+BRAND_PALETTE = {
+    "Electric-Cyan": ELECTRIC_CYAN,
+    "Deep-Navy": DEEP_NAVY,
+    "Lumen-Purple": LUMEN_PURPLE,
+    "Prompt-Magenta": PROMPT_MAGENTA,
+    "Light-Sleet": LIGHT_SLEET,
+    "Graphite-900": GRAPHITE_900,
+    "Build-Green": BUILD_GREEN,
+    "Build-Green-700": BUILD_GREEN_700,
+    "Diff-Yellow": DIFF_YELLOW,
+    "Break-Red": BREAK_RED,
+}
+
+# ---------------------------------------------------------------------------
+# Semantic roles -> Rich style strings.
+#
+# The rule the palette encodes:
+#   * Commands are the hero of the CLI, so they wear the primary brand color.
+#   * Tags / labels / keys take Accent 1 so they stay visually distinct from
+#     commands at a glance.
+#   * Selections / highlights / CTAs take Accent 2 (used sparingly).
+#   * State is green / yellow / red — success / warning / error.
+# ---------------------------------------------------------------------------
+SEMANTIC_STYLES = {
+    # Structure & identifiers (primary / Electric-Cyan)
+    "command": ELECTRIC_CYAN,
+    "command.strong": f"bold {ELECTRIC_CYAN}",
+    "heading": f"bold {ELECTRIC_CYAN}",
+    "info": ELECTRIC_CYAN,
+    "value": ELECTRIC_CYAN,
+
+    # Tags, labels, keys (Accent 1 / Lumen-Purple)
+    "tag": LUMEN_PURPLE,
+    "tag.strong": f"bold {LUMEN_PURPLE}",
+    "label": LUMEN_PURPLE,
+
+    # Selections, highlights, CTAs (Accent 2 / Prompt-Magenta — use sparingly)
+    "accent": PROMPT_MAGENTA,
+    "selector": f"bold {PROMPT_MAGENTA}",
+
+    # States
+    "success": BUILD_GREEN,
+    "success.strong": f"bold {BUILD_GREEN}",
+    "version": BUILD_GREEN_700,
+    "warning": DIFF_YELLOW,
+    "warning.strong": f"bold {DIFF_YELLOW}",
+    "error": f"bold {BREAK_RED}",
+    "danger": BREAK_RED,
+
+    # Neutral helpers
+    "path": f"dim {ELECTRIC_CYAN}",
+    "muted": "dim",
+}
+
+# Rich theme: any console built with it resolves the role names above as styles,
+# so ``console.print("[command]pdd sync[/command] [success]done[/success]")``
+# renders consistently everywhere.
+PDD_THEME = Theme(SEMANTIC_STYLES)
+
+
+def get_console(**kwargs) -> Console:
+    """Return a Rich ``Console`` pre-configured with the PDD theme.
+
+    Extra keyword arguments are forwarded to ``Console`` (e.g. ``stderr=True``),
+    so callers can route to stderr or tweak width while keeping the shared
+    palette. A caller-supplied ``theme`` overrides the default.
+    """
+    kwargs.setdefault("theme", PDD_THEME)
+    return Console(**kwargs)
+
+
+def style(role: str, text: str) -> str:
+    """Wrap ``text`` in Rich markup for a semantic ``role``.
+
+    Example: ``style("command", "pdd sync")`` -> ``"[command]pdd sync[/command]"``.
+    Useful when building a string for a console that already carries
+    :data:`PDD_THEME`.
+    """
+    return f"[{role}]{text}[/{role}]"
+
+
+# Shared, ready-to-use themed console for simple call sites.
+console = get_console()
+
+__all__ = [
+    "ELECTRIC_CYAN",
+    "DEEP_NAVY",
+    "LUMEN_PURPLE",
+    "PROMPT_MAGENTA",
+    "LIGHT_SLEET",
+    "GRAPHITE_900",
+    "BUILD_GREEN",
+    "BUILD_GREEN_700",
+    "DIFF_YELLOW",
+    "BREAK_RED",
+    "BRAND_PALETTE",
+    "SEMANTIC_STYLES",
+    "PDD_THEME",
+    "get_console",
+    "style",
+    "console",
+]

--- a/pdd/content_selector.py
+++ b/pdd/content_selector.py
@@ -17,11 +17,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
-from rich.console import Console
-from rich.theme import Theme
-
 from ._selector_parse import parse_selectors_string
 from .api_contract_slicer import ApiContractSlicer, ContractSlicerError
+from .cli_theme import get_console
 from .compression_reporting import (
     CompressionFallbackError,
     record_compression_applied,
@@ -37,18 +35,9 @@ try:
 except ImportError:  # pragma: no cover
     _HAS_YAML = False
 
-# Rich console with custom theme for error reporting
-_theme = Theme(
-    {
-        "info": "cyan",
-        "warning": "yellow",
-        "error": "bold red",
-        "success": "green",
-        "path": "dim blue",
-        "selector": "bold magenta",
-    }
-)
-console = Console(theme=_theme)
+# Rich console for error reporting, themed by the central PDD color system
+# (pdd/cli_theme.py) so commands, tags, and states render consistently.
+console = get_console()
 
 
 # ---------------------------------------------------------------------------

--- a/pdd/prompts/cli_theme_python.prompt
+++ b/pdd/prompts/cli_theme_python.prompt
@@ -1,0 +1,91 @@
+<pdd-reason>Centralizes the PDD CLI color system so every command renders commands, tags, labels, and states with one consistent, brand-derived palette instead of ad-hoc per-module colors.</pdd-reason>
+
+<pdd-interface>
+{
+  "type": "module",
+  "module": {
+    "constants": [
+      {"name": "ELECTRIC_CYAN", "type": "str"},
+      {"name": "DEEP_NAVY", "type": "str"},
+      {"name": "LUMEN_PURPLE", "type": "str"},
+      {"name": "PROMPT_MAGENTA", "type": "str"},
+      {"name": "LIGHT_SLEET", "type": "str"},
+      {"name": "GRAPHITE_900", "type": "str"},
+      {"name": "BUILD_GREEN", "type": "str"},
+      {"name": "BUILD_GREEN_700", "type": "str"},
+      {"name": "DIFF_YELLOW", "type": "str"},
+      {"name": "BREAK_RED", "type": "str"},
+      {"name": "BRAND_PALETTE", "type": "dict"},
+      {"name": "SEMANTIC_STYLES", "type": "dict"},
+      {"name": "PDD_THEME", "type": "rich.theme.Theme"}
+    ],
+    "functions": [
+      {"name": "get_console", "signature": "(**kwargs) -> rich.console.Console"},
+      {"name": "style", "signature": "(role: str, text: str) -> str"}
+    ]
+  }
+}
+</pdd-interface>
+
+% You are an expert Python engineer. Your goal is to write `pdd/cli_theme.py`.
+
+% Role & Scope
+  This module is the single source of truth for color across the PDD CLI. Every
+  command should obtain its console from here and style output by semantic role
+  (command, tag, label, success, warning, error, ...) rather than picking raw
+  colors. Colors must communicate meaning, not decoration.
+
+  All values come from the PromptDriven.ai Brand Guidelines v1.4 — §3 Color
+  Palette and §7 ASCII & Terminal Assets. Do not invent colors outside that
+  palette.
+
+% Requirements
+  1. Define the brand palette as module constants, hex strings exactly as in the
+     guidelines:
+       - ELECTRIC_CYAN   = "#00D8FF"   (Primary)
+       - DEEP_NAVY       = "#0A0A23"   (Ink / Fill)
+       - LUMEN_PURPLE    = "#8C47FF"   (Accent 1)
+       - PROMPT_MAGENTA  = "#FF2AA6"   (Accent 2)
+       - LIGHT_SLEET     = "#F5F7FA"   (Surface-Light)
+       - GRAPHITE_900    = "#1A1B26"   (Surface-Dark)
+       - BUILD_GREEN     = "#18C07A"   (Success)
+       - BUILD_GREEN_700 = "#0FA86A"   (Success tint)
+       - DIFF_YELLOW     = "#FBBB35"   (Warning)
+       - BREAK_RED       = "#F34842"   (Error)
+  2. Define `BRAND_PALETTE`: a dict mapping the human brand name (e.g.
+     "Electric-Cyan") to its hex value, covering all ten colors above.
+  3. Define `SEMANTIC_STYLES`: a dict mapping semantic role names to Rich style
+     strings, built from the palette constants. Roles, and the rule behind each:
+       - Commands are the hero, so they take the primary color:
+           "command" -> ELECTRIC_CYAN, "command.strong" -> f"bold {ELECTRIC_CYAN}",
+           "heading" -> f"bold {ELECTRIC_CYAN}", "info" -> ELECTRIC_CYAN.
+       - Tags / labels / keys take Accent 1 so they read distinctly from commands:
+           "tag" -> LUMEN_PURPLE, "tag.strong" -> f"bold {LUMEN_PURPLE}",
+           "label" -> LUMEN_PURPLE.
+       - Selections / highlights / CTAs take Accent 2 (use sparingly):
+           "accent" -> PROMPT_MAGENTA, "selector" -> f"bold {PROMPT_MAGENTA}".
+       - State colors:
+           "success" -> BUILD_GREEN, "success.strong" -> f"bold {BUILD_GREEN}",
+           "version" -> BUILD_GREEN_700,
+           "warning" -> DIFF_YELLOW, "warning.strong" -> f"bold {DIFF_YELLOW}",
+           "error" -> f"bold {BREAK_RED}", "danger" -> BREAK_RED.
+       - Neutral helpers:
+           "path" -> f"dim {ELECTRIC_CYAN}", "value" -> ELECTRIC_CYAN,
+           "muted" -> "dim".
+     Keep the keys `info`, `warning`, `error`, `success`, `path`, and `selector`
+     present and resolvable so existing modules that already use those style
+     names keep working when they switch to this theme.
+  4. Define `PDD_THEME = Theme(SEMANTIC_STYLES)` using `rich.theme.Theme`.
+  5. Provide `get_console(**kwargs) -> Console` that returns a `rich.console.Console`
+     constructed with `theme=PDD_THEME`, forwarding any extra keyword arguments
+     (e.g. `stderr=True`). It must not cache in a way that breaks per-call kwargs.
+  6. Provide `style(role: str, text: str) -> str` that wraps `text` in Rich markup
+     for the given role, e.g. `style("command", "pdd sync")` -> "[command]pdd sync[/command]".
+  7. Provide a module-level convenience `console = get_console()`.
+  8. Define `__all__` listing the palette constants, BRAND_PALETTE,
+     SEMANTIC_STYLES, PDD_THEME, get_console, style, and console.
+  9. No side effects beyond constructing the shared `console`. No environment
+     access, no printing at import time.
+
+% Deliverables
+  - Code: `pdd/cli_theme.py`

--- a/pdd/prompts/content_selector_python.prompt
+++ b/pdd/prompts/content_selector_python.prompt
@@ -115,7 +115,7 @@ Deterministic content extraction from files based on line ranges, Python AST str
 - If `mode="compressed"` is combined with selectors, apply compression only to the resulting extracted spans.
 
 % Error Reporting
-- Use `rich.console.Console` with a custom theme for formatted error messages. Print error context (including file path when available) before raising `SelectorError`.
+- Obtain the module-level Rich console from the central PDD color system via `from .cli_theme import get_console` and `console = get_console()`, rather than constructing a `Console` with an inline theme. This keeps error styling (`info`, `warning`, `error`, `success`, `path`, `selector`) consistent with the rest of the CLI. Print error context (including file path when available) before raising `SelectorError`.
 
 % Dependencies
 <pytest_slicer_interface>

--- a/tests/test_cli_theme.py
+++ b/tests/test_cli_theme.py
@@ -1,0 +1,146 @@
+"""Tests for the central PDD CLI color system (pdd/cli_theme.py).
+
+These lock the palette to the PromptDriven.ai Brand Guidelines v1.4 hex values
+and verify that every semantic role resolves to a valid Rich style, so commands,
+tags, and states stay consistent across the CLI.
+"""
+
+import sys
+from pathlib import Path
+
+# Add project root to sys.path to ensure local code is prioritized
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root))
+
+from io import StringIO
+
+import pytest
+from rich.theme import Theme
+
+from pdd import cli_theme
+
+
+# ---------------------------------------------------------------------------
+# Palette: must match the brand guidelines exactly
+# ---------------------------------------------------------------------------
+
+# Brand name -> hex from Brand Guidelines v1.4 §3.
+EXPECTED_PALETTE = {
+    "Electric-Cyan": "#00D8FF",
+    "Deep-Navy": "#0A0A23",
+    "Lumen-Purple": "#8C47FF",
+    "Prompt-Magenta": "#FF2AA6",
+    "Light-Sleet": "#F5F7FA",
+    "Graphite-900": "#1A1B26",
+    "Build-Green": "#18C07A",
+    "Build-Green-700": "#0FA86A",
+    "Diff-Yellow": "#FBBB35",
+    "Break-Red": "#F34842",
+}
+
+
+def test_brand_palette_matches_guidelines():
+    assert cli_theme.BRAND_PALETTE == EXPECTED_PALETTE
+
+
+@pytest.mark.parametrize("hex_value", EXPECTED_PALETTE.values())
+def test_palette_values_are_six_digit_hex(hex_value):
+    assert hex_value.startswith("#")
+    assert len(hex_value) == 7
+    int(hex_value[1:], 16)  # raises ValueError if not valid hex
+
+
+def test_named_constants_match_palette():
+    assert cli_theme.ELECTRIC_CYAN == "#00D8FF"
+    assert cli_theme.LUMEN_PURPLE == "#8C47FF"
+    assert cli_theme.PROMPT_MAGENTA == "#FF2AA6"
+    assert cli_theme.BUILD_GREEN == "#18C07A"
+    assert cli_theme.BUILD_GREEN_700 == "#0FA86A"
+    assert cli_theme.DIFF_YELLOW == "#FBBB35"
+    assert cli_theme.BREAK_RED == "#F34842"
+
+
+# ---------------------------------------------------------------------------
+# Semantic roles and theme
+# ---------------------------------------------------------------------------
+
+# Roles every command relies on, including the legacy names kept for back-compat.
+REQUIRED_ROLES = [
+    "command", "command.strong", "heading", "info", "value",
+    "tag", "tag.strong", "label",
+    "accent", "selector",
+    "success", "success.strong", "version",
+    "warning", "warning.strong", "error", "danger",
+    "path", "muted",
+]
+
+
+def test_pdd_theme_is_a_rich_theme():
+    assert isinstance(cli_theme.PDD_THEME, Theme)
+
+
+@pytest.mark.parametrize("role", REQUIRED_ROLES)
+def test_every_required_role_is_defined(role):
+    assert role in cli_theme.SEMANTIC_STYLES
+
+
+@pytest.mark.parametrize("role", REQUIRED_ROLES)
+def test_every_role_resolves_to_a_valid_style(role):
+    console = cli_theme.get_console()
+    # Console.get_style raises rich.errors.MissingStyle / StyleSyntaxError on a
+    # bad name or definition; a clean return means the role is valid.
+    assert console.get_style(role) is not None
+
+
+def test_backward_compatible_role_names_present():
+    # The four ad-hoc themes this module replaces used exactly these names.
+    for legacy in ("info", "warning", "error", "success", "path", "selector"):
+        assert legacy in cli_theme.SEMANTIC_STYLES
+
+
+def test_meaning_mapping_is_intentional():
+    # Commands are the hero color; tags read distinctly; states are green/red.
+    assert cli_theme.ELECTRIC_CYAN in cli_theme.SEMANTIC_STYLES["command"]
+    assert cli_theme.LUMEN_PURPLE in cli_theme.SEMANTIC_STYLES["tag"]
+    assert cli_theme.BUILD_GREEN in cli_theme.SEMANTIC_STYLES["success"]
+    assert cli_theme.BREAK_RED in cli_theme.SEMANTIC_STYLES["error"]
+    # command and tag must not share a color, or they would not be distinct.
+    assert cli_theme.SEMANTIC_STYLES["command"] != cli_theme.SEMANTIC_STYLES["tag"]
+
+
+# ---------------------------------------------------------------------------
+# Console factory and style helper
+# ---------------------------------------------------------------------------
+
+def test_get_console_applies_theme():
+    assert cli_theme.get_console().get_style("command") is not None
+
+
+def test_get_console_forwards_kwargs():
+    console = cli_theme.get_console(stderr=True)
+    assert console.stderr is True
+
+
+def test_get_console_allows_theme_override():
+    custom = Theme({"command": "red"})
+    console = cli_theme.get_console(theme=custom)
+    # Override wins, but unrelated rendering still works.
+    assert console.get_style("command") is not None
+
+
+def test_shared_console_is_themed():
+    assert cli_theme.console.get_style("tag") is not None
+
+
+def test_style_wraps_markup():
+    assert cli_theme.style("command", "pdd sync") == "[command]pdd sync[/command]"
+    assert cli_theme.style("error", "boom") == "[error]boom[/error]"
+
+
+def test_roles_render_ansi_on_a_truecolor_console():
+    console = cli_theme.get_console(
+        file=StringIO(), force_terminal=True, color_system="truecolor", width=80
+    )
+    console.print("[command]pdd[/command] [tag]<include>[/tag] [success]ok[/success]")
+    out = console.file.getvalue()
+    assert "\x1b[" in out  # ANSI escape sequence emitted


### PR DESCRIPTION
**EPIC:** #1540 — Design refresh · **Workstream 1: Command color system**
**Base:** `epic/1540-design-refresh` (not `main`)

## What

Introduces `pdd/cli_theme.py` — a single, brand-derived color system for the PDD CLI. Today ~20 color names are used ad-hoc across the package (516 `[yellow]`, 239 `[red]`, 205 `[bold red]`, …) and four modules each define their own inline Rich `Theme`, so the same concept can print in different colors depending on the file. This centralizes that.

Color now communicates **meaning, not decoration**:

| Concept | Color | Role names |
|--------|-------|-----------|
| Commands / headings / info | Electric-Cyan `#00D8FF` (primary) | `command`, `command.strong`, `heading`, `info`, `value` |
| Tags / labels / keys | Lumen-Purple `#8C47FF` (Accent 1) | `tag`, `tag.strong`, `label` |
| Selections / CTAs | Prompt-Magenta `#FF2AA6` (Accent 2) | `accent`, `selector` |
| Success | Build-Green `#18C07A` | `success`, `success.strong` |
| Version line | Build-Green-700 `#0FA86A` | `version` |
| Warning | Diff-Yellow `#FBBB35` | `warning`, `warning.strong` |
| Error / destructive | Break-Red `#F34842` | `error`, `danger` |
| Paths / muted | dim Electric-Cyan / dim | `path`, `muted` |

All values come straight from the PromptDriven.ai Brand Guidelines v1.4 (§3 Color Palette, §7 Terminal Assets).

## Files
- `pdd/cli_theme.py` — palette constants, `BRAND_PALETTE`, `SEMANTIC_STYLES`, `PDD_THEME`, `get_console(**kwargs)`, `style(role, text)`, shared `console`.
- `pdd/prompts/cli_theme_python.prompt` — prompt source for the module (PDD convention).
- `pdd/content_selector.py` — first module migrated onto `get_console()`; its prompt updated to match.
- `docs/design/color-system.md` — palette, role mapping, usage, terminal-fallback notes.
- `tests/test_cli_theme.py` — locks the palette to brand hexes and verifies every role resolves (59 tests).

## Compatibility
Legacy role names (`info`, `warning`, `error`, `success`, `path`, `selector`) stay resolvable, so the remaining prompt-driven modules (`construct_paths`, `metadata_sync`, `update_main`, and the broader inline `[color]` markup) migrate incrementally in follow-on PRs under this EPIC. Hex styles downgrade automatically on limited terminals and drop on non-TTY output (CI logs), per §7.

## Tests
`pytest tests/test_cli_theme.py` → 59 passed. `pytest tests/test_content_selector.py` → 96 passed (refactor is behavior-preserving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)