### PR TITLE
Sizzle brand: match Sizzle's professional voice in app copy

### DIFF
--- a/pdd/frontend/App.tsx
+++ b/pdd/frontend/App.tsx
@@ -1157,7 +1157,7 @@ const App: React.FC = () => {
                 </div>
                 <div>
                   <h2 className="text-lg sm:text-xl font-semibold text-white">Dev Units</h2>
-                  <p className="text-xs sm:text-sm text-surface-400">Manage your development modules and architecture</p>
+                  <p className="text-xs sm:text-sm text-surface-400">Your prompts are the source. Manage every module and its architecture in one place.</p>
                 </div>
               </div>
               {/* Graph/List toggle */}
@@ -1192,7 +1192,7 @@ const App: React.FC = () => {
               </div>
               <div>
                 <h2 className="text-lg sm:text-xl font-semibold text-white">Bug Investigation Agent</h2>
-                <p className="text-xs sm:text-sm text-surface-400">Automatically investigate GitHub issues and generate failing test cases</p>
+                <p className="text-xs sm:text-sm text-surface-400">Point it at a GitHub issue. It reproduces the bug and writes the failing test.</p>
               </div>
             </div>
           )}
@@ -1205,7 +1205,7 @@ const App: React.FC = () => {
               </div>
               <div>
                 <h2 className="text-lg sm:text-xl font-semibold text-white">PR Fix Agent</h2>
-                <p className="text-xs sm:text-sm text-surface-400">Automatically fix code issues based on PR review comments</p>
+                <p className="text-xs sm:text-sm text-surface-400">Turns PR review comments into committed fixes — no manual round-trips.</p>
               </div>
             </div>
           )}
@@ -1218,7 +1218,7 @@ const App: React.FC = () => {
               </div>
               <div>
                 <h2 className="text-lg sm:text-xl font-semibold text-white">Change Request Agent</h2>
-                <p className="text-xs sm:text-sm text-surface-400">Automatically implement feature requests and changes from GitHub issues</p>
+                <p className="text-xs sm:text-sm text-surface-400">Describe the change in a GitHub issue. Ship the implementation as a reviewable PR.</p>
               </div>
             </div>
           )}
@@ -1229,7 +1229,7 @@ const App: React.FC = () => {
               </div>
               <div>
                 <h2 className="text-lg sm:text-xl font-semibold text-white">Settings</h2>
-                <p className="text-xs sm:text-sm text-surface-400">Configure project settings and preferences</p>
+                <p className="text-xs sm:text-sm text-surface-400">Configure your project, models, and workflow preferences.</p>
               </div>
             </div>
           )}


### PR DESCRIPTION
## Sub-PR of Epic #1666 — text/voice to match Sizzle

Matches the **text** in `pdd/frontend` to the professional, tech-savvy voice of the [Sizzle landing page](https://video.promptdriven.ai/sizzle), using the gist's promptdriven.ai / Sizzle copy as the reference.

### What changed
Rewrote the five view-header subtitles from generic `Automatically…` filler into Sizzle's confident, concrete, declarative voice:

| View | Before | After |
|------|--------|-------|
| Dev Units | Manage your development modules and architecture | Your prompts are the source. Manage every module and its architecture in one place. |
| Bug Investigation Agent | Automatically investigate GitHub issues and generate failing test cases | Point it at a GitHub issue. It reproduces the bug and writes the failing test. |
| PR Fix Agent | Automatically fix code issues based on PR review comments | Turns PR review comments into committed fixes — no manual round-trips. |
| Change Request Agent | Automatically implement feature requests and changes from GitHub issues | Describe the change in a GitHub issue. Ship the implementation as a reviewable PR. |
| Settings | Configure project settings and preferences | Configure your project, models, and workflow preferences. |

### Scope notes
- **Text only.** No color/layout changes — the header wordmark restyle and color tokens belong to sibling PR #1670.
- Base is **`epic/sizzle-brand-consistency`**, not `main`.
- `pdd/frontend` is the PDD app UI (not the marketing site, which is a separate private Next.js repo), so this matches Sizzle's *voice* on the app's most prominent copy rather than porting marketing sections 1:1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)