### PR TITLE
Increase Cloud Batch pytest shard timeout

### DIFF
--- a/ci/cloud-batch/job-template-standard.json
+++ b/ci/cloud-batch/job-template-standard.json
@@ -14,7 +14,8 @@
                                 "PDD_TEST_HEADLESS": "1",
                                 "GCS_BUCKET_NAME": "litellm_cache",
                                 "FIXED_TASK_INDEX": "54",
-                                "PDD_CLOUD_TIMEOUT": "720"
+                                "PDD_CLOUD_TIMEOUT": "720",
+                                "PYTEST_CHUNK_TIMEOUT": "1800"
                             },
                             "secretVariables": {
                                 "GCS_HMAC_ACCESS_KEY_ID": "projects/{{PROJECT_ID}}/secrets/GCS_HMAC_ACCESS_KEY_ID/versions/latest",

--- a/ci/cloud-batch/job-template.json
+++ b/ci/cloud-batch/job-template.json
@@ -14,7 +14,8 @@
                                 "PDD_TEST_HEADLESS": "1",
                                 "GCS_BUCKET_NAME": "litellm_cache",
                                 "SKIP_INDEX": "54",
-                                "PDD_CLOUD_TIMEOUT": "720"
+                                "PDD_CLOUD_TIMEOUT": "720",
+                                "PYTEST_CHUNK_TIMEOUT": "1800"
                             },
                             "secretVariables": {
                                 "GCS_HMAC_ACCESS_KEY_ID": "projects/{{PROJECT_ID}}/secrets/GCS_HMAC_ACCESS_KEY_ID/versions/latest",


### PR DESCRIPTION
## Summary
- Pass PYTEST_CHUNK_TIMEOUT=1800 into Cloud Batch SPOT and STANDARD jobs.
- Keeps the existing entrypoint timeout mechanism, but gives long pytest release-gate shards enough headroom.

## Validation
- pdd_cloud release gate rerun: `PDD_PUBLIC_REPO_DIR=/Users/gregtanaka/Documents/pdd.worktrees/pdd-cli-release-gate make test-pdd-cli-release`
- Cloud Batch run `run-20260615-001611-97b28cf40`: 77 passed, 0 failed, 0 errors.
- LLM smoke Cloud Build `f5f95943-bbc6-4dc1-a303-3f776d38acae`: SUCCESS.
