### PR TITLE
Fix Cloud Batch release preflight sources

### DIFF
--- a/ci/cloud-batch/submit.sh
+++ b/ci/cloud-batch/submit.sh
@@ -65,6 +65,7 @@ SOURCE_PATHS=(
     context
     examples
     demos
+    research
     docs
     Makefile
     pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ markers = [
     "integration: mark a test as an integration test (makes real API calls, costs money)",
     "slow: mark a test as slow-running",
     "e2e: mark a test as E2E test (uses real LLM calls, costs money, runs slowly)",
+    "timeout: mark a test with a custom timeout in seconds",
     "private_prompt: mark a test as exercising a private prompt fixture not shipped in the public repo",
     "uses_real_cli_detector: mark a test that exercises the real CLI detector instead of a stub",
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,4 +14,6 @@ markers =
     integration: mark a test as an integration test (makes real API calls, costs money)
     slow: mark a test as slow-running
     e2e: mark a test as E2E test (uses real LLM calls, costs money, runs slowly)
+    timeout: mark a test with a custom timeout in seconds
     private_prompt: mark a test that checks private _python.prompt content (not synced to public repo)
+    uses_real_cli_detector: mark a test that exercises the real CLI detector instead of a stub


### PR DESCRIPTION
## Summary
- include tracked research fixtures in Cloud Batch source uploads
- explicitly register pytest timeout markers for strict marker collection
- mirror uses_real_cli_detector marker registration in pytest.ini

## Test plan
- PDD_PUBLIC_REPO_DIR=/Users/gregtanaka/Documents/pdd.worktrees/pdd-cli-release-gate-20260618-204159 make test-pdd-cli-release
- Cloud Batch run pdd-test-run-20260618-210443-990f832fe: 77 passed, 0 failed, 0 errors
- LLM smoke Cloud Build fee45a02-7699-4292-afd4-8d349f08faa8: SUCCESS