### PR TITLE
Add shared Sizzle brand color tokens

### DIFF
--- a/pdd/frontend/index.html
+++ b/pdd/frontend/index.html
@@ -50,6 +50,17 @@
                 goldActive: '#DFA84A',
                 goldHover: '#FFD966',
               },
+              // Shared PromptDriven brand palette (matches the Sizzle site)
+              brand: {
+                cyan: '#00d8ff',
+                navy: '#0a0a23',
+                graphite: '#1a1b26',
+                magenta: '#ff2aa6',
+                purple: '#8c47ff',
+                green: '#18c07a',
+                sleet: '#f5f7fa',
+                mute: '#5b6378',
+              },
             },
             fontFamily: {
               sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],


### PR DESCRIPTION
## Sub-PR of #1666 — Add shared Sizzle brand color tokens

Targets `epic/sizzle-brand-consistency` (not `main`).

Adds the shared PromptDriven `brand-*` palette to `pdd/frontend/index.html`'s inline Tailwind config, so the app shares one color identity with the [Sizzle site](https://video.promptdriven.ai/sizzle):

`cyan #00d8ff`, `navy #0a0a23`, `graphite #1a1b26`, `magenta #ff2aa6`, `purple #8c47ff`, `green #18c07a`, `sleet #f5f7fa`, `mute #5b6378`.

Tokens only — no visual change on its own. The Header sub-PR consumes `brand-sleet` / `brand-cyan`.

> `heal` / `auto-heal` red = paid PDD Cloud gate, unrelated to this frontend-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
