### PR TITLE
Fix release video OAuth token rotation

### DIFF
--- a/.github/workflows/backfill-release-notes.yml
+++ b/.github/workflows/backfill-release-notes.yml
@@ -19,12 +19,12 @@ jobs:
   rewrite-notes:
     runs-on: ubuntu-latest
     env:
-      HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' && 'true' || 'false' }}
+      HAS_CLAUDE_OAUTH: ${{ (secrets.CLAUDE_CODE_OAUTH_TOKEN_1 != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN_2 != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN_3 != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '') && 'true' || 'false' }}
     steps:
       - name: Fail if OAuth token missing
         if: env.HAS_CLAUDE_OAUTH != 'true'
         run: |
-          echo "::error::CLAUDE_CODE_OAUTH_TOKEN secret is not set."
+          echo "::error::No Claude Code OAuth token secret is set."
           exit 1
 
       - uses: actions/checkout@v6
@@ -39,6 +39,9 @@ jobs:
       - name: Rewrite release notes with Claude Code
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN_1: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_1 }}
+          CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          CLAUDE_CODE_OAUTH_TOKEN_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           TAG: ${{ inputs.tag }}
         run: |
@@ -99,12 +102,12 @@ jobs:
           } >"$prompt_file"
 
           notes_file=$(mktemp --suffix=.md)
-          claude -p \
+          scripts/claude_code_oauth_retry.sh "$notes_file" claude -p \
               --model sonnet \
               --tools "" \
               --no-session-persistence \
               --output-format text \
-              <"$prompt_file" >"$notes_file"
+              <"$prompt_file"
 
           if [ ! -s "$notes_file" ]; then
             echo "::error::Claude Code produced no output."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       contents: write
       id-token: write
     env:
-      HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' && 'true' || 'false' }}
+      HAS_CLAUDE_OAUTH: ${{ (secrets.CLAUDE_CODE_OAUTH_TOKEN_1 != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN_2 != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN_3 != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '') && 'true' || 'false' }}
       HAS_PDS: ${{ secrets.PDS_TOKEN != '' && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@v6
@@ -99,6 +99,9 @@ jobs:
         if: env.HAS_CLAUDE_OAUTH == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN_1: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_1 }}
+          CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          CLAUDE_CODE_OAUTH_TOKEN_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           set -euo pipefail
@@ -159,12 +162,12 @@ jobs:
           } >"$prompt_file"
 
           notes_file=$(mktemp --suffix=.md)
-          if ! claude -p \
+          if ! scripts/claude_code_oauth_retry.sh "$notes_file" claude -p \
                 --model sonnet \
                 --tools "" \
                 --no-session-persistence \
                 --output-format text \
-                <"$prompt_file" >"$notes_file"; then
+                <"$prompt_file"; then
             echo "Claude Code failed; keeping auto-generated notes."
             exit 0
           fi
@@ -235,6 +238,9 @@ jobs:
           PDS_API_URL: ${{ vars.PDS_API_URL || 'https://video.promptdriven.ai' }}
           PDS_CLI_PACKAGE: ${{ vars.PDS_CLI_PACKAGE }}
           PDS_CLI: ${{ vars.PDS_CLI || 'pds --timeout 120s' }}
+          CLAUDE_CODE_OAUTH_TOKEN_1: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_1 }}
+          CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          CLAUDE_CODE_OAUTH_TOKEN_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           RELEASE_VIDEO_PROJECT_ID: ${{ vars.RELEASE_VIDEO_PROJECT_ID }}
           RELEASE_VIDEO_SCRIPT_PATH: ${{ vars.RELEASE_VIDEO_SCRIPT_PATH }}

--- a/scripts/claude_code_oauth_retry.sh
+++ b/scripts/claude_code_oauth_retry.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 OUTPUT_FILE COMMAND [ARGS...]" >&2
+  exit 2
+fi
+
+output_file="$1"
+shift
+
+stdin_file="$(mktemp)"
+stderr_file="$(mktemp)"
+trap 'rm -f "$stdin_file" "$stderr_file"' EXIT
+cat >"$stdin_file"
+
+is_quota_or_auth_failure() {
+  grep -Eiq \
+    'hit your .*limit.*reset|weekly .*limit|usage .*limit|session .*limit|quota (exhausted|exceeded|reached)|not logged in|please run /login|claude auth login|authentication failed|invalid (bearer|api key|key)|\b401\b|unauthorized|access denied|permission denied'
+}
+
+token_names=(
+  CLAUDE_CODE_OAUTH_TOKEN_1
+  CLAUDE_CODE_OAUTH_TOKEN_2
+  CLAUDE_CODE_OAUTH_TOKEN_3
+  CLAUDE_CODE_OAUTH_TOKEN
+)
+
+attempted=0
+for token_name in "${token_names[@]}"; do
+  token="${!token_name:-}"
+  if [ -z "$token" ]; then
+    continue
+  fi
+  attempted=$((attempted + 1))
+  export CLAUDE_CODE_OAUTH_TOKEN="$token"
+  echo "Trying Claude Code OAuth token slot ${token_name}."
+  if "$@" <"$stdin_file" >"$output_file" 2>"$stderr_file"; then
+    exit 0
+  fi
+  status=$?
+  cat "$stderr_file" >&2
+  if [ -s "$output_file" ]; then
+    cat "$output_file" >&2
+  fi
+  if cat "$stderr_file" "$output_file" 2>/dev/null | is_quota_or_auth_failure; then
+    echo "::warning::Claude Code failed with quota/auth using ${token_name}; trying next token." >&2
+    continue
+  fi
+  exit "$status"
+done
+
+if [ "$attempted" -eq 0 ]; then
+  "$@" <"$stdin_file" >"$output_file"
+  exit $?
+fi
+
+echo "::error::Claude Code failed with every configured OAuth token slot." >&2
+exit 1

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -20,6 +20,12 @@ YOUTUBE_URL_RE = re.compile(r"https?://(?:www\.)?(?:youtube\.com|youtu\.be)/[^\s
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_RELEASE_VIDEO_PROMPT = REPO_ROOT / "pdd" / "prompts" / "release_video_script_LLM.prompt"
 DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
+CLAUDE_OAUTH_TOKEN_ENV_VARS = (
+    "CLAUDE_CODE_OAUTH_TOKEN_1",
+    "CLAUDE_CODE_OAUTH_TOKEN_2",
+    "CLAUDE_CODE_OAUTH_TOKEN_3",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+)
 CLAUDE_FAILURE_CLASSES: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
         "credential-limit",
@@ -586,26 +592,79 @@ def generate_script_with_claude(
     prompt = render_release_video_prompt(context, prompt_template, cwd)
     claude_env = os.environ.copy()
     strip_anthropic_creds_for_claude_subprocess(claude_env)
-    try:
-        completed = run(
-            command,
-            cwd=cwd,
-            input_text=prompt,
-            timeout=timeout,
-            env=claude_env,
-            check=False,
+
+    token_attempts = claude_oauth_token_attempts(claude_env)
+    attempts: list[tuple[str | None, dict[str, str]]] = []
+    if token_attempts:
+        for token_name, token in token_attempts:
+            attempt_env = claude_env.copy()
+            attempt_env["CLAUDE_CODE_OAUTH_TOKEN"] = token
+            attempts.append((token_name, attempt_env))
+    else:
+        attempts.append((None, claude_env))
+
+    failed_quota_auth_slots: list[str] = []
+    for attempt_label, attempt_env in attempts:
+        try:
+            completed = run(
+                command,
+                cwd=cwd,
+                input_text=prompt,
+                timeout=timeout,
+                env=attempt_env,
+                check=False,
+            )
+        except ReleaseVideoError as exc:
+            raise ReleaseVideoError(
+                "Claude Code script generation failed before PDS publish; "
+                f"PDS was not invoked. {exc}"
+            ) from exc
+        if completed.returncode == 0:
+            break
+
+        classification = classify_claude_quota_auth_failure(
+            "\n".join(
+                text for text in (completed.stderr.strip(), completed.stdout.strip()) if text
+            )
         )
-    except ReleaseVideoError as exc:
+        if attempt_label and classification:
+            failed_quota_auth_slots.append(f"{attempt_label}:{classification}")
+            print(
+                "release-video: Claude Code OAuth token slot "
+                f"{attempt_label} failed with quota/auth class {classification!r}; "
+                "trying next token.",
+                file=sys.stderr,
+            )
+            continue
+
         raise ReleaseVideoError(
-            "Claude Code script generation failed before PDS publish; "
-            f"PDS was not invoked. {exc}"
-        ) from exc
-    if completed.returncode != 0:
-        raise ReleaseVideoError(format_claude_script_generation_failure(command, completed))
+            format_claude_script_generation_failure(command, completed, attempt_label)
+        )
+    else:
+        failed = ", ".join(failed_quota_auth_slots) or "none"
+        raise ReleaseVideoError(
+            "Claude Code script generation failed before PDS publish; PDS was not invoked. "
+            f"All configured Claude Code OAuth token slots failed ({failed}). "
+            "Set a fresh CLAUDE_CODE_OAUTH_TOKEN_1/2/3 secret or use "
+            "RELEASE_VIDEO_SCRIPT_PATH pointing at a previously generated script."
+        )
+
     script = normalize_release_video_script(strip_markdown_fence(completed.stdout.strip()))
     if len(script) < 200:
         raise ReleaseVideoError("Claude Code produced an unexpectedly short release video script.")
     return script.rstrip() + "\n"
+
+
+def claude_oauth_token_attempts(env: dict[str, str]) -> list[tuple[str, str]]:
+    attempts: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for name in CLAUDE_OAUTH_TOKEN_ENV_VARS:
+        token = env.get(name, "").strip()
+        if not token or token in seen:
+            continue
+        attempts.append((name, token))
+        seen.add(token)
+    return attempts
 
 
 def strip_anthropic_creds_for_claude_subprocess(env: dict[str, str]) -> bool:
@@ -624,7 +683,7 @@ def strip_anthropic_creds_for_claude_subprocess(env: dict[str, str]) -> bool:
     if not (env.get("ANTHROPIC_API_KEY") or env.get("ANTHROPIC_AUTH_TOKEN")):
         return False
 
-    if env.get("CLAUDE_CODE_OAUTH_TOKEN"):
+    if claude_oauth_token_attempts(env):
         env.pop("ANTHROPIC_API_KEY", None)
         env.pop("ANTHROPIC_AUTH_TOKEN", None)
         return True
@@ -650,6 +709,7 @@ def classify_claude_quota_auth_failure(output: str) -> str | None:
 def format_claude_script_generation_failure(
     command: list[str],
     completed: subprocess.CompletedProcess[str],
+    attempt_label: str | None = None,
 ) -> str:
     combined_output = "\n".join(
         text for text in (completed.stderr.strip(), completed.stdout.strip()) if text
@@ -667,6 +727,8 @@ def format_claude_script_generation_failure(
         )
     else:
         message += " This is a script-generation failure, not a PDS publish failure."
+    if attempt_label:
+        message += f" OAuth token slot: {attempt_label}."
     return f"{message} Command: {shlex.join(command)}. Details: {process_details(completed)}"
 
 

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -16,6 +16,10 @@ def release_video_env(extra: dict | None = None) -> dict:
     for key in (
         "CLAUDE_MODEL",
         "CLAUDE_TIMEOUT",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN_1",
+        "CLAUDE_CODE_OAUTH_TOKEN_2",
+        "CLAUDE_CODE_OAUTH_TOKEN_3",
         "RELEASE_VIDEO_ATTEMPT_ID",
         "RELEASE_VIDEO_CLAUDE_TOOLS",
         "RELEASE_VIDEO_IDEMPOTENCY_KEY",
@@ -832,6 +836,66 @@ def test_release_video_claude_generation_prefers_oauth_over_inherited_api_key(
     assert "\nNARRATOR:\n" in script
 
 
+def test_release_video_claude_generation_rotates_oauth_token_slots(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    release_video = load_release_video_module()
+    prompt_template = tmp_path / "release_video_LLM.prompt"
+    prompt_template.write_text("Context:\n{release_context}\n", encoding="utf8")
+    attempted_tokens: list[str | None] = []
+
+    def fake_run(
+        command,
+        *,
+        cwd: Path,
+        input_text: str | None = None,
+        timeout: float | None = None,
+        env: dict[str, str] | None = None,
+        check: bool = True,
+    ):
+        token = env.get("CLAUDE_CODE_OAUTH_TOKEN") if env else None
+        attempted_tokens.append(token)
+        assert env is not None
+        assert "ANTHROPIC_API_KEY" not in env
+        if token == "limited-token":
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                stdout="You've hit your weekly limit; resets tomorrow.",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=reusable_script_text(),
+            stderr="",
+        )
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "stale-depleted-api-key")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "limited-token")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_2", "fresh-token")
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN_3", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setattr(release_video, "ensure_command_exists", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(release_video, "run", fake_run)
+
+    script = release_video.generate_script_with_claude(
+        context="# PDD release context",
+        claude_cli="claude",
+        claude_model="claude-opus-4-8",
+        claude_tools="",
+        prompt_template=prompt_template,
+        timeout=60,
+        cwd=tmp_path,
+    )
+
+    assert attempted_tokens == ["limited-token", "fresh-token"]
+    assert "\nNARRATOR:\n" in script
+    assert "CLAUDE_CODE_OAUTH_TOKEN_1 failed" in capsys.readouterr().err
+
+
 def test_release_video_env_oauth_strip_does_not_import_pdd(monkeypatch):
     release_video = load_release_video_module()
     env = {
@@ -853,6 +917,19 @@ def test_release_video_env_oauth_strip_does_not_import_pdd(monkeypatch):
     assert "ANTHROPIC_API_KEY" not in env
     assert "ANTHROPIC_AUTH_TOKEN" not in env
     assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "oauth-token"
+
+
+def test_release_video_env_oauth_strip_recognizes_token_slots(monkeypatch):
+    release_video = load_release_video_module()
+    env = {
+        "ANTHROPIC_API_KEY": "stale-depleted-api-key",
+        "CLAUDE_CODE_OAUTH_TOKEN_2": "oauth-token",
+    }
+
+    assert release_video.strip_anthropic_creds_for_claude_subprocess(env) is True
+
+    assert "ANTHROPIC_API_KEY" not in env
+    assert env["CLAUDE_CODE_OAUTH_TOKEN_2"] == "oauth-token"
 
 
 def test_release_video_strip_missing_optional_pdd_dependency_is_nonfatal(monkeypatch):


### PR DESCRIPTION
## Summary
- rotate through configured Claude Code OAuth token slots for release-video script generation
- use the same retry helper in release-note rewrite workflows
- pass token-slot secrets into release-video workflow env

## Test plan
- conda run -n pdd python -m pytest tests/test_release_video.py -q
- PDD_PUBLIC_REPO_DIR=/Users/gregtanaka/Documents/pdd.worktrees/pdd-cli-release-gate-20260624-222427 make test-pdd-cli-release from /Users/gregtanaka/Documents/pdd_cloud.worktrees/pdd-cli-release-gate-20260624-222427
  - Cloud Batch: 77 passed, 0 failed, 0 errors
  - LLM smoke Cloud Build: SUCCESS
