### PR TITLE
[codex] add direnv conda activation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+# direnv evaluates this file with bash syntax, even for fish terminals.
+source "$(conda info --base)/etc/profile.d/conda.sh"
+conda activate pdd


### PR DESCRIPTION
## Summary

Adds a checked-in `.envrc` for direnv users so entering the repository activates the shared `pdd` Conda environment.

## Impact

This keeps local shell setup aligned with the repository guidance to use `conda activate pdd`. The file contains no credentials or machine-specific absolute paths.

## Validation

- `bash -n .envrc`
- Inspected the staged diff before commit