### PR TITLE
Add shared Sizzle brand color tokens

### DIFF
--- a/pdd/frontend/index.html
+++ b/pdd/frontend/index.html
@@ -50,6 +50,17 @@
                 goldActive: '#DFA84A',
                 goldHover: '#FFD966',
               },
+              // Shared PromptDriven brand palette (matches the Sizzle site)
+              brand: {
+                cyan: '#00d8ff',
+                navy: '#0a0a23',
+                graphite: '#1a1b26',
+                magenta: '#ff2aa6',
+                purple: '#8c47ff',
+                green: '#18c07a',
+                sleet: '#f5f7fa',
+                mute: '#5b6378',
+              },
             },
             fontFamily: {
               sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],


### PR DESCRIPTION
Part of the **Sizzle brand consistency** epic (#1658).

Adds a `brand` color group to the Tailwind config in `pdd/frontend/index.html`, mirroring the palette defined on the [Sizzle site](https://video.promptdriven.ai/sizzle) so both surfaces share one identity:

| token | hex |
|---|---|
| `brand-cyan` | `#00d8ff` |
| `brand-navy` | `#0a0a23` |
| `brand-graphite` | `#1a1b26` |
| `brand-magenta` | `#ff2aa6` |
| `brand-purple` | `#8c47ff` |
| `brand-green` | `#18c07a` |
| `brand-sleet` | `#f5f7fa` |
| `brand-mute` | `#5b6378` |

Purely additive — existing `surface` / `accent` / `pdd` tokens are untouched, so nothing else changes. The header sub-PR is the first consumer of `brand-cyan` / `brand-navy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
