### PR TITLE
Make the enhanced CLI experience the default (EPIC #1540)

### DIFF
--- a/docs/design/EPIC-1540-design-refresh.md
+++ b/docs/design/EPIC-1540-design-refresh.md
@@ -37,6 +37,34 @@ Terminal captures of the merged workstreams (PRs 1–3) live in
 
 Legend: ✅ merged · 🟡 in progress · ⬜ not started
 
+## Enhanced experience is the default (no flags required)
+
+Phase 1 landed the *infrastructure* — the brand palette (`pdd/cli_theme.py`),
+the status primitives (`pdd/cli_status.py`), and the revamped `pdd context`
+usage box — but several surfaces still defaulted to the pre-refresh look. This
+follow-up makes the enhanced experience the **default**, so users get it without
+opting in via any flag:
+
+- **Color system, on by default.** The shared CLI console (`pdd/core/errors.py`,
+  re-exported as `pdd.console` and used by the command-execution summary,
+  `pdd update`, `pdd templates`, and other base commands) now renders every
+  semantic role from the central brand palette in `pdd/cli_theme.py` instead of
+  an ad-hoc per-module theme. `[command]`/`[success]`/`[error]` markup that was
+  already in place across the CLI now resolves to the brand colors automatically.
+- **Consistent status vocabulary, on by default.** The per-step *Command
+  Execution Summary* (`pdd/core/cli.py`) now prefixes each step with the shared
+  `cli_status` glyphs — `✓` for success, `✗` for failure — in their semantic
+  roles, so chained commands end with the same SUCCESS/FAILURE shorthand the
+  rest of the refresh uses.
+- **`pdd context` revamped view, on by default.** The Claude-Code-style usage
+  box is the no-flag default (`--table`/`--json` remain opt-in); color
+  auto-enables on a TTY and respects `NO_COLOR` / `--no-color`. Locked by
+  `tests/commands/test_context.py::test_default_output_is_context_usage_box`.
+
+Remaining ad-hoc `Console()` instances in individual command modules are left
+for incremental adoption of `pdd.cli_theme.get_console()` and
+`pdd.cli_status.StatusReporter` (as already done in `detect_change`/`conflicts`).
+
 ## Phase 2 (split out to #1560)
 
 The remaining workstreams moved to **[#1560](https://github.com/promptdriven/pdd/issues/1560)**

--- a/docs/design/EPIC-1540-design-refresh.md
+++ b/docs/design/EPIC-1540-design-refresh.md
@@ -61,9 +61,27 @@ opting in via any flag:
   auto-enables on a TTY and respects `NO_COLOR` / `--no-color`. Locked by
   `tests/commands/test_context.py::test_default_output_is_context_usage_box`.
 
+### Limiting color: a global `--color` / `--no-color`
+
+Color is the default, and a single global flag on the root `pdd` command lets a
+user force or disable it across **every** command (not just `pdd context`):
+
+- `pdd --no-color …` disables color everywhere; `pdd --color …` forces it on
+  even through a pipe (`pdd --color sync | less -R`).
+- Default is auto: color on a TTY, off when piped or when `NO_COLOR` is set.
+- Precedence for `pdd context` (which keeps its own `--color/--no-color`): the
+  command's own flag wins, else the global flag, else auto-detect.
+- Implementation (`pdd.core.errors.apply_color_preference`): sets
+  `NO_COLOR` / `FORCE_COLOR` so every console built during the run inherits the
+  choice (including `get_console`/`StatusReporter` and per-command consoles),
+  and updates the already-constructed shared console(s) in place. No per-command
+  plumbing was required.
+
 Remaining ad-hoc `Console()` instances in individual command modules are left
 for incremental adoption of `pdd.cli_theme.get_console()` and
-`pdd.cli_status.StatusReporter` (as already done in `detect_change`/`conflicts`).
+`pdd.cli_status.StatusReporter` (as already done in `detect_change`/`conflicts`);
+because they read `NO_COLOR`/`FORCE_COLOR` at construction, they already honor
+the global flag.
 
 ## Phase 2 (split out to #1560)
 

--- a/pdd/commands/context.py
+++ b/pdd/commands/context.py
@@ -365,7 +365,15 @@ def context(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         # does not second-guess us: click strips ANSI on a non-TTY by default,
         # which would drop color from a forced ``--color`` run, and would keep
         # it on a TTY even when we chose to suppress it.
-        use_color = _color_enabled(color, sys.stdout)
+        #
+        # Precedence: this command's own ``--color/--no-color`` wins; otherwise
+        # inherit the global ``pdd --color/--no-color`` preference (ctx.obj);
+        # otherwise auto-detect. This keeps ``pdd --color context …`` consistent
+        # with the rest of the CLI even through a pipe.
+        color_pref = color
+        if color_pref is None and isinstance(ctx.obj, dict):
+            color_pref = ctx.obj.get("color")
+        use_color = _color_enabled(color_pref, sys.stdout)
         paint = _make_painter(use_color)
         if table_output:
             rendered = _render_table(audit, paint)

--- a/pdd/core/cli.py
+++ b/pdd/core/cli.py
@@ -20,7 +20,7 @@ from ..auto_update import auto_update
 from ..cli_branding import PDD_FULL_TAGLINE, PDD_POSITIONING
 from ..construct_paths import list_available_contexts
 from ..install_completion import get_local_pdd_path
-from .errors import console, handle_error, clear_core_dump_errors
+from .errors import console, handle_error, clear_core_dump_errors, apply_color_preference
 from ..cli_status import GLYPHS as _STATUS_GLYPHS, Status as _Status
 from .utils import _first_pending_command, _should_show_onboarding_reminder
 
@@ -554,6 +554,14 @@ class PDDCLI(click.Group):
     help="Decrease output verbosity for minimal information.",
 )
 @click.option(
+    "--color/--no-color",
+    "color",
+    default=None,
+    help="Force or disable colored output across all commands. "
+    "Default: auto (color on a TTY, off when piped or when NO_COLOR is set). "
+    "--no-color disables it everywhere; --color forces it even through a pipe.",
+)
+@click.option(
     "--output-cost",
     type=click.Path(dir_okay=False, writable=True),
     default=None,
@@ -645,6 +653,7 @@ def cli(
     temperature: float,
     verbose: bool,
     quiet: bool,
+    color: Optional[bool],
     output_cost: Optional[str],
     estimate: bool,
     estimate_json: bool,
@@ -705,6 +714,11 @@ def cli(
         os.environ["PDD_QUIET"] = "1"
     else:
         os.environ.pop("PDD_QUIET", None)
+    # Color is the default (auto-detected); --color/--no-color lets the user force
+    # or disable it across every command. Apply it before any console output below
+    # so the choice covers the whole run, including later-constructed consoles.
+    ctx.obj["color"] = color
+    apply_color_preference(color)
     ctx.obj["estimate"] = estimate_mode
     ctx.obj["estimate_json"] = bool(estimate_json)
     ctx.obj["estimate_results"] = []

--- a/pdd/core/cli.py
+++ b/pdd/core/cli.py
@@ -21,7 +21,13 @@ from ..cli_branding import PDD_FULL_TAGLINE, PDD_POSITIONING
 from ..construct_paths import list_available_contexts
 from ..install_completion import get_local_pdd_path
 from .errors import console, handle_error, clear_core_dump_errors
+from ..cli_status import GLYPHS as _STATUS_GLYPHS, Status as _Status
 from .utils import _first_pending_command, _should_show_onboarding_reminder
+
+# Shared status glyphs (EPIC #1540, workstream 2) so the per-step execution
+# summary speaks the same SUCCESS/FAILURE vocabulary as every other command.
+_OK_GLYPH = _STATUS_GLYPHS[_Status.SUCCESS]   # ✓
+_FAIL_GLYPH = _STATUS_GLYPHS[_Status.FAILURE]  # ✗
 from .duplicate_cli_guard import check_duplicate_before_subcommand, record_after_guarded_command
 
 
@@ -986,16 +992,16 @@ def process_commands(ctx: click.Context, results: List[Optional[Tuple[Any, float
             if not ctx.obj.get("quiet") and not suppress_result_summary:
                 # Check if it was install_completion (which normally returns None)
                 if command_name == "install_completion":
-                    console.print(f"  [info]Step {i+1} ({command_name}):[/info] Command completed.")
+                    console.print(f"  [success]{_OK_GLYPH}[/success] [info]Step {i+1} ({command_name}):[/info] Command completed.")
                 # If command name is unknown, and it might be install_completion which prints its own status
                 elif command_name.startswith("Unknown Command"):
                     console.print(f"  [info]Step {i+1} ({command_name}):[/info] Command executed (see output above for status details).")
                 # Check if it was preprocess (which returns a dummy tuple on success)
                 # This case handles actual failure for preprocess
                 elif command_name == "preprocess":
-                    console.print(f"  [error]Step {i+1} ({command_name}):[/error] Command failed.")
+                    console.print(f"  [error]{_FAIL_GLYPH}[/error] [error]Step {i+1} ({command_name}):[/error] Command failed.")
                 else:
-                    console.print(f"  [error]Step {i+1} ({command_name}):[/error] Command failed.")
+                    console.print(f"  [error]{_FAIL_GLYPH}[/error] [error]Step {i+1} ({command_name}):[/error] Command failed.")
         # Check if the result is the expected tuple structure from @track_cost or preprocess success
         elif isinstance(result_tuple, tuple) and len(result_tuple) == 3:
             result_data, cost, model_name = result_tuple
@@ -1004,7 +1010,7 @@ def process_commands(ctx: click.Context, results: List[Optional[Tuple[Any, float
                 # Special handling for preprocess success message (check actual command name)
                 actual_command_name = invoked_subcommands[i] if i < num_commands else None # Get actual name if possible
                 if actual_command_name == "preprocess" and cost == 0.0 and model_name == "local":
-                    console.print(f"  [info]Step {i+1} ({command_name}):[/info] Command completed (local).")
+                    console.print(f"  [success]{_OK_GLYPH}[/success] [info]Step {i+1} ({command_name}):[/info] Command completed (local).")
                 else:
                     # Generic output using potentially "Unknown Command" name.
                     # Suppress the Model: segment when no model was used (zero-cost
@@ -1013,9 +1019,9 @@ def process_commands(ctx: click.Context, results: List[Optional[Tuple[Any, float
                     # blank "Model: " label (#1103).
                     model_repr = (model_name or "").strip()
                     if model_repr and model_repr.lower() not in {"unknown", "n/a", "none", "skipped"}:
-                        console.print(f"  [info]Step {i+1} ({command_name}):[/info] Cost: ${cost:.6f}, Model: {model_repr}")
+                        console.print(f"  [success]{_OK_GLYPH}[/success] [info]Step {i+1} ({command_name}):[/info] Cost: ${cost:.6f}, Model: {model_repr}")
                     else:
-                        console.print(f"  [info]Step {i+1} ({command_name}):[/info] Cost: ${cost:.6f}")
+                        console.print(f"  [success]{_OK_GLYPH}[/success] [info]Step {i+1} ({command_name}):[/info] Cost: ${cost:.6f}")
                 
                 # Display examples used for grounding
                 if isinstance(result_data, dict) and result_data.get("examplesUsed"):
@@ -1028,7 +1034,7 @@ def process_commands(ctx: click.Context, results: List[Optional[Tuple[Any, float
         # Handle dicts with examplesUsed (e.g. from commands not using track_cost but returning metadata)
         elif isinstance(result_tuple, dict) and result_tuple.get("examplesUsed"):
             if not ctx.obj.get("quiet") and not suppress_result_summary:
-                console.print(f"  [info]Step {i+1} ({command_name}):[/info] Command completed.")
+                console.print(f"  [success]{_OK_GLYPH}[/success] [info]Step {i+1} ({command_name}):[/info] Command completed.")
                 console.print("    Examples used:")
                 for ex in result_tuple["examplesUsed"]:
                     slug = ex.get("slug", "unknown")

--- a/pdd/core/errors.py
+++ b/pdd/core/errors.py
@@ -2,6 +2,7 @@
 Error handling logic for PDD CLI.
 """
 import os
+import sys
 import traceback
 from typing import Any, Dict, List, Optional
 import click
@@ -29,6 +30,67 @@ from ..cli_theme import SEMANTIC_STYLES
 
 custom_theme = Theme(SEMANTIC_STYLES)
 console = Console(theme=custom_theme)
+
+
+def _set_console_color(con: Console, enabled: bool) -> None:
+    """Force or disable color on an already-constructed Rich console.
+
+    Color is cosmetic, so any failure poking Rich internals is swallowed rather
+    than allowed to break a command.
+    """
+    try:
+        if enabled:
+            con.no_color = False
+            con._force_terminal = True  # render color even when piped / non-TTY
+            if getattr(con, "_color_system", None) is None:
+                from rich.color import ColorSystem
+                truecolor = os.environ.get("COLORTERM", "").strip().lower() in (
+                    "truecolor",
+                    "24bit",
+                )
+                con._color_system = (
+                    ColorSystem.TRUECOLOR if truecolor else ColorSystem.EIGHT_BIT
+                )
+        else:
+            con.no_color = True
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def apply_color_preference(preference: Optional[bool]) -> None:
+    """Apply the global ``--color`` / ``--no-color`` preference for this run.
+
+    ``preference`` is ``True`` (force color even when piped), ``False`` (disable
+    color everywhere), or ``None`` (auto: color on a TTY, off when piped or when
+    ``NO_COLOR`` is set — the default, so omitting the flag changes nothing).
+
+    The choice is wired two ways so it reaches every surface:
+
+    * The ``NO_COLOR`` / ``FORCE_COLOR`` environment variables are set, which
+      every Rich console constructed *after* this point honors automatically —
+      ``pdd.cli_theme.get_console`` (and thus every ``StatusReporter``), plus the
+      per-command ad-hoc consoles.
+    * The shared consoles already built at import time (this module's
+      :data:`console`, and ``pdd.update_main.console`` if it is loaded) are
+      updated in place, since they captured their color state before the flag
+      was parsed.
+    """
+    if preference is None:
+        return
+    if preference:
+        os.environ.pop("NO_COLOR", None)
+        os.environ["FORCE_COLOR"] = "1"
+    else:
+        os.environ.pop("FORCE_COLOR", None)
+        os.environ["NO_COLOR"] = "1"
+
+    _set_console_color(console, preference)
+    # Mutate sibling shared consoles only if their module is already imported;
+    # ones imported later inherit the choice from the env vars set above.
+    update_main = sys.modules.get("pdd.update_main")
+    sibling = getattr(update_main, "console", None) if update_main else None
+    if isinstance(sibling, Console):
+        _set_console_color(sibling, preference)
 
 # Buffer to collect errors for optional core dumps
 _core_dump_errors: List[Dict[str, Any]] = []

--- a/pdd/core/errors.py
+++ b/pdd/core/errors.py
@@ -17,15 +17,17 @@ except ImportError:
         return None
 
 # --- Initialize Rich Console ---
-# Define a custom theme for consistent styling
-custom_theme = Theme({
-    "info": "cyan",
-    "warning": "yellow",
-    "error": "bold red",
-    "success": "green",
-    "path": "dim blue",
-    "command": "bold magenta",
-})
+# Brand color is the single source of truth (EPIC #1540, workstream 1). The
+# shared console renders every semantic role from the central palette in
+# ``pdd.cli_theme`` so the enhanced color system is the *default* across the
+# whole CLI — every existing ``[command]``/``[success]``/``[error]`` markup now
+# resolves to the brand palette instead of an ad-hoc per-module theme. The role
+# names below are a superset of the historical ones (``info``/``warning``/
+# ``error``/``success``/``path``/``command``), so existing call sites keep
+# working unchanged.
+from ..cli_theme import SEMANTIC_STYLES
+
+custom_theme = Theme(SEMANTIC_STYLES)
 console = Console(theme=custom_theme)
 
 # Buffer to collect errors for optional core dumps

--- a/pdd/update_main.py
+++ b/pdd/update_main.py
@@ -148,13 +148,11 @@ def _is_pddignored(filepath: str, pddignore_root: str, patterns: List[str]) -> b
                 return True
     return False
 
-custom_theme = Theme({
-    "info": "cyan",
-    "warning": "yellow",
-    "error": "bold red",
-    "success": "green",
-    "path": "dim blue",
-})
+# Use the central brand palette (EPIC #1540) so ``pdd update`` shares the same
+# enhanced color system as the rest of the CLI rather than a local ad-hoc theme.
+from .cli_theme import SEMANTIC_STYLES
+
+custom_theme = Theme(SEMANTIC_STYLES)
 console = Console(theme=custom_theme)
 
 def _extract_template_vars(concrete_path: str, template: str) -> Optional[Dict[str, str]]:

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -537,6 +537,93 @@ def test_shared_console_uses_brand_palette():
     assert ELECTRIC_CYAN.lower() in str(custom_theme.styles.get("command")).lower()
     assert BUILD_GREEN.lower() in str(custom_theme.styles.get("success")).lower()
 
+
+import io as _io
+from contextlib import contextmanager as _contextmanager
+
+
+@_contextmanager
+def _restore_shared_console_color():
+    """Snapshot/restore the shared console's color state and NO_COLOR/FORCE_COLOR
+    so a test that flips the global color preference never leaks into others."""
+    from pdd.core import errors as _errors
+
+    con = _errors.console
+    saved = (con.no_color, con._force_terminal, con._color_system, con.file)
+    saved_env = {k: os.environ.get(k) for k in ("NO_COLOR", "FORCE_COLOR")}
+    try:
+        yield con
+    finally:
+        con.no_color, con._force_terminal, con._color_system, con.file = saved
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _render(con):
+    buf = _io.StringIO()
+    con.file = buf
+    con.print("[command]pdd[/command]")
+    return buf.getvalue()
+
+
+def test_set_console_color_toggles_a_console():
+    """_set_console_color forces color on (even non-TTY) and strips it off."""
+    from rich.console import Console
+    from rich.theme import Theme
+    from pdd.core.errors import _set_console_color
+    from pdd.cli_theme import SEMANTIC_STYLES
+
+    con = Console(theme=Theme(SEMANTIC_STYLES), force_terminal=True)
+    _set_console_color(con, False)
+    assert "\x1b[" not in _render(con)
+    _set_console_color(con, True)
+    assert "\x1b[" in _render(con)
+
+
+def test_apply_color_preference_env_and_shared_console():
+    """The global preference sets NO_COLOR/FORCE_COLOR (so later-built consoles
+    inherit it) and updates the already-constructed shared console in place."""
+    from pdd.core import errors
+
+    with _restore_shared_console_color() as con:
+        errors.apply_color_preference(False)
+        assert os.environ.get("NO_COLOR") == "1"
+        assert "FORCE_COLOR" not in os.environ
+        assert con.no_color is True
+
+        errors.apply_color_preference(True)
+        assert os.environ.get("FORCE_COLOR") == "1"
+        assert "NO_COLOR" not in os.environ
+        assert con.no_color is False
+        assert "\x1b[" in _render(con)
+
+        # None is auto (the default) and must change nothing it was just set to.
+        errors.apply_color_preference(None)
+        assert os.environ.get("FORCE_COLOR") == "1"
+
+
+def test_cli_no_color_flag_disables_color(runner):
+    """`pdd --no-color …` flows through the group callback and disables color
+    globally (NO_COLOR set, shared console stripped) before any command runs."""
+    with _restore_shared_console_color() as con:
+        result = runner.invoke(cli_command, ["--no-color", "--list-contexts"])
+        assert result.exit_code == 0
+        assert os.environ.get("NO_COLOR") == "1"
+        assert con.no_color is True
+
+
+def test_cli_color_flag_forces_color(runner):
+    """`pdd --color …` forces color on (FORCE_COLOR set) even though the test
+    runner is not a TTY."""
+    with _restore_shared_console_color() as con:
+        result = runner.invoke(cli_command, ["--color", "--list-contexts"])
+        assert result.exit_code == 0
+        assert os.environ.get("FORCE_COLOR") == "1"
+        assert con.no_color is False
+
 @patch('pdd.core.cli.auto_update')
 @patch('pdd.commands.generate.code_generator_main')
 def test_user_cancellation_does_not_show_error_message_issue_186(mock_main, mock_auto_update, runner, tmp_path, monkeypatch):

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -506,6 +506,37 @@ def test_cli_result_callback_non_tuple_result_warning():
     summary = "\n".join(lines)
     assert "Step 1 (generate):[/warning] Unexpected result format: str" in summary
 
+
+def test_cli_summary_uses_shared_status_glyphs():
+    """EPIC #1540, workstream 2: the execution summary speaks the same
+    SUCCESS/FAILURE vocabulary as every other command, so each step line is
+    prefixed with the shared cli_status glyph (✓ for success, ✗ for failure)."""
+    from pdd.cli_status import GLYPHS, Status
+
+    ok, fail = GLYPHS[Status.SUCCESS], GLYPHS[Status.FAILURE]
+
+    # A successful (cost-bearing) step is marked with the success glyph.
+    success = "\n".join(_capture_summary(['generate'], ('code', 0.1, 'model-A')))
+    assert ok in success
+    assert f"[success]{ok}[/success]" in success
+
+    # A failed step (None result) is marked with the failure glyph.
+    failure = "\n".join(_capture_summary(['generate'], [None]))
+    assert fail in failure
+    assert f"[error]{fail}[/error]" in failure
+
+
+def test_shared_console_uses_brand_palette():
+    """EPIC #1540, workstream 1: the shared CLI console renders semantic roles
+    from the central brand palette by default (not an ad-hoc per-module theme),
+    so the enhanced color system is on without any flag."""
+    from pdd.core.errors import custom_theme
+    from pdd.cli_theme import ELECTRIC_CYAN, BUILD_GREEN
+
+    # 'command' is the hero role -> Electric-Cyan (brand), not the old magenta.
+    assert ELECTRIC_CYAN.lower() in str(custom_theme.styles.get("command")).lower()
+    assert BUILD_GREEN.lower() in str(custom_theme.styles.get("success")).lower()
+
 @patch('pdd.core.cli.auto_update')
 @patch('pdd.commands.generate.code_generator_main')
 def test_user_cancellation_does_not_show_error_message_issue_186(mock_main, mock_auto_update, runner, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Phase 1 (#1557) landed the design-refresh **infrastructure** — the brand palette (`pdd/cli_theme.py`), the status primitives (`pdd/cli_status.py`), and the revamped `pdd context` usage box — but several base surfaces still defaulted to the pre-refresh look, so users had to opt in. This follow-up makes the enhanced experience the **default**, with no flags required.

## What changes

- **Color system, on by default.** The shared CLI console (`pdd/core/errors.py`, re-exported as `pdd.console` and used by the command-execution summary, `pdd update`, `pdd templates`, and other base commands) now renders every semantic role from the central brand palette in `pdd/cli_theme.py` instead of an ad-hoc per-module theme. Existing `[command]`/`[success]`/`[error]` markup across the CLI now resolves to the brand colors automatically. `update_main`'s near-duplicate theme points at the same palette.
- **Consistent status vocabulary, on by default.** The per-step *Command Execution Summary* (`pdd/core/cli.py`) now prefixes each step with the shared `cli_status` glyphs — `✓` for success, `✗` for failure — in their semantic roles, so chained commands end with the same SUCCESS/FAILURE shorthand the rest of the refresh uses.
- **`pdd context` revamped view, on by default.** The Claude-Code-style usage box is already the no-flag default (`--table`/`--json` stay opt-in; color auto-detects TTY / `NO_COLOR`). This is confirmed/locked by `test_default_output_is_context_usage_box`.

## Safety / compatibility

- The role names in the rebranded theme are a **superset** of the historical ones (`info`/`warning`/`error`/`success`/`path`/`command`), so existing call sites and the summary's exact-substring test assertions are unchanged — the status glyphs are *prepended* to summary lines, never replacing existing markup.
- No circular imports: `cli_theme`/`cli_status` import only `rich` (+ `cli_theme`), never `core`.

## Tests

- New: `test_shared_console_uses_brand_palette` (brand color is the default) and `test_cli_summary_uses_shared_status_glyphs` (✓/✗ in the summary).
- Existing `tests/core/test_cli.py` summary suite, `tests/commands/test_context.py`, `tests/test_commands_templates.py`, `tests/test_update_main.py`, `tests/test_cli_theme.py`, `tests/test_cli_status.py` all pass. (Pre-existing `auto_update`-related failures in `test_cli.py` are environment-only and unrelated to this change.)

Live render verification (truecolor): summary header in Electric-Cyan `#00D8FF`, `✓` in Build-Green `#18C07A`, `✗` in Break-Red `#F34842`.

Part of **EPIC #1540** (design refresh). Targets `epic/1540-design-refresh` per the EPIC's child-PR convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Opting out / limiting color

Color is the default; users limit it via the new global flag or the existing standard mechanisms:

- **Global flag (new in this PR):** `pdd --no-color …` disables color across **every** command; `pdd --color …` forces it on even through a pipe (`pdd --color sync | less -R`). Default is auto.
- **`NO_COLOR=1`** (the [no-color.org](https://no-color.org) standard) also disables color. The shared Rich console honors it, and PDD already relies on `NO_COLOR=1` internally (checkup/agentic/CI gates) to render plain.
- **Piped / non-TTY output is auto-plain:** redirecting or piping (`pdd … | tee`, CI logs) drops ANSI automatically — no flag needed. `FORCE_COLOR=1` is the inverse if you *want* color through a pipe.
- **`pdd context` keeps an explicit toggle:** `--color` / `--no-color` overrides auto-detection for that command; JSON output (`--json`) is always uncolored.
- **Silence the status/summary lines:** the global `--quiet` flag suppresses the per-step status messaging and the execution summary entirely (machine-readable stdout is unaffected).

**Precedence for `pdd context`** (which keeps its own `--color/--no-color`): the command's own flag wins, then the global `pdd --color/--no-color`, then auto-detect. The global flag is implemented in `pdd.core.errors.apply_color_preference` — it sets `NO_COLOR`/`FORCE_COLOR` (so every console built during the run inherits it) and updates the already-constructed shared console(s) in place, so no per-command plumbing was needed.


