### PR TITLE
Match Sizzle's clean wordmark text style in the header

### DIFF
--- a/pdd/frontend/App.tsx
+++ b/pdd/frontend/App.tsx
@@ -852,8 +852,9 @@ const App: React.FC = () => {
                   </g>
                 </svg>
               </div>
-              <div className="hidden sm:block">
-                <h1 className="text-base sm:text-lg font-bold text-white whitespace-nowrap">Prompt Driven</h1>
+              <div className="hidden sm:flex items-baseline gap-2">
+                <h1 className="font-sans font-semibold tracking-[0.01em] text-brand-sleet text-base sm:text-lg whitespace-nowrap">PromptDriven.ai</h1>
+                <span className="font-mono font-medium uppercase tracking-[0.12em] text-brand-cyan text-[0.65rem] whitespace-nowrap">Prompt Driven Development</span>
               </div>
             </div>
 

--- a/pdd/frontend/components/Header.tsx
+++ b/pdd/frontend/components/Header.tsx
@@ -23,26 +23,26 @@ const Header: React.FC<HeaderProps> = ({ currentView, onViewChange }) => {
     <header className="bg-gray-900/80 backdrop-blur-sm sticky top-0 z-10 py-4 mb-8">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3 flex-1 min-w-0">
+          <a
+            href="https://promptdriven.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-3 flex-1 min-w-0 group"
+          >
             <img
               src="/logo.svg"
               alt="PromptDriven.ai logo"
               className="h-11 w-11 flex-shrink-0"
             />
-            <div className="min-w-0">
-              <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
-                PromptDriven<span className="text-brand-cyan">.ai</span>
+            <div className="flex items-baseline gap-2.5 min-w-0">
+              <h1 className="font-sans font-semibold tracking-[0.01em] text-brand-sleet text-3xl sm:text-4xl group-hover:text-white transition-colors">
+                PromptDriven.ai
               </h1>
-              <a
-                href="https://promptdriven.ai"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="mt-0.5 inline-block text-sm text-brand-cyan hover:underline"
-              >
-                Prompt Driven Development IDE — Regenerate, don't patch
-              </a>
+              <span className="font-mono font-medium uppercase tracking-[0.12em] text-brand-cyan text-[0.65rem] sm:text-xs">
+                Prompt Driven Development
+              </span>
             </div>
-          </div>
+          </a>
           <nav className="flex items-center space-x-2 flex-shrink-0">
             <Tooltip content="View prompt dependency graph">
               <button onClick={() => onViewChange('dependencies')} className={navButtonClasses('dependencies')}>

--- a/pdd/frontend/components/Header.tsx
+++ b/pdd/frontend/components/Header.tsx
@@ -12,29 +12,36 @@ interface HeaderProps {
 const Header: React.FC<HeaderProps> = ({ currentView, onViewChange }) => {
   const navButtonClasses = (view: View) => `
     px-3 py-2 rounded-md text-sm font-medium transition-colors
-    ${currentView === view 
-      ? 'bg-blue-600 text-white' 
+    ${currentView === view
+      ? 'bg-brand-cyan text-brand-navy'
       : 'text-gray-300 hover:bg-gray-700 hover:text-white'
     }
-    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-blue-500
+    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-brand-cyan
   `;
 
   return (
     <header className="bg-gray-900/80 backdrop-blur-sm sticky top-0 z-10 py-4 mb-8">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between">
-          <div className="flex-1">
-             <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
-                Prompt Driven Development IDE
-            </h1>
-            <a 
-              href="https://promptdriven.ai" 
-              target="_blank" 
-              rel="noopener noreferrer"
-              className="mt-1 text-base text-blue-400 hover:underline"
-            >
-              Regenerate, don't patch
-            </a>
+          <div className="flex items-center gap-3 flex-1 min-w-0">
+            <img
+              src="/logo.svg"
+              alt="PromptDriven.ai logo"
+              className="h-11 w-11 flex-shrink-0"
+            />
+            <div className="min-w-0">
+              <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+                PromptDriven<span className="text-brand-cyan">.ai</span>
+              </h1>
+              <a
+                href="https://promptdriven.ai"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-0.5 inline-block text-sm text-brand-cyan hover:underline"
+              >
+                Prompt Driven Development IDE — Regenerate, don't patch
+              </a>
+            </div>
           </div>
           <nav className="flex items-center space-x-2 flex-shrink-0">
             <Tooltip content="View prompt dependency graph">

--- a/pdd/frontend/components/Header.tsx
+++ b/pdd/frontend/components/Header.tsx
@@ -12,37 +12,30 @@ interface HeaderProps {
 const Header: React.FC<HeaderProps> = ({ currentView, onViewChange }) => {
   const navButtonClasses = (view: View) => `
     px-3 py-2 rounded-md text-sm font-medium transition-colors
-    ${currentView === view
-      ? 'bg-brand-cyan text-brand-navy'
+    ${currentView === view 
+      ? 'bg-blue-600 text-white' 
       : 'text-gray-300 hover:bg-gray-700 hover:text-white'
     }
-    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-brand-cyan
+    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-blue-500
   `;
 
   return (
     <header className="bg-gray-900/80 backdrop-blur-sm sticky top-0 z-10 py-4 mb-8">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between">
-          <a
-            href="https://promptdriven.ai"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-3 flex-1 min-w-0 group"
-          >
-            <img
-              src="/logo.svg"
-              alt="PromptDriven.ai logo"
-              className="h-11 w-11 flex-shrink-0"
-            />
-            <div className="flex items-baseline gap-2.5 min-w-0">
-              <h1 className="font-sans font-semibold tracking-[0.01em] text-brand-sleet text-3xl sm:text-4xl group-hover:text-white transition-colors">
-                PromptDriven.ai
-              </h1>
-              <span className="font-mono font-medium uppercase tracking-[0.12em] text-brand-cyan text-[0.65rem] sm:text-xs">
-                Prompt Driven Development
-              </span>
-            </div>
-          </a>
+          <div className="flex-1">
+             <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+                Prompt Driven Development IDE
+            </h1>
+            <a 
+              href="https://promptdriven.ai" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              className="mt-1 text-base text-blue-400 hover:underline"
+            >
+              Regenerate, don't patch
+            </a>
+          </div>
           <nav className="flex items-center space-x-2 flex-shrink-0">
             <Tooltip content="View prompt dependency graph">
               <button onClick={() => onViewChange('dependencies')} className={navButtonClasses('dependencies')}>

--- a/pdd/frontend/index.html
+++ b/pdd/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Prompt Driven Development</title>
+    <title>PromptDriven.ai — Prompt Driven Development IDE</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/pdd/frontend/index.html
+++ b/pdd/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PromptDriven.ai — Prompt Driven Development IDE</title>
+    <title>PromptDriven.ai — Prompt Driven Development</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {


### PR DESCRIPTION
Part of the **Sizzle brand consistency** epic (#1658).

Restyles the app header (`pdd/frontend/components/Header.tsx`) to mirror the [Sizzle site](https://video.promptdriven.ai/sizzle)'s wordmark typography exactly — the *clean look*, while **keeping the existing (glowing) logo**.

### The Sizzle treatment being adopted
Sizzle's lockup is:
```html
<span class="font-sans font-semibold tracking-[0.01em] text-brand-sleet text-lg">Sizzle</span>
<span class="font-mono font-medium tracking-[0.12em] text-brand-cyan text-xs">by Prompt Driven</span>
```
i.e. a **semibold sans wordmark in near-white `brand-sleet`** beside a **tiny, wide-tracked, uppercase mono `brand-cyan` descriptor**, baseline-aligned.

### Applied here
- Wordmark **`PromptDriven.ai`** → `font-sans font-semibold tracking-[0.01em] text-brand-sleet`.
- Descriptor **`Prompt Driven Development`** → `font-mono font-medium uppercase tracking-[0.12em] text-brand-cyan`.
- Nav active-state / focus ring use `brand-cyan` / `brand-navy`.
- Page `<title>` → `PromptDriven.ai — Prompt Driven Development`.
- Drops the busier bold-white heading + slogan link for the cleaner lockup.

### Dependency
Uses the `brand-sleet` / `brand-cyan` / `brand-navy` tokens from **Add shared Sizzle brand color tokens** (#1656). The logo (`/logo.svg`) is unchanged. No frontend tests assert on the old header text/title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)