### PR TITLE
Add SOPS-backed release env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
       id-token: write
     env:
       HAS_CLAUDE_OAUTH: ${{ (secrets.CLAUDE_CODE_OAUTH_TOKEN_1 != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN_2 != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN_3 != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '') && 'true' || 'false' }}
+      HAS_CLAUDE_OAUTH_SLOTS: ${{ (secrets.CLAUDE_CODE_OAUTH_TOKEN_1 != '' && secrets.CLAUDE_CODE_OAUTH_TOKEN_2 != '' && secrets.CLAUDE_CODE_OAUTH_TOKEN_3 != '') && 'true' || 'false' }}
       HAS_PDS: ${{ secrets.PDS_TOKEN != '' && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@v6
@@ -88,6 +89,11 @@ jobs:
           else
             gh release create "$tag" --generate-notes --verify-tag --target main
           fi
+
+      - name: Audit Claude Code OAuth rotation slots
+        if: env.HAS_CLAUDE_OAUTH == 'true' && env.HAS_CLAUDE_OAUTH_SLOTS != 'true'
+        run: |
+          echo "::warning::Only a partial Claude Code OAuth rotation is configured. Set CLAUDE_CODE_OAUTH_TOKEN_1, CLAUDE_CODE_OAUTH_TOKEN_2, and CLAUDE_CODE_OAUTH_TOKEN_3 in repo secrets."
 
       - name: Setup Node for Claude Code
         if: env.HAS_CLAUDE_OAUTH == 'true'

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ help:
 	@echo "  make publish-public          - Copy artifacts to public repo only"
 	@echo "  make release-video           - Generate and upload a YouTube video for the current release tag"
 	@echo "  make release-video-discord-backfill RELEASE_TAG=vX.Y.Z RELEASE_VIDEO_YOUTUBE_URL=url - Post recovered video follow-up to Discord"
-	@echo "  make release-local           - Run release with local Infisical PDS release token"
+	@echo "  make release-local           - Run release with local SOPS release secrets"
+	@echo "  make check-release-claude-oauth-config-local - Verify local SOPS Claude OAuth rotation slots"
 	@echo "  make check-deps              - Check pyproject.toml and requirements.txt are in sync"
 	@echo "  make release                 - On main: tag HEAD with next vN.N.N and push (BUMP=patch|minor|major; default patch)"
 	@echo "                                  Actions publishes to PyPI via OIDC after gltanaka approval"
@@ -100,9 +101,11 @@ RELEASE_VIDEO_YOUTUBE_URL ?=
 CLAUDE_CLI ?= claude
 PDS_CLI ?= pds
 PDS_API_URL ?= https://video.promptdriven.ai
-INFISICAL ?= infisical
-INFISICAL_ENV ?= prod
-INFISICAL_PATH ?= /
+SOPS ?= sops
+SOPS_RELEASE_ENV_FILE ?= $(firstword $(wildcard ../secrets/pdd_cloud/shared.prod.sops.env ../pdd_cloud/secrets/pdd_cloud/shared.prod.sops.env secrets/pdd_cloud/shared.prod.sops.env) ../secrets/pdd_cloud/shared.prod.sops.env)
+SOPS_RELEASE_CLAUDE_ENV_FILES ?= $(wildcard ../secrets/pdd_cloud/shared.staging.sops.env ../secrets/pdd_cloud/shared.staging2.sops.env ../secrets/pdd_cloud/shared.prod.sops.env ../pdd_cloud/secrets/pdd_cloud/shared.staging.sops.env ../pdd_cloud/secrets/pdd_cloud/shared.staging2.sops.env ../pdd_cloud/secrets/pdd_cloud/shared.prod.sops.env secrets/pdd_cloud/shared.staging.sops.env secrets/pdd_cloud/shared.staging2.sops.env secrets/pdd_cloud/shared.prod.sops.env)
+SOPS_RELEASE_ENV_RUNNER := python scripts/sops_release_env.py --sops "$(SOPS)" --release-env-file "$(SOPS_RELEASE_ENV_FILE)" $(foreach file,$(SOPS_RELEASE_CLAUDE_ENV_FILES),--claude-env-file "$(file)")
+REQUIRE_CLAUDE_OAUTH_SLOTS ?= 1
 
 # Python files
 PY_PROMPTS := $(shell find $(PROMPTS_DIR) -name "*_python.prompt")
@@ -118,7 +121,7 @@ ifeq ($(CI),true)
 SKIP_MAKEFILE_REGEN := 1
 endif
 
-RELEASE_MAKE_GOALS := release release-video release-video-discord-backfill release-local release-infisical check-release-video-config check-release-video-config-local check-release-video-config-infisical
+RELEASE_MAKE_GOALS := release release-video release-video-discord-backfill release-local release-sops release-infisical check-release-video-config check-release-video-config-local check-release-video-config-sops check-release-video-config-infisical check-release-claude-oauth-config check-release-claude-oauth-config-local check-release-claude-oauth-config-sops
 ifneq ($(filter $(RELEASE_MAKE_GOALS),$(MAKECMDGOALS)),)
 SKIP_MAKEFILE_REGEN := 1
 endif
@@ -139,7 +142,7 @@ TEST_OUTPUTS := $(patsubst $(PDD_DIR)/%.py,$(TESTS_DIR)/test_%.py,$(PY_OUTPUTS))
 # All Example files in context directory (recursive)
 EXAMPLE_FILES := $(shell find $(CONTEXT_DIR) -name "*_example.py" 2>/dev/null)
 
-.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release release-local release-infisical release-video release-video-discord-backfill check-release-remote check-release-branch check-release-clean check-release-video-config check-release-video-config-local check-release-video-config-infisical
+.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release release-local release-sops release-infisical release-video release-video-discord-backfill check-release-remote check-release-branch check-release-clean check-release-video-config check-release-video-config-local check-release-video-config-sops check-release-video-config-infisical check-release-claude-oauth-config check-release-claude-oauth-config-local check-release-claude-oauth-config-sops
 
 all: $(PY_OUTPUTS) $(MAKEFILE_OUTPUT) $(CSV_OUTPUTS) $(EXAMPLE_OUTPUTS) $(TEST_OUTPUTS)
 
@@ -762,19 +765,69 @@ check-release-video-config:
 		--pds-cli "$(PDS_CLI)" \
 		--project-id "$(RELEASE_VIDEO_PROJECT_ID)"
 
-check-release-video-config-local: check-release-video-config-infisical
+check-release-claude-oauth-config:
+	@if [ "$(RELEASE_VIDEO)" = "0" ]; then \
+		echo "Claude Code OAuth token preflight skipped because RELEASE_VIDEO=0"; \
+		exit 0; \
+	fi; \
+	configured=0; missing=""; \
+	for name in CLAUDE_CODE_OAUTH_TOKEN_1 CLAUDE_CODE_OAUTH_TOKEN_2 CLAUDE_CODE_OAUTH_TOKEN_3; do \
+		if [ -n "$$(printenv "$$name")" ]; then \
+			configured=$$((configured + 1)); \
+		else \
+			missing="$$missing $$name"; \
+		fi; \
+	done; \
+	if [ "$$configured" -eq 3 ]; then \
+		echo "Claude Code OAuth token slots verified: 3/3 numbered slots configured."; \
+		if [ -n "$${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then \
+			echo "Fallback CLAUDE_CODE_OAUTH_TOKEN is also configured."; \
+		fi; \
+	else \
+		echo "Claude Code OAuth token slots configured: $$configured/3. Missing:$$missing"; \
+		if [ -n "$${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then \
+			echo "Fallback CLAUDE_CODE_OAUTH_TOKEN is configured, but numbered slots should be set for rotation."; \
+		fi; \
+		if [ "$(REQUIRE_CLAUDE_OAUTH_SLOTS)" = "1" ]; then exit 1; fi; \
+	fi
+
+check-release-claude-oauth-config-local: check-release-claude-oauth-config-sops
+
+check-release-claude-oauth-config-sops:
+	@command -v "$(SOPS)" >/dev/null 2>&1 || { echo "Error: $(SOPS) CLI is required."; exit 1; }
+	@test -f "$(SOPS_RELEASE_ENV_FILE)" || { echo "Error: SOPS release env file not found: $(SOPS_RELEASE_ENV_FILE)"; echo "Set SOPS_RELEASE_ENV_FILE to the prod SOPS env file."; exit 1; }
+	@$(SOPS_RELEASE_ENV_RUNNER) \
+		--require-claude-slots "$(REQUIRE_CLAUDE_OAUTH_SLOTS)" \
+		--release-video "$(RELEASE_VIDEO)" \
+		-- $(MAKE) --no-print-directory check-release-claude-oauth-config
+
+check-release-video-config-local: check-release-video-config-sops
+
+check-release-video-config-sops:
+	@command -v "$(SOPS)" >/dev/null 2>&1 || { echo "Error: $(SOPS) CLI is required."; exit 1; }
+	@test -f "$(SOPS_RELEASE_ENV_FILE)" || { echo "Error: SOPS release env file not found: $(SOPS_RELEASE_ENV_FILE)"; echo "Set SOPS_RELEASE_ENV_FILE to the prod SOPS env file."; exit 1; }
+	@$(SOPS_RELEASE_ENV_RUNNER) \
+		--require-claude-slots "$(REQUIRE_CLAUDE_OAUTH_SLOTS)" \
+		--release-video "$(RELEASE_VIDEO)" \
+		-- $(MAKE) --no-print-directory check-release-claude-oauth-config check-release-video-config
 
 check-release-video-config-infisical:
-	@command -v "$(INFISICAL)" >/dev/null 2>&1 || { echo "Error: $(INFISICAL) CLI is required."; exit 1; }
-	@"$(INFISICAL)" run --env "$(INFISICAL_ENV)" --path "$(INFISICAL_PATH)" --silent -- \
-		$(MAKE) --no-print-directory check-release-video-config
+	@echo "check-release-video-config-infisical is deprecated; use make check-release-video-config-local (SOPS-backed)." >&2
+	@$(MAKE) --no-print-directory check-release-video-config-sops
 
-release-local: release-infisical
+release-local: release-sops
+
+release-sops:
+	@command -v "$(SOPS)" >/dev/null 2>&1 || { echo "Error: $(SOPS) CLI is required."; exit 1; }
+	@test -f "$(SOPS_RELEASE_ENV_FILE)" || { echo "Error: SOPS release env file not found: $(SOPS_RELEASE_ENV_FILE)"; echo "Set SOPS_RELEASE_ENV_FILE to the prod SOPS env file."; exit 1; }
+	@$(SOPS_RELEASE_ENV_RUNNER) \
+		--require-claude-slots "$(REQUIRE_CLAUDE_OAUTH_SLOTS)" \
+		--release-video "$(RELEASE_VIDEO)" \
+		-- $(MAKE) --no-print-directory check-release-claude-oauth-config release
 
 release-infisical:
-	@command -v "$(INFISICAL)" >/dev/null 2>&1 || { echo "Error: $(INFISICAL) CLI is required."; exit 1; }
-	@"$(INFISICAL)" run --env "$(INFISICAL_ENV)" --path "$(INFISICAL_PATH)" --silent -- \
-		$(MAKE) --no-print-directory release
+	@echo "release-infisical is deprecated; use make release-local (SOPS-backed)." >&2
+	@$(MAKE) --no-print-directory release-sops
 
 release-video:
 	@if [ "$(RELEASE_VIDEO)" = "0" ]; then \

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -667,16 +667,17 @@ git commit -m "docs: update documentation"
 The version is derived from git tags via setuptools-scm. To release, on `main`:
 
 ```bash
-make release-local             # patch bump with local Infisical PDS token
+make release-local             # patch bump with local SOPS release secrets
 make release-local BUMP=minor  # minor bump
 make release-local BUMP=major  # major bump
 ```
 
-`make release-local` injects the local Infisical `PDS_RELEASE_TOKEN`, tags `HEAD` with the next `vX.Y.Z`, pushes the tag, then runs `make release-video`. The release-video step asks Claude Code to turn the release diff/notes into a short video script and calls the Prompt Driven Studio CLI (`pds release-video create --target publish --platform youtube --privacy unlisted --wait`) to create and upload an unlisted YouTube video. GitHub Actions then builds the wheel, waits for the `gltanaka` approval on the `pypi-publish` environment, publishes to PyPI via OIDC, and creates a GitHub Release with auto-generated notes.
+`make release-local` injects release secrets from SOPS, tags `HEAD` with the next `vX.Y.Z`, pushes the tag, then runs `make release-video`. By default it looks for `../secrets/pdd_cloud/shared.prod.sops.env`; set `SOPS_RELEASE_ENV_FILE` if your `pdd_cloud` checkout is elsewhere. The local wrapper maps `CLAUDE_CODE_OAUTH_TOKEN` from `shared.staging.sops.env`, `shared.staging2.sops.env`, and `shared.prod.sops.env` into Claude Code rotation slots `_1`, `_2`, and `_3` at process runtime. The release-video step asks Claude Code to turn the release diff/notes into a short video script and calls the Prompt Driven Studio CLI (`pds release-video create --target publish --platform youtube --privacy unlisted --wait`) to create and upload an unlisted YouTube video. GitHub Actions then builds the wheel, waits for the `gltanaka` approval on the `pypi-publish` environment, publishes to PyPI via OIDC, and creates a GitHub Release with auto-generated notes.
 
 Release-video diagnostics and recovery:
 
-- Run `make check-release-video-config` before a local release. If `PDS_TOKEN` is set, local preflight can only confirm that a token exists; it cannot verify scopes or project access unless the PDS server preflight is run.
+- Run `make check-release-video-config-local` before a local release. If `PDS_TOKEN` is set, local preflight can only confirm that a token exists; it cannot verify scopes or project access unless the PDS server preflight is run.
+- Set repo secrets `CLAUDE_CODE_OAUTH_TOKEN_1`, `CLAUDE_CODE_OAUTH_TOKEN_2`, and `CLAUDE_CODE_OAUTH_TOKEN_3` for release-note and release-video CI rotation, using staging, staging2, and prod respectively. `CLAUDE_CODE_OAUTH_TOKEN` is only a fallback compatibility slot.
 - Normal create-mode creates a new per-release PDS project. The token must be able to create that project and continue accessing it afterward; otherwise use a backend fix/wildcard token or set `RELEASE_VIDEO_PROJECT_ID` for an authorized fixed project.
 - If Claude Code quota/auth blocks script generation, reuse a generated script artifact with `RELEASE_VIDEO_SCRIPT_PATH=.pdd/release-videos/<tag>/release_video_script.md make release-video RELEASE_TAG=<tag>`.
 - For selected-project bootstrap recovery, reuse the generated script and run `make release-video RELEASE_TAG=<tag> RELEASE_VIDEO_PROJECT_ID=<project-id> RELEASE_VIDEO_SCRIPT_PATH=.pdd/release-videos/<tag>/release_video_script.md RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT=1 RELEASE_VIDEO_FORCE_REGENERATE=1 RELEASE_VIDEO_ATTEMPT_ID=<timestamp-or-label>`.

--- a/scripts/sops_release_env.py
+++ b/scripts/sops_release_env.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Run a command with release env plus Claude OAuth slots from SOPS files."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+CLAUDE_SLOT_NAMES = (
+    "CLAUDE_CODE_OAUTH_TOKEN_1",
+    "CLAUDE_CODE_OAUTH_TOKEN_2",
+    "CLAUDE_CODE_OAUTH_TOKEN_3",
+)
+
+
+def parse_dotenv(text: str) -> dict[str, str]:
+    """Parse the dotenv subset emitted by the SOPS release files."""
+    env: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key or key.startswith("sops_"):
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        env[key] = value
+    return env
+
+
+def decrypt_env_file(sops: str, path: Path) -> dict[str, str]:
+    """Decrypt a SOPS dotenv file and return parsed environment variables."""
+    if not path.is_file():
+        raise RuntimeError(f"SOPS env file not found: {path}")
+    completed = subprocess.run(
+        [sops, "decrypt", str(path)],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        details = completed.stderr.strip() or "sops decrypt failed"
+        raise RuntimeError(f"Could not decrypt {path}: {details}")
+    return parse_dotenv(completed.stdout)
+
+
+def build_env(args: argparse.Namespace) -> dict[str, str]:
+    """Build the child process environment from release and Claude SOPS files."""
+    if shutil.which(args.sops) is None:
+        raise RuntimeError(f"{args.sops} CLI is required")
+
+    env = os.environ.copy()
+    release_env = decrypt_env_file(args.sops, Path(args.release_env_file))
+    env.update(release_env)
+
+    for name in CLAUDE_SLOT_NAMES:
+        env.pop(name, None)
+
+    seen_tokens: set[str] = set()
+    slot_index = 0
+    for source in args.claude_env_file:
+        source_path = Path(source)
+        if slot_index >= len(CLAUDE_SLOT_NAMES):
+            print(
+                f"Claude Code OAuth source ignored because all slots are assigned: {source_path}",
+                file=sys.stderr,
+            )
+            continue
+        slot_name = CLAUDE_SLOT_NAMES[slot_index]
+        source_env = decrypt_env_file(args.sops, source_path)
+        token = source_env.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+        if not token:
+            print(
+                "Claude Code OAuth source has no CLAUDE_CODE_OAUTH_TOKEN "
+                f"for {slot_name}: {source_path}",
+                file=sys.stderr,
+            )
+            continue
+        if token in seen_tokens:
+            print(
+                "Claude Code OAuth source duplicates an earlier token; "
+                f"not assigning another slot: {source_path}",
+                file=sys.stderr,
+            )
+            continue
+        env[slot_name] = token
+        seen_tokens.add(token)
+        slot_index += 1
+        print(
+            f"Mapped {source_path} CLAUDE_CODE_OAUTH_TOKEN to {slot_name}.",
+            file=sys.stderr,
+        )
+
+    env["REQUIRE_CLAUDE_OAUTH_SLOTS"] = args.require_claude_slots
+    env["RELEASE_VIDEO"] = args.release_video
+    return env
+
+
+def main() -> int:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sops", default="sops")
+    parser.add_argument("--release-env-file", required=True)
+    parser.add_argument("--claude-env-file", action="append", default=[])
+    parser.add_argument("--require-claude-slots", default="1")
+    parser.add_argument("--release-video", default="1")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("command is required after --")
+
+    try:
+        env = build_env(args)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    completed = subprocess.run(command, env=env, check=False)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sops_release_env.py
+++ b/tests/test_sops_release_env.py
@@ -1,0 +1,80 @@
+"""Tests for scripts/sops_release_env.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "sops_release_env.py"
+
+
+def load_module():
+    """Load the script as an importable module for unit tests."""
+    spec = importlib.util.spec_from_file_location("sops_release_env", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_dotenv_handles_export_quotes_and_sops_metadata():
+    """The dotenv parser handles the syntax used by encrypted release files."""
+    module = load_module()
+
+    parsed = module.parse_dotenv(
+        """
+        # comment
+        export PDS_RELEASE_TOKEN='release-token'
+        CLAUDE_CODE_OAUTH_TOKEN="oauth-token"
+        EMPTY=
+        sops_mac=encrypted-metadata
+        """
+    )
+
+    assert parsed == {
+        "PDS_RELEASE_TOKEN": "release-token",
+        "CLAUDE_CODE_OAUTH_TOKEN": "oauth-token",
+        "EMPTY": "",
+    }
+
+
+def test_build_env_maps_distinct_claude_tokens_to_compact_slots(monkeypatch):
+    """Distinct Claude OAuth tokens fill numbered slots without gaps."""
+    module = load_module()
+
+    decrypted = {
+        Path("release.sops.env"): {"PDS_RELEASE_TOKEN": "release-token"},
+        Path("dev.sops.env"): {"CLAUDE_CODE_OAUTH_TOKEN": "dev-token"},
+        Path("staging.sops.env"): {"CLAUDE_CODE_OAUTH_TOKEN": "dev-token"},
+        Path("prod.sops.env"): {"CLAUDE_CODE_OAUTH_TOKEN": "prod-token"},
+    }
+
+    monkeypatch.setattr(module.shutil, "which", lambda _: "/opt/homebrew/bin/sops")
+    monkeypatch.setattr(
+        module,
+        "decrypt_env_file",
+        lambda _sops, path: decrypted[Path(path)],
+    )
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "old-token")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_2", "old-token")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_3", "old-token")
+
+    env = module.build_env(
+        SimpleNamespace(
+            sops="sops",
+            release_env_file="release.sops.env",
+            claude_env_file=["dev.sops.env", "staging.sops.env", "prod.sops.env"],
+            require_claude_slots="1",
+            release_video="1",
+        )
+    )
+
+    assert env["PDS_RELEASE_TOKEN"] == "release-token"
+    assert env["CLAUDE_CODE_OAUTH_TOKEN_1"] == "dev-token"
+    assert env["CLAUDE_CODE_OAUTH_TOKEN_2"] == "prod-token"
+    assert "CLAUDE_CODE_OAUTH_TOKEN_3" not in env
+    assert env["REQUIRE_CLAUDE_OAUTH_SLOTS"] == "1"
+    assert env["RELEASE_VIDEO"] == "1"


### PR DESCRIPTION
## Summary
- replace local release Infisical injection with a SOPS-backed release env wrapper
- map Claude OAuth tokens from staging, staging2, and prod SOPS files into numbered release-video rotation slots
- add a release workflow warning for partial Claude OAuth slot configuration
- document SOPS-backed local release flow in onboarding

## Investigation
- Sibling bug hunt: existing release tooling already supports numbered Claude OAuth slots in `scripts/release_video.py` and `.github/workflows/release.yml`; the gap was local `make release-local` still depending on Infisical and not populating the numbered slots from SOPS.
- SOPS file check: `shared.dev.sops.env` does not contain `CLAUDE_CODE_OAUTH_TOKEN`; `shared.staging.sops.env`, `shared.staging2.sops.env`, and `shared.prod.sops.env` do. Defaults use those three token-bearing files.
- Prior conventions: release Makefile targets already use explicit preflight targets and avoid Makefile regeneration for release goals. This keeps that pattern and adds a helper script covered by focused unit tests.

## Test Plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYDANTIC_DISABLE_PLUGINS=1 python -m pytest --noconftest tests/test_sops_release_env.py -q`
- `python -m pylint scripts/sops_release_env.py tests/test_sops_release_env.py`
- `CLAUDE_CODE_OAUTH_TOKEN_1=dev CLAUDE_CODE_OAUTH_TOKEN_2=staging CLAUDE_CODE_OAUTH_TOKEN_3=prod make --no-print-directory check-release-claude-oauth-config`
- `make --no-print-directory check-release-claude-oauth-config-sops SOPS_RELEASE_ENV_FILE=/Users/gregtanaka/Documents/pdd_cloud/secrets/pdd_cloud/shared.prod.sops.env SOPS_RELEASE_CLAUDE_ENV_FILES="/Users/gregtanaka/Documents/pdd_cloud/secrets/pdd_cloud/shared.staging.sops.env /Users/gregtanaka/Documents/pdd_cloud/secrets/pdd_cloud/shared.staging2.sops.env /Users/gregtanaka/Documents/pdd_cloud/secrets/pdd_cloud/shared.prod.sops.env"`

## Notes
- No plaintext secrets are committed. The unit test token strings are fake placeholders.
- The pytest command uses `--noconftest` because this helper test does not need the repo-wide conftest; the active shell environment otherwise imports the full package and hits slow plugin discovery before collection.
