### PR TITLE
Match Sizzle's clean wordmark text style in the header

### DIFF
--- a/pdd/frontend/App.tsx
+++ b/pdd/frontend/App.tsx
@@ -852,8 +852,9 @@ const App: React.FC = () => {
                   </g>
                 </svg>
               </div>
-              <div className="hidden sm:block">
-                <h1 className="text-base sm:text-lg font-bold text-white whitespace-nowrap">Prompt Driven</h1>
+              <div className="hidden sm:flex items-baseline gap-2">
+                <h1 className="font-sans font-semibold tracking-[0.01em] text-brand-sleet text-base sm:text-lg whitespace-nowrap">PromptDriven.ai</h1>
+                <span className="font-mono font-medium uppercase tracking-[0.12em] text-brand-cyan text-[0.65rem] whitespace-nowrap">Prompt Driven Development</span>
               </div>
             </div>
 

--- a/pdd/frontend/index.html
+++ b/pdd/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Prompt Driven Development</title>
+    <title>PromptDriven.ai — Prompt Driven Development</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {


### PR DESCRIPTION
## Sub-PR of #1666 — Match Sizzle's clean wordmark text style in the header

Targets `epic/sizzle-brand-consistency` (not `main`).

Restyles the **live** header wordmark — rendered inline in `pdd/frontend/App.tsx` (the unused `components/Header.tsx` is *not* mounted, which is what tripped up the earlier attempts). The bold-white `Prompt Driven` heading becomes the Sizzle lockup:

- semibold sans **`PromptDriven.ai`** in `brand-sleet`
- tiny, wide-tracked, uppercase **mono `brand-cyan`** descriptor `Prompt Driven Development`, baseline-aligned

Also aligns the page `<title>`. **Existing logo kept.**

> **Depends on #1668** (brand color tokens) — `brand-sleet` / `brand-cyan` resolve once that sub-PR is merged into the epic branch.

> `heal` / `auto-heal` red = paid PDD Cloud gate, unrelated to this frontend-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
