### PR TITLE
Fix release video Discord backfill

### DIFF
--- a/.github/workflows/backfill-release-video-discord.yml
+++ b/.github/workflows/backfill-release-video-discord.yml
@@ -1,0 +1,43 @@
+name: Backfill release video Discord post
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag, for example v0.0.283"
+        required: true
+        type: string
+      youtube_url:
+        description: "Recovered YouTube release-video URL"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  backfill-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Backfill Discord release-video follow-up
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          TAG: ${{ inputs.tag }}
+          YOUTUBE_URL: ${{ inputs.youtube_url }}
+        run: |
+          set -euo pipefail
+          python scripts/backfill_release_video_discord.py \
+            --tag "$TAG" \
+            --youtube-url "$YOUTUBE_URL" \
+            --repo "${{ github.repository }}"

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ help:
 	@echo "  make publish                 - Build & upload current version to PyPI"
 	@echo "  make publish-public          - Copy artifacts to public repo only"
 	@echo "  make release-video           - Generate and upload a YouTube video for the current release tag"
+	@echo "  make release-video-discord-backfill RELEASE_TAG=vX.Y.Z RELEASE_VIDEO_YOUTUBE_URL=url - Post recovered video follow-up to Discord"
 	@echo "  make release-local           - Run release with local Infisical PDS release token"
 	@echo "  make check-deps              - Check pyproject.toml and requirements.txt are in sync"
 	@echo "  make release                 - On main: tag HEAD with next vN.N.N and push (BUMP=patch|minor|major; default patch)"
@@ -95,6 +96,7 @@ RELEASE_VIDEO_IDEMPOTENCY_KEY ?=
 RELEASE_VIDEO_ATTEMPT_ID ?=
 RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT ?= 0
 RELEASE_VIDEO_FORCE_REGENERATE ?= 0
+RELEASE_VIDEO_YOUTUBE_URL ?=
 CLAUDE_CLI ?= claude
 PDS_CLI ?= pds
 PDS_API_URL ?= https://video.promptdriven.ai
@@ -116,7 +118,7 @@ ifeq ($(CI),true)
 SKIP_MAKEFILE_REGEN := 1
 endif
 
-RELEASE_MAKE_GOALS := release release-video release-local release-infisical check-release-video-config check-release-video-config-local check-release-video-config-infisical
+RELEASE_MAKE_GOALS := release release-video release-video-discord-backfill release-local release-infisical check-release-video-config check-release-video-config-local check-release-video-config-infisical
 ifneq ($(filter $(RELEASE_MAKE_GOALS),$(MAKECMDGOALS)),)
 SKIP_MAKEFILE_REGEN := 1
 endif
@@ -137,7 +139,7 @@ TEST_OUTPUTS := $(patsubst $(PDD_DIR)/%.py,$(TESTS_DIR)/test_%.py,$(PY_OUTPUTS))
 # All Example files in context directory (recursive)
 EXAMPLE_FILES := $(shell find $(CONTEXT_DIR) -name "*_example.py" 2>/dev/null)
 
-.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release release-local release-infisical release-video check-release-remote check-release-branch check-release-clean check-release-video-config check-release-video-config-local check-release-video-config-infisical
+.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release release-local release-infisical release-video release-video-discord-backfill check-release-remote check-release-branch check-release-clean check-release-video-config check-release-video-config-local check-release-video-config-infisical
 
 all: $(PY_OUTPUTS) $(MAKEFILE_OUTPUT) $(CSV_OUTPUTS) $(EXAMPLE_OUTPUTS) $(TEST_OUTPUTS)
 
@@ -801,6 +803,12 @@ release-video:
 		--platform "$(RELEASE_VIDEO_PLATFORM)" \
 		--privacy "$(RELEASE_VIDEO_PRIVACY)" \
 		$$DRY_RUN_FLAG
+
+release-video-discord-backfill:
+	@python scripts/backfill_release_video_discord.py \
+		--tag "$(RELEASE_TAG)" \
+		--youtube-url "$(RELEASE_VIDEO_YOUTUBE_URL)" \
+		--repo "$${GITHUB_REPOSITORY:-promptdriven/pdd}"
 
 release: check-deps check-suspicious-files check-release-remote check-release-branch check-release-clean check-release-video-config
 	@echo "Preparing release"

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -681,6 +681,7 @@ Release-video diagnostics and recovery:
 - If Claude Code quota/auth blocks script generation, reuse a generated script artifact with `RELEASE_VIDEO_SCRIPT_PATH=.pdd/release-videos/<tag>/release_video_script.md make release-video RELEASE_TAG=<tag>`.
 - For selected-project bootstrap recovery, reuse the generated script and run `make release-video RELEASE_TAG=<tag> RELEASE_VIDEO_PROJECT_ID=<project-id> RELEASE_VIDEO_SCRIPT_PATH=.pdd/release-videos/<tag>/release_video_script.md RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT=1 RELEASE_VIDEO_FORCE_REGENERATE=1 RELEASE_VIDEO_ATTEMPT_ID=<timestamp-or-label>`.
 - For PDS publish retries, inspect the previous run first. Exact retries should reuse the original idempotency key; start a new attempt only after confirming the old run should not be reused, with `make release-video RELEASE_TAG=<tag> RELEASE_VIDEO_ATTEMPT_ID=<timestamp-or-label>` or a full `RELEASE_VIDEO_IDEMPOTENCY_KEY=<key>`.
+- If a release video is recovered after the release workflow already posted to Discord, run the **Backfill release video Discord post** workflow with the release tag and YouTube URL. Local equivalent: `DISCORD_WEBHOOK_URL=<webhook> make release-video-discord-backfill RELEASE_TAG=<tag> RELEASE_VIDEO_YOUTUBE_URL=<youtube-url>`.
 - Set `PDS_CLI` if `pds` is not on `PATH`. Use `RELEASE_VIDEO=0` only for an emergency release that must skip paid video generation/upload.
 
 ### 9. Troubleshooting Development Setup

--- a/scripts/backfill_release_video_discord.py
+++ b/scripts/backfill_release_video_discord.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Backfill a Discord follow-up for a recovered PDD release video."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from typing import Any
+
+
+SEMVER_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
+YOUTUBE_URL_RE = re.compile(r"^https?://(?:www\.)?(?:youtube\.com|youtu\.be)/[^\s\"'<>]+$")
+GITHUB_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+MARKER_NAME = "pdd-release-video-discord-backfill"
+
+
+class BackfillError(RuntimeError):
+    """Raised for actionable release-video Discord backfill failures."""
+
+
+class BackfillResult:
+    def __init__(
+        self,
+        *,
+        posted: bool,
+        release_body_updated: bool,
+        marker_added: bool,
+        skipped_reason: str | None = None,
+    ) -> None:
+        self.posted = posted
+        self.release_body_updated = release_body_updated
+        self.marker_added = marker_added
+        self.skipped_reason = skipped_reason
+
+
+class GitHubReleaseClient:
+    """Tiny wrapper around gh release commands for testable release-note edits."""
+
+    def __init__(
+        self,
+        *,
+        gh_cli: str = "gh",
+        repo: str,
+        run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    ) -> None:
+        self.gh_cli = gh_cli
+        self.repo = repo
+        self.run = run
+
+    def get_release_body(self, tag: str) -> str:
+        completed = self._run(
+            [
+                self.gh_cli,
+                "release",
+                "view",
+                tag,
+                "--repo",
+                self.repo,
+                "--json",
+                "body",
+                "--jq",
+                ".body",
+            ]
+        )
+        return completed.stdout
+
+    def edit_release_body(self, tag: str, body: str) -> None:
+        self._run(
+            [
+                self.gh_cli,
+                "release",
+                "edit",
+                tag,
+                "--repo",
+                self.repo,
+                "--notes-file",
+                "-",
+            ],
+            input=body,
+        )
+
+    def _run(
+        self,
+        command: list[str],
+        *,
+        input: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        try:
+            completed = self.run(
+                command,
+                input=input,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise BackfillError(f"Could not run {self.gh_cli!r}: {exc}") from exc
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout or "").strip()
+            if detail:
+                raise BackfillError(f"gh command failed: {' '.join(command)}\n{detail}")
+            raise BackfillError(f"gh command failed: {' '.join(command)}")
+        return completed
+
+
+def discord_backfill_marker(tag: str, youtube_url: str) -> str:
+    digest = hashlib.sha256(f"{tag}\n{youtube_url}".encode("utf8")).hexdigest()
+    return f"<!-- {MARKER_NAME}: tag={tag} url_sha256={digest} -->"
+
+
+def ensure_release_body_has_video_link(body: str, youtube_url: str) -> tuple[str, bool]:
+    if youtube_url in body:
+        return body, False
+    prefix = f"Release video: {youtube_url}"
+    if body.strip():
+        return f"{prefix}\n\n{body}", True
+    return f"{prefix}\n", True
+
+
+def ensure_release_body_has_marker(body: str, tag: str, youtube_url: str) -> tuple[str, bool]:
+    marker = discord_backfill_marker(tag, youtube_url)
+    if marker in body:
+        return body, False
+    if body.strip():
+        return f"{body.rstrip()}\n\n{marker}\n", True
+    return f"{marker}\n", True
+
+
+def build_discord_payload(tag: str, youtube_url: str, repo: str) -> dict[str, str]:
+    release_url = f"https://github.com/{repo}/releases/tag/{tag}"
+    return {
+        "content": f"Release video recovered for {tag}: {youtube_url}\nRelease: {release_url}"
+    }
+
+
+def send_discord_webhook(
+    webhook_url: str,
+    payload: dict[str, Any],
+    *,
+    timeout: float = 20,
+) -> None:
+    data = json.dumps(payload).encode("utf8")
+    request = urllib.request.Request(
+        webhook_url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = getattr(response, "status", response.getcode())
+            if status >= 400:
+                raise BackfillError(f"Discord webhook returned HTTP {status}")
+    except urllib.error.HTTPError as exc:
+        raise BackfillError(f"Discord webhook returned HTTP {exc.code}: {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise BackfillError(f"Discord webhook request failed: {exc.reason}") from exc
+
+
+def validate_inputs(tag: str, youtube_url: str, repo: str) -> None:
+    if not SEMVER_TAG_RE.fullmatch(tag):
+        raise BackfillError(f"Release tag must look like vX.Y.Z, got {tag!r}.")
+    if not YOUTUBE_URL_RE.fullmatch(youtube_url):
+        raise BackfillError(f"YouTube URL does not look valid: {youtube_url!r}.")
+    if not GITHUB_REPO_RE.fullmatch(repo):
+        raise BackfillError(f"GitHub repo must look like owner/name, got {repo!r}.")
+
+
+def backfill_release_video_discord(
+    *,
+    tag: str,
+    youtube_url: str,
+    repo: str,
+    webhook_url: str | None,
+    github: GitHubReleaseClient,
+    post_discord: Callable[[str, dict[str, Any]], None] = send_discord_webhook,
+) -> BackfillResult:
+    validate_inputs(tag, youtube_url, repo)
+
+    body = github.get_release_body(tag)
+    marker = discord_backfill_marker(tag, youtube_url)
+    body_with_link, link_added = ensure_release_body_has_video_link(body, youtube_url)
+
+    if marker in body:
+        if link_added:
+            github.edit_release_body(tag, body_with_link)
+        return BackfillResult(
+            posted=False,
+            release_body_updated=link_added,
+            marker_added=False,
+            skipped_reason="discord-followup-already-marked",
+        )
+
+    if not webhook_url:
+        raise BackfillError("DISCORD_WEBHOOK_URL is required when a follow-up has not been marked.")
+
+    if link_added:
+        github.edit_release_body(tag, body_with_link)
+
+    post_discord(webhook_url, build_discord_payload(tag, youtube_url, repo))
+
+    marked_body, marker_added = ensure_release_body_has_marker(body_with_link, tag, youtube_url)
+    if marker_added:
+        github.edit_release_body(tag, marked_body)
+
+    return BackfillResult(
+        posted=True,
+        release_body_updated=link_added or marker_added,
+        marker_added=marker_added,
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Post an idempotent Discord follow-up after a release video is "
+            "recovered outside the normal release workflow."
+        )
+    )
+    parser.add_argument("--tag", required=True, help="Release tag, for example v0.0.283.")
+    parser.add_argument("--youtube-url", required=True, help="Recovered YouTube release-video URL.")
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", "promptdriven/pdd"),
+        help="GitHub repository in owner/name form. Defaults to GITHUB_REPOSITORY.",
+    )
+    parser.add_argument(
+        "--webhook-url",
+        default=os.environ.get("DISCORD_WEBHOOK_URL", ""),
+        help="Discord webhook URL. Defaults to DISCORD_WEBHOOK_URL.",
+    )
+    parser.add_argument(
+        "--gh-cli",
+        default=os.environ.get("GH_CLI", "gh"),
+        help="gh executable path. Defaults to gh.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    github = GitHubReleaseClient(gh_cli=args.gh_cli, repo=args.repo)
+    try:
+        result = backfill_release_video_discord(
+            tag=args.tag,
+            youtube_url=args.youtube_url,
+            repo=args.repo,
+            webhook_url=args.webhook_url,
+            github=github,
+        )
+    except BackfillError as exc:
+        print(f"release-video-discord-backfill: {exc}", file=sys.stderr)
+        return 1
+
+    if result.posted:
+        print(f"Posted Discord release-video follow-up for {args.tag}.")
+    elif result.skipped_reason == "discord-followup-already-marked":
+        print(f"Skipped Discord follow-up for {args.tag}; matching marker already exists.")
+    if result.release_body_updated:
+        print(f"Updated GitHub release body for {args.tag}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/backfill_release_video_discord.py
+++ b/scripts/backfill_release_video_discord.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Callable
 from typing import Any
@@ -18,6 +19,8 @@ from typing import Any
 
 SEMVER_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
 YOUTUBE_URL_RE = re.compile(r"^https?://(?:www\.)?(?:youtube\.com|youtu\.be)/[^\s\"'<>]+$")
+YOUTUBE_URL_IN_TEXT_RE = re.compile(r"https?://(?:www\.)?(?:youtube\.com|youtu\.be)/[^\s\"'<>]+")
+YOUTUBE_VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{6,}$")
 GITHUB_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 MARKER_NAME = "pdd-release-video-discord-backfill"
 
@@ -111,13 +114,50 @@ class GitHubReleaseClient:
         return completed
 
 
+def youtube_video_id(youtube_url: str) -> str:
+    parsed = urllib.parse.urlparse(youtube_url)
+    if parsed.scheme not in {"http", "https"}:
+        raise BackfillError(f"YouTube URL must use http or https: {youtube_url!r}.")
+
+    host = parsed.netloc.lower()
+    if host.startswith("www."):
+        host = host[4:]
+
+    video_id = ""
+    if host == "youtu.be":
+        video_id = parsed.path.strip("/").split("/", 1)[0]
+    elif host == "youtube.com":
+        if parsed.path == "/watch":
+            video_id = urllib.parse.parse_qs(parsed.query).get("v", [""])[0]
+        elif parsed.path.startswith("/embed/") or parsed.path.startswith("/shorts/"):
+            parts = parsed.path.strip("/").split("/")
+            if len(parts) >= 2:
+                video_id = parts[1]
+
+    if not YOUTUBE_VIDEO_ID_RE.fullmatch(video_id):
+        raise BackfillError(f"YouTube URL does not include a valid video id: {youtube_url!r}.")
+    return video_id
+
+
 def discord_backfill_marker(tag: str, youtube_url: str) -> str:
-    digest = hashlib.sha256(f"{tag}\n{youtube_url}".encode("utf8")).hexdigest()
-    return f"<!-- {MARKER_NAME}: tag={tag} url_sha256={digest} -->"
+    video_id = youtube_video_id(youtube_url)
+    digest = hashlib.sha256(f"{tag}\n{video_id}".encode("utf8")).hexdigest()
+    return f"<!-- {MARKER_NAME}: tag={tag} video_sha256={digest} -->"
+
+
+def release_body_has_youtube_video(body: str, video_id: str) -> bool:
+    for match in YOUTUBE_URL_IN_TEXT_RE.finditer(body):
+        try:
+            if youtube_video_id(match.group(0)) == video_id:
+                return True
+        except BackfillError:
+            continue
+    return False
 
 
 def ensure_release_body_has_video_link(body: str, youtube_url: str) -> tuple[str, bool]:
-    if youtube_url in body:
+    video_id = youtube_video_id(youtube_url)
+    if release_body_has_youtube_video(body, video_id):
         return body, False
     prefix = f"Release video: {youtube_url}"
     if body.strip():
@@ -170,6 +210,7 @@ def validate_inputs(tag: str, youtube_url: str, repo: str) -> None:
         raise BackfillError(f"Release tag must look like vX.Y.Z, got {tag!r}.")
     if not YOUTUBE_URL_RE.fullmatch(youtube_url):
         raise BackfillError(f"YouTube URL does not look valid: {youtube_url!r}.")
+    youtube_video_id(youtube_url)
     if not GITHUB_REPO_RE.fullmatch(repo):
         raise BackfillError(f"GitHub repo must look like owner/name, got {repo!r}.")
 
@@ -187,9 +228,9 @@ def backfill_release_video_discord(
 
     body = github.get_release_body(tag)
     marker = discord_backfill_marker(tag, youtube_url)
-    body_with_link, link_added = ensure_release_body_has_video_link(body, youtube_url)
 
     if marker in body:
+        body_with_link, link_added = ensure_release_body_has_video_link(body, youtube_url)
         if link_added:
             github.edit_release_body(tag, body_with_link)
         return BackfillResult(
@@ -202,14 +243,27 @@ def backfill_release_video_discord(
     if not webhook_url:
         raise BackfillError("DISCORD_WEBHOOK_URL is required when a follow-up has not been marked.")
 
-    if link_added:
-        github.edit_release_body(tag, body_with_link)
+    latest_body = github.get_release_body(tag)
+    if marker in latest_body:
+        latest_body_with_link, link_added = ensure_release_body_has_video_link(
+            latest_body,
+            youtube_url,
+        )
+        if link_added:
+            github.edit_release_body(tag, latest_body_with_link)
+        return BackfillResult(
+            posted=False,
+            release_body_updated=link_added,
+            marker_added=False,
+            skipped_reason="discord-followup-already-marked",
+        )
+
+    body_with_link, link_added = ensure_release_body_has_video_link(latest_body, youtube_url)
+    marked_body, marker_added = ensure_release_body_has_marker(body_with_link, tag, youtube_url)
+    if link_added or marker_added:
+        github.edit_release_body(tag, marked_body)
 
     post_discord(webhook_url, build_discord_payload(tag, youtube_url, repo))
-
-    marked_body, marker_added = ensure_release_body_has_marker(body_with_link, tag, youtube_url)
-    if marker_added:
-        github.edit_release_body(tag, marked_body)
 
     return BackfillResult(
         posted=True,

--- a/tests/test_release_video_discord_backfill.py
+++ b/tests/test_release_video_discord_backfill.py
@@ -1,0 +1,200 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "backfill_release_video_discord.py"
+
+
+class FakeGitHubReleaseClient:
+    def __init__(self, body: str):
+        self.body = body
+        self.edits: list[tuple[str, str]] = []
+        self.viewed_tags: list[str] = []
+
+    def get_release_body(self, tag: str) -> str:
+        self.viewed_tags.append(tag)
+        return self.body
+
+    def edit_release_body(self, tag: str, body: str) -> None:
+        self.edits.append((tag, body))
+        self.body = body
+
+
+def load_backfill_module():
+    spec = importlib.util.spec_from_file_location("backfill_release_video_discord", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_backfill_posts_discord_followup_and_marks_release_body():
+    module = load_backfill_module()
+    youtube_url = "https://www.youtube.com/watch?v=RIkxCaylRAQ"
+    github = FakeGitHubReleaseClient("PDD v0.0.283 fixes release video recovery.\n")
+    posts: list[tuple[str, dict]] = []
+
+    result = module.backfill_release_video_discord(
+        tag="v0.0.283",
+        youtube_url=youtube_url,
+        repo="promptdriven/pdd",
+        webhook_url="https://discord.example/webhook",
+        github=github,
+        post_discord=lambda webhook_url, payload: posts.append((webhook_url, payload)),
+    )
+
+    assert result.posted is True
+    assert posts == [
+        (
+            "https://discord.example/webhook",
+            {
+                "content": (
+                    "Release video recovered for v0.0.283: "
+                    "https://www.youtube.com/watch?v=RIkxCaylRAQ\n"
+                    "Release: https://github.com/promptdriven/pdd/releases/tag/v0.0.283"
+                )
+            },
+        )
+    ]
+    assert github.body.startswith(f"Release video: {youtube_url}\n\n")
+    assert module.discord_backfill_marker("v0.0.283", youtube_url) in github.body
+
+
+def test_backfill_is_idempotent_when_same_video_marker_exists():
+    module = load_backfill_module()
+    youtube_url = "https://youtu.be/RIkxCaylRAQ"
+    marker = module.discord_backfill_marker("v0.0.283", youtube_url)
+    github = FakeGitHubReleaseClient(f"Release video: {youtube_url}\n\nNotes.\n\n{marker}\n")
+    posts: list[tuple[str, dict]] = []
+
+    result = module.backfill_release_video_discord(
+        tag="v0.0.283",
+        youtube_url=youtube_url,
+        repo="promptdriven/pdd",
+        webhook_url="https://discord.example/webhook",
+        github=github,
+        post_discord=lambda webhook_url, payload: posts.append((webhook_url, payload)),
+    )
+
+    assert result.posted is False
+    assert result.skipped_reason == "discord-followup-already-marked"
+    assert posts == []
+    assert github.edits == []
+
+
+def test_backfill_adds_missing_link_without_reposting_when_marker_exists():
+    module = load_backfill_module()
+    youtube_url = "https://youtu.be/RIkxCaylRAQ"
+    marker = module.discord_backfill_marker("v0.0.283", youtube_url)
+    github = FakeGitHubReleaseClient(f"Notes.\n\n{marker}\n")
+    posts: list[tuple[str, dict]] = []
+
+    result = module.backfill_release_video_discord(
+        tag="v0.0.283",
+        youtube_url=youtube_url,
+        repo="promptdriven/pdd",
+        webhook_url="",
+        github=github,
+        post_discord=lambda webhook_url, payload: posts.append((webhook_url, payload)),
+    )
+
+    assert result.posted is False
+    assert result.release_body_updated is True
+    assert result.skipped_reason == "discord-followup-already-marked"
+    assert posts == []
+    assert github.body.startswith(f"Release video: {youtube_url}\n\n")
+
+
+def test_backfill_does_not_skip_for_a_different_video_url():
+    module = load_backfill_module()
+    first_url = "https://youtu.be/oldvideo"
+    second_url = "https://youtu.be/newvideo"
+    old_marker = module.discord_backfill_marker("v0.0.283", first_url)
+    github = FakeGitHubReleaseClient(f"Release video: {first_url}\n\nNotes.\n\n{old_marker}\n")
+    posts: list[tuple[str, dict]] = []
+
+    result = module.backfill_release_video_discord(
+        tag="v0.0.283",
+        youtube_url=second_url,
+        repo="promptdriven/pdd",
+        webhook_url="https://discord.example/webhook",
+        github=github,
+        post_discord=lambda webhook_url, payload: posts.append((webhook_url, payload)),
+    )
+
+    assert result.posted is True
+    assert len(posts) == 1
+    assert f"Release video recovered for v0.0.283: {second_url}" in posts[0][1]["content"]
+    assert module.discord_backfill_marker("v0.0.283", second_url) in github.body
+
+
+def test_backfill_requires_webhook_before_mutating_unmarked_release_body():
+    module = load_backfill_module()
+    github = FakeGitHubReleaseClient("Existing notes.\n")
+
+    with pytest.raises(module.BackfillError, match="DISCORD_WEBHOOK_URL is required"):
+        module.backfill_release_video_discord(
+            tag="v0.0.283",
+            youtube_url="https://youtu.be/recoveredvideo",
+            repo="promptdriven/pdd",
+            webhook_url="",
+            github=github,
+            post_discord=lambda webhook_url, payload: None,
+        )
+
+    assert github.edits == []
+
+
+def test_github_client_uses_gh_release_view_and_edit_without_network():
+    module = load_backfill_module()
+    calls: list[tuple[list[str], str | None]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs.get("input")))
+        if command[:3] == ["gh", "release", "view"]:
+            return type("Completed", (), {"returncode": 0, "stdout": "Existing notes\n", "stderr": ""})()
+        return type("Completed", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    client = module.GitHubReleaseClient(
+        gh_cli="gh",
+        repo="promptdriven/pdd",
+        run=fake_run,
+    )
+
+    assert client.get_release_body("v0.0.283") == "Existing notes\n"
+    client.edit_release_body("v0.0.283", "Updated notes\n")
+
+    assert calls == [
+        (
+            [
+                "gh",
+                "release",
+                "view",
+                "v0.0.283",
+                "--repo",
+                "promptdriven/pdd",
+                "--json",
+                "body",
+                "--jq",
+                ".body",
+            ],
+            None,
+        ),
+        (
+            [
+                "gh",
+                "release",
+                "edit",
+                "v0.0.283",
+                "--repo",
+                "promptdriven/pdd",
+                "--notes-file",
+                "-",
+            ],
+            "Updated notes\n",
+        ),
+    ]

--- a/tests/test_release_video_discord_backfill.py
+++ b/tests/test_release_video_discord_backfill.py
@@ -23,6 +23,18 @@ class FakeGitHubReleaseClient:
         self.body = body
 
 
+class SequencedGitHubReleaseClient(FakeGitHubReleaseClient):
+    def __init__(self, bodies: list[str]):
+        super().__init__(bodies[-1])
+        self.bodies = bodies
+
+    def get_release_body(self, tag: str) -> str:
+        self.viewed_tags.append(tag)
+        if self.bodies:
+            self.body = self.bodies.pop(0)
+        return self.body
+
+
 def load_backfill_module():
     spec = importlib.util.spec_from_file_location("backfill_release_video_discord", SCRIPT)
     assert spec is not None
@@ -61,6 +73,56 @@ def test_backfill_posts_discord_followup_and_marks_release_body():
         )
     ]
     assert github.body.startswith(f"Release video: {youtube_url}\n\n")
+    assert module.discord_backfill_marker("v0.0.283", youtube_url) in github.body
+
+
+def test_backfill_persists_marker_before_posting_discord():
+    module = load_backfill_module()
+    github = FakeGitHubReleaseClient("Existing notes.\n")
+    posts: list[tuple[str, dict]] = []
+
+    def fail_edit(tag: str, body: str) -> None:
+        raise module.BackfillError("release edit failed")
+
+    github.edit_release_body = fail_edit
+
+    with pytest.raises(module.BackfillError, match="release edit failed"):
+        module.backfill_release_video_discord(
+            tag="v0.0.283",
+            youtube_url="https://youtu.be/RIkxCaylRAQ",
+            repo="promptdriven/pdd",
+            webhook_url="https://discord.example/webhook",
+            github=github,
+            post_discord=lambda webhook_url, payload: posts.append((webhook_url, payload)),
+        )
+
+    assert posts == []
+
+
+def test_backfill_merges_marker_into_latest_release_body_before_posting():
+    module = load_backfill_module()
+    youtube_url = "https://youtu.be/RIkxCaylRAQ"
+    github = SequencedGitHubReleaseClient(
+        [
+            "Initial notes.\n",
+            "Concurrent maintainer edit.\n",
+        ]
+    )
+    posts: list[tuple[str, dict]] = []
+
+    result = module.backfill_release_video_discord(
+        tag="v0.0.283",
+        youtube_url=youtube_url,
+        repo="promptdriven/pdd",
+        webhook_url="https://discord.example/webhook",
+        github=github,
+        post_discord=lambda webhook_url, payload: posts.append((webhook_url, payload)),
+    )
+
+    assert result.posted is True
+    assert len(posts) == 1
+    assert "Concurrent maintainer edit." in github.body
+    assert "Initial notes." not in github.body
     assert module.discord_backfill_marker("v0.0.283", youtube_url) in github.body
 
 
@@ -107,6 +169,29 @@ def test_backfill_adds_missing_link_without_reposting_when_marker_exists():
     assert result.skipped_reason == "discord-followup-already-marked"
     assert posts == []
     assert github.body.startswith(f"Release video: {youtube_url}\n\n")
+
+
+def test_backfill_uses_canonical_youtube_id_for_markers_and_existing_links():
+    module = load_backfill_module()
+    watch_url = "https://www.youtube.com/watch?v=RIkxCaylRAQ&utm_source=discord"
+    short_url = "https://youtu.be/RIkxCaylRAQ"
+    marker = module.discord_backfill_marker("v0.0.283", watch_url)
+    github = FakeGitHubReleaseClient(f"Release video: {watch_url}\n\nNotes.\n\n{marker}\n")
+    posts: list[tuple[str, dict]] = []
+
+    result = module.backfill_release_video_discord(
+        tag="v0.0.283",
+        youtube_url=short_url,
+        repo="promptdriven/pdd",
+        webhook_url="",
+        github=github,
+        post_discord=lambda webhook_url, payload: posts.append((webhook_url, payload)),
+    )
+
+    assert marker == module.discord_backfill_marker("v0.0.283", short_url)
+    assert result.posted is False
+    assert posts == []
+    assert github.edits == []
 
 
 def test_backfill_does_not_skip_for_a_different_video_url():


### PR DESCRIPTION
## Summary

- Add an idempotent `scripts/backfill_release_video_discord.py` helper for recovered release videos.
- Add a manual `Backfill release video Discord post` workflow and `make release-video-discord-backfill` wrapper.
- Document the recovery path in onboarding release-video diagnostics.

Fixes #1693.

## Repro Before Fix

`v0.0.283` published its release video after the release workflow had already posted to Discord. Updating the GitHub release body later did not send a Discord follow-up, so the update channel never received the YouTube link.

TDD failing checks from the isolated worktree:

```text
pytest tests/test_release_video_discord_backfill.py -v
# initial result: 4 failed because scripts/backfill_release_video_discord.py did not exist

pytest tests/test_release_video_discord_backfill.py -q
# intermediate result: 1 failed, proving the helper mutated release notes before validating the webhook
```

## Test Plan

- [x] `pytest tests/test_release_video_discord_backfill.py -v` (`6 passed`)
- [x] `pytest tests/test_release_video.py tests/test_release_video_discord_backfill.py -q` (`34 passed`)
- [x] `python -m py_compile scripts/backfill_release_video_discord.py`
- [x] `python scripts/backfill_release_video_discord.py --help`
- [x] workflow YAML parse via Python/PyYAML
- [x] `git diff --check`
- [x] `make help`

## Risks / Out of Scope

- The helper marks the release body after Discord accepts the follow-up. If Discord accepts the post but the final release edit fails, a rerun can still duplicate the follow-up. That is the only practical non-transactional gap because Discord webhooks do not expose a shared idempotency key.
- Normal release publishing and the existing release-video step are unchanged.
