### PR TITLE
feat(sync): spell out execute sub-commands in the animation step strip (EPIC #1560)

### DIFF
--- a/demo_sync_animation.py
+++ b/demo_sync_animation.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Demo harness for the redesigned `pdd sync` animation (issue #1560, w6).
+
+Modes:
+
+    python demo_sync_animation.py                # live: play the animation in-terminal
+    python demo_sync_animation.py --width 50     # ...forced to a narrow width
+    python demo_sync_animation.py --storyboard   # print one frame per lifecycle stage
+    python demo_sync_animation.py --strip        # compare the step strip across widths
+
+The live mode drives AnimationState through a realistic sync lifecycle
+(initialize -> inspect -> plan -> auto-deps -> generate -> example -> verify ->
+crash -> test -> fix -> update -> synced), advancing several frames per stage so
+arrows, blinks and probe pulses are visible. No LLM calls, no cost — it only
+feeds the renderer canned state, exactly the way the orchestrator would.
+
+The `--strip` mode is the quickest way to verify the execute sub-commands are
+spelt out in full and that the strip resizes (tighter separators) and finally
+rotates (marquee) as the terminal narrows — it prints the strip at a ladder of
+widths, and animates the marquee at a narrow width so the rotation is visible.
+"""
+from __future__ import annotations
+
+import sys
+import time
+
+from rich.console import Console
+
+from pdd import sync_animation as sa
+
+PATHS = (
+    "prompts/calculator_python.prompt",
+    "src/calculator.py",
+    "examples/calculator_example.py",
+    "tests/test_calculator.py",
+)
+
+# (function_name, frames_to_dwell, cost_at_stage)
+LIFECYCLE = [
+    ("initializing", 12, 0.00),
+    ("checking",     10, 0.00),
+    ("auto-deps",    20, 0.04),
+    ("generate",     24, 0.31),
+    ("example",      20, 0.46),
+    ("verify",       24, 0.58),
+    ("crash",        16, 0.58),
+    ("fix",          20, 0.79),
+    ("test",         20, 1.02),
+    ("fix",          18, 1.21),
+    ("update",       18, 1.40),
+    ("synced",       14, 1.40),
+]
+
+
+def _new_state() -> sa.AnimationState:
+    state = sa.AnimationState(basename="calculator", budget=5.00)
+    state.set_box_colors(sa.LUMEN_PURPLE, sa.ELECTRIC_CYAN, sa.BUILD_GREEN, sa.PROMPT_MAGENTA)
+    return state
+
+
+def run_live(width: int | None = None) -> None:
+    from rich.live import Live
+
+    console = Console()
+    forced = width is not None
+    state = _new_state()
+    with Live(console=console, refresh_per_second=12, screen=False) as live:
+        for fn, dwell, cost in LIFECYCLE:
+            for _ in range(dwell):
+                state.update_dynamic_state(fn, cost, *PATHS)
+                # Re-read the terminal width each frame (unless --width forces
+                # one), mirroring the real orchestrator — resize the window
+                # mid-run and the step strip resizes/rotates live.
+                frame_width = width if forced else min(96, console.width or 80)
+                live.update(sa._render_animation_frame(state, frame_width))
+                time.sleep(1 / 12)
+    console.print("[bold #18C07A]✓ demo complete[/]  (this was canned state — no sync ran)")
+
+
+def run_storyboard() -> None:
+    console = Console(width=82)
+    # Use one state so the step strip accumulates "done" marks like a real run.
+    state = _new_state()
+    # Pick a mid-animation frame so arrows are visible, not at rest.
+    for fn, _dwell, cost in LIFECYCLE:
+        for f in range(6):  # advance a few frames so the arrow leaves the box
+            state.update_dynamic_state(fn, cost, *PATHS)
+            state.frame_count = f + 3
+        with console.capture() as cap:
+            console.print(sa._render_animation_frame(state, 82), end="")
+        title = f" stage: {sa.stage_for_function(fn):8}  function_name = {fn!r} "
+        console.rule(title)
+        print("\n".join(l.rstrip() for l in cap.get().split("\n") if l != ""))
+        print()
+
+
+def _strip_tier(state: sa.AnimationState, content_width: int) -> str:
+    """Name which adaptive tier the strip lands in at a given width."""
+    for i, sep in enumerate(sa._STRIP_SEPARATORS):
+        if len(sa._step_strip_cells(state, True, sep)) <= content_width:
+            return "full" if i == 0 else "resized"
+    return "rotating"
+
+
+def run_strip() -> None:
+    """Show the command step strip across a ladder of terminal widths.
+
+    Builds a mid-run state (a few steps done, a probe step active) so the strip
+    carries checks and a probe glyph, then renders it at each width and labels
+    which tier engaged: full names, resized (tighter separators), or rotating.
+    """
+    console = Console()
+    state = _new_state()
+    for fn in ["auto-deps", "generate", "example", "verify"]:
+        state.update_dynamic_state(fn, 0.58, *PATHS)
+
+    # Ladder of simulated widths, capped to the real terminal so no row wraps;
+    # always includes the current terminal width plus narrower steps so the
+    # full -> resized -> rotating progression is visible.
+    term = console.width or 80
+    widths = []
+    for w in (term, 100, 80, 64, 50, 40, 30, 24):
+        if 24 <= w <= term and w not in widths:
+            widths.append(w)
+
+    console.rule("[bold]step strip vs. terminal width[/]")
+    for width in widths:
+        content_width = max(10, width - 4)
+        strip = sa._render_step_strip(state, True, content_width)
+        tier = _strip_tier(state, content_width)
+        # Render the strip inside a console clamped to its own width so it reads
+        # the same regardless of the real terminal; print it on its own line so
+        # the label never pushes it past the edge.
+        sub = Console(width=content_width)
+        with sub.capture() as cap:
+            sub.print(strip, end="")
+        line = cap.get().split("\n")[0]
+        console.print(f"[dim]── simulated width {width:>3}  ({tier})[/]")
+        console.print("  " + line)
+
+    # Animate the marquee at a narrow width so the rotation is visible.
+    console.rule("[bold]marquee rotation @ width 34 (12 frames)[/]")
+    marquee_state = _new_state()
+    for fn in ["auto-deps", "generate"]:
+        marquee_state.update_dynamic_state(fn, 0.31, *PATHS)
+    for _ in range(12):
+        console.print("  ", sa._render_step_strip(marquee_state, True, 30))
+        time.sleep(0.18)
+    console.print("\n[bold #18C07A]✓ strip demo complete[/]  (canned state — no sync ran)")
+
+
+if __name__ == "__main__":
+    if "--storyboard" in sys.argv:
+        run_storyboard()
+    elif "--strip" in sys.argv:
+        run_strip()
+    else:
+        width = None
+        if "--width" in sys.argv:
+            width = int(sys.argv[sys.argv.index("--width") + 1])
+        run_live(width)

--- a/pdd/sync_animation.py
+++ b/pdd/sync_animation.py
@@ -209,6 +209,10 @@ class AnimationState:
             "example": DEFAULT_EXAMPLE_COLOR, "tests": DEFAULT_TESTS_COLOR
         }
         self.scroll_offsets: Dict[str, int] = {"prompt": 0, "code": 0, "example": 0, "tests": 0}
+        # Horizontal marquee offset for the command step strip, used only when
+        # the fully-spelt-out strip is too wide for the terminal (see
+        # _render_step_strip). Advances one cell per rendered frame.
+        self.step_scroll_offset: int = 0
         self.path_box_content_width = 16 # Base chars for path inside its small box (will be dynamic)
         self.auto_deps_progress: int = 0  # Progress counter for auto-deps border thickening
 
@@ -558,17 +562,26 @@ _STAGE_TITLES = {
     STAGE_OUTPUT:  "Outputs",
 }
 
-# Short labels for the command step strip.
+# Labels for the command step strip. The execute sub-commands are spelt out in
+# full (issue #1560) — `auto-deps`, `generate`, … rather than `deps`, `gen`, …
+# — so the strip reads as the real CLI commands the loop runs. When the full
+# strip is too wide for the terminal it is first tightened (a compact separator)
+# and, failing that, rotated as a marquee so every step still scrolls past; see
+# _render_step_strip.
 _STEP_LABELS = {
-    "auto-deps": "deps",
-    "generate": "gen",
-    "example": "ex",
+    "auto-deps": "auto-deps",
+    "generate": "generate",
+    "example": "example",
     "verify": "verify",
     "test": "test",
     "fix": "fix",
-    "update": "upd",
+    "update": "update",
 }
 _PROBE_SLOTS = {"verify", "test"}  # canonical strip slots that are checks, not builds
+
+# Separators tried in order when fitting the strip to the available width: the
+# roomy one first, then a compact one. If neither fits the strip rotates.
+_STRIP_SEPARATORS = ("  ·  ", " · ")
 
 
 def _render_phase_rail(state: AnimationState, blink_on: bool) -> Text:
@@ -596,37 +609,88 @@ def _render_phase_rail(state: AnimationState, blink_on: bool) -> Text:
     return rail
 
 
-def _render_step_strip(state: AnimationState, blink_on: bool) -> Text:
-    """One-line strip of the command-execution loop with the active step lit.
+def _step_strip_cells(state: AnimationState, blink_on: bool,
+                      separator: str) -> List[Tuple[str, str]]:
+    """Build the command-execution strip as a flat list of (char, style) cells.
 
-    Done steps get a check, the active step pulses (probe steps carry a probe
-    glyph and turn red on a crash), and upcoming steps stay dim — so the user
-    sees intermediate steps and where the current operation sits in the loop.
+    Working in cells lets the renderer measure the strip's true width, choose a
+    separator that fits, and — when nothing fits — take a styled marquee window
+    without re-deriving any of the per-step coloring. Done steps get a check,
+    the active step pulses (probe steps carry a probe glyph and turn red on a
+    crash), and upcoming steps stay dim.
     """
     cur_op = state.current_function_name
     cur_slot = _STEP_ALIASES.get(cur_op, cur_op)
     is_crash = cur_op == "crash"
-    strip = Text(justify="center")
+    cells: List[Tuple[str, str]] = []
+
+    def add(segment: str, style: str) -> None:
+        cells.extend((ch, style) for ch in segment)
+
     for i, step in enumerate(COMMAND_SEQUENCE):
         if i > 0:
-            strip.append("  ·  ", style="dim " + ELECTRIC_CYAN)
+            add(separator, "dim " + ELECTRIC_CYAN)
         label = _STEP_LABELS.get(step, step)
         if step == cur_slot:
             if step in _PROBE_SLOTS:
                 marker = "◈" if blink_on else "◇"
                 style = f"bold {BREAK_RED}" if is_crash else f"bold {DIFF_YELLOW}"
-                strip.append(f"{marker} ", style=style)
-                strip.append(label, style=style)
+                add(f"{marker} ", style)
+                add(label, style)
             else:
                 glyph = "▸ " if blink_on else "▹ "
-                strip.append(glyph, style=f"bold {ELECTRIC_CYAN}")
-                strip.append(label, style=f"bold {ELECTRIC_CYAN}")
+                style = f"bold {ELECTRIC_CYAN}"
+                add(glyph, style)
+                add(label, style)
         elif step in state.executed_steps:
-            strip.append("✓ ", style=BUILD_GREEN)
-            strip.append(label, style=BUILD_GREEN)
+            add("✓ ", BUILD_GREEN)
+            add(label, BUILD_GREEN)
         else:
-            strip.append(label, style="dim " + ELECTRIC_CYAN)
-    return strip
+            add(label, "dim " + ELECTRIC_CYAN)
+    return cells
+
+
+def _cells_to_text(cells: List[Tuple[str, str]]) -> Text:
+    """Reassemble (char, style) cells into a single-line, crop-safe Text."""
+    text = Text(justify="center", no_wrap=True, overflow="crop")
+    for ch, style in cells:
+        text.append(ch, style=style or None)
+    return text
+
+
+def _render_step_strip(state: AnimationState, blink_on: bool,
+                       content_width: Optional[int] = None) -> Text:
+    """One-line strip of the command-execution loop with the active step lit.
+
+    The execute sub-commands are spelt out in full, so the user sees the real
+    commands the loop runs and where the current operation sits among them. The
+    strip adapts to the terminal so the full names stay legible at any width:
+
+    1. render it with the roomy separator if it fits;
+    2. otherwise tighten the separator (resize) and render if *that* fits;
+    3. otherwise rotate it as a marquee — a fixed-width window that scrolls one
+       cell per frame, looping through a small gap — so every step still
+       scrolls past on a narrow terminal instead of being silently cropped.
+
+    ``content_width`` is the cell budget for the strip; when omitted (e.g. unit
+    tests) the full strip is rendered untruncated.
+    """
+    if content_width is None or content_width <= 0:
+        return _cells_to_text(_step_strip_cells(state, blink_on, _STRIP_SEPARATORS[0]))
+
+    cells: List[Tuple[str, str]] = []
+    for separator in _STRIP_SEPARATORS:
+        cells = _step_strip_cells(state, blink_on, separator)
+        if len(cells) <= content_width:
+            return _cells_to_text(cells)
+
+    # Still too wide even tightened: rotate the (compact) strip as a marquee.
+    gap = [(" ", "")] * 4  # blank run so the loop seam reads as a gap, not a join
+    loop = cells + gap
+    offset = state.step_scroll_offset % len(loop)
+    window = (loop + loop)[offset:offset + content_width]
+    state.step_scroll_offset = (offset + 1) % len(loop)
+    return _cells_to_text(window)
 
 
 def _render_stage_card(state: AnimationState, console_width: int, blink_on: bool) -> Align:
@@ -794,9 +858,12 @@ def _render_animation_frame(state: AnimationState, console_width: int) -> Panel:
     rail = _render_phase_rail(state, blink_on)
 
     if state.current_stage == STAGE_EXECUTE:
+        # The strip lives inside the framed panel: subtract its border (2 cells)
+        # and horizontal padding (2 cells) to get the real cell budget.
+        strip_width = max(10, console_width - 4)
         body_layout.split_column(
             Layout(rail, name="rail", size=1),
-            Layout(_render_step_strip(state, blink_on), name="step_strip", size=1),
+            Layout(_render_step_strip(state, blink_on, strip_width), name="step_strip", size=1),
             Layout(_build_artifact_graph(state, console_width, blink_on), name="graph", ratio=1),
         )
     else:

--- a/tests/test_sync_animation_e2e.py
+++ b/tests/test_sync_animation_e2e.py
@@ -1,0 +1,156 @@
+"""End-to-end test for the sync-animation step strip (issue #1560).
+
+This drives the *real* CLI data path rather than calling the renderer in
+isolation. In production the chain is:
+
+    sync_orchestration  →  mutable refs (function_name_ref, cost_ref, …)
+                        →  SyncApp.update_animation reads the refs each tick
+                        →  AnimationState.update_dynamic_state(…)
+                        →  _render_animation_frame(state, width)
+                        →  _render_step_strip(…)
+
+`_drive_lifecycle` reproduces that loop exactly (see SyncApp.update_animation in
+sync_tui.py: read refs → set_box_colors → update_dynamic_state → render at the
+app width), walks a realistic sync lifecycle, and captures the actual rendered
+frames. We assert the execute sub-commands are spelt out in full and that the
+strip adapts to width without ever breaking the fixed-height frame:
+
+* wide terminal  → full names, roomy separators;
+* 80-col floor   → resized (tighter separators) — the tier the Textual app hits
+  at its _min_ui_width floor;
+* narrow         → rotating marquee, never overflowing one line.
+"""
+
+from rich.console import Console
+
+from pdd.sync_animation import (
+    AnimationState,
+    ANIMATION_BOX_HEIGHT,
+    COMMAND_SEQUENCE,
+    STAGE_EXECUTE,
+    _render_animation_frame,
+    stage_for_function,
+    DEFAULT_PROMPT_COLOR,
+    DEFAULT_CODE_COLOR,
+    DEFAULT_EXAMPLE_COLOR,
+    DEFAULT_TESTS_COLOR,
+)
+
+# The function-name sequence the orchestrator emits over a realistic run:
+# entry → state inspection → planning → the full command-execution loop
+# (including a crash/fix detour) → terminal "synced".
+LIFECYCLE = [
+    "initializing", "checking",
+    "auto-deps", "generate", "example", "verify", "crash", "fix",
+    "test", "fix", "update",
+    "synced",
+]
+
+PATHS = (
+    "prompts/calculator_python.prompt",
+    "src/calculator.py",
+    "examples/calculator_example.py",
+    "tests/test_calculator.py",
+)
+
+
+def _render_frame_lines(state: AnimationState, width: int):
+    console = Console(width=width)
+    with console.capture() as cap:
+        console.print(_render_animation_frame(state, width), end="")
+    return [ln for ln in cap.get().split("\n") if ln != ""]
+
+
+def _drive_lifecycle(width: int):
+    """Run the orchestrator→SyncApp render loop for one terminal width.
+
+    Returns (state, frames) where frames is a list of (function_name, lines).
+    """
+    # The mutable refs are exactly what sync_orchestration constructs and the
+    # worker thread mutates; the UI thread only ever reads index [0].
+    function_name_ref = ["initializing"]
+    cost_ref = [0.0]
+    prompt_path_ref, code_path_ref = [PATHS[0]], [PATHS[1]]
+    example_path_ref, tests_path_ref = [PATHS[2]], [PATHS[3]]
+    color_refs = (
+        [DEFAULT_PROMPT_COLOR], [DEFAULT_CODE_COLOR],
+        [DEFAULT_EXAMPLE_COLOR], [DEFAULT_TESTS_COLOR],
+    )
+
+    state = AnimationState(basename="calculator", budget=5.00)
+    frames = []
+    cost = 0.0
+    for fn in LIFECYCLE:
+        function_name_ref[0] = fn
+        cost += 0.12
+        cost_ref[0] = cost
+        # Several ticks per stage, as the 0.05s app timer would fire.
+        for _ in range(6):
+            # --- mirror SyncApp.update_animation ---
+            state.set_box_colors(*(ref[0] for ref in color_refs))
+            state.update_dynamic_state(
+                function_name_ref[0], cost_ref[0],
+                prompt_path_ref[0], code_path_ref[0],
+                example_path_ref[0], tests_path_ref[0],
+            )
+            lines = _render_frame_lines(state, width)
+            frames.append((fn, lines))
+    return state, frames
+
+
+class TestSyncAnimationEndToEnd:
+    def test_every_frame_keeps_fixed_height_across_widths(self):
+        # The frame must stay ANIMATION_BOX_HEIGHT lines tall the whole run, at
+        # every width — proving the (possibly resized/rotating) strip never
+        # wraps to a second line.
+        for width in (120, 80, 50):
+            _state, frames = _drive_lifecycle(width)
+            for fn, lines in frames:
+                assert len(lines) == ANIMATION_BOX_HEIGHT, (
+                    f"width={width} fn={fn}: {len(lines)} lines"
+                )
+
+    def test_execute_subcommands_spelt_out_in_full(self):
+        # Over the run, every execute sub-command appears spelt out in full in
+        # the rendered frame (not abbreviated to deps/gen/ex/upd).
+        _state, frames = _drive_lifecycle(120)
+        execute_text = "\n".join(
+            "\n".join(lines) for fn, lines in frames
+            if stage_for_function(fn) == STAGE_EXECUTE
+        )
+        for full in COMMAND_SEQUENCE:  # auto-deps, generate, example, verify, …
+            assert full in execute_text, full
+        # The old short forms are gone as standalone strip labels.
+        assert "▸ gen " not in execute_text
+        assert " upd " not in execute_text
+
+    def test_floor_width_resizes_rather_than_rotating(self):
+        # At the Textual app's 80-col floor the strip tightens its separators
+        # but keeps full names, and never needs to rotate.
+        state, frames = _drive_lifecycle(80)
+        execute_text = "\n".join(
+            "\n".join(lines) for fn, lines in frames
+            if stage_for_function(fn) == STAGE_EXECUTE
+        )
+        assert "auto-deps" in execute_text and "update" in execute_text
+        # Resize uses the compact separator, so the roomy one never appears in
+        # the strip, and the marquee is never engaged at this width.
+        assert state.step_scroll_offset == 0
+
+    def test_narrow_width_engages_rotating_marquee(self):
+        # Below the floor (e.g. a forced-narrow demo run) the strip rotates: the
+        # marquee offset advances while still rendering full command names.
+        state, frames = _drive_lifecycle(50)
+        execute_text = "\n".join(
+            "\n".join(lines) for fn, lines in frames
+            if stage_for_function(fn) == STAGE_EXECUTE
+        )
+        assert "auto-deps" in execute_text  # full names still scroll past
+        assert state.step_scroll_offset > 0  # the marquee actually rotated
+
+    def test_full_run_never_crashes(self):
+        # The whole lifecycle renders cleanly end to end at every width.
+        for width in (120, 100, 80, 64, 50, 40):
+            state, frames = _drive_lifecycle(width)
+            assert frames  # produced output
+            assert stage_for_function(frames[-1][0]) != STAGE_EXECUTE  # ended at Output

--- a/tests/test_sync_animation_phases.py
+++ b/tests/test_sync_animation_phases.py
@@ -129,10 +129,44 @@ class TestFrameRendering:
         for fn in ["auto-deps", "generate", "example", "verify"]:
             state.update_dynamic_state(fn, 0.0, *PATHS)
         strip = _render_step_strip(state, blink_on=True).plain
-        assert "deps" in strip and "verify" in strip
+        assert "auto-deps" in strip and "verify" in strip
         # Done steps get a check, the active probe step gets a probe glyph.
         assert "✓" in strip
         assert "◈" in strip
+
+    def test_step_strip_spells_out_every_command(self):
+        # The execute sub-commands are shown in full, not abbreviated.
+        state = AnimationState(basename="m", budget=5.0)
+        state.update_dynamic_state("generate", 0.0, *PATHS)
+        strip = _render_step_strip(state, blink_on=True, content_width=200).plain
+        for full in COMMAND_SEQUENCE:  # auto-deps, generate, example, ...
+            assert full in strip, full
+
+    def test_step_strip_tightens_separator_to_fit(self):
+        # When the roomy separator overflows but a compact one fits, the strip
+        # resizes (tighter spacing) rather than rotating, keeping full names.
+        state = AnimationState(basename="m", budget=5.0)
+        state.update_dynamic_state("update", 0.0, *PATHS)  # all prior steps done
+        for fn in ["auto-deps", "generate", "example", "verify", "test", "fix"]:
+            state.update_dynamic_state(fn, 0.0, *PATHS)
+        state.update_dynamic_state("update", 0.0, *PATHS)
+        strip = _render_step_strip(state, blink_on=True, content_width=80)
+        assert len(strip.plain) <= 80
+        assert "auto-deps" in strip.plain and "update" in strip.plain
+        # No rotation needed at this width, so the marquee offset stays put.
+        assert state.step_scroll_offset == 0
+
+    def test_step_strip_rotates_when_too_narrow(self):
+        state = AnimationState(basename="m", budget=5.0)
+        state.update_dynamic_state("generate", 0.0, *PATHS)
+        narrow = 24
+        first = _render_step_strip(state, blink_on=True, content_width=narrow)
+        # The marquee window never overflows its budget (stays one line).
+        assert len(first.plain) <= narrow
+        # ...and it advances each frame so every step scrolls into view.
+        before = state.step_scroll_offset
+        _render_step_strip(state, blink_on=True, content_width=narrow)
+        assert state.step_scroll_offset != before
 
     def test_execute_frame_shows_artifact_boxes(self):
         state = AnimationState(basename="m", budget=5.0)


### PR DESCRIPTION
## What & why

The redesigned `pdd sync` animation (PR #1621, EPIC #1560 workstream 6) renders the command-execution loop as a one-line **step strip**, but it abbreviated the execute sub-commands — `deps`, `gen`, `ex`, `upd`. This spells them out in full (`auto-deps`, `generate`, `example`, `verify`, `test`, `fix`, `update`) so the strip reads as the real CLI commands the loop runs.

Because full names don't always fit, the strip now adapts to terminal width:

1. **full** — roomy `  ·  ` separators when it fits;
2. **resize** — tightens to a compact ` · ` separator (the tier the Textual app hits at its 80-col `_min_ui_width` floor);
3. **rotate** — a fixed-width marquee that scrolls one cell/frame on narrow terminals, so every step still passes by instead of being silently cropped.

The strip is refactored into `(char, style)` cells so width can be measured and a styled marquee window taken without re-deriving per-step coloring, and it is built `no_wrap`/`overflow="crop"` so it stays one line — preserving the fixed frame height.

## Wiring

`_render_step_strip` is on the real CLI path: the live TUI (`SyncApp.update_animation`, `sync_tui.py:1537`) calls `_render_animation_frame` → `_render_step_strip` each tick.

## Tests

- `test_sync_animation_phases.py`: full spelling, separator-tightening (resize), marquee rotation.
- `test_sync_animation_e2e.py`: drives the real orchestrator→`SyncApp` render contract (mutable refs → `update_dynamic_state` → `_render_animation_frame`) across the full lifecycle at 3 width regimes; asserts fixed frame height never breaks, full names render, 80-col floor resizes, narrow width rotates.

24 tests pass locally (run via the installed `pdd-cli` interpreter; the local `uv` env can't build z3 on py3.13).

## Try it

`demo_sync_animation.py` (added here) is a no-cost harness:
- `python demo_sync_animation.py --strip` — strip across a width ladder, labeled full/resized/rotating
- `python demo_sync_animation.py --width 50` — live animation forced narrow to watch the marquee
- `python demo_sync_animation.py` / `--storyboard`

Note: the rotating tier is a sub-80 safety net — the TUI floors width at 80, so in practice the real CLI uses **full** (wide) or **resized** (at the floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)