### PR TITLE
frontend: replace alert() with Toast (#1718)

### DIFF
--- a/pdd/frontend/App.tsx
+++ b/pdd/frontend/App.tsx
@@ -332,7 +332,7 @@ const App: React.FC = () => {
 
   const handleRunCommand = async (command: CommandType, prompt: PromptInfo, commandOptions?: Record<string, any>) => {
     if (!serverConnected) {
-      alert('Server not connected. Run "pdd connect" in your terminal first.');
+      addToast('Server not connected. Run "pdd connect" in your terminal first.', 'error', 5000);
       return;
     }
 
@@ -440,12 +440,12 @@ const App: React.FC = () => {
 
   const handleRunBugCommand = async () => {
     if (!serverConnected) {
-      alert('Server not connected. Run "pdd connect" in your terminal first.');
+      addToast('Server not connected. Run "pdd connect" in your terminal first.', 'error', 5000);
       return;
     }
 
     if (!bugIssueUrl.trim()) {
-      alert('Please enter a GitHub issue URL');
+      addToast('Please enter a GitHub issue URL', 'error', 5000);
       return;
     }
 
@@ -537,12 +537,12 @@ const App: React.FC = () => {
 
   const handleRunFixCommand = async () => {
     if (!serverConnected) {
-      alert('Server not connected. Run "pdd connect" in your terminal first.');
+      addToast('Server not connected. Run "pdd connect" in your terminal first.', 'error', 5000);
       return;
     }
 
     if (!fixPrUrl.trim()) {
-      alert('Please enter a GitHub PR URL');
+      addToast('Please enter a GitHub PR URL', 'error', 5000);
       return;
     }
 
@@ -634,12 +634,12 @@ const App: React.FC = () => {
 
   const handleRunChangeCommand = async () => {
     if (!serverConnected) {
-      alert('Server not connected. Run "pdd connect" in your terminal first.');
+      addToast('Server not connected. Run "pdd connect" in your terminal first.', 'error', 5000);
       return;
     }
 
     if (!changeIssueUrl.trim()) {
-      alert('Please enter a GitHub issue URL');
+      addToast('Please enter a GitHub issue URL', 'error', 5000);
       return;
     }
 


### PR DESCRIPTION
## What
Replace all 7 native `alert()` calls in `pdd/frontend/App.tsx` with the existing `addToast()` API. Sub-PR of EPIC #1720 — **targets `epic/frontend-ui-polish`, not main.**

## Why
`alert()` is an unbranded, page-blocking OS dialog. The app already has a Toast system (`useToast` / `addToast`, destructured at `App.tsx:82` and used ~20 times nearby). These 7 sites were the last hold-outs.

## Mapping
All 7 are blocking error/validation conditions, so each becomes `addToast(msg, 'error', 5000)` — consistent with the existing `addToast('Error: …', 'error', 5000)` pattern:
- "Server not connected…" guard — 4 sites (run / bug / fix / change handlers)
- "Please enter a GitHub issue URL" — bug + change handlers
- "Please enter a GitHub PR URL" — fix handler

## Out of scope (intentionally untouched)
The 4 `window.confirm()` stale-session dialogs stay — they need a yes/no return value a toast can't provide.

## Verification
- [x] 0 `alert()` calls remain in `App.tsx`
- [x] 4 `window.confirm()` dialogs preserved
- [x] `npm test` (vitest) — **54 passed / 12 files**

Closes #1718

🤖 Generated with [Claude Code](https://claude.com/claude-code)
