### PR TITLE
Sizzle brand restyle: palette, blue/green accents, light-blue background

### DIFF
--- a/pdd/frontend/App.tsx
+++ b/pdd/frontend/App.tsx
@@ -852,8 +852,9 @@ const App: React.FC = () => {
                   </g>
                 </svg>
               </div>
-              <div className="hidden sm:block">
-                <h1 className="text-base sm:text-lg font-bold text-white whitespace-nowrap">Prompt Driven</h1>
+              <div className="hidden sm:flex items-baseline gap-2">
+                <h1 className="font-sans font-semibold tracking-[0.01em] text-brand-sleet text-base sm:text-lg whitespace-nowrap">PromptDriven.ai</h1>
+                <span className="font-mono font-medium uppercase tracking-[0.12em] text-brand-cyan text-[0.65rem] whitespace-nowrap">Prompt Driven Development</span>
               </div>
             </div>
 

--- a/pdd/frontend/App.tsx
+++ b/pdd/frontend/App.tsx
@@ -828,7 +828,7 @@ const App: React.FC = () => {
 
   return (
     <ErrorBoundary>
-    <div className="min-h-screen bg-surface-950">
+    <div className="min-h-screen app-bg">
       {/* Modern responsive header - Restructured with branding left, workflows center, status right */}
       <header className="glass sticky top-0 z-40 border-b border-surface-700/50">
         <div className="mx-auto px-4 sm:px-6 lg:px-8 2xl:px-12">
@@ -860,13 +860,13 @@ const App: React.FC = () => {
 
             {/* CENTER: Main workflow buttons with gold border */}
             <div className="flex-1 flex justify-center">
-              <div className="flex gap-1 sm:gap-1.5 p-1.5 rounded-xl border-2 border-[#FDCE49]/60 bg-surface-800/40 max-w-fit overflow-x-auto scrollbar-hide">
+              <div className="flex gap-1 sm:gap-1.5 p-1.5 rounded-xl border-2 border-[#18c07a]/60 bg-surface-800/40 glow-white max-w-fit overflow-x-auto scrollbar-hide">
                 <button
                   onClick={() => setView('devunits')}
                   className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-medium transition-all duration-200 ${
                     view === 'devunits'
-                      ? 'bg-[#DFA84A] text-surface-900 shadow-lg'
-                      : 'text-surface-300 hover:text-white hover:bg-surface-700/80 hover:shadow-[0_0_10px_rgba(253,206,73,0.3)]'
+                      ? 'bg-[#00d8ff]/20 text-[#00d8ff] border border-[#00d8ff]/50 shadow-lg glow-white'
+                      : 'text-surface-300 hover:text-white hover:bg-surface-700/80 hover:shadow-[0_0_10px_rgba(0, 216, 255,0.3)]'
                   }`}
                 >
                   <Squares2X2Icon className="hidden sm:inline w-4 h-4 mr-1.5" />Dev Units
@@ -875,8 +875,8 @@ const App: React.FC = () => {
                   onClick={() => setView('bug')}
                   className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-medium transition-all duration-200 ${
                     view === 'bug'
-                      ? 'bg-[#DFA84A] text-surface-900 shadow-lg'
-                      : 'text-surface-300 hover:text-white hover:bg-surface-700/80 hover:shadow-[0_0_10px_rgba(253,206,73,0.3)]'
+                      ? 'bg-[#00d8ff]/20 text-[#00d8ff] border border-[#00d8ff]/50 shadow-lg glow-white'
+                      : 'text-surface-300 hover:text-white hover:bg-surface-700/80 hover:shadow-[0_0_10px_rgba(0, 216, 255,0.3)]'
                   }`}
                 >
                   <BugAntIcon className="hidden sm:inline w-4 h-4 mr-1.5" />Bug
@@ -885,8 +885,8 @@ const App: React.FC = () => {
                   onClick={() => setView('fix')}
                   className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-medium transition-all duration-200 ${
                     view === 'fix'
-                      ? 'bg-[#DFA84A] text-surface-900 shadow-lg'
-                      : 'text-surface-300 hover:text-white hover:bg-surface-700/80 hover:shadow-[0_0_10px_rgba(253,206,73,0.3)]'
+                      ? 'bg-[#00d8ff]/20 text-[#00d8ff] border border-[#00d8ff]/50 shadow-lg glow-white'
+                      : 'text-surface-300 hover:text-white hover:bg-surface-700/80 hover:shadow-[0_0_10px_rgba(0, 216, 255,0.3)]'
                   }`}
                 >
                   <svg className="hidden sm:inline w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -897,8 +897,8 @@ const App: React.FC = () => {
                   onClick={() => setView('change')}
                   className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-medium transition-all duration-200 ${
                     view === 'change'
-                      ? 'bg-[#DFA84A] text-surface-900 shadow-lg'
-                      : 'text-surface-300 hover:text-white hover:bg-surface-700/80 hover:shadow-[0_0_10px_rgba(253,206,73,0.3)]'
+                      ? 'bg-[#00d8ff]/20 text-[#00d8ff] border border-[#00d8ff]/50 shadow-lg glow-white'
+                      : 'text-surface-300 hover:text-white hover:bg-surface-700/80 hover:shadow-[0_0_10px_rgba(0, 216, 255,0.3)]'
                   }`}
                 >
                   <svg className="hidden sm:inline w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -909,8 +909,8 @@ const App: React.FC = () => {
                   onClick={() => setView('settings')}
                   className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-medium transition-all duration-200 ${
                     view === 'settings'
-                      ? 'bg-[#DFA84A] text-surface-900 shadow-lg'
-                      : 'text-surface-300 hover:text-white hover:bg-surface-700/80 hover:shadow-[0_0_10px_rgba(253,206,73,0.3)]'
+                      ? 'bg-[#00d8ff]/20 text-[#00d8ff] border border-[#00d8ff]/50 shadow-lg glow-white'
+                      : 'text-surface-300 hover:text-white hover:bg-surface-700/80 hover:shadow-[0_0_10px_rgba(0, 216, 255,0.3)]'
                   }`}
                 >
                   <Cog6ToothIcon className="hidden sm:inline w-4 h-4 mr-1.5" />Settings
@@ -965,9 +965,9 @@ const App: React.FC = () => {
               <div className={`flex items-center gap-1.5 text-xs px-2 py-1.5 rounded-full transition-colors ${
                 serverConnected
                   ? 'bg-green-500/10 text-green-400 border border-green-500/20'
-                  : 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'
+                  : 'bg-cyan-500/10 text-cyan-400 border border-cyan-500/20'
               }`}>
-                <span className={`w-2 h-2 rounded-full ${serverConnected ? 'bg-green-400 animate-pulse-slow' : 'bg-yellow-400 animate-pulse'}`} />
+                <span className={`w-2 h-2 rounded-full ${serverConnected ? 'bg-green-400 animate-pulse-slow' : 'bg-cyan-400 animate-pulse'}`} />
                 <span className="hidden sm:inline">{serverConnected ? 'Connected' : 'Offline'}</span>
               </div>
 
@@ -1057,7 +1057,7 @@ const App: React.FC = () => {
               <div className="px-4 py-3 border-t border-surface-700/50 bg-surface-800/30">
                 <button
                   onClick={() => setShowRemotePanel(false)}
-                  className="w-full px-4 py-2 bg-[#DFA84A] hover:bg-[#FDCE49] text-surface-900 rounded-lg text-sm font-medium transition-colors"
+                  className="w-full px-4 py-2 bg-[#00d8ff]/20 hover:bg-[#00d8ff]/30 text-[#00d8ff] border border-[#00d8ff]/40 rounded-lg text-sm font-medium transition-colors"
                 >
                   Done
                 </button>
@@ -1153,8 +1153,8 @@ const App: React.FC = () => {
           {view === 'devunits' && (
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
               <div className="flex items-center gap-3">
-                <div className="w-10 h-10 rounded-xl bg-[#FDCE49]/20 flex items-center justify-center">
-                  <Squares2X2Icon className="w-5 h-5 text-[#FDCE49]" />
+                <div className="w-10 h-10 rounded-xl bg-[#18c07a]/20 flex items-center justify-center">
+                  <Squares2X2Icon className="w-5 h-5 text-[#18c07a]" />
                 </div>
                 <div>
                   <h2 className="text-lg sm:text-xl font-semibold text-white">Dev Units</h2>
@@ -1167,7 +1167,7 @@ const App: React.FC = () => {
                   onClick={() => setDevUnitsSubView('graph')}
                   className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-md text-xs sm:text-sm font-medium transition-all duration-200 ${
                     devUnitsSubView === 'graph'
-                      ? 'bg-[#DFA84A] text-surface-900 shadow-md'
+                      ? 'bg-[#00d8ff]/20 text-[#00d8ff] border border-[#00d8ff]/50 shadow-md glow-white'
                       : 'text-surface-300 hover:text-white hover:bg-surface-700/50'
                   }`}
                 >
@@ -1177,7 +1177,7 @@ const App: React.FC = () => {
                   onClick={() => setDevUnitsSubView('list')}
                   className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-md text-xs sm:text-sm font-medium transition-all duration-200 ${
                     devUnitsSubView === 'list'
-                      ? 'bg-[#DFA84A] text-surface-900 shadow-md'
+                      ? 'bg-[#00d8ff]/20 text-[#00d8ff] border border-[#00d8ff]/50 shadow-md glow-white'
                       : 'text-surface-300 hover:text-white hover:bg-surface-700/50'
                   }`}
                 >
@@ -1258,17 +1258,17 @@ const App: React.FC = () => {
       ) : (
       <main className="mx-auto px-4 sm:px-6 lg:px-8 2xl:px-12 py-4 sm:py-6 pb-16 sm:pb-20">
         {!serverConnected && (
-          <div className="mb-4 sm:mb-6 p-3 sm:p-4 glass-light rounded-xl border border-yellow-500/20 animate-fade-in">
+          <div className="mb-4 sm:mb-6 p-3 sm:p-4 glass-light rounded-xl border border-cyan-500/20 animate-fade-in">
             <div className="flex items-start gap-3">
-              <div className="w-8 h-8 rounded-lg bg-yellow-500/20 flex items-center justify-center flex-shrink-0">
-                <svg className="w-4 h-4 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div className="w-8 h-8 rounded-lg bg-cyan-500/20 flex items-center justify-center flex-shrink-0">
+                <svg className="w-4 h-4 text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                 </svg>
               </div>
               <div>
-                <p className="text-yellow-300 text-sm sm:text-base font-medium">Server not connected</p>
-                <p className="text-yellow-200/70 text-xs sm:text-sm mt-1">
-                  Run <code className="bg-surface-800/80 px-1.5 py-0.5 rounded font-mono text-yellow-300">pdd connect</code> in your terminal to enable command execution.
+                <p className="text-cyan-300 text-sm sm:text-base font-medium">Server not connected</p>
+                <p className="text-cyan-200/70 text-xs sm:text-sm mt-1">
+                  Run <code className="bg-surface-800/80 px-1.5 py-0.5 rounded font-mono text-cyan-300">pdd connect</code> in your terminal to enable command execution.
                 </p>
               </div>
             </div>
@@ -1352,7 +1352,7 @@ const App: React.FC = () => {
                 {/* Prerequisites card */}
                 <div className="glass rounded-2xl p-4 sm:p-5 border border-surface-700/50">
                   <h3 className="text-sm font-semibold text-white mb-3 flex items-center gap-2">
-                    <svg className="w-4 h-4 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-4 h-4 text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
                     Prerequisites
@@ -1465,7 +1465,7 @@ const App: React.FC = () => {
                       mt-4 w-full px-4 py-2.5 sm:py-3 rounded-xl font-medium transition-all duration-200 flex items-center justify-center gap-2 text-sm sm:text-base
                       ${isExecuting || !serverConnected || !fixPrUrl.trim()
                         ? 'bg-surface-700 text-surface-500 cursor-not-allowed'
-                        : 'bg-gradient-to-r from-blue-600 to-blue-500 hover:from-blue-500 hover:to-blue-400 text-white shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40'}
+                        : 'bg-gradient-to-r from-blue-500 to-blue-500 hover:from-blue-500 hover:to-blue-400 text-white shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40'}
                     `}
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1478,7 +1478,7 @@ const App: React.FC = () => {
                 {/* Prerequisites card */}
                 <div className="glass rounded-2xl p-4 sm:p-5 border border-surface-700/50">
                   <h3 className="text-sm font-semibold text-white mb-3 flex items-center gap-2">
-                    <svg className="w-4 h-4 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-4 h-4 text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
                     Prerequisites
@@ -1601,7 +1601,7 @@ const App: React.FC = () => {
                 {/* Prerequisites card */}
                 <div className="glass rounded-2xl p-4 sm:p-5 border border-surface-700/50">
                   <h3 className="text-sm font-semibold text-white mb-3 flex items-center gap-2">
-                    <svg className="w-4 h-4 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-4 h-4 text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
                     Prerequisites

--- a/pdd/frontend/components/AddToQueueModal.tsx
+++ b/pdd/frontend/components/AddToQueueModal.tsx
@@ -255,7 +255,7 @@ const AddToQueueModal: React.FC<AddToQueueModalProps> = ({
                   className={`
                     flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm text-left transition-all
                     ${selectedCommand === cmd.name
-                      ? 'bg-accent-600 text-white border border-accent-500'
+                      ? 'bg-accent-500 text-white border border-accent-500'
                       : 'bg-surface-800/50 text-surface-300 border border-surface-700 hover:bg-surface-700/50'
                     }
                   `}

--- a/pdd/frontend/components/ArchitectureView.tsx
+++ b/pdd/frontend/components/ArchitectureView.tsx
@@ -1141,7 +1141,7 @@ const ArchitectureView: React.FC<ArchitectureViewProps> = ({
                 className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                   isGeneratingFromIssue
                     ? 'bg-surface-600 text-surface-400 cursor-not-allowed'
-                    : 'bg-accent-600 hover:bg-accent-500 text-white'
+                    : 'bg-accent-500 hover:bg-accent-500 text-white'
                 }`}
                 disabled={!serverConnected || isGeneratingFromIssue || !issueUrl.trim()}
               >
@@ -1195,7 +1195,7 @@ const ArchitectureView: React.FC<ArchitectureViewProps> = ({
           </div>
 
           {!serverConnected && (
-            <p className="text-yellow-400 text-xs mt-4">
+            <p className="text-cyan-400 text-xs mt-4">
               Connect to server to enable architecture generation
             </p>
           )}
@@ -1282,7 +1282,7 @@ const ArchitectureView: React.FC<ArchitectureViewProps> = ({
                     className={`w-full px-4 py-2.5 rounded-xl font-medium transition-all duration-200 flex items-center justify-center gap-2 ${
                       remainingModulesCount === 0
                         ? 'bg-surface-700 text-surface-500 cursor-not-allowed'
-                        : 'bg-gradient-to-r from-blue-600 to-blue-500 hover:from-blue-500 hover:to-blue-400 text-white shadow-lg shadow-blue-500/25'
+                        : 'bg-gradient-to-r from-blue-500 to-blue-500 hover:from-blue-500 hover:to-blue-400 text-white shadow-lg shadow-blue-500/25'
                     }`}
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1476,7 +1476,7 @@ const ArchitectureView: React.FC<ArchitectureViewProps> = ({
                   <button
                     onClick={() => handleGeneratePrompts()}
                     disabled={isGeneratingPrompts}
-                    className="mt-6 w-full px-4 py-3 bg-gradient-to-r from-accent-600 to-accent-500 hover:from-accent-500 hover:to-accent-400 text-white rounded-xl font-medium transition-all duration-200 shadow-lg shadow-accent-500/25 hover:shadow-accent-500/40 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="mt-6 w-full px-4 py-3 bg-gradient-to-r from-accent-500 to-accent-500 hover:from-accent-500 hover:to-accent-400 text-white rounded-xl font-medium transition-all duration-200 shadow-lg shadow-accent-500/25 hover:shadow-accent-500/40 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {isGeneratingPrompts ? 'Generating Prompts...' : 'Generate All Prompts'}
                   </button>

--- a/pdd/frontend/components/AuthStatusIndicator.tsx
+++ b/pdd/frontend/components/AuthStatusIndicator.tsx
@@ -47,7 +47,7 @@ const AuthStatusIndicator: React.FC<AuthStatusIndicatorProps> = ({ onReauth }) =
       className={`flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm px-2 sm:px-3 py-1.5 rounded-full transition-colors ${
         isAuthenticated
           ? 'bg-blue-500/10 text-blue-400 border border-blue-500/20 hover:bg-blue-500/20'
-          : 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20 hover:bg-yellow-500/20'
+          : 'bg-cyan-500/10 text-cyan-400 border border-cyan-500/20 hover:bg-cyan-500/20'
       }`}
       title={isAuthenticated ? 'Cloud Authenticated - Click to manage authentication' : 'Not authenticated - Click to login'}
     >
@@ -64,7 +64,7 @@ const AuthStatusIndicator: React.FC<AuthStatusIndicatorProps> = ({ onReauth }) =
       </span>
       {/* Status dot */}
       <span className={`w-1.5 h-1.5 sm:w-2 sm:h-2 rounded-full ${
-        isAuthenticated ? 'bg-blue-400' : 'bg-yellow-400 animate-pulse'
+        isAuthenticated ? 'bg-blue-400' : 'bg-cyan-400 animate-pulse'
       }`} />
     </button>
   );

--- a/pdd/frontend/components/BatchFilterDropdown.tsx
+++ b/pdd/frontend/components/BatchFilterDropdown.tsx
@@ -85,7 +85,7 @@ const BatchFilterDropdown: React.FC<BatchFilterDropdownProps> = ({
             className={`px-3 py-1.5 rounded-lg text-sm font-medium flex items-center gap-1.5 transition-colors ${
               disabled || selectedRemaining === 0
                 ? 'bg-surface-700 text-surface-500 cursor-not-allowed'
-                : 'bg-gradient-to-r from-[#FDCE49] to-[#DFA84A] hover:from-[#FFD966] hover:to-[#FDCE49] text-surface-900'
+                : 'bg-gradient-to-r from-[#18c07a] to-[#00d8ff] hover:from-[#5ce3ff] hover:to-[#18c07a] text-surface-900'
             }`}
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -177,7 +177,7 @@ const BatchFilterDropdown: React.FC<BatchFilterDropdownProps> = ({
                     className={`mt-2 w-full px-3 py-1.5 rounded-lg text-xs font-medium flex items-center justify-center gap-1.5 transition-colors ${
                       disabled || remaining === 0
                         ? 'bg-surface-700 text-surface-500 cursor-not-allowed'
-                        : 'bg-gradient-to-r from-[#FDCE49] to-[#DFA84A] hover:from-[#FFD966] hover:to-[#FDCE49] text-surface-900'
+                        : 'bg-gradient-to-r from-[#18c07a] to-[#00d8ff] hover:from-[#5ce3ff] hover:to-[#18c07a] text-surface-900'
                     }`}
                   >
                     <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pdd/frontend/components/ChangeModal.tsx
+++ b/pdd/frontend/components/ChangeModal.tsx
@@ -58,7 +58,7 @@ const ChangeModal: React.FC<ChangeModalProps> = ({ onClose, onSubmit, onDetect }
                 <p className="font-mono text-lg text-blue-400">{suggestedFile}</p>
               </div>
               <p className="text-sm text-gray-300">
-                Do you want to proceed with this suggestion? This will set up the <code className="bg-gray-700 px-1 py-0.5 rounded text-xs text-amber-400">pdd change</code> command for you in the builder.
+                Do you want to proceed with this suggestion? This will set up the <code className="bg-gray-700 px-1 py-0.5 rounded text-xs text-cyan-400">pdd change</code> command for you in the builder.
               </p>
             </main>
             <footer className="px-6 py-4 bg-gray-800/50 border-t border-gray-700 flex justify-end space-x-3 rounded-b-lg">
@@ -72,7 +72,7 @@ const ChangeModal: React.FC<ChangeModalProps> = ({ onClose, onSubmit, onDetect }
               <button
                 type="button"
                 onClick={handleConfirmSubmit}
-                className="px-4 py-2 rounded-md text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-blue-500 transition-colors"
+                className="px-4 py-2 rounded-md text-sm font-medium bg-blue-500 text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-blue-500 transition-colors"
               >
                 Confirm & Proceed
               </button>
@@ -136,7 +136,7 @@ const ChangeModal: React.FC<ChangeModalProps> = ({ onClose, onSubmit, onDetect }
               </button>
               <button
                 type="submit"
-                className="px-4 py-2 rounded-md text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-blue-500 transition-colors disabled:opacity-50"
+                className="px-4 py-2 rounded-md text-sm font-medium bg-blue-500 text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-blue-500 transition-colors disabled:opacity-50"
                 disabled={!changeRequest.trim()}
               >
                 Find Prompt

--- a/pdd/frontend/components/CommandOutput.tsx
+++ b/pdd/frontend/components/CommandOutput.tsx
@@ -118,7 +118,7 @@ const CommandOutput: React.FC<CommandOutputProps> = ({ jobId, command, onClose, 
       case 'running': return 'text-blue-400';
       case 'completed': return 'text-green-400';
       case 'failed': return 'text-red-400';
-      case 'cancelled': return 'text-yellow-400';
+      case 'cancelled': return 'text-cyan-400';
     }
   };
 

--- a/pdd/frontend/components/CreatePromptModal.tsx
+++ b/pdd/frontend/components/CreatePromptModal.tsx
@@ -196,7 +196,7 @@ const CreatePromptModal: React.FC<CreatePromptModalProps> = ({
             </button>
             <button
               type="submit"
-              className="px-4 py-2 rounded-md text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-blue-500 transition-colors disabled:opacity-50 flex items-center gap-2"
+              className="px-4 py-2 rounded-md text-sm font-medium bg-blue-500 text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-blue-500 transition-colors disabled:opacity-50 flex items-center gap-2"
               disabled={isCreating || !name.trim() || isDuplicate}
             >
               {isCreating ? (

--- a/pdd/frontend/components/DependencyViewer.tsx
+++ b/pdd/frontend/components/DependencyViewer.tsx
@@ -128,10 +128,10 @@ const getCategoryColors = (category: 'frontend' | 'backend' | 'shared') => {
   switch (category) {
     case 'frontend':
       return {
-        bg: 'bg-orange-500/20',
-        border: 'border-orange-500/50',
-        hover: 'hover:border-orange-400',
-        text: 'text-orange-300',
+        bg: 'bg-sky-500/20',
+        border: 'border-sky-500/50',
+        hover: 'hover:border-sky-400',
+        text: 'text-sky-300',
       };
     case 'backend':
       return {
@@ -892,7 +892,7 @@ const DependencyViewer: React.FC<DependencyViewerProps> = ({
               if (node.type === 'groupNode') return '#8b5cf6';
               const data = node.data as ModuleNodeData;
               if (data.hasPrompt) return '#10b981';
-              if (data.colors?.bg?.includes('orange')) return '#f97316';
+              if (data.colors?.bg?.includes('orange')) return '#00d8ff';
               if (data.colors?.bg?.includes('blue')) return '#3b82f6';
               return '#22c55e';
             }}
@@ -930,7 +930,7 @@ const DependencyViewer: React.FC<DependencyViewerProps> = ({
               </div>
               <div className="space-y-1.5">
                 <div className="flex items-center gap-2">
-                  <div className="w-3 h-3 rounded bg-orange-500/40 border border-orange-500/50" />
+                  <div className="w-3 h-3 rounded bg-sky-500/40 border border-sky-500/50" />
                   <span className="text-xs text-surface-300">Frontend</span>
                 </div>
                 <div className="flex items-center gap-2">
@@ -952,7 +952,7 @@ const DependencyViewer: React.FC<DependencyViewerProps> = ({
                 <div className="flex items-center gap-2 pt-1 border-t border-surface-700/50 mt-1">
                   <div className="flex gap-0.5">
                     <div className="w-3 h-3 rounded-full bg-green-500 flex items-center justify-center text-[7px] font-bold text-white">C</div>
-                    <div className="w-3 h-3 rounded-full bg-yellow-500 flex items-center justify-center text-[7px] font-bold text-white">T</div>
+                    <div className="w-3 h-3 rounded-full bg-cyan-500 flex items-center justify-center text-[7px] font-bold text-white">T</div>
                     <div className="w-3 h-3 rounded-full bg-blue-500 flex items-center justify-center text-[7px] font-bold text-white">E</div>
                   </div>
                   <span className="text-xs text-surface-300">Code/Test/Example</span>
@@ -1001,7 +1001,7 @@ const DependencyViewer: React.FC<DependencyViewerProps> = ({
                 {editMode && (
                   <div className="pt-1 border-t border-surface-700/50 mt-1">
                     <p className="text-[10px] text-surface-400 leading-relaxed">
-                      <span className="text-orange-400">Edit mode:</span> Right-click edge to delete, or click + Delete/Backspace
+                      <span className="text-sky-400">Edit mode:</span> Right-click edge to delete, or click + Delete/Backspace
                     </p>
                   </div>
                 )}

--- a/pdd/frontend/components/ExtractsPanel.tsx
+++ b/pdd/frontend/components/ExtractsPanel.tsx
@@ -56,7 +56,7 @@ const ExtractRow: React.FC<ExtractRowProps> = ({ extract }) => {
     extract.is_fresh === true
       ? 'bg-green-500/20 text-green-400 border-green-500/30'
       : extract.is_fresh === false
-      ? 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30'
+      ? 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30'
       : 'bg-surface-600/30 text-surface-400 border-surface-500/30';
 
   return (
@@ -162,7 +162,7 @@ const ExtractsPanel: React.FC = () => {
         <p className="text-red-400 text-sm">{error}</p>
         <button
           onClick={loadExtracts}
-          className="px-3 py-1.5 bg-accent-600 hover:bg-accent-500 text-white rounded-lg text-sm transition-colors"
+          className="px-3 py-1.5 bg-accent-500 hover:bg-accent-500 text-white rounded-lg text-sm transition-colors"
         >
           Retry
         </button>
@@ -194,7 +194,7 @@ const ExtractsPanel: React.FC = () => {
           <span className="font-medium text-white">{data.total}</span> cached extract{data.total !== 1 ? 's' : ''}
         </span>
         {data.stale_count > 0 && (
-          <span className="text-yellow-400">
+          <span className="text-cyan-400">
             {data.stale_count} stale
           </span>
         )}

--- a/pdd/frontend/components/FileBrowser.tsx
+++ b/pdd/frontend/components/FileBrowser.tsx
@@ -81,7 +81,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, onSelect, filter, depth, dire
     <div>
       <div
         className={`flex items-center py-1 px-2 cursor-pointer rounded transition-colors ${
-          isDirectory ? 'hover:bg-surface-700' : 'hover:bg-accent-600/20'
+          isDirectory ? 'hover:bg-surface-700' : 'hover:bg-accent-500/20'
         }`}
         style={{ paddingLeft: `${depth * 16 + 8}px` }}
         onClick={handleClick}
@@ -102,7 +102,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, onSelect, filter, depth, dire
         {directoryMode && isDirectory && (
           <button
             onClick={handleSelectDirectory}
-            className="ml-2 px-2 py-0.5 text-xs bg-accent-600/20 hover:bg-accent-600/40 text-accent-400 rounded transition-colors"
+            className="ml-2 px-2 py-0.5 text-xs bg-accent-500/20 hover:bg-accent-500/40 text-accent-400 rounded transition-colors"
           >
             Select
           </button>

--- a/pdd/frontend/components/FilePickerInput.tsx
+++ b/pdd/frontend/components/FilePickerInput.tsx
@@ -48,7 +48,7 @@ const FilePickerInput: React.FC<FilePickerInputProps> = ({
 
   // Determine border color based on detection status
   const borderClass = isDetected !== undefined
-    ? (isDetected ? 'border-green-500/50' : 'border-yellow-500/50')
+    ? (isDetected ? 'border-green-500/50' : 'border-cyan-500/50')
     : 'border-surface-600';
 
   return (

--- a/pdd/frontend/components/GenerationProgressModal.tsx
+++ b/pdd/frontend/components/GenerationProgressModal.tsx
@@ -141,7 +141,7 @@ const GenerationProgressModal: React.FC<GenerationProgressModalProps> = ({
             {/* Close button */}
             <button
               onClick={onClose}
-              className="w-full px-4 py-2.5 bg-accent-600 hover:bg-accent-500 text-white rounded-xl font-medium transition-colors"
+              className="w-full px-4 py-2.5 bg-accent-500 hover:bg-accent-500 text-white rounded-xl font-medium transition-colors"
             >
               Close
             </button>

--- a/pdd/frontend/components/GraphToolbar.tsx
+++ b/pdd/frontend/components/GraphToolbar.tsx
@@ -45,7 +45,7 @@ const GraphToolbar: React.FC<GraphToolbarProps> = ({
           className={`
             flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors
             ${editMode
-              ? 'bg-accent-600 text-white hover:bg-accent-500'
+              ? 'bg-accent-500 text-white hover:bg-accent-500'
               : 'bg-surface-700 text-surface-300 hover:bg-surface-600'
             }
           `}
@@ -166,7 +166,7 @@ const GraphToolbar: React.FC<GraphToolbarProps> = ({
           {hasUnsavedChanges && (
             <>
               <div className="w-px h-6 bg-surface-700" />
-              <span className="text-xs text-yellow-400 flex items-center gap-1">
+              <span className="text-xs text-cyan-400 flex items-center gap-1">
                 <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
                 </svg>
@@ -178,7 +178,7 @@ const GraphToolbar: React.FC<GraphToolbarProps> = ({
                 <button
                   onClick={onSave}
                   disabled={isSaving}
-                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-blue-500 text-white hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
                   {isSaving ? (
                     <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">

--- a/pdd/frontend/components/GroupEditModal.tsx
+++ b/pdd/frontend/components/GroupEditModal.tsx
@@ -118,7 +118,7 @@ const GroupEditModal: React.FC<GroupEditModalProps> = ({
                       {m.filename.replace(/\.prompt$/, '')}
                     </p>
                     {m.group && m.group !== name.trim() && (
-                      <p className="text-[10px] text-yellow-500 truncate">Currently in: {m.group}</p>
+                      <p className="text-[10px] text-cyan-500 truncate">Currently in: {m.group}</p>
                     )}
                   </div>
                 </label>
@@ -136,7 +136,7 @@ const GroupEditModal: React.FC<GroupEditModalProps> = ({
             <button
               onClick={handleSave}
               disabled={!name.trim()}
-              className="px-4 py-2 rounded-lg text-sm font-medium bg-accent-600 hover:bg-accent-500 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="px-4 py-2 rounded-lg text-sm font-medium bg-accent-500 hover:bg-accent-500 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               Save Group
             </button>

--- a/pdd/frontend/components/GroupNode.tsx
+++ b/pdd/frontend/components/GroupNode.tsx
@@ -89,7 +89,7 @@ const GroupNode: React.FC<NodeProps<GroupNodeData>> = ({ data }) => {
         {editMode && onEditGroup && (
           <button
             onClick={handleEdit}
-            className="absolute -top-2 -left-2 w-6 h-6 bg-accent-600 hover:bg-accent-500 rounded-full flex items-center justify-center shadow-lg z-20 opacity-0 group-hover:opacity-100 transition-opacity"
+            className="absolute -top-2 -left-2 w-6 h-6 bg-accent-500 hover:bg-accent-500 rounded-full flex items-center justify-center shadow-lg z-20 opacity-0 group-hover:opacity-100 transition-opacity"
             title="Edit group"
           >
             <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pdd/frontend/components/GuidanceSidebar.tsx
+++ b/pdd/frontend/components/GuidanceSidebar.tsx
@@ -107,7 +107,7 @@ const GuidanceSidebar: React.FC<GuidanceSidebarProps> = ({ isOpen, onClose }) =>
                   <h5 className="text-xs font-medium text-text-secondary mb-2 flex items-center gap-1.5">
                     <span className={`w-2 h-2 rounded-full ${
                       category === 'include' ? 'bg-blue-400' :
-                      category === 'dynamic' ? 'bg-amber-400' :
+                      category === 'dynamic' ? 'bg-cyan-400' :
                       category === 'grounding' ? 'bg-purple-400' :
                       'bg-gray-400'
                     }`} />

--- a/pdd/frontend/components/Header.tsx
+++ b/pdd/frontend/components/Header.tsx
@@ -13,7 +13,7 @@ const Header: React.FC<HeaderProps> = ({ currentView, onViewChange }) => {
   const navButtonClasses = (view: View) => `
     px-3 py-2 rounded-md text-sm font-medium transition-colors
     ${currentView === view 
-      ? 'bg-blue-600 text-white' 
+      ? 'bg-blue-500 text-white' 
       : 'text-gray-300 hover:bg-gray-700 hover:text-white'
     }
     focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-blue-500

--- a/pdd/frontend/components/JobCard.tsx
+++ b/pdd/frontend/components/JobCard.tsx
@@ -75,7 +75,7 @@ function extractDevUnitName(displayCommand: string): string | null {
 function getStatusStyle(status: JobStatus): { bg: string; text: string; icon: string } {
   switch (status) {
     case 'queued':
-      return { bg: 'bg-yellow-500/20', text: 'text-yellow-400', icon: 'clock' };
+      return { bg: 'bg-cyan-500/20', text: 'text-cyan-400', icon: 'clock' };
     case 'running':
       return { bg: 'bg-accent-500/20', text: 'text-accent-400', icon: 'spinner' };
     case 'completed':
@@ -193,7 +193,7 @@ const JobCard: React.FC<JobCardProps> = ({
           </div>
           <div className="h-1.5 bg-surface-700 rounded-full overflow-hidden">
             <div
-              className="h-full bg-gradient-to-r from-accent-600 to-accent-400 rounded-full transition-all duration-300"
+              className="h-full bg-gradient-to-r from-accent-500 to-accent-400 rounded-full transition-all duration-300"
               style={{ width: `${progressPercent}%` }}
             />
           </div>
@@ -204,7 +204,7 @@ const JobCard: React.FC<JobCardProps> = ({
       {job.status === 'running' && progressPercent === null && (
         <div className="mb-3">
           <div className="h-1.5 bg-surface-700 rounded-full overflow-hidden">
-            <div className="h-full w-1/3 bg-gradient-to-r from-accent-600 to-accent-400 rounded-full animate-indeterminate" />
+            <div className="h-full w-1/3 bg-gradient-to-r from-accent-500 to-accent-400 rounded-full animate-indeterminate" />
           </div>
         </div>
       )}

--- a/pdd/frontend/components/JobDashboard.tsx
+++ b/pdd/frontend/components/JobDashboard.tsx
@@ -86,7 +86,7 @@ const JobDashboard: React.FC<JobDashboardProps> = ({
             {/* Toggle icon with gold accent when jobs active */}
             <div className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all ${
               activeJobs.length > 0
-                ? 'bg-[#FDCE49]/20 text-[#FDCE49]'
+                ? 'bg-[#18c07a]/20 text-[#18c07a]'
                 : isCollapsed
                   ? 'bg-accent-500/20 text-accent-400'
                   : 'bg-surface-700 text-white'
@@ -118,8 +118,8 @@ const JobDashboard: React.FC<JobDashboardProps> = ({
 
             {/* Active jobs badge with gold styling */}
             {activeJobs.length > 0 && (
-              <span className="px-2.5 py-0.5 text-xs font-medium bg-[#FDCE49]/20 text-[#FDCE49] rounded-full flex items-center gap-1.5 animate-pulse">
-                <span className="w-1.5 h-1.5 rounded-full bg-[#FDCE49]" />
+              <span className="px-2.5 py-0.5 text-xs font-medium bg-[#18c07a]/20 text-[#18c07a] rounded-full flex items-center gap-1.5 animate-pulse">
+                <span className="w-1.5 h-1.5 rounded-full bg-[#18c07a]" />
                 {activeJobs.length} running
               </span>
             )}
@@ -194,8 +194,8 @@ const JobDashboard: React.FC<JobDashboardProps> = ({
             {/* Active jobs section - Expandable cards */}
             {activeJobs.length > 0 && (
               <div className="mb-4">
-                <h3 className="text-xs font-medium text-[#FDCE49] uppercase tracking-wider mb-3 flex items-center gap-2">
-                  <span className="w-2 h-2 rounded-full bg-[#FDCE49] animate-pulse" />
+                <h3 className="text-xs font-medium text-[#18c07a] uppercase tracking-wider mb-3 flex items-center gap-2">
+                  <span className="w-2 h-2 rounded-full bg-[#18c07a] animate-pulse" />
                   Active Jobs
                 </h3>
                 <div className="space-y-2">

--- a/pdd/frontend/components/JobOutputPanel.tsx
+++ b/pdd/frontend/components/JobOutputPanel.tsx
@@ -99,7 +99,7 @@ const JobOutputPanel: React.FC<JobOutputPanelProps> = ({
           {/* Status indicator */}
           <div className={`w-2 h-2 rounded-full flex-shrink-0 ${
             job.status === 'running' ? 'bg-accent-400 animate-pulse' :
-            job.status === 'queued' ? 'bg-yellow-400' :
+            job.status === 'queued' ? 'bg-cyan-400' :
             job.status === 'completed' ? 'bg-green-400' :
             job.status === 'failed' ? 'bg-red-400' :
             'bg-surface-400'
@@ -182,14 +182,14 @@ const JobOutputPanel: React.FC<JobOutputPanelProps> = ({
               </div>
               <div className="h-1.5 bg-surface-700 rounded-full overflow-hidden">
                 <div
-                  className="h-full bg-gradient-to-r from-accent-600 to-accent-400 rounded-full transition-all duration-300"
+                  className="h-full bg-gradient-to-r from-accent-500 to-accent-400 rounded-full transition-all duration-300"
                   style={{ width: `${progressPercent}%` }}
                 />
               </div>
             </div>
           ) : (
             <div className="h-1.5 bg-surface-700 rounded-full overflow-hidden">
-              <div className="h-full w-1/3 bg-gradient-to-r from-accent-600 to-accent-400 rounded-full animate-indeterminate" />
+              <div className="h-full w-1/3 bg-gradient-to-r from-accent-500 to-accent-400 rounded-full animate-indeterminate" />
             </div>
           )}
         </div>
@@ -233,7 +233,7 @@ const JobOutputPanel: React.FC<JobOutputPanelProps> = ({
                 outputRef.current.scrollTop = outputRef.current.scrollHeight;
               }
             }}
-            className="fixed bottom-20 right-8 px-3 py-2 bg-accent-600 hover:bg-accent-500 text-white text-xs font-medium rounded-lg shadow-lg transition-colors flex items-center gap-2"
+            className="fixed bottom-20 right-8 px-3 py-2 bg-accent-500 hover:bg-accent-500 text-white text-xs font-medium rounded-lg shadow-lg transition-colors flex items-center gap-2"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />

--- a/pdd/frontend/components/ModelSelector.tsx
+++ b/pdd/frontend/components/ModelSelector.tsx
@@ -186,7 +186,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
                       <div className="flex items-center gap-2 text-[10px] text-surface-400 flex-shrink-0">
                         <span className="text-green-400">{formatCost(model.input_cost)}</span>
                         <span>{formatTokens(model.context_limit)} ctx</span>
-                        <span className="text-yellow-400">ELO {model.elo}</span>
+                        <span className="text-cyan-400">ELO {model.elo}</span>
                       </div>
                     </div>
                     {model.max_thinking_tokens > 0 && (

--- a/pdd/frontend/components/ModelSliders.tsx
+++ b/pdd/frontend/components/ModelSliders.tsx
@@ -133,7 +133,7 @@ const ModelSliders: React.FC<ModelSlidersProps> = ({
                 step="0.1"
                 value={temperature}
                 onChange={(e) => onTemperatureChange(parseFloat(e.target.value))}
-                className="w-full h-1.5 bg-surface-700 rounded-full appearance-none cursor-pointer accent-orange-500"
+                className="w-full h-1.5 bg-surface-700 rounded-full appearance-none cursor-pointer accent-sky-500"
               />
             </div>
           </div>

--- a/pdd/frontend/components/ModuleEditModal.tsx
+++ b/pdd/frontend/components/ModuleEditModal.tsx
@@ -344,7 +344,7 @@ const ModuleEditModal: React.FC<ModuleEditModalProps> = ({
             <button
               onClick={handleSave}
               disabled={errors.length > 0}
-              className="px-4 py-2 rounded-lg text-sm font-medium bg-accent-600 text-white hover:bg-accent-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="px-4 py-2 rounded-lg text-sm font-medium bg-accent-500 text-white hover:bg-accent-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               Save Changes
             </button>

--- a/pdd/frontend/components/ModuleNode.tsx
+++ b/pdd/frontend/components/ModuleNode.tsx
@@ -103,7 +103,7 @@ const ModuleNode: React.FC<NodeProps<ModuleNodeData>> = ({ data, selected, xPos,
                 </div>
                 <div className="flex items-center gap-2 text-xs mt-1">
                   <span className={hasCode ? 'text-green-400' : 'text-surface-500'}>{hasCode ? '✓' : '✗'} Code</span>
-                  <span className={hasTest ? 'text-yellow-400' : 'text-surface-500'}>{hasTest ? '✓' : '✗'} Test</span>
+                  <span className={hasTest ? 'text-cyan-400' : 'text-surface-500'}>{hasTest ? '✓' : '✗'} Test</span>
                   <span className={hasExample ? 'text-blue-400' : 'text-surface-500'}>{hasExample ? '✓' : '✗'} Example</span>
                 </div>
               </div>
@@ -137,7 +137,7 @@ const ModuleNode: React.FC<NodeProps<ModuleNodeData>> = ({ data, selected, xPos,
           {editMode && (
             <button
               onClick={handleEditClick}
-              className="absolute -top-2 -left-2 w-6 h-6 bg-accent-600 hover:bg-accent-500 rounded-full flex items-center justify-center shadow-lg z-20 opacity-0 group-hover:opacity-100 transition-opacity"
+              className="absolute -top-2 -left-2 w-6 h-6 bg-accent-500 hover:bg-accent-500 rounded-full flex items-center justify-center shadow-lg z-20 opacity-0 group-hover:opacity-100 transition-opacity"
               title="Edit module"
             >
               <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -150,7 +150,7 @@ const ModuleNode: React.FC<NodeProps<ModuleNodeData>> = ({ data, selected, xPos,
           {hasPrompt && onRunSync && !editMode && (
             <button
               onClick={handleSyncClick}
-              className="absolute -top-2 -right-2 w-6 h-6 bg-gradient-to-br from-[#FDCE49] to-[#DFA84A] hover:from-[#FFD966] hover:to-[#FDCE49] rounded-full flex items-center justify-center shadow-lg z-20 transition-all hover:scale-110"
+              className="absolute -top-2 -right-2 w-6 h-6 bg-gradient-to-br from-[#18c07a] to-[#00d8ff] hover:from-[#5ce3ff] hover:to-[#18c07a] rounded-full flex items-center justify-center shadow-lg z-20 transition-all hover:scale-110"
               title="Run pdd sync (prompt → code)"
             >
               <svg className="w-3 h-3 text-surface-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -178,7 +178,7 @@ const ModuleNode: React.FC<NodeProps<ModuleNodeData>> = ({ data, selected, xPos,
                 C
               </div>
               <div
-                className={`w-3.5 h-3.5 rounded-full flex items-center justify-center text-[8px] font-bold ${hasTest ? 'bg-yellow-500 text-white' : 'bg-surface-700 text-surface-500'}`}
+                className={`w-3.5 h-3.5 rounded-full flex items-center justify-center text-[8px] font-bold ${hasTest ? 'bg-cyan-500 text-white' : 'bg-surface-700 text-surface-500'}`}
                 title={hasTest ? 'Test exists' : 'No test file'}
               >
                 T

--- a/pdd/frontend/components/ProjectSettings.tsx
+++ b/pdd/frontend/components/ProjectSettings.tsx
@@ -521,7 +521,7 @@ const ProjectSettings: React.FC = () => {
         <p className="text-surface-400">Failed to load configuration</p>
         <button
           onClick={loadConfig}
-          className="px-4 py-2 bg-accent-600 hover:bg-accent-500 text-white rounded-lg transition-colors"
+          className="px-4 py-2 bg-accent-500 hover:bg-accent-500 text-white rounded-lg transition-colors"
         >
           Retry
         </button>
@@ -550,7 +550,7 @@ const ProjectSettings: React.FC = () => {
               ? 'bg-surface-700 text-surface-500 cursor-not-allowed'
               : saveSuccess
               ? 'bg-green-600 text-white'
-              : 'bg-accent-600 hover:bg-accent-500 text-white'
+              : 'bg-accent-500 hover:bg-accent-500 text-white'
           }`}
         >
           {saving ? (
@@ -640,7 +640,7 @@ const ProjectSettings: React.FC = () => {
         {/* Current Status */}
         <div className="flex items-center gap-3 p-3 rounded-lg bg-surface-800/50 mb-4">
           <div className={`w-3 h-3 rounded-full ${
-            authStatus?.authenticated ? 'bg-green-400' : 'bg-yellow-400 animate-pulse'
+            authStatus?.authenticated ? 'bg-green-400' : 'bg-cyan-400 animate-pulse'
           }`} />
           <div>
             <p className="text-sm font-medium text-white">
@@ -696,7 +696,7 @@ const ProjectSettings: React.FC = () => {
 
       {/* Unsaved changes warning */}
       {hasChanges() && (
-        <div className="mt-4 p-3 bg-yellow-500/20 border border-yellow-500/50 rounded-lg text-yellow-300 text-sm">
+        <div className="mt-4 p-3 bg-cyan-500/20 border border-cyan-500/50 rounded-lg text-cyan-300 text-sm">
           You have unsaved changes. Click "Save Changes" to persist your configuration.
         </div>
       )}

--- a/pdd/frontend/components/PromptCodeDiffModal.tsx
+++ b/pdd/frontend/components/PromptCodeDiffModal.tsx
@@ -34,7 +34,7 @@ interface PromptCodeDiffModalProps {
 // Color scheme for different statuses
 const STATUS_COLORS = {
   matched: { bg: 'bg-emerald-500/10', border: 'border-emerald-500/30', text: 'text-emerald-400', headerBg: 'bg-emerald-500/20' },
-  partial: { bg: 'bg-yellow-500/10', border: 'border-yellow-500/30', text: 'text-yellow-400', headerBg: 'bg-yellow-500/20' },
+  partial: { bg: 'bg-cyan-500/10', border: 'border-cyan-500/30', text: 'text-cyan-400', headerBg: 'bg-cyan-500/20' },
   missing: { bg: 'bg-red-500/15', border: 'border-red-500/50', text: 'text-red-400', headerBg: 'bg-red-500/30' },
   extra: { bg: 'bg-red-500/15', border: 'border-red-500/50', text: 'text-red-400', headerBg: 'bg-red-500/30' },
 };
@@ -285,14 +285,14 @@ export const PromptCodeDiffModal: React.FC<PromptCodeDiffModalProps> = ({
                     {/* Regeneration Risk Badge */}
                     <div className={`flex items-center gap-2 px-3 py-1.5 rounded-lg ${
                       diffResult.result.regenerationRisk === 'critical' ? 'bg-red-500/20 border border-red-500/50' :
-                      diffResult.result.regenerationRisk === 'high' ? 'bg-orange-500/20 border border-orange-500/50' :
-                      diffResult.result.regenerationRisk === 'medium' ? 'bg-yellow-500/20 border border-yellow-500/50' :
+                      diffResult.result.regenerationRisk === 'high' ? 'bg-sky-500/20 border border-sky-500/50' :
+                      diffResult.result.regenerationRisk === 'medium' ? 'bg-cyan-500/20 border border-cyan-500/50' :
                       'bg-emerald-500/20 border border-emerald-500/50'
                     }`}>
                       <span className={`text-xs font-medium ${
                         diffResult.result.regenerationRisk === 'critical' ? 'text-red-400' :
-                        diffResult.result.regenerationRisk === 'high' ? 'text-orange-400' :
-                        diffResult.result.regenerationRisk === 'medium' ? 'text-yellow-400' :
+                        diffResult.result.regenerationRisk === 'high' ? 'text-sky-400' :
+                        diffResult.result.regenerationRisk === 'medium' ? 'text-cyan-400' :
                         'text-emerald-400'
                       }`}>
                         {diffResult.result.regenerationRisk === 'critical' ? 'CRITICAL RISK' :
@@ -317,7 +317,7 @@ export const PromptCodeDiffModal: React.FC<PromptCodeDiffModalProps> = ({
                         className="text-lg font-bold"
                         style={{
                           color: diffResult.result.overallScore >= 80 ? '#10b981' :
-                                 diffResult.result.overallScore >= 50 ? '#f59e0b' : '#ef4444'
+                                 diffResult.result.overallScore >= 50 ? '#00d8ff' : '#ef4444'
                         }}
                       >
                         {diffResult.result.overallScore}%
@@ -487,7 +487,7 @@ export const PromptCodeDiffModal: React.FC<PromptCodeDiffModalProps> = ({
                         {diffResult.result.stats.documentedFeatures}/{diffResult.result.stats.totalCodeFeatures} documented
                       </span>
                       {diffResult.result.hiddenKnowledge && diffResult.result.hiddenKnowledge.length > 0 && (
-                        <span className="text-orange-400">
+                        <span className="text-sky-400">
                           {diffResult.result.hiddenKnowledge.length} hidden
                         </span>
                       )}
@@ -547,7 +547,7 @@ export const PromptCodeDiffModal: React.FC<PromptCodeDiffModalProps> = ({
                           <div className="flex items-start gap-3">
                             <div className={`w-2 h-2 rounded-full mt-1.5 flex-shrink-0 ${
                               section.status === 'matched' ? 'bg-emerald-500' :
-                              section.status === 'partial' ? 'bg-yellow-500' : 'bg-red-500'
+                              section.status === 'partial' ? 'bg-cyan-500' : 'bg-red-500'
                             }`} />
                             <div className="flex-1 min-w-0">
                               <div className="flex items-center justify-between gap-2">
@@ -620,7 +620,7 @@ export const PromptCodeDiffModal: React.FC<PromptCodeDiffModalProps> = ({
                           <div className="flex items-start gap-3">
                             <div className={`w-2 h-2 rounded-full mt-1.5 flex-shrink-0 ${
                               section.status === 'matched' ? 'bg-emerald-500' :
-                              section.status === 'partial' ? 'bg-yellow-500' : 'bg-red-500'
+                              section.status === 'partial' ? 'bg-cyan-500' : 'bg-red-500'
                             }`} />
                             <div className="flex-1 min-w-0">
                               <div className="flex items-center justify-between gap-2">
@@ -860,7 +860,7 @@ export const PromptCodeDiffModal: React.FC<PromptCodeDiffModalProps> = ({
                     <h3 className="text-sm font-medium text-white mb-3">
                       Version History ({historyResponse.versions.length} commits)
                       {historyResponse.has_uncommitted_changes && (
-                        <span className="ml-2 text-xs text-yellow-400">(uncommitted changes)</span>
+                        <span className="ml-2 text-xs text-cyan-400">(uncommitted changes)</span>
                       )}
                     </h3>
                     <div className="space-y-2">
@@ -968,7 +968,7 @@ export const PromptCodeDiffModal: React.FC<PromptCodeDiffModalProps> = ({
                               <div className={`w-2.5 h-2.5 rounded-full mt-1 flex-shrink-0 ${
                                 change.change_type === 'added' ? 'bg-emerald-500' :
                                 change.change_type === 'removed' ? 'bg-red-500' :
-                                'bg-yellow-500'
+                                'bg-cyan-500'
                               }`} />
                               <div className="flex-1 min-w-0">
                                 {/* Short summary when collapsed, full when expanded */}
@@ -985,7 +985,7 @@ export const PromptCodeDiffModal: React.FC<PromptCodeDiffModalProps> = ({
                               <span className={`text-xs px-2 py-0.5 rounded-full ${
                                 change.change_type === 'added' ? 'bg-emerald-500/20 text-emerald-400' :
                                 change.change_type === 'removed' ? 'bg-red-500/20 text-red-400' :
-                                'bg-yellow-500/20 text-yellow-400'
+                                'bg-cyan-500/20 text-cyan-400'
                               }`}>
                                 {change.change_type}
                               </span>
@@ -1144,8 +1144,8 @@ export const PromptCodeDiffModal: React.FC<PromptCodeDiffModalProps> = ({
                     </span>
                   )}
                   {diffResult.result.stats.hiddenKnowledgeCount > 0 && (
-                    <span className="text-orange-400 flex items-center gap-1">
-                      <span className="w-2 h-2 rounded-full bg-orange-500" />
+                    <span className="text-sky-400 flex items-center gap-1">
+                      <span className="w-2 h-2 rounded-full bg-sky-500" />
                       {diffResult.result.stats.hiddenKnowledgeCount} hidden knowledge
                     </span>
                   )}
@@ -1179,7 +1179,7 @@ export const PromptCodeDiffModal: React.FC<PromptCodeDiffModalProps> = ({
               <div className="text-sm text-surface-300">
                 {historyResponse.versions.length} version{historyResponse.versions.length !== 1 ? 's' : ''} found
                 {historyResponse.has_uncommitted_changes && (
-                  <span className="text-yellow-400 ml-2">• Uncommitted changes present</span>
+                  <span className="text-cyan-400 ml-2">• Uncommitted changes present</span>
                 )}
               </div>
             )}

--- a/pdd/frontend/components/PromptEditor.tsx
+++ b/pdd/frontend/components/PromptEditor.tsx
@@ -200,8 +200,8 @@ const PromptEditor: React.FC<PromptEditorProps> = ({ promptPath, onSave, onCance
           <span className="font-mono">{promptPath}</span>
         </div>
         {hasChanges && (
-          <span className="text-yellow-400 text-sm flex items-center gap-1">
-            <span className="w-2 h-2 bg-yellow-400 rounded-full"></span>
+          <span className="text-cyan-400 text-sm flex items-center gap-1">
+            <span className="w-2 h-2 bg-cyan-400 rounded-full"></span>
             Unsaved changes
           </span>
         )}
@@ -241,7 +241,7 @@ const PromptEditor: React.FC<PromptEditorProps> = ({ promptPath, onSave, onCance
             disabled={!hasChanges || saving}
             className={`px-4 py-1.5 text-sm rounded flex items-center gap-2 transition-colors ${
               hasChanges && !saving
-                ? 'bg-blue-600 text-white hover:bg-blue-500'
+                ? 'bg-blue-500 text-white hover:bg-blue-500'
                 : 'bg-gray-700 text-gray-500 cursor-not-allowed'
             }`}
           >

--- a/pdd/frontend/components/PromptMetricsBar.tsx
+++ b/pdd/frontend/components/PromptMetricsBar.tsx
@@ -78,16 +78,16 @@ const PromptMetricsBar: React.FC<PromptMetricsBarProps> = ({
   // Determine context usage color
   const getUsageColor = (percent: number): string => {
     if (percent < 50) return 'text-green-400';
-    if (percent < 75) return 'text-yellow-400';
-    if (percent < 90) return 'text-orange-400';
+    if (percent < 75) return 'text-cyan-400';
+    if (percent < 90) return 'text-sky-400';
     return 'text-red-400';
   };
 
   // Get progress bar color class
   const getBarColor = (percent: number): string => {
     if (percent < 50) return 'bg-green-500';
-    if (percent < 75) return 'bg-yellow-500';
-    if (percent < 90) return 'bg-orange-500';
+    if (percent < 75) return 'bg-cyan-500';
+    if (percent < 90) return 'bg-sky-500';
     return 'bg-red-500';
   };
 
@@ -125,7 +125,7 @@ const PromptMetricsBar: React.FC<PromptMetricsBarProps> = ({
             onClick={() => onViewModeChange('raw')}
             className={`px-2 sm:px-3 py-1 text-[10px] sm:text-xs font-medium transition-all duration-200 ${
               viewMode === 'raw'
-                ? 'bg-accent-600 text-white'
+                ? 'bg-accent-500 text-white'
                 : 'bg-surface-700/50 text-surface-300 hover:bg-surface-600'
             }`}
           >
@@ -136,7 +136,7 @@ const PromptMetricsBar: React.FC<PromptMetricsBarProps> = ({
             disabled={!processedMetrics && !preprocessingError}
             className={`px-2 sm:px-3 py-1 text-[10px] sm:text-xs font-medium transition-all duration-200 ${
               viewMode === 'processed'
-                ? 'bg-accent-600 text-white'
+                ? 'bg-accent-500 text-white'
                 : 'bg-surface-700/50 text-surface-300 hover:bg-surface-600'
             } ${!processedMetrics && !preprocessingError ? 'opacity-50 cursor-not-allowed' : ''}`}
             title={preprocessingError ? `Error: ${preprocessingError}` : 'View processed prompt with includes expanded'}
@@ -162,7 +162,7 @@ const PromptMetricsBar: React.FC<PromptMetricsBarProps> = ({
               !hasCodeFile
                 ? 'bg-surface-700/30 text-surface-500 cursor-not-allowed'
                 : showCodePanel
-                ? 'bg-blue-600 text-white'
+                ? 'bg-blue-500 text-white'
                 : 'bg-surface-700/50 text-surface-300 hover:bg-surface-600 hover:text-white'
             }`}
             title={!hasCodeFile ? 'No code file available' : showCodePanel ? 'Hide code panel' : 'Show code side-by-side'}
@@ -181,7 +181,7 @@ const PromptMetricsBar: React.FC<PromptMetricsBarProps> = ({
               !hasTestFile
                 ? 'bg-surface-700/30 text-surface-500 cursor-not-allowed'
                 : showTestPanel
-                ? 'bg-yellow-600 text-white'
+                ? 'bg-cyan-600 text-white'
                 : 'bg-surface-700/50 text-surface-300 hover:bg-surface-600 hover:text-white'
             }`}
             title={!hasTestFile ? 'No test file available' : showTestPanel ? 'Hide test panel' : 'Show test side-by-side'}
@@ -216,7 +216,7 @@ const PromptMetricsBar: React.FC<PromptMetricsBarProps> = ({
             onClick={onTogglePreview}
             className={`flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-all duration-200 ${
               showPreview
-                ? 'bg-accent-600 text-white'
+                ? 'bg-accent-500 text-white'
                 : 'bg-surface-700/50 text-surface-300 hover:bg-surface-600 hover:text-white'
             }`}
             title={showPreview ? 'Show source code' : 'Show rendered preview'}
@@ -241,7 +241,7 @@ const PromptMetricsBar: React.FC<PromptMetricsBarProps> = ({
             className={`flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-all duration-200 ${
               !hasCodeFile
                 ? 'bg-surface-700/30 text-surface-500 cursor-not-allowed'
-                : 'bg-gradient-to-r from-purple-600/50 to-blue-600/50 text-purple-200 hover:from-purple-500 hover:to-blue-500 hover:text-white'
+                : 'bg-gradient-to-r from-purple-600/50 to-blue-500/50 text-purple-200 hover:from-purple-500 hover:to-blue-500 hover:text-white'
             }`}
             title={!hasCodeFile ? 'No code file available' : 'View detailed diff analysis'}
           >
@@ -321,7 +321,7 @@ const PromptMetricsBar: React.FC<PromptMetricsBarProps> = ({
               <div className="flex items-center gap-1.5" title={`${codeLineCount} lines of code / ${promptLineCount} lines of prompt`}>
                 <span className="text-[10px] sm:text-xs text-surface-400 hidden sm:inline">Code:Prompt:</span>
                 <span className={`text-xs sm:text-sm font-mono ${
-                  codeLineCount / promptLineCount >= 1 ? 'text-blue-400' : 'text-orange-400'
+                  codeLineCount / promptLineCount >= 1 ? 'text-blue-400' : 'text-sky-400'
                 }`}>
                   {(codeLineCount / promptLineCount).toFixed(1)}x
                 </span>
@@ -359,7 +359,7 @@ const PromptMetricsBar: React.FC<PromptMetricsBarProps> = ({
               />
               {/* Output capacity (green/orange based on warning) */}
               <div
-                className={`h-full transition-all ${isOutputWarning ? 'bg-orange-500/50' : 'bg-green-500/30'}`}
+                className={`h-full transition-all ${isOutputWarning ? 'bg-sky-500/50' : 'bg-green-500/30'}`}
                 style={{ width: `${Math.max(outputPercent, 0)}%` }}
                 title={`Output capacity: ${formatTokens(outputCapacity)} tokens (${outputPercent.toFixed(1)}%)`}
               />
@@ -376,8 +376,8 @@ const PromptMetricsBar: React.FC<PromptMetricsBarProps> = ({
               <span>Thinking {formatTokens(thinkingBudget)}</span>
             </div>
             <div className="flex items-center gap-1">
-              <div className={`w-2 h-2 rounded-sm ${isOutputWarning ? 'bg-orange-500' : 'bg-green-500/50'}`} />
-              <span className={isOutputWarning ? 'text-orange-400' : ''}>
+              <div className={`w-2 h-2 rounded-sm ${isOutputWarning ? 'bg-sky-500' : 'bg-green-500/50'}`} />
+              <span className={isOutputWarning ? 'text-sky-400' : ''}>
                 Output {formatTokens(outputCapacity)}
                 {isOutputWarning && ' (low)'}
               </span>
@@ -420,7 +420,7 @@ const PromptMetricsBar: React.FC<PromptMetricsBarProps> = ({
             ))}
           </div>
           {contextAudit.warnings.length > 0 && (
-            <div className="mt-1 text-[9px] sm:text-[10px] text-orange-400/80">
+            <div className="mt-1 text-[9px] sm:text-[10px] text-sky-400/80">
               {contextAudit.warnings.length} deferred/unresolved warning
               {contextAudit.warnings.length === 1 ? '' : 's'}
             </div>

--- a/pdd/frontend/components/PromptOrderModal.tsx
+++ b/pdd/frontend/components/PromptOrderModal.tsx
@@ -300,7 +300,7 @@ const PromptOrderModal: React.FC<PromptOrderModalProps> = ({
                   item.module.priority === 'high'
                     ? 'bg-red-500/20 text-red-300'
                     : item.module.priority === 'medium'
-                    ? 'bg-yellow-500/20 text-yellow-300'
+                    ? 'bg-cyan-500/20 text-cyan-300'
                     : 'bg-green-500/20 text-green-300'
                 }`}>
                   {item.module.priority || 'normal'}

--- a/pdd/frontend/components/PromptSelector.tsx
+++ b/pdd/frontend/components/PromptSelector.tsx
@@ -15,8 +15,8 @@ interface PromptSelectorProps {
 const LANGUAGE_COLORS: Record<string, string> = {
   python: 'bg-blue-500/15 text-blue-300 border-blue-500/30',
   typescript: 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30',
-  javascript: 'bg-yellow-500/15 text-yellow-300 border-yellow-500/30',
-  java: 'bg-orange-500/15 text-orange-300 border-orange-500/30',
+  javascript: 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30',
+  java: 'bg-sky-500/15 text-sky-300 border-sky-500/30',
   go: 'bg-teal-500/15 text-teal-300 border-teal-500/30',
   rust: 'bg-red-500/15 text-red-300 border-red-500/30',
 };
@@ -68,7 +68,7 @@ const PromptCard: React.FC<{
             {onSyncClick && (
               <button
                 onClick={handleSyncClick}
-                className="flex-shrink-0 w-7 h-7 bg-gradient-to-br from-[#FDCE49] to-[#DFA84A] hover:from-[#FFD966] hover:to-[#FDCE49] rounded-full flex items-center justify-center shadow-lg transition-all hover:scale-110"
+                className="flex-shrink-0 w-7 h-7 bg-gradient-to-br from-[#18c07a] to-[#00d8ff] hover:from-[#5ce3ff] hover:to-[#18c07a] rounded-full flex items-center justify-center shadow-lg transition-all hover:scale-110"
                 title="Run pdd sync (prompt → code)"
               >
                 <svg className="w-3.5 h-3.5 text-surface-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -102,7 +102,7 @@ const FileTag: React.FC<{
   const colorClasses = {
     purple: exists ? 'bg-purple-500/15 text-purple-300 border-purple-500/30' : 'bg-surface-800/50 text-surface-500 border-surface-700/50',
     green: exists ? 'bg-green-500/15 text-green-300 border-green-500/30' : 'bg-surface-800/50 text-surface-500 border-surface-700/50',
-    yellow: exists ? 'bg-yellow-500/15 text-yellow-300 border-yellow-500/30' : 'bg-surface-800/50 text-surface-500 border-surface-700/50',
+    yellow: exists ? 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30' : 'bg-surface-800/50 text-surface-500 border-surface-700/50',
     blue: exists ? 'bg-blue-500/15 text-blue-300 border-blue-500/30' : 'bg-surface-800/50 text-surface-500 border-surface-700/50',
   };
 
@@ -257,7 +257,7 @@ const PromptSelector: React.FC<PromptSelectorProps> = ({
         </p>
         <button
           onClick={() => setShowCreateModal(true)}
-          className="flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-accent-600 to-accent-500 hover:from-accent-500 hover:to-accent-400 text-white rounded-xl font-medium shadow-lg shadow-accent-500/25 transition-all"
+          className="flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-accent-500 to-accent-500 hover:from-accent-500 hover:to-accent-400 text-white rounded-xl font-medium shadow-lg shadow-accent-500/25 transition-all"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
@@ -319,7 +319,7 @@ const PromptSelector: React.FC<PromptSelectorProps> = ({
           </button>
           <button
             onClick={() => setShowCreateModal(true)}
-            className="flex items-center gap-1.5 px-2.5 sm:px-3 py-1.5 text-xs sm:text-sm bg-accent-600 hover:bg-accent-500 text-white rounded-lg transition-colors"
+            className="flex items-center gap-1.5 px-2.5 sm:px-3 py-1.5 text-xs sm:text-sm bg-accent-500 hover:bg-accent-500 text-white rounded-lg transition-colors"
             title="Create new prompt"
           >
             <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pdd/frontend/components/PromptSpace.tsx
+++ b/pdd/frontend/components/PromptSpace.tsx
@@ -429,7 +429,7 @@ const CommandOptionsModal: React.FC<{
             )}
             <button
               type="submit"
-              className="w-full sm:w-auto px-4 py-2.5 rounded-xl text-sm font-medium bg-gradient-to-r from-accent-600 to-accent-500 hover:from-accent-500 hover:to-accent-400 text-white shadow-lg shadow-accent-500/25 transition-all flex items-center justify-center gap-2"
+              className="w-full sm:w-auto px-4 py-2.5 rounded-xl text-sm font-medium bg-gradient-to-r from-accent-500 to-accent-500 hover:from-accent-500 hover:to-accent-400 text-white shadow-lg shadow-accent-500/25 transition-all flex items-center justify-center gap-2"
             >
               <span>{command.icon}</span>
               <span>Run {command.shortDescription}</span>
@@ -1274,8 +1274,8 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
           </button>
 
           {hasChanges && (
-            <span className="text-yellow-400 text-xs sm:text-sm flex items-center gap-1.5 px-2 py-1 rounded-full bg-yellow-500/10 border border-yellow-500/20">
-              <span className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-yellow-400 rounded-full animate-pulse"></span>
+            <span className="text-cyan-400 text-xs sm:text-sm flex items-center gap-1.5 px-2 py-1 rounded-full bg-cyan-500/10 border border-cyan-500/20">
+              <span className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-cyan-400 rounded-full animate-pulse"></span>
               <span className="hidden xs:inline">Unsaved</span>
             </span>
           )}
@@ -1329,7 +1329,7 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
             disabled={!hasChanges || saving || viewMode === 'processed'}
             className={`px-2.5 sm:px-4 py-1.5 text-xs sm:text-sm rounded-lg flex items-center gap-1.5 sm:gap-2 transition-all duration-200 ${
               hasChanges && !saving && viewMode === 'raw'
-                ? 'bg-gradient-to-r from-accent-600 to-accent-500 hover:from-accent-500 hover:to-accent-400 text-white shadow-lg shadow-accent-500/25'
+                ? 'bg-gradient-to-r from-accent-500 to-accent-500 hover:from-accent-500 hover:to-accent-400 text-white shadow-lg shadow-accent-500/25'
                 : 'bg-surface-700/50 text-surface-500 cursor-not-allowed'
             }`}
             title={viewMode === 'processed' ? 'Switch to Raw view to save changes' : undefined}
@@ -1354,8 +1354,8 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
       {embedded && (
         <div className="flex items-center justify-end gap-2 sm:gap-3 px-3 sm:px-4 py-2 border-b border-surface-700/50 bg-surface-900/50">
           {hasChanges && (
-            <span className="text-yellow-400 text-xs sm:text-sm flex items-center gap-1.5 px-2 py-1 rounded-full bg-yellow-500/10 border border-yellow-500/20">
-              <span className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-yellow-400 rounded-full animate-pulse"></span>
+            <span className="text-cyan-400 text-xs sm:text-sm flex items-center gap-1.5 px-2 py-1 rounded-full bg-cyan-500/10 border border-cyan-500/20">
+              <span className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-cyan-400 rounded-full animate-pulse"></span>
               <span className="hidden xs:inline">Unsaved</span>
             </span>
           )}
@@ -1408,7 +1408,7 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
             disabled={!hasChanges || saving || viewMode === 'processed'}
             className={`px-2.5 sm:px-4 py-1.5 text-xs sm:text-sm rounded-lg flex items-center gap-1.5 sm:gap-2 transition-all duration-200 ${
               hasChanges && !saving && viewMode === 'raw'
-                ? 'bg-gradient-to-r from-accent-600 to-accent-500 hover:from-accent-500 hover:to-accent-400 text-white shadow-lg shadow-accent-500/25'
+                ? 'bg-gradient-to-r from-accent-500 to-accent-500 hover:from-accent-500 hover:to-accent-400 text-white shadow-lg shadow-accent-500/25'
                 : 'bg-surface-700/50 text-surface-500 cursor-not-allowed'
             }`}
             title={viewMode === 'processed' ? 'Switch to Raw view to save changes' : undefined}
@@ -1527,7 +1527,7 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
                       <span className="text-base">{cmd.icon}</span>
                       <span className="flex-1">{cmd.shortDescription}</span>
                       {hasMissingFiles && (
-                        <span className="w-5 h-5 rounded-full bg-yellow-500/20 text-yellow-400 text-xs flex items-center justify-center">!</span>
+                        <span className="w-5 h-5 rounded-full bg-cyan-500/20 text-cyan-400 text-xs flex items-center justify-center">!</span>
                       )}
                     </button>
                   );
@@ -1554,7 +1554,7 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
                       <span className="text-base">{cmd.icon}</span>
                       <span className="flex-1">{cmd.shortDescription}</span>
                       {hasMissingFiles && (
-                        <span className="w-5 h-5 rounded-full bg-yellow-500/20 text-yellow-400 text-xs flex items-center justify-center">!</span>
+                        <span className="w-5 h-5 rounded-full bg-cyan-500/20 text-cyan-400 text-xs flex items-center justify-center">!</span>
                       )}
                     </button>
                   );
@@ -1580,7 +1580,7 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
                     <span className="text-base">{cmd.icon}</span>
                     <span className="flex-1">{cmd.shortDescription}</span>
                     {hasMissingFiles && (
-                      <span className="w-5 h-5 rounded-full bg-yellow-500/20 text-yellow-400 text-xs flex items-center justify-center">!</span>
+                      <span className="w-5 h-5 rounded-full bg-cyan-500/20 text-cyan-400 text-xs flex items-center justify-center">!</span>
                     )}
                   </button>
                 );
@@ -1625,7 +1625,7 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
                           <span className="text-surface-500 text-xs">{cmd.icon}</span>
                           <span className="flex-1 text-xs">{cmd.shortDescription}</span>
                           {hasMissingFiles && (
-                            <span className="w-4 h-4 rounded-full bg-yellow-500/20 text-yellow-400 text-[10px] flex items-center justify-center">!</span>
+                            <span className="w-4 h-4 rounded-full bg-cyan-500/20 text-cyan-400 text-[10px] flex items-center justify-center">!</span>
                           )}
                         </button>
                       );
@@ -1715,7 +1715,7 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
               <div className="px-3 sm:px-4 py-2 bg-surface-800/30 border-b border-surface-700/50 text-xs sm:text-sm text-surface-400 font-mono flex items-center gap-2 overflow-hidden">
                 <span className="truncate flex-1">{prompt.prompt}</span>
                 {viewMode === 'processed' && (
-                  <span className="px-2 py-0.5 rounded-full text-[10px] sm:text-xs bg-yellow-500/15 text-yellow-300 border border-yellow-500/30 flex-shrink-0">Read Only</span>
+                  <span className="px-2 py-0.5 rounded-full text-[10px] sm:text-xs bg-cyan-500/15 text-cyan-300 border border-cyan-500/30 flex-shrink-0">Read Only</span>
                 )}
                 {/* Analyze Include button */}
                 <button
@@ -1738,7 +1738,7 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
                   onClick={() => setGuidanceSidebarOpen(!guidanceSidebarOpen)}
                   className={`flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-all duration-200 flex-shrink-0 ${
                     guidanceSidebarOpen
-                      ? 'bg-accent-600 text-white'
+                      ? 'bg-accent-500 text-white'
                       : 'bg-surface-700/50 text-surface-300 hover:bg-surface-600 hover:text-white'
                   }`}
                   title={guidanceSidebarOpen ? 'Hide prompting guide' : 'Show prompting guide'}
@@ -1823,7 +1823,7 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
                                   <span className="text-lg relative">
                                     {cmd.icon}
                                     {hasMissingFiles && (
-                                      <span className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-yellow-500/80"></span>
+                                      <span className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-cyan-500/80"></span>
                                     )}
                                   </span>
                                   <span className="text-[10px] leading-tight text-center">{cmd.shortDescription}</span>
@@ -1892,7 +1892,7 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
                           onClick={() => { if (!isExecuting) handleCommandClick(CommandType.TEST); }}
                           disabled={isExecuting}
                           className={`flex items-center gap-1.5 px-3 py-1 rounded-lg text-[10px] font-medium transition-all duration-200 ${
-                            isExecuting ? 'text-surface-500 cursor-not-allowed' : 'text-yellow-300 hover:bg-yellow-500/20 hover:text-white'
+                            isExecuting ? 'text-surface-500 cursor-not-allowed' : 'text-cyan-300 hover:bg-cyan-500/20 hover:text-white'
                           }`}
                           title="Generate test from prompt + code"
                         >
@@ -1913,13 +1913,13 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
                             <svg className={`w-3 h-3 text-surface-400 transition-transform ${testCollapsed ? '-rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                             </svg>
-                            <svg className="w-4 h-4 text-yellow-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg className="w-4 h-4 text-cyan-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
                             </svg>
                             <span className="text-xs text-surface-400 font-mono truncate" title={prompt.test || ''}>
                               {prompt.test?.split('/').pop() || 'Test'}
                             </span>
-                            <span className="px-1.5 py-0.5 rounded text-[10px] bg-yellow-500/20 text-yellow-300 flex-shrink-0">Read Only</span>
+                            <span className="px-1.5 py-0.5 rounded text-[10px] bg-cyan-500/20 text-cyan-300 flex-shrink-0">Read Only</span>
                           </div>
                           <div className="flex items-center gap-1" onClick={e => e.stopPropagation()}>
                             <button onClick={() => loadTestContent()} disabled={testLoading} className="p-1.5 text-surface-400 hover:text-white hover:bg-surface-700 rounded transition-colors" title="Reload">
@@ -1937,7 +1937,7 @@ const PromptSpace: React.FC<PromptSpaceProps> = ({
                         {!testCollapsed && (
                           testLoading ? (
                             <div className="flex-1 flex items-center justify-center py-8">
-                              <svg className="animate-spin h-5 w-5 text-yellow-400" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" /><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" /></svg>
+                              <svg className="animate-spin h-5 w-5 text-cyan-400" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" /><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" /></svg>
                             </div>
                           ) : testError ? (
                             <div className="flex-1 flex items-center justify-center py-4">

--- a/pdd/frontend/components/ReauthModal.tsx
+++ b/pdd/frontend/components/ReauthModal.tsx
@@ -174,7 +174,7 @@ const ReauthModal: React.FC<ReauthModalProps> = ({ onClose }) => {
           {/* Current Status */}
           <div className="flex items-center gap-3 p-3 rounded-lg bg-gray-700/50">
             <div className={`w-3 h-3 rounded-full ${
-              authStatus?.authenticated ? 'bg-green-400' : 'bg-yellow-400 animate-pulse'
+              authStatus?.authenticated ? 'bg-green-400' : 'bg-cyan-400 animate-pulse'
             }`} />
             <div>
               <p className="text-sm font-medium text-white">
@@ -312,7 +312,7 @@ const ReauthModal: React.FC<ReauthModalProps> = ({ onClose }) => {
           {(loginState.phase === 'idle' || loginState.phase === 'error') && (
             <button
               onClick={handleLogin}
-              className="px-4 py-2 rounded-md text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-blue-500 transition-colors flex items-center gap-2"
+              className="px-4 py-2 rounded-md text-sm font-medium bg-blue-500 text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-blue-500 transition-colors flex items-center gap-2"
             >
               {/* GitHub icon */}
               <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">

--- a/pdd/frontend/components/RemoteSessionSelector.tsx
+++ b/pdd/frontend/components/RemoteSessionSelector.tsx
@@ -100,14 +100,14 @@ const RemoteSessionSelector: React.FC<RemoteSessionSelectorProps> = ({
               className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium ${
                 selectedSession.status === 'active'
                   ? 'bg-green-500/10 text-green-400 border border-green-500/20'
-                  : 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'
+                  : 'bg-cyan-500/10 text-cyan-400 border border-cyan-500/20'
               }`}
             >
               <span
                 className={`w-1.5 h-1.5 rounded-full ${
                   selectedSession.status === 'active'
                     ? 'bg-green-400'
-                    : 'bg-yellow-400 animate-pulse'
+                    : 'bg-cyan-400 animate-pulse'
                 }`}
               />
               {selectedSession.status === 'active' ? 'Active' : 'Offline'}
@@ -131,14 +131,14 @@ const RemoteSessionSelector: React.FC<RemoteSessionSelectorProps> = ({
 
       {/* Stale session warning banner */}
       {selectedSession && selectedSession.status === 'stale' && (
-        <div className="mt-2 p-2 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
+        <div className="mt-2 p-2 bg-cyan-500/10 border border-cyan-500/20 rounded-lg">
           <div className="flex items-start gap-2">
-            <svg className="w-4 h-4 text-yellow-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-4 h-4 text-cyan-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
             <div>
-              <p className="text-xs font-medium text-yellow-400">Session Offline</p>
-              <p className="text-xs text-yellow-200/70 mt-0.5">
+              <p className="text-xs font-medium text-cyan-400">Session Offline</p>
+              <p className="text-xs text-cyan-200/70 mt-0.5">
                 This session has not sent a heartbeat recently. The remote machine may not be running.
                 Commands submitted may not be executed.
               </p>

--- a/pdd/frontend/components/SyncFromPromptModal.tsx
+++ b/pdd/frontend/components/SyncFromPromptModal.tsx
@@ -151,12 +151,12 @@ const SyncFromPromptModal: React.FC<SyncFromPromptModalProps> = ({
 
               {/* Sync Errors */}
               {result.errors && result.errors.length > 0 && (
-                <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-4">
-                  <h4 className="text-sm font-medium text-yellow-300 mb-2">Sync Warnings:</h4>
-                  <ul className="text-sm text-yellow-200/80 space-y-1">
+                <div className="bg-cyan-500/10 border border-cyan-500/30 rounded-lg p-4">
+                  <h4 className="text-sm font-medium text-cyan-300 mb-2">Sync Warnings:</h4>
+                  <ul className="text-sm text-cyan-200/80 space-y-1">
                     {result.errors.map((err, i) => (
                       <li key={i} className="flex items-start gap-2">
-                        <span className="text-yellow-400 flex-shrink-0">•</span>
+                        <span className="text-cyan-400 flex-shrink-0">•</span>
                         <span>{err}</span>
                       </li>
                     ))}
@@ -203,7 +203,7 @@ const SyncFromPromptModal: React.FC<SyncFromPromptModalProps> = ({
               <button
                 onClick={onSync}
                 disabled={isSyncing}
-                className="px-4 py-2 bg-accent-600 hover:bg-accent-500 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                className="px-4 py-2 bg-accent-500 hover:bg-accent-500 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
               >
                 {isSyncing && (
                   <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">

--- a/pdd/frontend/components/SyncOptionsModal.tsx
+++ b/pdd/frontend/components/SyncOptionsModal.tsx
@@ -83,7 +83,7 @@ const SyncOptionsModal: React.FC<SyncOptionsModalProps> = ({
         {/* Header */}
         <div className="px-5 py-4 border-b border-surface-700/50">
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-[#FDCE49] to-[#DFA84A] flex items-center justify-center">
+            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-[#18c07a] to-[#00d8ff] flex items-center justify-center">
               <svg className="w-5 h-5 text-surface-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
               </svg>
@@ -131,7 +131,7 @@ const SyncOptionsModal: React.FC<SyncOptionsModalProps> = ({
           <button
             type="button"
             onClick={handleConfirm}
-            className="w-full sm:w-auto px-4 py-2 rounded-xl text-sm font-medium bg-gradient-to-r from-[#FDCE49] to-[#DFA84A] hover:from-[#FFD966] hover:to-[#FDCE49] text-surface-900 shadow-lg transition-all flex items-center justify-center gap-2"
+            className="w-full sm:w-auto px-4 py-2 rounded-xl text-sm font-medium bg-gradient-to-r from-[#18c07a] to-[#00d8ff] hover:from-[#5ce3ff] hover:to-[#18c07a] text-surface-900 shadow-lg transition-all flex items-center justify-center gap-2"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />

--- a/pdd/frontend/components/SyncStatusBadge.tsx
+++ b/pdd/frontend/components/SyncStatusBadge.tsx
@@ -31,9 +31,9 @@ const STATUS_CONFIG: Record<SyncStatusType, StatusConfig> = {
     description: 'Prompt and code are in sync',
   },
   prompt_changed: {
-    color: 'text-yellow-400',
-    bgColor: 'bg-yellow-500/10',
-    borderColor: 'border-yellow-500/30',
+    color: 'text-cyan-400',
+    bgColor: 'bg-cyan-500/10',
+    borderColor: 'border-cyan-500/30',
     icon: (
       <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 10l7-7m0 0l7 7m-7-7v18" />
@@ -43,9 +43,9 @@ const STATUS_CONFIG: Record<SyncStatusType, StatusConfig> = {
     description: 'Prompt was edited since last sync',
   },
   code_changed: {
-    color: 'text-orange-400',
-    bgColor: 'bg-orange-500/10',
-    borderColor: 'border-orange-500/30',
+    color: 'text-sky-400',
+    bgColor: 'bg-sky-500/10',
+    borderColor: 'border-sky-500/30',
     icon: (
       <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />

--- a/pdd/frontend/components/TaskQueueControls.tsx
+++ b/pdd/frontend/components/TaskQueueControls.tsx
@@ -57,7 +57,7 @@ const TaskQueueControls: React.FC<TaskQueueControlsProps> = ({
             className={`
               px-3 py-1 text-xs font-medium rounded-md transition-colors
               ${executionMode === 'auto'
-                ? 'bg-accent-600 text-white'
+                ? 'bg-accent-500 text-white'
                 : 'text-surface-400 hover:text-white'
               }
             `}
@@ -69,7 +69,7 @@ const TaskQueueControls: React.FC<TaskQueueControlsProps> = ({
             className={`
               px-3 py-1 text-xs font-medium rounded-md transition-colors
               ${executionMode === 'manual'
-                ? 'bg-accent-600 text-white'
+                ? 'bg-accent-500 text-white'
                 : 'text-surface-400 hover:text-white'
               }
             `}
@@ -93,7 +93,7 @@ const TaskQueueControls: React.FC<TaskQueueControlsProps> = ({
       {hasAnyTasks && progress.total > 0 && (
         <div className="h-1.5 bg-surface-700 rounded-full overflow-hidden">
           <div
-            className="h-full bg-gradient-to-r from-accent-600 to-green-500 rounded-full transition-all duration-300"
+            className="h-full bg-gradient-to-r from-accent-500 to-green-500 rounded-full transition-all duration-300"
             style={{ width: `${(progress.completed / progress.total) * 100}%` }}
           />
         </div>
@@ -107,7 +107,7 @@ const TaskQueueControls: React.FC<TaskQueueControlsProps> = ({
             {!isQueueRunning && hasPendingTasks && (
               <button
                 onClick={onStartQueue}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-accent-600 text-white hover:bg-accent-500 rounded-lg transition-colors"
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-accent-500 text-white hover:bg-accent-500 rounded-lg transition-colors"
               >
                 <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
@@ -119,7 +119,7 @@ const TaskQueueControls: React.FC<TaskQueueControlsProps> = ({
             {isQueueRunning && !isPaused && (
               <button
                 onClick={onPauseQueue}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-yellow-600 text-white hover:bg-yellow-500 rounded-lg transition-colors"
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-cyan-600 text-white hover:bg-cyan-500 rounded-lg transition-colors"
               >
                 <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -130,7 +130,7 @@ const TaskQueueControls: React.FC<TaskQueueControlsProps> = ({
             {isQueueRunning && isPaused && (
               <button
                 onClick={onResumeQueue}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-accent-600 text-white hover:bg-accent-500 rounded-lg transition-colors"
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-accent-500 text-white hover:bg-accent-500 rounded-lg transition-colors"
               >
                 <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
@@ -146,7 +146,7 @@ const TaskQueueControls: React.FC<TaskQueueControlsProps> = ({
         {executionMode === 'manual' && hasPendingTasks && progress.running === 0 && (
           <button
             onClick={onRunNextTask}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-accent-600 text-white hover:bg-accent-500 rounded-lg transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-accent-500 text-white hover:bg-accent-500 rounded-lg transition-colors"
           >
             <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 5l7 7-7 7M5 5l7 7-7 7" />

--- a/pdd/frontend/components/TaskQueueItem.tsx
+++ b/pdd/frontend/components/TaskQueueItem.tsx
@@ -50,7 +50,7 @@ function getStatusStyle(status: TaskStatus): { bg: string; text: string; icon: s
     case 'failed':
       return { bg: 'bg-red-500/20', text: 'text-red-400', icon: 'x' };
     case 'skipped':
-      return { bg: 'bg-yellow-500/20', text: 'text-yellow-400', icon: 'skip' };
+      return { bg: 'bg-cyan-500/20', text: 'text-cyan-400', icon: 'skip' };
     default:
       return { bg: 'bg-surface-500/20', text: 'text-surface-400', icon: 'question' };
   }
@@ -200,7 +200,7 @@ const TaskQueueItem: React.FC<TaskQueueItemProps> = ({
                   e.stopPropagation();
                   onSkip();
                 }}
-                className="p-1.5 text-yellow-400 hover:bg-yellow-500/20 rounded transition-colors"
+                className="p-1.5 text-cyan-400 hover:bg-cyan-500/20 rounded transition-colors"
                 title="Skip this task"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -245,7 +245,7 @@ const TaskQueueItem: React.FC<TaskQueueItemProps> = ({
       {/* Running indicator */}
       {isActive && (
         <div className="mt-2 h-1 bg-surface-700 rounded-full overflow-hidden">
-          <div className="h-full w-1/3 bg-gradient-to-r from-accent-600 to-accent-400 rounded-full animate-indeterminate" />
+          <div className="h-full w-1/3 bg-gradient-to-r from-accent-500 to-accent-400 rounded-full animate-indeterminate" />
         </div>
       )}
     </div>

--- a/pdd/frontend/components/TaskQueuePanel.tsx
+++ b/pdd/frontend/components/TaskQueuePanel.tsx
@@ -292,7 +292,7 @@ const TaskQueuePanel: React.FC<TaskQueuePanelProps> = ({
 
             {/* Paused indicator */}
             {isQueueRunning && isPaused && (
-              <span className="px-2 py-0.5 text-xs font-medium bg-yellow-500/20 text-yellow-400 rounded-full">
+              <span className="px-2 py-0.5 text-xs font-medium bg-cyan-500/20 text-cyan-400 rounded-full">
                 Paused
               </span>
             )}

--- a/pdd/frontend/data/mockPrompts.ts
+++ b/pdd/frontend/data/mockPrompts.ts
@@ -145,7 +145,7 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 const Button: React.FC<ButtonProps> = ({ children, ...props }) => {
   return (
     <button
-      className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+      className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
       {...props}
     >
       {children}

--- a/pdd/frontend/index.html
+++ b/pdd/frontend/index.html
@@ -46,20 +46,23 @@
               },
               // PDD brand colors
               pdd: {
-                gold: '#FDCE49',
-                goldActive: '#DFA84A',
-                goldHover: '#FFD966',
+                gold: '#18c07a',
+                goldActive: '#ff2aa6',
+                goldHover: '#ff5cc0',
               },
-              // Shared PromptDriven brand palette (matches the Sizzle site)
+              // PromptDriven Brand Guidelines v1.4 §3 — official palette
               brand: {
-                cyan: '#00d8ff',
-                navy: '#0a0a23',
-                graphite: '#1a1b26',
-                magenta: '#ff2aa6',
-                purple: '#8c47ff',
-                green: '#18c07a',
-                sleet: '#f5f7fa',
-                mute: '#5b6378',
+                cyan: '#00d8ff',     // Electric-Cyan · Primary
+                navy: '#0a0a23',     // Deep-Navy · Ink/Fill
+                purple: '#8c47ff',   // Lumen-Purple · Accent 1
+                magenta: '#ff2aa6',  // Prompt-Magenta · Accent 2
+                sleet: '#f5f7fa',    // Light-Sleet · Surface-Light
+                graphite: '#1a1b26', // Graphite-900 · Surface-Dark
+                green: '#18c07a',    // Build-Green · Success
+                green700: '#0fa86a', // Build-Green-700 · Success tint
+                yellow: '#fbbb35',   // Diff-Yellow · Warning
+                red: '#f34842',      // Break-Red · Error
+                mute: '#5b6378',     // neutral (UI only, not a brand pigment)
               },
             },
             fontFamily: {
@@ -165,8 +168,8 @@
         50% { opacity: 0.5; }
       }
       @keyframes glowPulse {
-        0%, 100% { box-shadow: 0 0 5px rgba(253, 206, 73, 0.3); }
-        50% { box-shadow: 0 0 20px rgba(253, 206, 73, 0.6); }
+        0%, 100% { box-shadow: 0 0 5px rgba(0, 216, 255, 0.3); }
+        50% { box-shadow: 0 0 20px rgba(0, 216, 255, 0.6); }
       }
 
       .animate-fade-in { animation: fadeIn 0.3s ease-out; }
@@ -201,6 +204,21 @@
         outline: none;
         box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.5);
       }
+
+      /* App background — Deep-Navy base with brand Electric-Cyan + Lumen-Purple light-blue glows */
+      .app-bg {
+        background-color: #0a0a23;
+        background-image:
+          radial-gradient(55rem 38rem at 12% -8%, rgba(0, 216, 255, 0.16), transparent 60%),
+          radial-gradient(48rem 34rem at 100% -6%, rgba(140, 71, 255, 0.13), transparent 55%),
+          radial-gradient(46rem 32rem at 50% 118%, rgba(0, 216, 255, 0.10), transparent 60%);
+        background-attachment: fixed;
+      }
+
+      /* White glow shadows */
+      .glow-white { box-shadow: 0 0 16px rgba(255, 255, 255, 0.16); }
+      .glow-white-strong { box-shadow: 0 0 24px rgba(255, 255, 255, 0.30); }
+      .glass, .glass-light { box-shadow: 0 0 18px rgba(255, 255, 255, 0.08); }
 
       /* Card hover effect */
       .card-hover {
@@ -302,7 +320,7 @@
 
       /* ReactFlow edge selection styles */
       .react-flow__edge.selected .react-flow__edge-path {
-        stroke: #f97316 !important;
+        stroke: #00d8ff !important;
         stroke-width: 3px !important;
       }
       .react-flow__edge:hover .react-flow__edge-path {
@@ -310,7 +328,7 @@
         stroke-width: 2.5px !important;
       }
       .react-flow__edge.selected:hover .react-flow__edge-path {
-        stroke: #fb923c !important;
+        stroke: #5ce3ff !important;
         stroke-width: 3px !important;
       }
 
@@ -405,7 +423,7 @@
 }
 </script>
 </head>
-  <body class="bg-surface-950 text-gray-200">
+  <body class="app-bg text-gray-200">
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
   </body>

--- a/pdd/frontend/index.html
+++ b/pdd/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Prompt Driven Development</title>
+    <title>PromptDriven.ai — Prompt Driven Development</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/pdd/frontend/index.html
+++ b/pdd/frontend/index.html
@@ -50,6 +50,17 @@
                 goldActive: '#DFA84A',
                 goldHover: '#FFD966',
               },
+              // Shared PromptDriven brand palette (matches the Sizzle site)
+              brand: {
+                cyan: '#00d8ff',
+                navy: '#0a0a23',
+                graphite: '#1a1b26',
+                magenta: '#ff2aa6',
+                purple: '#8c47ff',
+                green: '#18c07a',
+                sleet: '#f5f7fa',
+                mute: '#5b6378',
+              },
             },
             fontFamily: {
               sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],

--- a/pdd/frontend/lib/batchUtils.ts
+++ b/pdd/frontend/lib/batchUtils.ts
@@ -76,7 +76,7 @@ class UnionFind {
 const BATCH_COLORS = [
   '#8B5CF6', // Purple
   '#06B6D4', // Cyan
-  '#F59E0B', // Amber
+  '#00d8ff', // Amber
   '#10B981', // Emerald
   '#EC4899', // Pink
   '#6366F1', // Indigo


### PR DESCRIPTION
## Sub-PR of #1666 — Sizzle brand restyle (palette · blue/green accents · light-blue background)

Targets `epic/sizzle-brand-consistency` (not `main`). This is the full approved look (reviewed live in the dev server) and **supersedes #1668 (colors) + #1669 (header)** — it contains both plus the accent recolor and background.

### What changes (43 files, `pdd/frontend`)
- **Header** — Sizzle wordmark lockup in the live header (`App.tsx`): semibold `brand-sleet` `PromptDriven.ai` + tiny mono-uppercase `brand-cyan` descriptor; aligned `<title>`. **Existing logo kept.**
- **Brand palette** — full **Brand Guidelines v1.4 §3** token set added to the Tailwind config (Electric-Cyan, Deep-Navy, Lumen-Purple, Prompt-Magenta, Light-Sleet, Graphite-900, Build-Green + 700, Diff-Yellow, Break-Red).
- **Accents** — the legacy **gold/yellow is gone app-wide**: **green** (`Build-Green`) for structure (borders, icon tiles), **blue** (`Electric-Cyan`) for active/selected states, toggles, and graph-edge selection. Existing blue kept for primary actions. **No pink** on any rendered surface.
- **Background** — Deep-Navy base with brand Electric-Cyan + Lumen-Purple radial **light-blue glows** (`.app-bg`).
- **White glow** shadows on active controls, the nav container, and glass panels.

### Notes
- Fonts (Inter + JetBrains Mono) already loaded; logo unchanged.
- `heal` / `auto-heal` red = paid PDD Cloud gate, unrelated to this frontend-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
