### PR TITLE
feat(sync): redesign sync animation to mirror the system flow (EPIC #1560, workstream 6)

### DIFF
--- a/pdd/sync_animation.py
+++ b/pdd/sync_animation.py
@@ -14,19 +14,32 @@ from rich.table import Table
 from rich.progress_bar import ProgressBar # For cost/budget display if needed
 
 from . import logo_animation
+# Brand palette is owned by the central CLI color system (cli_theme.py, the
+# Phase 1 design-refresh deliverable). Import it so every surface shares one
+# palette rather than hand-defining hex values. Fall back to the same brand hex
+# values when that module is absent (e.g. an integration branch that predates
+# Phase 1), so the animation never hard-depends on it. The names are re-exported
+# here, since sync_tui imports DEEP_NAVY / ELECTRIC_CYAN from this module.
+try:
+    from .cli_theme import (
+        DEEP_NAVY,
+        ELECTRIC_CYAN,
+        LUMEN_PURPLE,
+        PROMPT_MAGENTA,
+        BUILD_GREEN,
+        DIFF_YELLOW,
+        BREAK_RED,
+    )
+except ImportError:  # pragma: no cover - palette fallback for pre-Phase-1 trees
+    DEEP_NAVY = "#0A0A23"
+    ELECTRIC_CYAN = "#00D8FF"
+    LUMEN_PURPLE = "#8C47FF"
+    PROMPT_MAGENTA = "#FF2AA6"
+    BUILD_GREEN = "#18C07A"
+    DIFF_YELLOW = "#FBBB35"
+    BREAK_RED = "#F34842"
 
-# Assuming these might be in pdd/__init__.py or a constants module
-# For this example, defining them locally based on the branding document
-# Primary Colors
-DEEP_NAVY = "#0A0A23"
-ELECTRIC_CYAN = "#00D8FF"
-
-# Accent Colors (can be used for boxes if specific inputs are not good)
-LUMEN_PURPLE = "#8C47FF"
-PROMPT_MAGENTA = "#FF2AA6"
-BUILD_GREEN = "#18C07A" # Success, good for 'example' or 'tests'
-
-# Default colors for boxes if not provided or invalid
+# Default colors for the four artifact boxes if not provided or invalid.
 DEFAULT_PROMPT_COLOR = LUMEN_PURPLE
 DEFAULT_CODE_COLOR = ELECTRIC_CYAN
 DEFAULT_EXAMPLE_COLOR = BUILD_GREEN
@@ -62,6 +75,7 @@ EMOJIS = {
     "verify_code": "🔍",
     "verify_example": "🔍",
     "test": "🧪",
+    "test_extend": "🧪",
     "fix_code": "🔧",
     "fix_tests": "🔧",
     "update": "⬆️",
@@ -71,6 +85,88 @@ EMOJIS = {
 
 CONSOLE_WIDTH = 80  # Target console width for layout
 ANIMATION_BOX_HEIGHT = 18 # Target height for the main animation box
+
+# ---------------------------------------------------------------------------
+# Execution pipeline model.
+#
+# The sync system flow (see the Mermaid diagram in issue #1560) is a pipeline:
+# the CLI parses options, inspects on-disk state, the planner picks the next
+# operation, the command-execution loop runs it, and outputs are written.
+# Subgraphs 1, 2, 3, 4 and 6 are *runtime* stages; subgraph 5 ("validation
+# seams") is test-only and never animated. The animation mirrors this: the front
+# and back stages stay high-level boxes, while the command-execution stage —
+# where the user actually spends time and money — is expanded in detail.
+#
+# The orchestrator drives the animation through a single mutable string
+# (current_function_name) that takes the values below. We map each onto a stage
+# so the visuals follow real execution rather than a decorative script.
+# ---------------------------------------------------------------------------
+STAGE_ENTRY = "entry"
+STAGE_INSPECT = "inspect"
+STAGE_PLAN = "plan"
+STAGE_EXECUTE = "execute"
+STAGE_OUTPUT = "output"
+
+# Ordered stages with the short label and the sub-steps each one performs
+# (sourced verbatim from the diagram's subgraph contents).
+PIPELINE_STAGES: List[Tuple[str, str, str]] = [
+    (STAGE_ENTRY,   "Entry",   "args · config · paths · budget"),
+    (STAGE_INSPECT, "Inspect", "lock · fingerprint · files · hashes"),
+    (STAGE_PLAN,    "Plan",    "determine next operation"),
+    (STAGE_EXECUTE, "Execute", "run command"),
+    (STAGE_OUTPUT,  "Output",  "artifacts · fingerprint · report"),
+]
+_STAGE_INDEX = {stage_id: i for i, (stage_id, _label, _sub) in enumerate(PIPELINE_STAGES)}
+
+# The canonical order the planner walks the command-execution loop in. Shown as
+# a step strip during Execute so the user can see intermediate steps and where
+# the current operation sits in the overall workflow. 'crash' is the failure
+# face of 'verify' and 'test_extend' the continuation of 'test', so they map
+# onto the same strip slot (see _STEP_ALIASES).
+COMMAND_SEQUENCE: List[str] = [
+    "auto-deps", "generate", "example", "verify", "test", "fix", "update",
+]
+_STEP_ALIASES = {"crash": "verify", "test_extend": "test"}
+
+# Probe operations run an artifact and inspect the result rather than producing
+# a new artifact — the "check" behavior in the diagram. They get a distinct
+# probe glyph and pulse so check steps read differently from build steps.
+PROBE_OPERATIONS = {"verify", "crash", "test", "test_extend"}
+
+# Operations that constitute the command-execution stage.
+EXECUTE_OPERATIONS = {
+    "auto-deps", "generate", "example", "verify", "crash",
+    "test", "test_extend", "fix", "update",
+}
+
+# Terminal function names the orchestrator emits when the loop ends.
+_OUTPUT_NAMES = {"synced", "nothing", "all_synced", "conflict", "done", "error",
+                 "fail_and_request_manual_merge"}
+_PLAN_NAMES = {"checking", "planning", "analyze", "analyze_conflict", "deciding"}
+_ENTRY_NAMES = {"initializing", "init", "startup", ""}
+
+
+def stage_for_function(function_name: Optional[str]) -> str:
+    """Map an orchestrator function name onto a pipeline stage id.
+
+    This is the single source of truth tying the animation to real execution:
+    every value the orchestrator writes into ``current_function_name_ref`` is
+    classified here, so the rail and body never show a stage the run is not
+    actually in.
+    """
+    fn = (function_name or "").strip().lower()
+    if fn in _ENTRY_NAMES:
+        # Entry (arg parse) happens before/while the logo plays; by the time the
+        # main frame renders we are reading on-disk state, so show Inspect.
+        return STAGE_INSPECT
+    if fn in _PLAN_NAMES:
+        return STAGE_PLAN
+    if fn in _OUTPUT_NAMES:
+        return STAGE_OUTPUT
+    if fn in EXECUTE_OPERATIONS:
+        return STAGE_EXECUTE
+    # Unknown / future operation names are still command execution.
+    return STAGE_EXECUTE
 
 def _get_valid_color(color_str: Optional[str], default_color: str) -> str:
     """Validates a color string or returns default."""
@@ -116,16 +212,37 @@ class AnimationState:
         self.path_box_content_width = 16 # Base chars for path inside its small box (will be dynamic)
         self.auto_deps_progress: int = 0  # Progress counter for auto-deps border thickening
 
+        # Pipeline-stage tracking (see PIPELINE_STAGES). current_stage is derived
+        # from current_function_name every update so it always matches reality.
+        self.current_stage: str = stage_for_function(self.current_function_name)
+        # Execute-loop steps that have already run this session, used to mark the
+        # command step strip. Only populated as real operations are observed.
+        self.executed_steps: List[str] = []
+        self._last_op: Optional[str] = None
+
     def update_dynamic_state(self, function_name: str, cost: float,
                              prompt_path: str, code_path: str, example_path: str, tests_path: str):
         self.current_function_name = function_name.lower() if function_name else "checking"
         self.cost = cost if cost is not None else self.cost
-        
+        self.current_stage = stage_for_function(self.current_function_name)
+
+        # Record completed execute-loop steps as the operation changes, so the
+        # step strip can show what has already run. We normalize aliases (crash
+        # -> verify, test_extend -> test) onto their canonical strip slot.
+        op = self.current_function_name
+        if op != self._last_op:
+            prev = self._last_op
+            if prev in EXECUTE_OPERATIONS:
+                slot = _STEP_ALIASES.get(prev, prev)
+                if slot not in self.executed_steps:
+                    self.executed_steps.append(slot)
+            self._last_op = op
+
         self.paths["prompt"] = prompt_path or ""
         self.paths["code"] = code_path or ""
         self.paths["example"] = example_path or ""
         self.paths["tests"] = tests_path or ""
-        
+
         # Update auto-deps progress for border thickening animation
         if self.current_function_name == "auto-deps":
             self.auto_deps_progress = (self.auto_deps_progress + 1) % 120  # Cycle every 12 seconds at 10fps
@@ -432,50 +549,136 @@ def _draw_connecting_lines_and_arrows(state: AnimationState, console_width: int)
     return lines
 
 
-def _render_animation_frame(state: AnimationState, console_width: int) -> Panel:
-    """Renders a single frame of the main animation box."""
-    layout = Layout(name="root")
-    layout.split_column(
-        Layout(name="header", size=1),
-        Layout(name="body", ratio=1, minimum_size=10), 
-        Layout(name="footer", size=1)
-    )
+# Full stage titles for the high-level cards (the diagram's subgraph names).
+_STAGE_TITLES = {
+    STAGE_ENTRY:   "CLI entry & options",
+    STAGE_INSPECT: "State inspection",
+    STAGE_PLAN:    "Operation planner",
+    STAGE_EXECUTE: "Command execution",
+    STAGE_OUTPUT:  "Outputs",
+}
 
-    blink_on = (state.frame_count // 5) % 2 == 0
+# Short labels for the command step strip.
+_STEP_LABELS = {
+    "auto-deps": "deps",
+    "generate": "gen",
+    "example": "ex",
+    "verify": "verify",
+    "test": "test",
+    "fix": "fix",
+    "update": "upd",
+}
+_PROBE_SLOTS = {"verify", "test"}  # canonical strip slots that are checks, not builds
 
-    header_table = Table.grid(expand=True, padding=(0,1))
-    header_table.add_column(justify="left", ratio=1)
-    header_table.add_column(justify="right", ratio=1)
-    # Make command blink in top right corner
-    command_text = state.current_function_name.capitalize() if blink_on else ""
-    header_table.add_row(
-        Text("Prompt Driven Development", style=f"bold {ELECTRIC_CYAN}"),
-        Text(command_text, style=f"bold {ELECTRIC_CYAN}")
-    )
-    layout["header"].update(header_table)
 
-    footer_table = Table.grid(expand=True, padding=(0,1))
-    footer_table.add_column(justify="left", ratio=1)      
-    footer_table.add_column(justify="center", ratio=1) 
-    footer_table.add_column(justify="right", ratio=1)     
-    
-    cost_str = f"${state.cost:.2f}"
-    budget_str = f"${state.budget:.2f}" if state.budget != float('inf') else "N/A"
-    
-    footer_table.add_row(
-        Text(state.basename, style=ELECTRIC_CYAN),
-        Text(f"Elapsed: {state.get_elapsed_time_str()}", style=ELECTRIC_CYAN),
-        Text(f"{cost_str} / {budget_str}", style=ELECTRIC_CYAN)
-    )
-    layout["footer"].update(footer_table) 
-    
+def _render_phase_rail(state: AnimationState, blink_on: bool) -> Text:
+    """One-line rail showing pipeline progression Entry → … → Output.
+
+    Completed stages are filled and green, the current stage pulses in accent,
+    and pending stages stay dim. This is the always-on orientation strip that
+    maps directly onto the diagram's top-level subgraphs.
+    """
+    cur_idx = _STAGE_INDEX.get(state.current_stage, _STAGE_INDEX[STAGE_INSPECT])
+    rail = Text(justify="center")
+    for i, (_stage_id, label, _sub) in enumerate(PIPELINE_STAGES):
+        if i > 0:
+            rail.append(" ─▶ ", style="dim " + ELECTRIC_CYAN)
+        if i < cur_idx:
+            rail.append("● ", style=BUILD_GREEN)
+            rail.append(label, style=BUILD_GREEN)
+        elif i == cur_idx:
+            glyph = "◆ " if blink_on else "◇ "
+            rail.append(glyph, style=f"bold {PROMPT_MAGENTA}")
+            rail.append(label, style=f"bold {ELECTRIC_CYAN}")
+        else:
+            rail.append("○ ", style="dim " + ELECTRIC_CYAN)
+            rail.append(label, style="dim " + ELECTRIC_CYAN)
+    return rail
+
+
+def _render_step_strip(state: AnimationState, blink_on: bool) -> Text:
+    """One-line strip of the command-execution loop with the active step lit.
+
+    Done steps get a check, the active step pulses (probe steps carry a probe
+    glyph and turn red on a crash), and upcoming steps stay dim — so the user
+    sees intermediate steps and where the current operation sits in the loop.
+    """
+    cur_op = state.current_function_name
+    cur_slot = _STEP_ALIASES.get(cur_op, cur_op)
+    is_crash = cur_op == "crash"
+    strip = Text(justify="center")
+    for i, step in enumerate(COMMAND_SEQUENCE):
+        if i > 0:
+            strip.append("  ·  ", style="dim " + ELECTRIC_CYAN)
+        label = _STEP_LABELS.get(step, step)
+        if step == cur_slot:
+            if step in _PROBE_SLOTS:
+                marker = "◈" if blink_on else "◇"
+                style = f"bold {BREAK_RED}" if is_crash else f"bold {DIFF_YELLOW}"
+                strip.append(f"{marker} ", style=style)
+                strip.append(label, style=style)
+            else:
+                glyph = "▸ " if blink_on else "▹ "
+                strip.append(glyph, style=f"bold {ELECTRIC_CYAN}")
+                strip.append(label, style=f"bold {ELECTRIC_CYAN}")
+        elif step in state.executed_steps:
+            strip.append("✓ ", style=BUILD_GREEN)
+            strip.append(label, style=BUILD_GREEN)
+        else:
+            strip.append(label, style="dim " + ELECTRIC_CYAN)
+    return strip
+
+
+def _render_stage_card(state: AnimationState, console_width: int, blink_on: bool) -> Align:
+    """High-level box for a non-execution stage (entry / inspect / plan / output).
+
+    Keeps the early and late stages clean and box-based: a titled panel naming
+    the stage, the sub-steps it performs, and a short live status line.
+    """
+    stage = state.current_stage
+    title = _STAGE_TITLES.get(stage, stage.capitalize())
+    sub = next((s for sid, _l, s in PIPELINE_STAGES if sid == stage), "")
+
+    border = ELECTRIC_CYAN
+    if stage == STAGE_OUTPUT:
+        fn = state.current_function_name
+        if fn in ("synced", "nothing", "all_synced", "done"):
+            border = BUILD_GREEN
+            status = "✓ workflow complete"
+        elif fn in ("conflict", "fail_and_request_manual_merge"):
+            border = DIFF_YELLOW
+            status = "manual merge required"
+        else:  # error
+            border = BREAK_RED
+            status = "✗ sync failed"
+    else:
+        ellipsis = "." * (1 + (state.frame_count // 4) % 3)
+        verb = {STAGE_INSPECT: "reading last-known state",
+                STAGE_PLAN: "choosing next operation",
+                STAGE_ENTRY: "resolving configuration"}.get(stage, "working")
+        status = f"{verb}{ellipsis}"
+
+    card = Text(justify="center")
+    card.append(sub + "\n", style=ELECTRIC_CYAN)
+    card.append(status, style=f"bold {border}")
+
+    inner_w = min(56, max(28, console_width - 8))
+    panel = Panel(Align.center(card, vertical="middle"),
+                  title=Text(title, style=f"bold {border}"),
+                  border_style=border, width=inner_w, height=5)
+    return Align.center(panel, vertical="middle")
+
+
+def _build_artifact_graph(state: AnimationState, console_width: int, blink_on: bool) -> Layout:
+    """Detailed command-execution view: the four artifact boxes plus the live
+    arrow/probe flow between them. This is the expanded heart of the animation."""
     # Calculate dynamic box width based on console width
     # Leave space for margins and spacing between boxes
     margin_space = 8  # Total margin space
     inter_box_space = 4  # Space between boxes (2 spaces each side)
     available_width = console_width - margin_space - inter_box_space
     box_width = max(state.path_box_content_width + 4, available_width // 3)
-    
+
     # Calculate the actual content width inside each panel (excluding borders)
     panel_content_width = box_width - 4  # Account for panel borders (2 chars each side)
 
@@ -500,7 +703,7 @@ def _render_animation_frame(state: AnimationState, console_width: int) -> Panel:
         else:
             # Final level: reverse colors for maximum thickness effect
             prompt_border_style = f"bold black on {state.colors['prompt']}"
-    
+
     prompt_panel = Panel(Align.center(state._render_scrolling_path("prompt", panel_content_width)),
                          title=Text.assemble(state.get_emoji_for_box("prompt", blink_on), "Prompt"),
                          border_style=prompt_border_style, width=box_width, height=3)
@@ -516,32 +719,21 @@ def _render_animation_frame(state: AnimationState, console_width: int) -> Panel:
 
     org_chart_layout = Layout(name="org_chart_area")
     org_chart_layout.split_column(
-        Layout(Text(" "), size=1),
         Layout(Align.center(prompt_panel), name="prompt_row", size=3),
-        Layout(name="lines_row_1", size=1), 
+        Layout(name="lines_row_1", size=1),
         Layout(name="lines_row_2", size=1),
         Layout(name="lines_row_3", size=1),
         Layout(name="lines_row_4", size=1),
         Layout(name="lines_row_5", size=1),
         Layout(name="lines_row_6", size=1),
-        Layout(name="bottom_boxes_row", size=3) 
+        Layout(name="bottom_boxes_row", size=3)
     )
 
     # Use full console width since we're no longer centering the lines
     connecting_lines = _draw_connecting_lines_and_arrows(state, console_width)
-    if len(connecting_lines) > 0:
-        org_chart_layout["lines_row_1"].update(connecting_lines[0])
-    if len(connecting_lines) > 1:
-        org_chart_layout["lines_row_2"].update(connecting_lines[1])
-    if len(connecting_lines) > 2:
-        org_chart_layout["lines_row_3"].update(connecting_lines[2])
-    if len(connecting_lines) > 3:
-        org_chart_layout["lines_row_4"].update(connecting_lines[3])
-    if len(connecting_lines) > 4:
-        org_chart_layout["lines_row_5"].update(connecting_lines[4])
-    if len(connecting_lines) > 5:
-        org_chart_layout["lines_row_6"].update(connecting_lines[5])
-
+    for idx in range(6):
+        if idx < len(connecting_lines):
+            org_chart_layout[f"lines_row_{idx + 1}"].update(connecting_lines[idx])
 
     bottom_boxes_table = Table.grid(expand=True)
     bottom_boxes_table.add_column()
@@ -549,12 +741,75 @@ def _render_animation_frame(state: AnimationState, console_width: int) -> Panel:
     bottom_boxes_table.add_column()
     bottom_boxes_table.add_row(code_panel, example_panel, tests_panel)
     org_chart_layout["bottom_boxes_row"].update(Align.center(bottom_boxes_table))
-    
-    layout["body"].update(org_chart_layout)
+    return org_chart_layout
+
+
+def _render_animation_frame(state: AnimationState, console_width: int) -> Panel:
+    """Renders a single frame of the main animation box.
+
+    The frame is a fixed-height panel with three regions: a header, a body, and
+    a footer. The body always carries the phase rail (pipeline progression). The
+    rest of the body switches on the current stage: high-level command-execution
+    detail (artifact graph + step strip) while a command runs, and a clean
+    high-level stage card for the entry / inspect / plan / output stages.
+    """
+    layout = Layout(name="root")
+    layout.split_column(
+        Layout(name="header", size=1),
+        Layout(name="body", ratio=1, minimum_size=10),
+        Layout(name="footer", size=1)
+    )
+
+    blink_on = (state.frame_count // 5) % 2 == 0
+
+    header_table = Table.grid(expand=True, padding=(0,1))
+    header_table.add_column(justify="left", ratio=1)
+    header_table.add_column(justify="right", ratio=1)
+    # Make command blink in top right corner
+    command_text = state.current_function_name.capitalize() if blink_on else ""
+    header_table.add_row(
+        Text("Prompt Driven Development", style=f"bold {ELECTRIC_CYAN}"),
+        Text(command_text, style=f"bold {ELECTRIC_CYAN}")
+    )
+    layout["header"].update(header_table)
+
+    footer_table = Table.grid(expand=True, padding=(0,1))
+    footer_table.add_column(justify="left", ratio=1)
+    footer_table.add_column(justify="center", ratio=1)
+    footer_table.add_column(justify="right", ratio=1)
+
+    cost_str = f"${state.cost:.2f}"
+    budget_str = f"${state.budget:.2f}" if state.budget != float('inf') else "N/A"
+
+    footer_table.add_row(
+        Text(state.basename, style=ELECTRIC_CYAN),
+        Text(f"Elapsed: {state.get_elapsed_time_str()}", style=ELECTRIC_CYAN),
+        Text(f"{cost_str} / {budget_str}", style=ELECTRIC_CYAN)
+    )
+    layout["footer"].update(footer_table)
+
+    # Body: always show the phase rail, then either the detailed execution view
+    # or the high-level stage card depending on the current pipeline stage.
+    body_layout = Layout(name="body_inner")
+    rail = _render_phase_rail(state, blink_on)
+
+    if state.current_stage == STAGE_EXECUTE:
+        body_layout.split_column(
+            Layout(rail, name="rail", size=1),
+            Layout(_render_step_strip(state, blink_on), name="step_strip", size=1),
+            Layout(_build_artifact_graph(state, console_width, blink_on), name="graph", ratio=1),
+        )
+    else:
+        body_layout.split_column(
+            Layout(rail, name="rail", size=1),
+            Layout(_render_stage_card(state, console_width, blink_on), name="card", ratio=1),
+        )
+
+    layout["body"].update(body_layout)
     state.frame_count += 1
-    
-    return Panel(layout, style=f"{ELECTRIC_CYAN} on {DEEP_NAVY}", 
-                 border_style=ELECTRIC_CYAN, height=ANIMATION_BOX_HEIGHT, 
+
+    return Panel(layout, style=f"{ELECTRIC_CYAN} on {DEEP_NAVY}",
+                 border_style=ELECTRIC_CYAN, height=ANIMATION_BOX_HEIGHT,
                  width=console_width)
 
 

--- a/tests/test_sync_animation_phases.py
+++ b/tests/test_sync_animation_phases.py
@@ -1,0 +1,155 @@
+"""Tests for the pipeline-stage animation model (issue #1560, workstream 6).
+
+The sync animation was redesigned so its motion mirrors the real system flow:
+high-level boxes for the framing stages (entry / inspect / plan / output) and an
+expanded, detailed view for the command-execution loop. These tests pin the
+mapping from orchestrator function names to pipeline stages, the step-strip
+progression, and that every frame stays a fixed-height, crash-free render.
+"""
+
+from rich.console import Console
+
+from pdd.sync_animation import (
+    AnimationState,
+    ANIMATION_BOX_HEIGHT,
+    COMMAND_SEQUENCE,
+    PIPELINE_STAGES,
+    STAGE_ENTRY,
+    STAGE_INSPECT,
+    STAGE_PLAN,
+    STAGE_EXECUTE,
+    STAGE_OUTPUT,
+    _render_animation_frame,
+    _render_phase_rail,
+    _render_step_strip,
+    stage_for_function,
+)
+
+PATHS = ("p.prompt", "c.py", "e.py", "t.py")
+
+
+def _render_lines(state: AnimationState, width: int = 80):
+    console = Console(width=width)
+    with console.capture() as cap:
+        console.print(_render_animation_frame(state, width), end="")
+    return [ln for ln in cap.get().split("\n") if ln != ""]
+
+
+class TestStageMapping:
+    """stage_for_function classifies every orchestrator signal correctly."""
+
+    def test_initializing_is_inspect(self):
+        # Entry (arg parse) is done by the time the main frame renders.
+        assert stage_for_function("initializing") == STAGE_INSPECT
+
+    def test_checking_is_plan(self):
+        assert stage_for_function("checking") == STAGE_PLAN
+
+    def test_operations_are_execute(self):
+        for op in ["auto-deps", "generate", "example", "verify", "crash",
+                   "test", "test_extend", "fix", "update"]:
+            assert stage_for_function(op) == STAGE_EXECUTE, op
+
+    def test_terminal_states_are_output(self):
+        for fn in ["synced", "nothing", "all_synced", "conflict", "error",
+                   "fail_and_request_manual_merge"]:
+            assert stage_for_function(fn) == STAGE_OUTPUT, fn
+
+    def test_unknown_defaults_to_execute(self):
+        # A future/unknown operation name is still command execution, never a
+        # fake stage.
+        assert stage_for_function("some_new_op") == STAGE_EXECUTE
+
+    def test_blank_and_none_are_entry_inspect(self):
+        assert stage_for_function("") == STAGE_INSPECT
+        assert stage_for_function(None) == STAGE_INSPECT
+
+    def test_pipeline_has_all_five_stages_in_order(self):
+        ids = [s[0] for s in PIPELINE_STAGES]
+        assert ids == [STAGE_ENTRY, STAGE_INSPECT, STAGE_PLAN,
+                       STAGE_EXECUTE, STAGE_OUTPUT]
+
+
+class TestExecutedStepProgression:
+    """The step strip records completed execute-loop steps as ops change."""
+
+    def test_steps_accumulate_in_order(self):
+        state = AnimationState(basename="m", budget=5.0)
+        for fn in ["initializing", "auto-deps", "generate", "example",
+                   "verify", "test", "fix", "update"]:
+            state.update_dynamic_state(fn, 0.0, *PATHS)
+        # Every prior execute op (canonicalized) is marked done; the current
+        # op (update) is not yet in the completed set.
+        assert state.executed_steps == [
+            "auto-deps", "generate", "example", "verify", "test", "fix"
+        ]
+
+    def test_aliases_collapse_onto_canonical_slot(self):
+        state = AnimationState(basename="m", budget=5.0)
+        # crash is the failure face of verify; test_extend continues test.
+        for fn in ["generate", "crash", "verify", "test", "test_extend", "fix"]:
+            state.update_dynamic_state(fn, 0.0, *PATHS)
+        assert "verify" in state.executed_steps
+        assert "test" in state.executed_steps
+        assert "crash" not in state.executed_steps
+        assert "test_extend" not in state.executed_steps
+
+    def test_non_execute_states_do_not_pollute_steps(self):
+        state = AnimationState(basename="m", budget=5.0)
+        for fn in ["initializing", "checking", "synced"]:
+            state.update_dynamic_state(fn, 0.0, *PATHS)
+        assert state.executed_steps == []
+
+
+class TestFrameRendering:
+    """Every frame is a fixed-height, non-crashing render at any width."""
+
+    def test_height_is_stable_across_stages_and_widths(self):
+        for fn in ["initializing", "checking", "generate", "verify", "crash",
+                   "test", "update", "synced", "conflict", "error"]:
+            for width in [20, 30, 44, 80, 120, 160]:
+                state = AnimationState(basename="calculator", budget=None)
+                state.update_dynamic_state(fn, 0.42, *PATHS)
+                state.frame_count = 3
+                lines = _render_lines(state, width)
+                assert len(lines) == ANIMATION_BOX_HEIGHT, (
+                    f"{fn} @ {width}: {len(lines)} lines"
+                )
+
+    def test_rail_shows_current_stage_label(self):
+        state = AnimationState(basename="m", budget=5.0)
+        state.update_dynamic_state("generate", 0.0, *PATHS)
+        rail = _render_phase_rail(state, blink_on=True).plain
+        # All five stage labels are present; Execute is the current one.
+        for _id, label, _sub in PIPELINE_STAGES:
+            assert label in rail
+
+    def test_step_strip_marks_current_and_done(self):
+        state = AnimationState(basename="m", budget=5.0)
+        for fn in ["auto-deps", "generate", "example", "verify"]:
+            state.update_dynamic_state(fn, 0.0, *PATHS)
+        strip = _render_step_strip(state, blink_on=True).plain
+        assert "deps" in strip and "verify" in strip
+        # Done steps get a check, the active probe step gets a probe glyph.
+        assert "✓" in strip
+        assert "◈" in strip
+
+    def test_execute_frame_shows_artifact_boxes(self):
+        state = AnimationState(basename="m", budget=5.0)
+        state.update_dynamic_state("generate", 0.0, *PATHS)
+        text = "\n".join(_render_lines(state, 80))
+        for box in ["Prompt", "Code", "Example", "Tests"]:
+            assert box in text
+
+    def test_output_frame_shows_completion(self):
+        state = AnimationState(basename="m", budget=5.0)
+        state.update_dynamic_state("synced", 0.0, *PATHS)
+        text = "\n".join(_render_lines(state, 80))
+        assert "Outputs" in text
+        assert "complete" in text.lower()
+
+    def test_command_sequence_matches_step_labels(self):
+        # Guard against the strip and sequence drifting apart.
+        assert COMMAND_SEQUENCE == [
+            "auto-deps", "generate", "example", "verify", "test", "fix", "update"
+        ]


### PR DESCRIPTION
## Workstream 6 — Sync & checkup animation improvements

Part of **EPIC #1560** (Design refresh, Phase 2). Redesigns the `pdd sync`
animation so its motion follows the real execution pipeline from the system-flow
diagram, instead of only showing the four-box artifact org-chart.

### How it maps to the system-flow diagram
The diagram's runtime subgraphs become an explicit pipeline. Subgraph 5
("validation seams") is test-only and is never animated.

| Diagram subgraph | Animation |
|---|---|
| 1. CLI entry & options | High-level **stage card** (Entry) |
| 2. State inspection | High-level **stage card** (Inspect — lock · fingerprint · files · hashes) |
| 3. Operation planner | High-level **stage card** (Plan — determine next operation) |
| 4. Command execution loop | **Expanded detail**: command step strip + artifact graph + live arrow/probe flow |
| 6. Outputs | High-level **stage card** (Output — artifacts · fingerprint · report) |

The framing stages stay clean and box-based; the **command-execution stage is
expanded** because that's where the user spends time and money.

### What changed
- **Phase model (`stage_for_function`)** — maps every value the orchestrator
  writes into `current_function_name` (`initializing`, `checking`, the
  operations, `synced`/`conflict`/`error`) onto a pipeline stage
  `Entry → Inspect → Plan → Execute → Output`. This is the single source of
  truth tying motion to *real* execution — no decorative/fake stages.
- **Always-on phase rail** showing progression (done ● / current ◆ / pending ○).
- **High-level stage cards** for entry/inspect/plan/output, naming the stage and
  its sub-steps, with a live status line (and success/warning/error coloring on
  the output card).
- **Expanded execute view**: a command **step strip**
  (`deps · gen · ex · verify · test · fix · upd`) with done/active markers, where
  **probe** steps (`verify`/`test`) and **crashes** read distinctly — on top of
  the existing artifact graph and animated arrow/probe flow.
- Builds on the Phase 1 **`cli_theme`** palette (with a graceful fallback so the
  module still works on this integration branch, which predates Phase 1).

### Faithfulness / no fake stages
- Stages are derived from the orchestrator's own `current_function_name`; the
  rail can only show a stage the run is actually in.
- The step strip's "done" marks are populated as real operations are observed
  (`crash`→`verify`, `test_extend`→`test` collapse onto their canonical slot).

### Compatibility
- Frame stays a fixed **18 rows**, preserving the logo→sync transition.
- `_draw_connecting_lines_and_arrows` still returns its **6-line** contract; the
  re-exported `DEEP_NAVY`/`ELECTRIC_CYAN` used by `sync_tui` are unchanged.

### Tests
- All existing `test_sync_animation*` (16) and `test_sync_tui` (24) pass.
- New `tests/test_sync_animation_phases.py` pins the stage mapping, step-strip
  progression (including alias collapse), probe/crash markers, and crash-free
  fixed-height rendering across widths **20–160**, plus failure/partial states.

### Tradeoffs
- Entry is shown as already-complete once the main frame renders (arg parsing
  finishes during the logo intro), so `initializing` maps to **Inspect**.
- Non-execute stages are brief in a real run, so the bulk of screen time is the
  expanded execute view — by design, per the issue's "core focus."

🤖 Generated with [Claude Code](https://claude.com/claude-code)