### PR TITLE
PR #2: Status and progress messaging improvements (EPIC #1540)

### DIFF
--- a/docs/design/EPIC-1540-design-refresh.md
+++ b/docs/design/EPIC-1540-design-refresh.md
@@ -22,7 +22,7 @@ mapping distilled from §3 (Color Palette) and §7 (ASCII & Terminal Assets).
 | # | Workstream | PR | Status |
 |---|------------|----|--------|
 | 1 | Command color system — one consistent palette for commands, tags, labels, and states | sohni-tagirisa/pdd#1 | ✅ Merged into EPIC |
-| 2 | Better status & progress communication | — | ⬜ Not started |
+| 2 | Better status & progress communication — START/STEP/WAITING/SUCCESS/FAILURE primitives (`pdd/cli_status.py`); see `docs/design/status-messaging.md` | _PR #2_ | 🟡 In progress |
 | 3 | `pdd context` token visualization (multi-color tokens) | — | ⬜ Not started |
 | 4 | Adaptive theming (detect IDE/editor light/dark theme) | — | ⬜ Not started |
 | 5 | `pdd connect` redesign | — | ⬜ Not started |

--- a/docs/design/EPIC-1540-design-refresh.md
+++ b/docs/design/EPIC-1540-design-refresh.md
@@ -22,7 +22,7 @@ mapping distilled from §3 (Color Palette) and §7 (ASCII & Terminal Assets).
 | # | Workstream | PR | Status |
 |---|------------|----|--------|
 | 1 | Command color system — one consistent palette for commands, tags, labels, and states | sohni-tagirisa/pdd#1 | ✅ Merged into EPIC |
-| 2 | Better status & progress communication — START/STEP/WAITING/SUCCESS/FAILURE primitives (`pdd/cli_status.py`); see `docs/design/status-messaging.md` | _PR #2_ | 🟡 In progress |
+| 2 | Better status & progress communication — START/STEP/WAITING/SUCCESS/FAILURE primitives (`pdd/cli_status.py`); see `docs/design/status-messaging.md` | sohni-tagirisa/pdd#2 | 🟡 In progress |
 | 3 | `pdd context` token visualization (multi-color tokens) | — | ⬜ Not started |
 | 4 | Adaptive theming (detect IDE/editor light/dark theme) | — | ⬜ Not started |
 | 5 | `pdd connect` redesign | — | ⬜ Not started |

--- a/docs/design/status-messaging.md
+++ b/docs/design/status-messaging.md
@@ -1,0 +1,117 @@
+# PDD CLI status & progress messaging
+
+EPIC #1540, workstream 2. This is the design note for `pdd/cli_status.py`, the
+single source of truth for *what a command is doing right now*. It builds on the
+color system (`pdd/cli_theme.py`, workstream 1) and does not introduce any new
+colors.
+
+## Why
+
+Across PDD commands, status output was ad-hoc: some commands printed a green
+"done", others said nothing during a multi-second LLM call, and failures often
+gave a bare exception string with no next step. Users couldn't reliably tell
+what was happening, whether the tool was stuck, or what to do when it failed.
+
+This workstream defines one small, consistent vocabulary so that — in every
+command — the user can always answer four questions:
+
+1. **What is happening now?**  → `start` / `step`
+2. **What comes next?**        → `next_step=` on `start` / `success`
+3. **Is it waiting on me / IO / the model?** → `waiting(...)`
+4. **What succeeded or failed, and what do I do about it?** → `success` / `failure`
+
+## The five primitives
+
+There are exactly five message types (`Status` enum). Keeping the set small is
+the point — the same kind of event looks identical in every command.
+
+| Primitive  | Glyph | Theme role        | Meaning |
+|------------|:-----:|-------------------|---------|
+| `START`    | `▶`   | `command.strong`  | A command/operation is beginning. |
+| `STEP`     | `→`   | `info`            | The current human-readable step. |
+| `WAITING`  | `…`   | `muted`           | Blocked on IO / network / LLM — show progress, not silence. |
+| `SUCCESS`  | `✓`   | `success.strong`  | Finished, with an optional next action. |
+| `FAILURE`  | `✗`   | `error`           | Failed, with root cause + what to try next. |
+
+Glyphs come from `GLYPHS`, colors from `ROLES` (semantic roles resolved by the
+central theme). Nothing here hard-codes a hex value.
+
+## Message rules
+
+- **Short and skimmable.** One line per event; structured extras (`Why:`,
+  `Try:`, `Next:`) are indented follow-on lines.
+- **Action-oriented.** Say what is being done ("analyzing 3 prompts"), not just
+  that something is happening.
+- **Non-duplicative.** An identical rendered line emitted twice in a row is
+  collapsed, so retry loops and re-entrant steps don't spam the terminal.
+- **Consistent.** Every command uses the same five primitives and wording shape.
+
+## Errors must be actionable
+
+`failure(step, *, reason=None, suggestions=())` is structured to meet the UX
+criteria: it names **what** failed (the step), **why** (root cause if known), and
+**what to try next** (1–2 concrete suggestions). Example render:
+
+```
+✗ reading the change file
+  Why: change.txt not found
+  Try: check the path to the change file
+  Try: run `pdd detect --help` for the expected arguments
+```
+
+## Long-running work shows progress
+
+`with reporter.waiting("asking the model …", on="LLM"):` records a `WAITING`
+event and, on an interactive terminal, shows a spinner for the duration so a
+multi-second model/network/disk call never looks frozen. `on=` names what is
+being awaited (`"LLM"`, `"network"`, `"disk"`). The spinner is automatically
+inert when output is suppressed, redirected, or non-TTY — so it adds no timing
+dependence and tests stay deterministic.
+
+## Machine-readable output is preserved
+
+Some commands emit JSON on stdout for dashboards/automation. Status messaging
+never breaks that contract:
+
+- **`quiet` mode** (`--quiet`, and machine-JSON invocations that set
+  `PDD_QUIET`): nothing is printed.
+- **`json_mode`**: the reporter's default console is `get_console(stderr=True)`,
+  so human status goes to **stderr** and stdout stays payload-only.
+
+Either way the reporter still *records* every message (`reporter.messages`),
+which is also how tests assert behavior by shape — no wall-clock, no ANSI
+scraping.
+
+## Using it from a command
+
+```python
+from .cli_status import from_context
+
+def my_main(ctx, ...):
+    status = from_context(ctx, command="pdd detect")
+    status.start("analyzing 3 prompt(s) against the change description")
+    try:
+        with status.waiting("asking the model which prompts need changes", on="LLM"):
+            result = detect_change(...)
+    except Exception as e:
+        status.failure(
+            "detecting changes",
+            reason=str(e),
+            suggestions=["verify the prompt and change files exist",
+                         "re-run with --verbose for details"],
+        )
+        raise
+    status.success(
+        f"{len(result)} prompt(s) need changes",
+        next_step="review the results, then run `pdd change`",
+    )
+```
+
+`from_context` inherits the global `--quiet` flag from `ctx.obj`, so commands
+don't re-plumb it.
+
+## Adoption
+
+`detect_change_main` and `conflicts_main` are migrated as the first adopters in
+this PR. Remaining commands move onto the reporter incrementally in follow-on
+work under this EPIC, the same way the color system rolled out.

--- a/pdd/cli_status.py
+++ b/pdd/cli_status.py
@@ -1,0 +1,266 @@
+"""Consistent status & progress messaging for the PDD CLI.
+
+Single source of truth for *what the tool is doing right now*. Commands route
+their human-facing progress through a small, fixed set of message primitives so
+that — across every command — the user can always tell:
+
+1. what is happening now              -> :meth:`StatusReporter.start` / ``step``
+2. what step comes next               -> ``next_step=`` on ``start`` / ``success``
+3. whether it is waiting on IO/LLM     -> :meth:`StatusReporter.waiting`
+4. what succeeded or failed, and what  -> :meth:`StatusReporter.success` /
+   to do about it                         :meth:`StatusReporter.failure`
+
+Design rules (kept deliberately small so commands stay consistent):
+
+* Five primitives only — ``START`` / ``STEP`` / ``WAITING`` / ``SUCCESS`` /
+  ``FAILURE``. Each has one glyph and one semantic color role, so the same kind
+  of event looks the same everywhere.
+* Messages are short, skimmable, and action-oriented (say what is being done).
+* Output is *non-duplicative*: an identical line emitted twice in a row is
+  collapsed, so retries/loops do not spam the terminal.
+* Color comes from the central :mod:`pdd.cli_theme` palette (EPIC #1540,
+  workstream 1) — this module never picks raw colors.
+* Machine-readable output is protected: in ``quiet`` mode nothing is printed,
+  and in ``json_mode`` status goes to **stderr** so stdout stays payload-only.
+
+The reporter also *records* every message it emits (:attr:`StatusReporter.messages`)
+so tests can assert on message *shape* deterministically — no wall-clock, no
+spinner-frame, no captured-ANSI assertions.
+"""
+
+from __future__ import annotations
+
+import enum
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Iterator, List, Optional, Sequence, Tuple
+
+from rich.console import Console
+
+from .cli_theme import get_console
+
+__all__ = [
+    "Status",
+    "StatusMessage",
+    "StatusReporter",
+    "from_context",
+    "GLYPHS",
+    "ROLES",
+]
+
+
+class Status(enum.Enum):
+    """The five message primitives every command shares."""
+
+    START = "start"          # a command/operation is beginning
+    STEP = "step"            # the current human-readable step within it
+    WAITING = "waiting"      # blocked on IO / network / LLM (slow, show progress)
+    SUCCESS = "success"      # finished, with an optional next action
+    FAILURE = "failure"      # failed, with cause + what to try next
+
+
+# One glyph per primitive — the visual shorthand stays identical across commands.
+GLYPHS = {
+    Status.START: "▶",
+    Status.STEP: "→",
+    Status.WAITING: "…",
+    Status.SUCCESS: "✓",
+    Status.FAILURE: "✗",
+}
+
+# Map each primitive to a *semantic role* from the central theme (pdd/cli_theme.py)
+# rather than a raw color, so status coloring tracks the brand palette.
+ROLES = {
+    Status.START: "command.strong",
+    Status.STEP: "info",
+    Status.WAITING: "muted",
+    Status.SUCCESS: "success.strong",
+    Status.FAILURE: "error",
+}
+
+
+def _escape(text: str) -> str:
+    """Escape Rich markup so user/content text can't smuggle in styling."""
+    return text.replace("[", r"\[")
+
+
+@dataclass(frozen=True)
+class StatusMessage:
+    """A single status event, recorded so behavior is testable by *shape*.
+
+    ``text`` is the plain headline (no markup). The optional fields carry the
+    structured extras the UX criteria require: what it's waiting on, the next
+    action on success, and — on failure — the root cause and concrete fixes.
+    """
+
+    status: Status
+    text: str
+    next_step: Optional[str] = None
+    waiting_on: Optional[str] = None
+    reason: Optional[str] = None
+    suggestions: Tuple[str, ...] = ()
+    command: Optional[str] = None
+
+    @property
+    def glyph(self) -> str:
+        return GLYPHS[self.status]
+
+    @property
+    def role(self) -> str:
+        return ROLES[self.status]
+
+    def render_plain(self) -> str:
+        """Markup-free rendering — used for logs, ``--quiet`` recall, and tests."""
+        lines = [f"{self.glyph} {self._headline()}"]
+        if self.waiting_on:
+            lines[0] += f" (waiting on {self.waiting_on})"
+        if self.reason:
+            lines.append(f"  Why: {self.reason}")
+        for hint in self.suggestions:
+            lines.append(f"  Try: {hint}")
+        if self.next_step:
+            lines.append(f"  Next: {self.next_step}")
+        return "\n".join(lines)
+
+    def render_markup(self) -> str:
+        """Rich-markup rendering, themed by semantic role from cli_theme."""
+        role = self.role
+        head = f"[{role}]{self.glyph} {_escape(self._headline())}[/{role}]"
+        if self.waiting_on:
+            head += f" [muted](waiting on {_escape(self.waiting_on)})[/muted]"
+        lines = [head]
+        if self.reason:
+            lines.append(f"  [muted]Why:[/muted] {_escape(self.reason)}")
+        for hint in self.suggestions:
+            lines.append(f"  [warning]Try:[/warning] {_escape(hint)}")
+        if self.next_step:
+            lines.append(f"  [tag]Next:[/tag] {_escape(self.next_step)}")
+        return "\n".join(lines)
+
+    def _headline(self) -> str:
+        if self.command and self.status is Status.START:
+            return f"{self.command}: {self.text}"
+        return self.text
+
+
+class StatusReporter:
+    """Emit consistent status messages for a single command run.
+
+    Parameters
+    ----------
+    command:
+        Human label for the command (e.g. ``"pdd detect"``), shown on ``start``.
+    console:
+        Optional Rich console. Defaults to a themed console from
+        :func:`pdd.cli_theme.get_console`; when ``json_mode`` is set the default
+        routes to **stderr** so machine-readable stdout is never polluted.
+    quiet:
+        When true, suppress all terminal output (messages are still recorded).
+    json_mode:
+        When true, the command emits machine-readable JSON on stdout; status is
+        sent to stderr instead of being dropped, so humans still get feedback.
+    """
+
+    GLYPH_SPINNER = GLYPHS[Status.WAITING]
+
+    def __init__(
+        self,
+        command: Optional[str] = None,
+        *,
+        console: Optional[Console] = None,
+        quiet: bool = False,
+        json_mode: bool = False,
+    ) -> None:
+        self.command = command
+        self.quiet = quiet
+        self.json_mode = json_mode
+        if console is None:
+            console = get_console(stderr=json_mode)
+        self.console = console
+        self.messages: List[StatusMessage] = []
+        self._last_plain: Optional[str] = None
+
+    # -- emission --------------------------------------------------------
+    def emit(self, message: StatusMessage) -> StatusMessage:
+        """Record ``message`` and print it unless suppressed or duplicative."""
+        self.messages.append(message)
+        plain = message.render_plain()
+        # Non-duplicative: collapse an identical line emitted twice in a row so
+        # retry loops and re-entrant steps don't spam the terminal.
+        if plain == self._last_plain:
+            return message
+        self._last_plain = plain
+        if not self.quiet:
+            self.console.print(message.render_markup())
+        return message
+
+    def start(self, text: str, *, next_step: Optional[str] = None) -> StatusMessage:
+        """Announce that the command/operation is beginning."""
+        return self.emit(
+            StatusMessage(
+                Status.START, text, command=self.command, next_step=next_step
+            )
+        )
+
+    def step(self, text: str) -> StatusMessage:
+        """Announce the current human-readable step."""
+        return self.emit(StatusMessage(Status.STEP, text))
+
+    def success(self, text: str, *, next_step: Optional[str] = None) -> StatusMessage:
+        """Report completion, with an optional next action for the user."""
+        return self.emit(StatusMessage(Status.SUCCESS, text, next_step=next_step))
+
+    def failure(
+        self,
+        text: str,
+        *,
+        reason: Optional[str] = None,
+        suggestions: Sequence[str] = (),
+    ) -> StatusMessage:
+        """Report a failure with cause and 1-2 concrete things to try next.
+
+        ``text`` names *what* failed (the step); ``reason`` is the root cause if
+        known; ``suggestions`` are concrete next actions.
+        """
+        return self.emit(
+            StatusMessage(
+                Status.FAILURE,
+                text,
+                reason=reason,
+                suggestions=tuple(suggestions),
+            )
+        )
+
+    @contextmanager
+    def waiting(self, text: str, *, on: str = "LLM") -> Iterator[StatusMessage]:
+        """Show a live progress indicator while blocked on slow work.
+
+        Use around IO/network/LLM calls so long operations never look frozen.
+        Records a ``WAITING`` message (so the wait is testable) and, on an
+        interactive terminal, shows a spinner for the duration. The spinner is
+        automatically inert when output is suppressed, redirected, or not a TTY,
+        which keeps tests free of timing- and animation-based flakiness.
+
+        ``on`` names what is being awaited — ``"LLM"``, ``"network"``, ``"disk"``.
+        """
+        message = self.emit(StatusMessage(Status.WAITING, text, waiting_on=on))
+        show_spinner = not self.quiet and self.console.is_terminal
+        if show_spinner:
+            with self.console.status(
+                f"[muted]{self.GLYPH_SPINNER} {_escape(text)} (waiting on {_escape(on)})[/muted]"
+            ):
+                yield message
+        else:
+            yield message
+
+
+def from_context(ctx, command: Optional[str] = None) -> StatusReporter:
+    """Build a :class:`StatusReporter` from a Click context.
+
+    Reads ``quiet`` from ``ctx.obj`` so commands inherit the global ``--quiet``
+    flag without re-plumbing it. ``json_mode`` is left to the caller, since which
+    invocations are machine-readable is command-specific (see
+    :mod:`pdd.json_invocation`).
+    """
+    obj = getattr(ctx, "obj", None) or {}
+    return StatusReporter(command, quiet=bool(obj.get("quiet", False)))

--- a/pdd/conflicts_main.py
+++ b/pdd/conflicts_main.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Tuple, Optional
 import click
 from rich import print as rprint
 
+from .cli_status import from_context
 from .construct_paths import construct_paths
 from .conflicts_in_prompts import conflicts_in_prompts
 from . import DEFAULT_TIME, DEFAULT_STRENGTH
@@ -20,7 +21,13 @@ def conflicts_main(ctx: click.Context, prompt1: str, prompt2: str, output: Optio
     :param language: Optional language hint for file processing.
     :return: A tuple containing the list of conflicts, total cost, and model name used.
     """
+    # Consistent status/progress messaging (EPIC #1540, workstream 2). Inherits
+    # the global --quiet flag from ctx, so status is suppressed in quiet mode.
+    status = from_context(ctx, command="pdd conflicts")
+    quiet = ctx.obj.get('quiet', False)
     try:
+        status.start(f"checking '{prompt1}' and '{prompt2}' for conflicting instructions")
+
         # Construct file paths
         input_file_paths = {
             "prompt1": prompt1,
@@ -49,14 +56,15 @@ def conflicts_main(ctx: click.Context, prompt1: str, prompt2: str, output: Optio
         strength = ctx.obj.get('strength', DEFAULT_STRENGTH)
         temperature = ctx.obj.get('temperature', 0)
         time_budget = ctx.obj.get('time', DEFAULT_TIME)
-        conflicts, total_cost, model_name = conflicts_in_prompts(
-            prompt1_content,
-            prompt2_content,
-            strength,
-            temperature,
-            time_budget,
-            verbose
-        )
+        with status.waiting("comparing the two prompts for conflicts", on="LLM"):
+            conflicts, total_cost, model_name = conflicts_in_prompts(
+                prompt1_content,
+                prompt2_content,
+                strength,
+                temperature,
+                time_budget,
+                verbose
+            )
 
         # Replace prompt1 and prompt2 with actual file paths
         for conflict in conflicts:
@@ -73,9 +81,20 @@ def conflicts_main(ctx: click.Context, prompt1: str, prompt2: str, output: Optio
             for conflict in conflicts:
                 writer.writerow(conflict)
 
+        # Completion message with a clear next action.
+        if conflicts:
+            status.success(
+                f"{len(conflicts)} conflict(s) found between the two prompts",
+                next_step="review the conflicts below and reconcile the prompts",
+            )
+        else:
+            status.success(
+                "no conflicts found between the two prompts",
+                next_step="the prompts are consistent — nothing to reconcile",
+            )
+
         # Provide user feedback
-        if not ctx.obj.get('quiet', False):
-            rprint("[bold green]Conflict analysis completed successfully.[/bold green]")
+        if not quiet:
             rprint(f"[bold]Model used:[/bold] {model_name}")
             rprint(f"[bold]Total cost:[/bold] ${total_cost:.6f}")
             if output:
@@ -94,6 +113,12 @@ def conflicts_main(ctx: click.Context, prompt1: str, prompt2: str, output: Optio
         return conflicts, total_cost, model_name
 
     except Exception as e:
-        if not ctx.obj.get('quiet', False):
-            rprint(f"[bold red]Error:[/bold red] {str(e)}")
+        status.failure(
+            "analyzing the prompts for conflicts",
+            reason=str(e),
+            suggestions=[
+                "check that both prompt files exist and are readable",
+                "re-run without --quiet to see more detail",
+            ],
+        )
         sys.exit(1)

--- a/pdd/detect_change_main.py
+++ b/pdd/detect_change_main.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Tuple, Optional
 import click
 from rich import print as rprint
 
+from .cli_status import from_context
 from .construct_paths import construct_paths
 from .detect_change import detect_change
 from . import DEFAULT_TIME, DEFAULT_STRENGTH
@@ -29,7 +30,15 @@ def detect_change_main(
         - Total cost of the operation
         - Name of the model used
     """
+    # Consistent status/progress messaging (EPIC #1540, workstream 2). Inherits
+    # the global --quiet flag from ctx, so nothing is printed in quiet mode.
+    status = from_context(ctx, command="pdd detect")
+    quiet = ctx.obj.get('quiet', False)
     try:
+        status.start(
+            f"checking {len(prompt_files)} prompt(s) against the change description"
+        )
+
         # Construct file paths
         input_file_paths = {
             "change_file": change_file,
@@ -42,7 +51,7 @@ def detect_change_main(
         resolved_config, input_strings, output_file_paths, _ = construct_paths(
             input_file_paths=input_file_paths,
             force=ctx.obj.get('force', False),
-            quiet=ctx.obj.get('quiet', False),
+            quiet=quiet,
             command="detect",
             command_options=command_options,
             context_override=ctx.obj.get('context')
@@ -59,18 +68,21 @@ def detect_change_main(
         temperature = ctx.obj.get('temperature', 0)
         time_budget = ctx.obj.get('time', DEFAULT_TIME)
 
-        # Analyze which prompts need changes
-        changes_list, total_cost, model_name = detect_change(
-            prompt_files,
-            change_description,
-            strength,
-            temperature,
-            time_budget,
-            verbose=not ctx.obj.get('quiet', False)
-        )
+        # Analyze which prompts need changes (LLM call — show a progress indicator
+        # so the wait never looks like a hang).
+        with status.waiting("asking the model which prompts need changes", on="LLM"):
+            changes_list, total_cost, model_name = detect_change(
+                prompt_files,
+                change_description,
+                strength,
+                temperature,
+                time_budget,
+                verbose=not quiet
+            )
 
         # Save results to CSV if output path is specified
         if output_file_paths.get("output"):
+            status.step(f"writing results to {output_file_paths['output']}")
             with open(output_file_paths["output"], 'w', newline='') as csvfile:
                 fieldnames = ['prompt_name', 'change_instructions']
                 writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
@@ -78,9 +90,21 @@ def detect_change_main(
                 for change in changes_list:
                     writer.writerow(change)
 
-        # Provide user feedback
-        if not ctx.obj.get('quiet', False):
-            rprint("[bold green]Change detection completed successfully.[/bold green]")
+        # Completion message with a clear next action.
+        if changes_list:
+            status.success(
+                f"{len(changes_list)} prompt(s) need changes",
+                next_step="review the changes below, then run `pdd change` on each",
+            )
+        else:
+            status.success(
+                "no prompts need changes for this change description",
+                next_step="nothing to do — the prompts already cover it",
+            )
+
+        # Detailed report (suppressed in quiet mode), preserved for parity with
+        # the prior output so downstream readers/scripts see the same fields.
+        if not quiet:
             rprint(f"[bold]Model used:[/bold] {model_name}")
             rprint(f"[bold]Total cost:[/bold] ${total_cost:.6f}")
             if output:
@@ -99,6 +123,12 @@ def detect_change_main(
         return changes_list, total_cost, model_name
 
     except Exception as e:
-        if not ctx.obj.get('quiet', False):
-            rprint(f"[bold red]Error:[/bold red] {str(e)}")
+        status.failure(
+            "detecting which prompts need changes",
+            reason=str(e),
+            suggestions=[
+                "check that the change file and prompt files exist and are readable",
+                "re-run without --quiet to see more detail",
+            ],
+        )
         sys.exit(1)

--- a/pdd/prompts/cli_status_python.prompt
+++ b/pdd/prompts/cli_status_python.prompt
@@ -1,0 +1,90 @@
+<pdd-reason>Centralizes PDD CLI status & progress messaging so every command reports start, current step, waiting-on-IO/LLM, success, and failure with one consistent, skimmable, non-duplicative, brand-themed vocabulary instead of ad-hoc per-module prints.</pdd-reason>
+
+<pdd-interface>
+{
+  "type": "module",
+  "module": {
+    "constants": [
+      {"name": "GLYPHS", "type": "dict"},
+      {"name": "ROLES", "type": "dict"}
+    ],
+    "classes": [
+      {"name": "Status", "kind": "enum", "members": ["START", "STEP", "WAITING", "SUCCESS", "FAILURE"]},
+      {"name": "StatusMessage", "kind": "dataclass"},
+      {"name": "StatusReporter"}
+    ],
+    "functions": [
+      {"name": "from_context", "signature": "(ctx, command: str | None = None) -> StatusReporter"}
+    ]
+  }
+}
+</pdd-interface>
+
+% You are an expert Python engineer. Your goal is to write `pdd/cli_status.py`.
+
+% Role & Scope
+  This module is the single source of truth for PDD CLI *status and progress*
+  messaging. Commands route their human-facing progress through it so that, in
+  every command, the user can always tell: (1) what is happening now, (2) what
+  step comes next, (3) whether the tool is waiting on IO/network/LLM, and
+  (4) what succeeded or failed and what to do about it.
+
+  Color must come from the central color system in `pdd/cli_theme.py` (EPIC
+  #1540, workstream 1) — obtain consoles via `get_console` and style by semantic
+  role. This module must never pick raw colors.
+
+% Design rules
+  - Exactly five message primitives, modeled as a `Status` enum: START, STEP,
+    WAITING, SUCCESS, FAILURE. Each maps to one glyph (`GLYPHS`) and one semantic
+    theme role (`ROLES`) so the same event type looks identical across commands.
+  - Messages are short, skimmable, and action-oriented.
+  - Output is non-duplicative: an identical rendered line emitted twice in a row
+    is collapsed so retry loops do not spam the terminal.
+  - Machine-readable output is protected: in `quiet` mode print nothing; in
+    `json_mode` send status to stderr so stdout stays payload-only.
+  - Deterministic & testable: the reporter records every emitted message so tests
+    can assert on message *shape* without wall-clock, spinner-frame, or
+    captured-ANSI assertions.
+
+% Requirements
+  1. `Status(enum.Enum)` with members START, STEP, WAITING, SUCCESS, FAILURE.
+  2. `GLYPHS`: dict mapping each `Status` to a single glyph — START "▶",
+     STEP "→", WAITING "…", SUCCESS "✓", FAILURE "✗".
+  3. `ROLES`: dict mapping each `Status` to a semantic role string from
+     `cli_theme`: START "command.strong", STEP "info", WAITING "muted",
+     SUCCESS "success.strong", FAILURE "error".
+  4. `StatusMessage` (frozen dataclass) with fields: `status: Status`,
+     `text: str`, `next_step: str | None`, `waiting_on: str | None`,
+     `reason: str | None`, `suggestions: tuple[str, ...]`, `command: str | None`.
+     Provide `glyph` and `role` properties (from GLYPHS/ROLES) and two renderers:
+       - `render_plain()` -> markup-free multi-line string for logs/quiet/tests.
+       - `render_markup()` -> Rich-markup string themed by `role`.
+     Both must include, when present: a "(waiting on <x>)" suffix on WAITING, a
+     "Why:" line for `reason`, one "Try:" line per suggestion, and a "Next:" line
+     for `next_step`. A START message whose reporter has a `command` renders the
+     headline as "<command>: <text>". User/content text must be escaped so it
+     cannot inject Rich markup.
+  5. `StatusReporter(command=None, *, console=None, quiet=False, json_mode=False)`:
+       - Defaults `console` to `get_console(stderr=json_mode)`.
+       - `messages: list[StatusMessage]` records everything emitted.
+       - `emit(message)`: record it; skip printing if `quiet`; collapse a line
+         identical to the immediately previous one; otherwise print
+         `render_markup()`.
+       - `start(text, *, next_step=None)`, `step(text)`,
+         `success(text, *, next_step=None)`,
+         `failure(text, *, reason=None, suggestions=())` convenience methods, each
+         returning the recorded `StatusMessage`.
+       - `waiting(text, *, on="LLM")`: a context manager that records a WAITING
+         message and, only on an interactive TTY that is not quiet, shows a Rich
+         `console.status` spinner for the duration. It must be inert (no spinner,
+         no timing dependence) when quiet, redirected, or non-TTY.
+  6. `from_context(ctx, command=None) -> StatusReporter`: read `quiet` from
+     `ctx.obj` (default False) and construct a reporter; leave `json_mode` to the
+     caller.
+  7. Define `__all__` listing Status, StatusMessage, StatusReporter, from_context,
+     GLYPHS, ROLES.
+  8. No side effects at import beyond defining the constants/classes. No
+     environment access, no printing at import time.
+
+% Deliverables
+  - Code: `pdd/cli_status.py`

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,251 @@
+"""Tests for the PDD CLI status & progress messaging system (pdd/cli_status.py).
+
+These assert on message *shape* and on plain-text console output captured from a
+non-terminal Rich console — so there are no wall-clock, spinner-frame, or
+ANSI-color assertions, and the suite stays deterministic (no timing flakes).
+"""
+
+import sys
+from io import StringIO
+from pathlib import Path
+
+# Prioritize local code.
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root))
+
+import pytest
+from rich.console import Console
+
+from pdd import cli_status
+from pdd.cli_status import (
+    GLYPHS,
+    ROLES,
+    Status,
+    StatusMessage,
+    StatusReporter,
+    from_context,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def plain_console():
+    """A non-terminal console that renders plain text into a buffer."""
+    buf = StringIO()
+    con = Console(file=buf, force_terminal=False, no_color=True, width=100)
+    return con, buf
+
+
+def reporter(**kwargs):
+    con, buf = plain_console()
+    return StatusReporter(console=con, **kwargs), buf
+
+
+# ---------------------------------------------------------------------------
+# Primitives: there are exactly five, each with one glyph and one theme role.
+# ---------------------------------------------------------------------------
+def test_five_primitives():
+    assert [s.name for s in Status] == [
+        "START",
+        "STEP",
+        "WAITING",
+        "SUCCESS",
+        "FAILURE",
+    ]
+
+
+def test_every_primitive_has_glyph_and_role():
+    for status in Status:
+        assert status in GLYPHS and GLYPHS[status]
+        assert status in ROLES and ROLES[status]
+
+
+def test_roles_are_real_theme_roles():
+    # Roles must resolve against the central color system, not be raw colors.
+    from pdd.cli_theme import SEMANTIC_STYLES
+
+    for role in ROLES.values():
+        assert role in SEMANTIC_STYLES, f"{role!r} is not a semantic role"
+
+
+# ---------------------------------------------------------------------------
+# StatusMessage rendering
+# ---------------------------------------------------------------------------
+def test_plain_render_includes_glyph_and_text():
+    msg = StatusMessage(Status.STEP, "doing the thing")
+    out = msg.render_plain()
+    assert GLYPHS[Status.STEP] in out
+    assert "doing the thing" in out
+
+
+def test_waiting_render_names_what_it_waits_on():
+    msg = StatusMessage(Status.WAITING, "calling the model", waiting_on="LLM")
+    assert "waiting on LLM" in msg.render_plain()
+    assert "waiting on LLM" in msg.render_markup()
+
+
+def test_failure_render_has_cause_and_suggestions():
+    msg = StatusMessage(
+        Status.FAILURE,
+        "reading the change file",
+        reason="file not found",
+        suggestions=("check the path", "run with --verbose"),
+    )
+    out = msg.render_plain()
+    assert "reading the change file" in out  # what failed
+    assert "Why: file not found" in out       # why
+    assert "Try: check the path" in out       # what to try (1)
+    assert "Try: run with --verbose" in out   # what to try (2)
+
+
+def test_success_render_has_next_step():
+    msg = StatusMessage(Status.SUCCESS, "done", next_step="run pdd sync")
+    assert "Next: run pdd sync" in msg.render_plain()
+
+
+def test_start_headline_includes_command():
+    msg = StatusMessage(Status.START, "beginning", command="pdd detect")
+    assert "pdd detect: beginning" in msg.render_plain()
+
+
+def test_markup_uses_semantic_role():
+    msg = StatusMessage(Status.SUCCESS, "ok")
+    markup = msg.render_markup()
+    assert f"[{ROLES[Status.SUCCESS]}]" in markup
+
+
+def test_markup_escapes_user_text():
+    # Brackets in content must not be interpreted as Rich markup.
+    msg = StatusMessage(Status.FAILURE, "boom", reason="value was [red]bad[/red]")
+    markup = msg.render_markup()
+    assert r"\[red]" in markup
+
+
+# ---------------------------------------------------------------------------
+# StatusReporter: recording + emission
+# ---------------------------------------------------------------------------
+def test_methods_record_and_return_messages():
+    rep, _ = reporter(command="pdd detect")
+    m_start = rep.start("checking 3 prompts", next_step="review")
+    m_step = rep.step("comparing")
+    m_ok = rep.success("2 need changes", next_step="run pdd change")
+    m_bad = rep.failure("detecting", reason="oops", suggestions=["retry"])
+
+    assert [m.status for m in rep.messages] == [
+        Status.START,
+        Status.STEP,
+        Status.SUCCESS,
+        Status.FAILURE,
+    ]
+    assert m_start.command == "pdd detect" and m_start.next_step == "review"
+    assert m_step.status == Status.STEP
+    assert m_ok.next_step == "run pdd change"
+    assert m_bad.reason == "oops" and m_bad.suggestions == ("retry",)
+
+
+def test_emit_prints_when_not_quiet():
+    rep, buf = reporter()
+    rep.start("hello world")
+    assert "hello world" in buf.getvalue()
+
+
+def test_quiet_suppresses_output_but_still_records():
+    rep, buf = reporter(quiet=True)
+    rep.start("hello world")
+    rep.success("done")
+    assert buf.getvalue() == ""              # nothing printed
+    assert len(rep.messages) == 2            # but still recorded
+
+
+def test_consecutive_duplicate_is_collapsed():
+    rep, buf = reporter()
+    rep.step("same line")
+    rep.step("same line")  # identical, immediately after -> collapsed
+    assert buf.getvalue().count("same line") == 1
+    # Both are still recorded (de-dup is about not spamming the terminal).
+    assert len(rep.messages) == 2
+
+
+def test_non_consecutive_duplicate_is_not_collapsed():
+    rep, buf = reporter()
+    rep.step("line A")
+    rep.step("line B")
+    rep.step("line A")  # same text but not immediately after -> printed again
+    assert buf.getvalue().count("line A") == 2
+
+
+# ---------------------------------------------------------------------------
+# JSON mode: status must not pollute stdout
+# ---------------------------------------------------------------------------
+def test_json_mode_routes_to_stderr_by_default():
+    rep = StatusReporter(json_mode=True)
+    assert rep.console.stderr is True
+
+
+# ---------------------------------------------------------------------------
+# waiting(): records a WAITING event, inert (no spinner) on a non-terminal.
+# ---------------------------------------------------------------------------
+def test_waiting_records_and_yields_message():
+    rep, buf = reporter()
+    with rep.waiting("calling the model", on="LLM") as msg:
+        assert isinstance(msg, StatusMessage)
+        assert msg.status == Status.WAITING
+        assert msg.waiting_on == "LLM"
+    # Recorded exactly once, regardless of how long the block ran.
+    waits = [m for m in rep.messages if m.status == Status.WAITING]
+    assert len(waits) == 1
+    assert "calling the model" in buf.getvalue()
+
+
+def test_waiting_inert_when_quiet():
+    rep, buf = reporter(quiet=True)
+    with rep.waiting("calling the model", on="network"):
+        pass
+    assert buf.getvalue() == ""
+    assert rep.messages[0].waiting_on == "network"
+
+
+def test_waiting_does_not_swallow_exceptions():
+    rep, _ = reporter()
+    with pytest.raises(ValueError):
+        with rep.waiting("calling the model"):
+            raise ValueError("boom")
+
+
+# ---------------------------------------------------------------------------
+# from_context
+# ---------------------------------------------------------------------------
+class _Ctx:
+    def __init__(self, obj):
+        self.obj = obj
+
+
+def test_from_context_inherits_quiet():
+    rep = from_context(_Ctx({"quiet": True}), command="pdd x")
+    assert rep.quiet is True
+    assert rep.command == "pdd x"
+
+
+def test_from_context_defaults_quiet_false_without_obj():
+    rep = from_context(_Ctx(None))
+    assert rep.quiet is False
+
+
+# ---------------------------------------------------------------------------
+# Full skim: a covered command emits start -> step/waiting -> success.
+# ---------------------------------------------------------------------------
+def test_typical_command_flow_shape():
+    rep, buf = reporter(command="pdd detect")
+    rep.start("checking 3 prompt(s) against the change description")
+    with rep.waiting("asking the model which prompts need changes", on="LLM"):
+        pass
+    rep.success("2 prompt(s) need changes", next_step="run `pdd change`")
+
+    kinds = [m.status for m in rep.messages]
+    assert kinds == [Status.START, Status.WAITING, Status.SUCCESS]
+    text = buf.getvalue()
+    # User can tell: what started, that it waited on the LLM, and the next action.
+    assert "pdd detect:" in text
+    assert "waiting on LLM" in text
+    assert "Next:" in text

--- a/tests/test_conflicts_main.py
+++ b/tests/test_conflicts_main.py
@@ -1,8 +1,12 @@
 import pytest
+from io import StringIO
 from unittest.mock import patch, MagicMock, mock_open
 from typing import List, Dict, Tuple, Optional
 
+from rich.console import Console
+
 from pdd.conflicts_main import conflicts_main
+from pdd.cli_status import Status, StatusReporter
 from pdd import DEFAULT_STRENGTH
 
 @pytest.fixture
@@ -18,12 +22,24 @@ def mock_ctx():
     return ctx
 
 
+@pytest.fixture
+def mock_status():
+    """Inject a recording StatusReporter so tests can assert message *shape*.
+
+    Writes to a throwaway StringIO console (no terminal, no spinner, no timing),
+    keeping assertions deterministic.
+    """
+    reporter = StatusReporter("pdd conflicts", console=Console(file=StringIO()))
+    with patch('pdd.conflicts_main.from_context', return_value=reporter):
+        yield reporter
+
+
 @patch('csv.DictWriter')  # Added patch for csv.DictWriter
 @patch('pdd.conflicts_main.conflicts_in_prompts')
 @patch('pdd.conflicts_main.construct_paths')
 @patch('pdd.conflicts_main.rprint')
 @patch('builtins.open', new_callable=mock_open)
-def test_success_with_output(mock_file, mock_rprint, mock_construct_paths, mock_conflicts_in_prompts, mock_dict_writer, mock_ctx):
+def test_success_with_output(mock_file, mock_rprint, mock_construct_paths, mock_conflicts_in_prompts, mock_dict_writer, mock_ctx, mock_status):
     """Test conflicts_main with valid inputs and an output path."""
     # Setup mock for construct_paths
     mock_construct_paths.return_value = (
@@ -104,11 +120,20 @@ def test_success_with_output(mock_file, mock_rprint, mock_construct_paths, mock_
     ]
     mock_writer_instance.writerow.assert_has_calls(expected_calls, any_order=False)
 
-    # Ensure rprint was called for user feedback
-    mock_rprint.assert_any_call("[bold green]Conflict analysis completed successfully.[/bold green]")
+    # Ensure rprint was called for the detailed data report (unchanged).
     mock_rprint.assert_any_call("[bold]Model used:[/bold] model_xyz")
     mock_rprint.assert_any_call("[bold]Total cost:[/bold] $0.123456")
     mock_rprint.assert_any_call("[bold]Results saved to:[/bold] output.csv")
+
+    # Status messaging: start, a waiting indicator on the LLM, and a success
+    # with a next action — the UX acceptance criteria for a covered command.
+    kinds = [m.status for m in mock_status.messages]
+    assert kinds[0] == Status.START
+    assert Status.WAITING in kinds
+    success = [m for m in mock_status.messages if m.status == Status.SUCCESS]
+    assert success and success[-1].next_step
+    waiting = [m for m in mock_status.messages if m.status == Status.WAITING]
+    assert waiting[0].waiting_on == "LLM"
 
 @patch('csv.DictWriter')
 @patch('pdd.conflicts_main.conflicts_in_prompts')
@@ -200,8 +225,7 @@ def test_success_without_output(
     ]
     mock_writer_instance.writerow.assert_has_calls(expected_calls, any_order=False)
     
-    # Ensure rprint was called for user feedback without output path
-    mock_rprint.assert_any_call("[bold green]Conflict analysis completed successfully.[/bold green]")
+    # Ensure rprint was called for the detailed report without an output path.
     mock_rprint.assert_any_call("[bold]Model used:[/bold] model_abc")
     mock_rprint.assert_any_call("[bold]Total cost:[/bold] $0.654321")
     
@@ -209,11 +233,11 @@ def test_success_without_output(
 
 @patch('pdd.conflicts_main.construct_paths')
 @patch('pdd.conflicts_main.rprint')
-def test_missing_prompt_files(mock_rprint, mock_construct_paths, mock_ctx):
+def test_missing_prompt_files(mock_rprint, mock_construct_paths, mock_ctx, mock_status):
     """Test conflicts_main handling of missing prompt files."""
     # Setup construct_paths to raise FileNotFoundError
     mock_construct_paths.side_effect = FileNotFoundError("Prompt files not found.")
-    
+
     # Call the function under test and expect it to exit
     with pytest.raises(SystemExit) as exc_info:
         conflicts_main(
@@ -222,16 +246,19 @@ def test_missing_prompt_files(mock_rprint, mock_construct_paths, mock_ctx):
             prompt2='path/to/nonexistent_prompt2',
             output='path/to/output.csv'
         )
-    
-    # Assertions
+
+    # Assertions: actionable failure (cause + suggestions) and exit code 1.
     assert exc_info.value.code == 1
-    mock_rprint.assert_any_call("[bold red]Error:[/bold red] Prompt files not found.")
+    failures = [m for m in mock_status.messages if m.status == Status.FAILURE]
+    assert failures, "a FAILURE status should be reported"
+    assert failures[-1].reason == "Prompt files not found."
+    assert len(failures[-1].suggestions) >= 1
 
 
 @patch('pdd.conflicts_main.conflicts_in_prompts')
 @patch('pdd.conflicts_main.construct_paths')
 @patch('pdd.conflicts_main.rprint')
-def test_conflicts_in_prompts_error(mock_rprint, mock_construct_paths, mock_conflicts_in_prompts, mock_ctx):
+def test_conflicts_in_prompts_error(mock_rprint, mock_construct_paths, mock_conflicts_in_prompts, mock_ctx, mock_status):
     """Test conflicts_main handling exceptions from conflicts_in_prompts."""
     # Setup construct_paths
     mock_construct_paths.return_value = (
@@ -258,9 +285,12 @@ def test_conflicts_in_prompts_error(mock_rprint, mock_construct_paths, mock_conf
             output='path/to/output.csv'
         )
     
-    # Assertions
+    # Assertions: actionable failure (cause + suggestions) and exit code 1.
     assert exc_info.value.code == 1
-    mock_rprint.assert_any_call("[bold red]Error:[/bold red] Model error occurred.")
+    failures = [m for m in mock_status.messages if m.status == Status.FAILURE]
+    assert failures, "a FAILURE status should be reported"
+    assert failures[-1].reason == "Model error occurred."
+    assert len(failures[-1].suggestions) >= 1
 
 
 @patch('csv.DictWriter')
@@ -402,8 +432,7 @@ def test_force_option(mock_file, mock_rprint, mock_construct_paths, mock_conflic
         {'prompt_name': 'path/to/prompt1', 'change_instructions': 'Force Change A'}
     )
     
-    # Ensure rprint was called for user feedback
-    mock_rprint.assert_any_call("[bold green]Conflict analysis completed successfully.[/bold green]")
+    # Ensure rprint was called for the detailed data report.
     mock_rprint.assert_any_call("[bold]Model used:[/bold] model_force")
     mock_rprint.assert_any_call("[bold]Total cost:[/bold] $0.789012")
     mock_rprint.assert_any_call("[bold]Results saved to:[/bold] output/output.csv")
@@ -462,8 +491,7 @@ def test_replace_prompt_names(mock_file, mock_rprint, mock_construct_paths, mock
         False
     )
     
-    # Ensure rprint was called correctly
-    mock_rprint.assert_any_call("[bold green]Conflict analysis completed successfully.[/bold green]")
+    # Ensure rprint was called correctly for the detailed report + listing.
     mock_rprint.assert_any_call("[bold]Model used:[/bold] model_replace")
     mock_rprint.assert_any_call("[bold]Total cost:[/bold] $0.333333")
     mock_rprint.assert_any_call("[bold]Conflicts detected:[/bold]")
@@ -554,6 +582,5 @@ def test_verbose_mode(mock_dict_writer, mock_file, mock_rprint, mock_construct_p
     # rather that verbose is passed to conflicts_in_prompts for *its* detailed output.
     # So, we just check the standard non-quiet prints.
     if not mock_ctx.obj.get('quiet', False):
-        mock_rprint.assert_any_call("[bold green]Conflict analysis completed successfully.[/bold green]")
         mock_rprint.assert_any_call("[bold]Model used:[/bold] model_verbose")
         mock_rprint.assert_any_call("[bold]Total cost:[/bold] $0.999000")

--- a/tests/test_detect_change_main.py
+++ b/tests/test_detect_change_main.py
@@ -1,9 +1,24 @@
 import pytest
 import click
+from io import StringIO
 from click.testing import CliRunner
 from unittest.mock import patch, MagicMock
+from rich.console import Console
 from pdd.detect_change_main import detect_change_main
+from pdd.cli_status import Status, StatusReporter
 from pdd import DEFAULT_STRENGTH
+
+
+@pytest.fixture
+def mock_status():
+    """Inject a recording StatusReporter so tests can assert message *shape*.
+
+    The reporter writes to a throwaway StringIO console (no terminal, no
+    spinner, no timing), so assertions stay deterministic.
+    """
+    reporter = StatusReporter("pdd detect", console=Console(file=StringIO()))
+    with patch('pdd.detect_change_main.from_context', return_value=reporter):
+        yield reporter
 
 @pytest.fixture
 def mock_construct_paths():
@@ -35,7 +50,7 @@ def mock_sys_exit():
     with patch('sys.exit') as mock:
         yield mock
 
-def test_detect_change_main_success(mock_construct_paths, mock_detect_change, mock_rprint, mock_csv_writer, mock_open):
+def test_detect_change_main_success(mock_status, mock_construct_paths, mock_detect_change, mock_rprint, mock_csv_writer, mock_open):
     """
     Test case for successful execution of detect_change_main.
     """
@@ -99,13 +114,23 @@ def test_detect_change_main_success(mock_construct_paths, mock_detect_change, mo
         verbose=True
     )
 
-    mock_rprint.assert_any_call("[bold green]Change detection completed successfully.[/bold green]")
+    # Detailed data report still flows through rprint, unchanged.
     mock_rprint.assert_any_call("[bold]Model used:[/bold] gpt-4")
     mock_rprint.assert_any_call("[bold]Total cost:[/bold] $0.050000")
     mock_rprint.assert_any_call("[bold]Results saved to:[/bold] output.csv")
     mock_rprint.assert_any_call("\n[bold]Changes needed:[/bold]")
     mock_rprint.assert_any_call("[bold]Prompt:[/bold] prompt1.prompt")
     mock_rprint.assert_any_call("[bold]Instructions:[/bold] Update prompt")
+
+    # Status messaging: a start, a waiting indicator, and a success with a
+    # next action — the UX acceptance criteria for a covered command.
+    kinds = [m.status for m in mock_status.messages]
+    assert kinds[0] == Status.START
+    assert Status.WAITING in kinds
+    success = [m for m in mock_status.messages if m.status == Status.SUCCESS]
+    assert success and success[-1].next_step
+    waiting = [m for m in mock_status.messages if m.status == Status.WAITING]
+    assert waiting[0].waiting_on == "LLM"
 
 def test_detect_change_main_no_changes(mock_construct_paths, mock_detect_change, mock_rprint):
     """
@@ -150,7 +175,7 @@ def test_detect_change_main_no_changes(mock_construct_paths, mock_detect_change,
     )
     mock_rprint.assert_any_call("No changes needed for any of the analyzed prompts.")
 
-def test_detect_change_main_error(mock_construct_paths, mock_rprint, mock_sys_exit):
+def test_detect_change_main_error(mock_status, mock_construct_paths, mock_rprint, mock_sys_exit):
     """
     Test case for detect_change_main when an error occurs.
     """
@@ -174,8 +199,13 @@ def test_detect_change_main_error(mock_construct_paths, mock_rprint, mock_sys_ex
     # Call the function
     detect_change_main(mock_ctx, prompt_files, change_file, output)
 
-    # Assertions
-    mock_rprint.assert_called_with("[bold red]Error:[/bold red] File not found")
+    # Assertions: an actionable failure (what failed, why, what to try) and exit 1.
+    failures = [m for m in mock_status.messages if m.status == Status.FAILURE]
+    assert failures, "a FAILURE status should be reported"
+    failure = failures[-1]
+    assert failure.reason == "File not found"          # root cause surfaced
+    assert len(failure.suggestions) >= 1               # concrete next steps
+    assert failure.text                                 # names the step that failed
     mock_sys_exit.assert_called_with(1)
 
 def test_detect_change_main_quiet_mode(mock_construct_paths, mock_detect_change, mock_rprint):


### PR DESCRIPTION
## PR #2 — Status and progress messaging improvements

Part of EPIC **[promptdriven/pdd#1540](https://github.com/promptdriven/pdd/issues/1540)** (workstream 2 of 7). Targets the EPIC integration branch `epic/1540-design-refresh`, **not** `main`.

> Scope is intentionally narrow: **messaging only**. No color-system changes (workstream 1, already merged), no `pdd context` token colors, adaptive theming, `connect` redesign, AI-review redesign, or motion work.

### What this adds

A small, reusable status-messaging vocabulary so that — across every PDD command — the user can always tell:

1. **what is happening now** → `start` / `step`
2. **what comes next** → `next_step=` on `start` / `success`
3. **whether it's waiting on IO/network/LLM** → `waiting(...)`
4. **what succeeded or failed, and what to do** → `success` / `failure`

New module `pdd/cli_status.py` defines exactly five primitives — `START` / `STEP` / `WAITING` / `SUCCESS` / `FAILURE` (a `Status` enum) — each with one glyph and one **semantic color role** resolved by the central color system (`pdd/cli_theme.py`, workstream 1). Nothing here hard-codes a color.

Message rules: short, skimmable, action-oriented, and **non-duplicative** (an identical line emitted twice in a row is collapsed, so retry loops don't spam the terminal).

### Backwards-compatible with machine-readable output

- **`--quiet`** (and machine-JSON invocations that set `PDD_QUIET`): nothing is printed.
- **`json_mode`**: status is routed to **stderr**, so stdout stays payload-only.

Either way, every message is still *recorded* (`reporter.messages`), which is how tests assert behavior by shape.

### Actionable errors

`failure(step, *, reason=None, suggestions=())` names **what** failed, **why** (root cause if known), and **1–2 concrete things to try next**:

```
✗ reading the change file
  Why: change.txt not found
  Try: check the path to the change file
  Try: run `pdd detect --help` for the expected arguments
```

### Long-running work shows progress

`with status.waiting("asking the model …", on="LLM"):` shows a spinner on an interactive terminal so multi-second model/network/disk calls never look frozen. The spinner is **automatically inert** when output is suppressed, redirected, or non-TTY — so there's no timing dependence and tests stay deterministic.

### First adopters

`detect_change_main` and `conflicts_main` are migrated end-to-end (start → waiting-on-LLM → success/failure with a next step), **preserving** existing return values, CSV output, and quiet behavior. Remaining commands move over incrementally in follow-on work, the same way the color system rolled out.

### Tests

- `tests/test_cli_status.py` — 22 shape-based tests (no wall-clock, spinner-frame, or ANSI assertions).
- `tests/test_detect_change_main.py`, `tests/test_conflicts_main.py` — extended to assert the new message shape and the actionable-error contract.
- Full affected set (incl. `test_cli_theme.py`, `tests/commands/test_analysis.py`) green: **132 passed**.

### UX acceptance criteria

For each covered command the user now sees a **starting** message, a **current step / waiting** indicator, and a **completed-or-failed** message with a next action; errors carry **what failed + why + what to try**.

### Docs

- `docs/design/status-messaging.md` — the design + usage.
- `docs/design/EPIC-1540-design-refresh.md` — workstream 2 marked in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)