### PR TITLE
fix(agentic): fail closed on symlink loop resolution

### DIFF
--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -609,6 +609,9 @@ def _resolve_symlink_target_path(
         target_path = link_path.parent / target_path
     try:
         target_path.resolve(strict=True)
+    except RuntimeError as exc:
+        errors.append(f"{link_path}: symlink loop while resolving {raw_target}: {exc}")
+        return None
     except OSError as exc:
         if getattr(exc, "errno", None) == errno.ELOOP:
             errors.append(f"{link_path}: symlink loop while resolving {raw_target}: {exc}")


### PR DESCRIPTION
## Summary

Fixes #1627, a PR #1582 CI failure in the agentic filesystem policy audit.

Python 3.12 can raise RuntimeError from Path.resolve(strict=True) when a symlink loop is encountered. The audit already treats symlink loops as fail-closed policy audit errors, but only caught RuntimeError on the later strict=False resolve path. This catches the strict=True RuntimeError too and records it in the existing audit error path.

## Validation

- pytest tests/test_agentic_common.py::test_run_agentic_task_claude_policy_fails_closed_on_symlink_loop tests/test_agentic_common.py::test_run_agentic_task_claude_policy_fails_closed_on_root_parent_loop -q -> 2 passed.

Targets epic/1431-task-routing-v1 because this blocks EPIC PR #1582 CI.