### PR TITLE
test: validate dormant task-routing fallbacks

### DIFF
--- a/tests/test_agentic_common.py
+++ b/tests/test_agentic_common.py
@@ -3008,6 +3008,45 @@ def test_run_agentic_task_routing_policy_selects_initial_config(
     assert payload["verifier_result"] == "pass"
 
 
+def test_run_agentic_task_routing_policy_unknown_task_class_falls_back_without_env_mutation(
+    mock_cwd,
+    monkeypatch,
+):
+    from pdd.routing_policy import default_policy
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+    monkeypatch.setenv("CLAUDE_MODEL", "preexisting-model")
+    monkeypatch.setattr("pdd.agentic_common.get_available_agents", lambda: ["anthropic"])
+    monkeypatch.setattr("pdd.agentic_common.get_agent_provider_preference", lambda: ["anthropic"])
+
+    calls = []
+
+    def fake_run(provider, prompt_path, cwd, timeout, verbose, quiet, **kwargs):
+        calls.append((provider, os.environ.get("CLAUDE_MODEL"), kwargs))
+        return (True, "done", 0.1, "actual-model", None)
+
+    monkeypatch.setattr("pdd.agentic_common._run_with_provider", fake_run)
+
+    result = run_agentic_task(
+        "Do the work",
+        mock_cwd,
+        routing_policy=default_policy(),
+        task_class="unknown-task-class",
+    )
+
+    assert result.success is True
+    assert calls == [("anthropic", "preexisting-model", calls[0][2])]
+    assert calls[0][2]["reasoning_time"] is None
+    assert os.environ["CLAUDE_MODEL"] == "preexisting-model"
+    records = list((mock_cwd / ".pdd" / "agentic-logs").glob("routing-*.jsonl"))
+    assert len(records) == 1
+    payload = json.loads(records[0].read_text().splitlines()[0])
+    assert payload["task_class"] == "default"
+    assert payload["selected_config"] is None
+    assert payload["fallback_reason"] == "no_policy_row"
+    assert payload["verifier_result"] == "pass"
+
+
 def test_run_agentic_task_routing_policy_escalates_after_failure(
     mock_cwd,
     monkeypatch,

--- a/tests/test_llm_invoke_task_routing.py
+++ b/tests/test_llm_invoke_task_routing.py
@@ -290,6 +290,31 @@ def test_flag_off_ignores_shots(monkeypatch):
     assert multishot_called["v"] is False
 
 
+def test_flag_off_ignores_task_class_router(monkeypatch):
+    """With the flag unset, task_class must not consult the routing table."""
+    router_called = {"v": False}
+
+    class _Sentinel(Exception):
+        pass
+
+    def fake_route(task_class):
+        router_called["v"] = True
+        return {"model": "should-not-be-used", "temperature": 0.0, "shots": 1}
+
+    monkeypatch.setattr(m, "_select_task_route", fake_route)
+    monkeypatch.setattr(m, "_load_model_data", lambda *a, **k: object())
+    monkeypatch.setattr(
+        m,
+        "_select_model_candidates",
+        lambda *a, **k: (_ for _ in ()).throw(_Sentinel()),
+    )
+
+    with pytest.raises(_Sentinel):
+        m.llm_invoke(prompt="p", input_json={}, task_class="generate", use_cloud=False)
+
+    assert router_called["v"] is False
+
+
 def test_flag_on_dispatches_and_clamps_shots(monkeypatch):
     captured = {}
     monkeypatch.setenv("PDD_ENABLE_TASK_ROUTING", "1")

--- a/tests/test_llm_invoke_task_routing.py
+++ b/tests/test_llm_invoke_task_routing.py
@@ -327,7 +327,7 @@ def test_flag_on_router_overrides_model(monkeypatch):
     class _Sentinel(Exception):
         pass
 
-    def fake_select(strength, base_model, df):
+    def fake_select(strength, base_model, df, *args, **kwargs):
         seen["base_model"] = base_model
         raise _Sentinel()
 


### PR DESCRIPTION
## Summary

Adds/repairs EPIC-targeted tests that validate the task-routing v1 machinery while it remains dormant by design:

- Fixes the stale router-override spy so it accepts the merged manifest_by_model kwarg.
- Adds a direct-generation assertion that task_class does not consult the router while PDD_ENABLE_TASK_ROUTING is unset.
- Adds an agentic routing assertion that an unknown task class records the default/no-policy fallback without mutating a pre-existing model env var.

## Validation

- pytest tests/test_llm_invoke_task_routing.py plus the three agentic routing-policy tests: 33 passed.
- Full routing feature set: test_llm_invoke_task_routing, test_routing_policy, test_agentic_multishot, test_failure_classification, test_agentic_config_benchmark, and the three agentic routing-policy tests: 120 passed.

Targets epic/1431-task-routing-v1, not main, consistent with the #1431 epic integration policy.