### PR TITLE
Sizzle brand: pdd connect redesign (StatusReporter + cli_theme)

### DIFF
--- a/context/cli_status_example.py
+++ b/context/cli_status_example.py
@@ -1,0 +1,49 @@
+# Curated usage example for PDD prompts that include cli_status.
+# Shows the canonical pattern for from_context + StatusReporter primitives.
+# This file is manually maintained — do not regenerate via pdd sync.
+
+import asyncio
+import click
+
+from pdd.cli_status import from_context
+
+
+@click.command("example")
+@click.pass_context
+def example_command(ctx):
+    """Illustrates the five StatusReporter primitives in a realistic flow."""
+    status = from_context(ctx, command="pdd example")
+
+    # START — first line of output, names the operation beginning.
+    status.start("launching example operation")
+
+    # STEP — a human-readable sub-step within the operation.
+    status.step("checking prerequisites")
+
+    # WAITING — blocks on slow IO/network/LLM; shows a spinner on TTYs.
+    try:
+        with status.waiting("fetching remote data", on="network"):
+            result = asyncio.run(_fetch())
+    except Exception as exc:
+        # FAILURE — names what failed, why, and what to try next.
+        status.failure(
+            "fetching remote data",
+            reason=str(exc),
+            suggestions=[
+                "check network connectivity",
+                "run with --local-only to skip remote calls",
+            ],
+        )
+        raise
+
+    # SUCCESS — operation finished; optional next_step guides the user forward.
+    status.success(
+        f"fetched {len(result)} items",
+        next_step="review the output, then run `pdd sync`",
+    )
+
+
+async def _fetch():
+    """Placeholder for an async network call."""
+    await asyncio.sleep(0)
+    return []

--- a/context/cli_theme_example.py
+++ b/context/cli_theme_example.py
@@ -1,0 +1,28 @@
+# Curated usage example for PDD prompts that include cli_theme.
+# Shows canonical console, console.rule(), and PDD_THEME semantic markup roles.
+# This file is manually maintained — do not regenerate via pdd sync.
+
+from pdd.cli_theme import console
+
+# console is a pre-built Rich Console configured with PDD_THEME.
+# Import it directly instead of constructing a new one.
+
+# --- Semantic markup roles (use these; never hard-code hex colors) ---
+#
+#   [path]    — file paths and URLs          (dim Electric-Cyan)
+#   [muted]   — labels, secondary info       (dim)
+#   [info]    — neutral informational text   (Electric-Cyan)
+#   [success.strong] — bold success output   (bold Build-Green)
+#   [error]   — bold error text              (bold Break-Red)
+#   [command] — command names / identifiers  (Electric-Cyan)
+
+def show_server_info(host: str, port: int, target_url: str) -> None:
+    """Print a themed server-info block after the setup phase."""
+    # Visual separator: marks the boundary between setup and running state.
+    console.rule("[muted]Server running[/muted]", style="muted")
+
+    # URL block: labels in [muted], values in [path].
+    console.print(f"  [muted]Local:[/muted]     [path]http://{host}:{port}[/path]")
+    console.print(f"  [muted]API docs:[/muted]  [path]http://{host}:{port}/docs[/path]")
+    console.print(f"  [muted]Frontend:[/muted]  [path]{target_url}[/path]")
+    console.print("  [muted]Stop:[/muted]      Ctrl+C")

--- a/docs/design/status-messaging.md
+++ b/docs/design/status-messaging.md
@@ -112,6 +112,25 @@ don't re-plumb it.
 
 ## Adoption
 
-`detect_change_main` and `conflicts_main` are migrated as the first adopters in
-this PR. Remaining commands move onto the reporter incrementally in follow-on
-work under this EPIC, the same way the color system rolled out.
+`detect_change_main` and `conflicts_main` were the first adopters (EPIC #1540,
+workstream 2). `connect` adopted `StatusReporter` in the `pdd connect` redesign
+(EPIC #1560, workstream 4), establishing the pattern for the remaining commands.
+Canonical usage in `connect.py`:
+
+```python
+from ..cli_status import from_context
+from ..cli_theme import console
+
+def connect(..., ctx):
+    status = from_context(ctx, command="pdd connect")
+    status.start("launching local REST server")
+
+    with status.waiting("registering session with PDD Cloud", on="network"):
+        cloud_url = asyncio.run(session_manager.register(session_name=session_name))
+    status.success("session registered with PDD Cloud")
+
+    console.rule("[muted]Server running[/muted]", style="muted")
+    console.print(f"  [muted]Local:[/muted]     [path]http://{host}:{port}[/path]")
+```
+
+Remaining commands move onto the reporter incrementally in follow-on work.

--- a/pdd/prompts/commands/connect_python.prompt
+++ b/pdd/prompts/commands/connect_python.prompt
@@ -1,3 +1,18 @@
+<pdd-reason>Provides the `pdd connect` CLI command to launch a local REST server and register with PDD Cloud.</pdd-reason>
+
+<pdd-interface>
+{
+  "type": "command",
+  "command": {
+    "commands": [
+      {"name": "connect", "description": "Launch a local REST server that enables the web frontend to interact with PDD commands through a browser interface, with optional PDD Cloud registration for remote access"}
+    ]
+  }
+}
+</pdd-interface>
+
+<pdd-dependency>context/python_preamble.prompt</pdd-dependency>
+
 % You are an expert Python engineer. Your goal is to write `pdd/commands/connect.py`.
 
 % Role & Scope
@@ -51,7 +66,7 @@
        - find_available_port(start, end, host) -> Optional[int]: Scan range
 
   3. **Security warnings**:
-     - If --allow-remote without --token: Warn and confirm
+     - If --allow-remote without --token: reject with a structured security failure message (no confirmation prompt)
      - Print security reminder about localhost-only default
 
   4. **Server startup**:
@@ -65,12 +80,49 @@
      - If --frontend-url: Open that URL instead
      - Use webbrowser.open()
 
-  6. **Output messages**:
-     - Print `PDD_POSITIONING` from `pdd.cli_branding` before the server details.
-     - "Starting PDD server on http://{host}:{port}"
-     - "API Documentation: http://{host}:{port}/docs"
-     - "Frontend: http://{host}:{port}" (or custom URL)
-     - "Press Ctrl+C to stop the server"
+  6. **Output messages** (use `StatusReporter` primitives for every line of output):
+     - `status.start("launching local REST server")` — first line of output,
+       before any checks.
+     - Port-scan outcome (when default port is busy):
+       `status.step(f"port {port} in use — scanning for an available port")`
+       followed by `status.step(f"using port {available_port}")` on success,
+       or `status.failure("no available port found in range 9876–9899",
+                          reason="all ports in the scan range are occupied",
+                          suggestions=["free a port in the range",
+                                       "specify --port to choose a different range"])`.
+     - Uvicorn not installed:
+       `status.failure("uvicorn not installed",
+                       reason="the connect command requires server dependencies",
+                       suggestions=["pip install 'pdd[server]'"])`.
+     - Cloud registration (authenticated, not --local-only):
+       `with status.waiting("registering session with PDD Cloud", on="network"):`
+           `cloud_url = asyncio.run(session_manager.register(...))`
+       `status.success("session registered with PDD Cloud")`
+       On `RemoteSessionError`:
+       `status.failure("cloud registration failed",
+                       reason=str(e),
+                       suggestions=["check network connectivity",
+                                    "run with --local-only to skip cloud registration"])`.
+     - Local-only / unauthenticated path:
+       `status.step("local-only mode — skipping cloud registration")`.
+     - Phase separator (between setup and server-info block):
+       `console.rule("[muted]Server running[/muted]", style="muted")`
+     - Server info block (after the rule):
+       ```
+       console.print(PDD_POSITIONING)
+       console.print(f"  [muted]Local:[/muted]     [path]http://{host}:{port}[/path]")
+       console.print(f"  [muted]API docs:[/muted]  [path]http://{host}:{port}/docs[/path]")
+       console.print(f"  [muted]Frontend:[/muted]  [path]{target_url}[/path]")
+       console.print("  [muted]Stop:[/muted]      Ctrl+C")
+       ```
+       Label column width is fixed (8 chars + colon + spaces) for visual alignment.
+     - Remote-session / non-interactive browser skip:
+       `status.step("skipping browser open — remote session detected")`.
+     - Shutdown path:
+       `status.step("stopping server")`
+       `with status.waiting("deregistering from PDD Cloud", on="network"):`
+           `asyncio.run(session_manager.deregister())`
+       `status.success("session deregistered")` or `status.failure(...)`.
 
   7. **Graceful shutdown**:
      - Handle KeyboardInterrupt
@@ -98,16 +150,39 @@
 
 <pdd.commands.misc><include>context/commands/misc_example.py</include></pdd.commands.misc>
 <pdd.commands><include>context/commands/__init___example.py</include></pdd.commands>
+<cli_status_usage><include>context/cli_status_example.py</include></cli_status_usage>
+<cli_theme_usage><include>context/cli_theme_example.py</include></cli_theme_usage>
 
 % Instructions
   - Use @click.command("connect")
   - NO @track_cost decorator (no LLM calls)
-  - Use click.echo() for output
-  - Use click.style() for colored output
-  - Import `PDD_POSITIONING` from `pdd.cli_branding`
-  - click.confirm() for security warning
-  - Determine project_root from current working directory
-  - Pass click context for potential future use
+  - Import `from_context` from `pdd.cli_status`; call
+    `status = from_context(ctx, command="pdd connect")` at the top of the
+    command body. Use ONLY `StatusReporter` primitives for all terminal output —
+    do NOT use `click.echo()` or `click.style()` for user-facing messages.
+  - Import `console` from `pdd.cli_theme` for structured display blocks
+    (`console.rule()`, `console.print()` with semantic markup roles).
+  - Use `console.rule("[muted]Server running[/muted]", style="muted")` as the
+    single visual separator between the setup phase and the server-info block.
+  - Use semantic Rich markup roles from `PDD_THEME` for the server-info URL
+    lines: `[path]` for URLs, `[muted]` for labels, `[info]` for neutral
+    notes. Do NOT hard-code `[green]`, `[blue]`, or any raw color name.
+  - Import `PDD_POSITIONING` from `pdd.cli_branding`; print it via
+    `console.print(PDD_POSITIONING)` immediately before the server-info block.
+  - Wrap `asyncio.run(session_manager.register(...))` in
+    `with status.waiting("registering session with PDD Cloud", on="network"):`
+    — this turns a silent network call into a visible progress event.
+  - The `--allow-remote` without `--token` security warning must use
+    `status.failure("insecure configuration",
+     reason="allowing remote connections without a token lets anyone on the
+             network execute code on this machine",
+     suggestions=["add --token <secret> to require bearer auth",
+                  "omit --allow-remote to bind to localhost only"])`.
+    This path only fires when `--allow-remote` is explicitly passed; it must
+    not fire in the default localhost case.
+  - Determine project_root from current working directory.
+  - Pass click context; `from_context` uses it to inherit the global
+    `--quiet` flag automatically — no extra plumbing needed.
 
 % Deliverables
   - Code: `pdd/commands/connect.py`


### PR DESCRIPTION
## Sub-PR of Epic #1666 — `pdd connect` redesign

Brings the **better `pdd connect` interface** into the Sizzle brand-consistency epic. Source: the connect redesign work in #1611 / issue #1606.

### What's included
- `pdd/prompts/commands/connect_python.prompt` — redesigned connect command prompt (StatusReporter + cli_theme integration, architecture tags)
- `context/cli_status_example.py` — StatusReporter usage example
- `context/cli_theme_example.py` — cli_theme usage example
- `docs/design/status-messaging.md` — design doc updates

### Deliberately excluded
- The `architecture.json` changes from #1611 — that branch was based on an older `main` and its architecture.json would **revert** `routing_policy` entries that have since landed. Only the connect-specific files are brought over.

### Notes
- Base is **`epic/sizzle-brand-consistency`**, not `main`.
- `heal` / `auto-heal` checks run against the paid PDD Cloud gate and show red without cloud auth — expected, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)