### PR TITLE
Fix release video Claude OAuth auth

### DIFF
--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -317,12 +317,14 @@ def run(
     cwd: Path,
     input_text: str | None = None,
     timeout: float | None = None,
+    env: dict[str, str] | None = None,
     check: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     try:
         completed = subprocess.run(
             command,
             cwd=str(cwd),
+            env=env,
             input=input_text,
             text=True,
             capture_output=True,
@@ -545,8 +547,17 @@ def generate_script_with_claude(
     if claude_tools.strip():
         command.extend(["--allowedTools", claude_tools.strip()])
     prompt = render_release_video_prompt(context, prompt_template, cwd)
+    claude_env = os.environ.copy()
+    strip_anthropic_creds_for_claude_subprocess(claude_env)
     try:
-        completed = run(command, cwd=cwd, input_text=prompt, timeout=timeout, check=False)
+        completed = run(
+            command,
+            cwd=cwd,
+            input_text=prompt,
+            timeout=timeout,
+            env=claude_env,
+            check=False,
+        )
     except ReleaseVideoError as exc:
         raise ReleaseVideoError(
             "Claude Code script generation failed before PDS publish; "
@@ -558,6 +569,15 @@ def generate_script_with_claude(
     if len(script) < 200:
         raise ReleaseVideoError("Claude Code produced an unexpectedly short release video script.")
     return script.rstrip() + "\n"
+
+
+def strip_anthropic_creds_for_claude_subprocess(env: dict[str, str]) -> bool:
+    """Keep release-video Claude generation on OAuth when both auth paths exist."""
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    from pdd.agentic_common import _strip_anthropic_creds_for_claude_subprocess
+
+    return _strip_anthropic_creds_for_claude_subprocess(env, quiet=True)
 
 
 def classify_claude_quota_auth_failure(output: str) -> str | None:

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -368,6 +368,66 @@ def test_release_video_claude_quota_failure_is_script_generation_diagnostic(tmp_
     assert not capture.exists()
 
 
+def test_release_video_claude_generation_prefers_oauth_over_inherited_api_key(
+    tmp_path: Path,
+    monkeypatch,
+):
+    release_video = load_release_video_module()
+    prompt_template = tmp_path / "release_video_LLM.prompt"
+    prompt_template.write_text("Context:\n{release_context}\n", encoding="utf8")
+    captured: dict[str, object] = {}
+
+    def fake_run(
+        command,
+        *,
+        cwd: Path,
+        input_text: str | None = None,
+        timeout: float | None = None,
+        env: dict[str, str] | None = None,
+        check: bool = True,
+    ):
+        captured["command"] = command
+        captured["input_text"] = input_text
+        captured["env"] = env
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=reusable_script_text(),
+            stderr="",
+        )
+
+    from pdd import agentic_common
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "stale-depleted-api-key")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "stale-auth-token")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+    monkeypatch.delenv("PDD_KEEP_ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(agentic_common, "_claude_has_oauth_login", lambda: True)
+    monkeypatch.setattr(release_video, "ensure_command_exists", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(release_video, "run", fake_run)
+
+    script = release_video.generate_script_with_claude(
+        context="# PDD release context",
+        claude_cli="claude",
+        claude_model="claude-opus-4-8",
+        claude_tools="",
+        prompt_template=prompt_template,
+        timeout=60,
+        cwd=tmp_path,
+    )
+
+    claude_env = captured["env"]
+    assert isinstance(claude_env, dict)
+    assert "ANTHROPIC_API_KEY" not in claude_env
+    assert "ANTHROPIC_AUTH_TOKEN" not in claude_env
+    assert claude_env["CLAUDE_CODE_OAUTH_TOKEN"] == "oauth-token"
+    assert os.environ["ANTHROPIC_API_KEY"] == "stale-depleted-api-key"
+    assert os.environ["ANTHROPIC_AUTH_TOKEN"] == "stale-auth-token"
+    assert "--model" in captured["command"]
+    assert "PDD release context" in captured["input_text"]
+    assert "\nNARRATOR:\n" in script
+
+
 def test_release_video_claude_quota_auth_classifier():
     release_video = load_release_video_module()
 


### PR DESCRIPTION
## Summary
- Strip inherited Anthropic API-key credentials from the release-video Claude subprocess when Claude OAuth is detected
- Keep the parent environment and PDS invocation unchanged
- Add a regression test for OAuth plus stale API key release-video generation

## Tests
- python -m pytest tests/test_release_video.py
- python -m pytest tests/test_agentic_common_issue_813_anthropic_api_key_oauth_shadow.py