### PR TITLE
Extend release video PDS timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,10 @@ jobs:
       #   vars.PDS_CLI_PACKAGE         install spec for the @promptdriven/pds
       #                                CLI, for example @promptdriven/pds@latest
       #                                or a pinned version.
+      #   vars.PDS_CLI                 optional pds command. Defaults to a
+      #                                longer timeout because release-video
+      #                                create can exceed the CLI's 30s default
+      #                                before returning a run handle.
       #   vars.PDS_API_URL             PDS backend. Defaults to production when
       #                                the repo variable is unset.
       #   vars.RELEASE_VIDEO_PROJECT_ID  optional stable PDS project to reuse
@@ -230,6 +234,7 @@ jobs:
           PDS_TOKEN: ${{ secrets.PDS_TOKEN }}
           PDS_API_URL: ${{ vars.PDS_API_URL || 'https://video.promptdriven.ai' }}
           PDS_CLI_PACKAGE: ${{ vars.PDS_CLI_PACKAGE }}
+          PDS_CLI: ${{ vars.PDS_CLI || 'pds --timeout 120s' }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           RELEASE_VIDEO_PROJECT_ID: ${{ vars.RELEASE_VIDEO_PROJECT_ID }}
           RELEASE_VIDEO_SCRIPT_PATH: ${{ vars.RELEASE_VIDEO_SCRIPT_PATH }}


### PR DESCRIPTION
## Summary
- Expose a release-video PDS_CLI command override from repo vars.
- Default CI release-video runs to pds --timeout 120s so the create request can return a run handle after slower PDS bootstrap work.

## Context
The v0.0.282 release-video recovery reached PDS with @promptdriven/pds@0.1.4, force-regenerate enabled, and a retry idempotency key, but failed before a run handle was returned: Request timed out after 30000ms.

## Test plan
- Static assertion that the release workflow wires PDS_CLI to vars.PDS_CLI or pds --timeout 120s.
