### PR TITLE
Smoke: same-role checkup review-loop CLI

### DIFF
--- a/docs/issues/issue-1736-same-role-cli-smoke.md
+++ b/docs/issues/issue-1736-same-role-cli-smoke.md
@@ -1,0 +1,6 @@
+# Same-role review-loop CLI smoke
+
+This disposable note exists only to exercise the `pdd checkup --review-loop`
+CLI path with `--reviewer codex --fixer codex --allow-same-reviewer-fixer`.
+
+It should be safe to remove after the smoke PR is closed.


### PR DESCRIPTION
Disposable PR for validating the real pdd checkup CLI path with --reviewer codex --fixer codex --allow-same-reviewer-fixer. Closes #1743.