### PR TITLE
Match Sizzle's clean wordmark text style + brand colors

### DIFF
--- a/pdd/frontend/App.tsx
+++ b/pdd/frontend/App.tsx
@@ -852,8 +852,9 @@ const App: React.FC = () => {
                   </g>
                 </svg>
               </div>
-              <div className="hidden sm:block">
-                <h1 className="text-base sm:text-lg font-bold text-white whitespace-nowrap">Prompt Driven</h1>
+              <div className="hidden sm:flex items-baseline gap-2">
+                <h1 className="font-sans font-semibold tracking-[0.01em] text-brand-sleet text-base sm:text-lg whitespace-nowrap">PromptDriven.ai</h1>
+                <span className="font-mono font-medium uppercase tracking-[0.12em] text-brand-cyan text-[0.65rem] whitespace-nowrap">Prompt Driven Development</span>
               </div>
             </div>
 

--- a/pdd/frontend/index.html
+++ b/pdd/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Prompt Driven Development</title>
+    <title>PromptDriven.ai — Prompt Driven Development</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {
@@ -49,6 +49,17 @@
                 gold: '#FDCE49',
                 goldActive: '#DFA84A',
                 goldHover: '#FFD966',
+              },
+              // Shared PromptDriven brand palette (matches the Sizzle site)
+              brand: {
+                cyan: '#00d8ff',
+                navy: '#0a0a23',
+                graphite: '#1a1b26',
+                magenta: '#ff2aa6',
+                purple: '#8c47ff',
+                green: '#18c07a',
+                sleet: '#f5f7fa',
+                mute: '#5b6378',
               },
             },
             fontFamily: {


### PR DESCRIPTION
## Sub-PR of #1666 — Match Sizzle's clean wordmark text style + brand colors

Targets `epic/sizzle-brand-consistency` (not `main`).

Brings `pdd/frontend`'s look in line with the [Sizzle site](https://video.promptdriven.ai/sizzle): same typographic identity, **existing logo kept**.

### Changes
- **`App.tsx`** (the *live* header — rendered inline here, not in the unused `components/Header.tsx`): the bold-white `Prompt Driven` heading becomes Sizzle's lockup — a semibold sans `brand-sleet` wordmark `PromptDriven.ai` beside a tiny, wide-tracked, uppercase **mono `brand-cyan`** descriptor `Prompt Driven Development`, baseline-aligned.
- **`index.html`**: adds the shared `brand-*` palette (`cyan #00d8ff`, `navy`, `graphite`, `magenta`, `purple`, `green`, `sleet`, `mute`) to the Tailwind config; aligns the page `<title>`.

Fonts (Inter + JetBrains Mono) were already loaded — no font-loading change needed. This combines the originally-scoped Colors (#1656) + Header (#1657) sub-PRs into one approvable unit.

### Verification
Frontend-only, class/text + Tailwind-token changes; the new `brand-*` classes resolve against the palette added in the same PR.

> The `heal` / `auto-heal` checks gate on the paid PDD Cloud build and will show red without cloud auth — expected and unrelated to these frontend-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
