### PR TITLE
Fix agentic sync dry-run mock contract

### DIFF
--- a/tests/test_e2e_issue_745_initial_cost_tracking.py
+++ b/tests/test_e2e_issue_745_initial_cost_tracking.py
@@ -91,7 +91,13 @@ class TestAgenticSyncInitialCostE2E:
                 llm_analysis_cost,
                 "anthropic",
             )
-            mock_dry_run.return_value = (True, {"mymod": Path("/tmp")}, [], 0.0)
+            mock_dry_run.return_value = (
+                True,
+                {"mymod": Path("/tmp")},
+                {"mymod": "mymod"},
+                [],
+                0.0,
+            )
 
             success, msg, total_cost, provider = run_agentic_sync(
                 "https://github.com/owner/repo/issues/1", quiet=True


### PR DESCRIPTION
## Summary
- Update the issue #745 E2E test mock for _run_dry_run_validation to match the current five-value return contract.

## Test plan
- python -m pytest tests/test_e2e_issue_745_initial_cost_tracking.py::TestAgenticSyncInitialCostE2E::test_run_agentic_sync_passes_llm_cost_to_runner_and_returns_total -q
- PDD_PUBLIC_REPO_DIR=/Users/gregtanaka/Documents/pdd.worktrees/pdd-cli-release-gate-20260621-000242 make test-pdd-cli-release
  - Cloud Batch: 77 passed, 0 failed, 0 errors (run-20260621-002918-cad9d0dc5)
  - LLM smoke Cloud Build: SUCCESS (900e2f18-4b48-4d06-b8e4-bb177fe9193f)