### PR TITLE
Adopt Sizzle mono-white brand logo

### DIFF
--- a/pdd/frontend/public/logo.svg
+++ b/pdd/frontend/public/logo.svg
@@ -1,23 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <filter id="glow" x="-60%" y="-60%" width="220%" height="220%">
-      <feGaussianBlur in="SourceGraphic" stdDeviation="40" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-  </defs>
-
-  <g stroke="#00e3ff"
-     stroke-width="60"
+  <!-- PromptDriven brand logo (mono-white), matching the Sizzle site.
+       Glow filter removed for a clean wordmark/favicon. -->
+  <g stroke="#FFFFFF"
+     stroke-width="70"
      stroke-linecap="round"
-     stroke-linejoin="round"
-     fill="none"
-     filter="url(#glow)">
+     stroke-linejoin="round">
 
-    <!-- speech-bubble "P" outline -->
+    <!-- speech-bubble "P" outline, filled white -->
     <path d="
       M 260 180
       H 600
@@ -25,9 +15,10 @@
       H 480
       L 260 880
       V 180
-      Z"/>
+      Z"
+      fill="#FFFFFF"/>
 
-    <!-- chevron shifted +15 px -->
-    <polyline points="505 340 585 420 505 500"/>
+    <!-- chevron (white stroke, no fill) -->
+    <polyline points="505 340 585 420 505 500" fill="none"/>
   </g>
 </svg>


### PR DESCRIPTION
Part of the **Sizzle brand consistency** epic (#1658).

Replaces the glowing cyan (`#00e3ff`) `pdd/frontend/public/logo.svg` with the clean **white-filled** "P" speech-bubble used on the [Sizzle site](https://video.promptdriven.ai/sizzle) (`PromptDriven_Logo_MonoWhite.svg`). The Gaussian-blur glow filter is removed for a crisp wordmark and favicon.

The favicon `<link>` in `index.html` already references `/logo.svg`, so it updates automatically.

### Before / after
- **Before:** cyan stroke `#00e3ff`, `stroke-width: 60`, blur glow filter, no fill.
- **After:** white stroke + fill `#FFFFFF`, `stroke-width: 70`, no filter — matches Sizzle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
