### PR TITLE
[codex] Fix release-video idempotency and PDS run persistence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,6 +251,7 @@ jobs:
           RELEASE_VIDEO_PROJECT_ID: ${{ vars.RELEASE_VIDEO_PROJECT_ID }}
           RELEASE_VIDEO_SCRIPT_PATH: ${{ vars.RELEASE_VIDEO_SCRIPT_PATH }}
           RELEASE_VIDEO_IDEMPOTENCY_KEY: ${{ vars.RELEASE_VIDEO_IDEMPOTENCY_KEY }}
+          RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE: ${{ vars.RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE || 'github-actions' }}
           RELEASE_VIDEO_ATTEMPT_ID: ${{ vars.RELEASE_VIDEO_ATTEMPT_ID }}
           RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT: ${{ vars.RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT }}
           RELEASE_VIDEO_FORCE_REGENERATE: ${{ vars.RELEASE_VIDEO_FORCE_REGENERATE }}
@@ -280,12 +281,22 @@ jobs:
               RELEASE_TAG="$tag" \
               RELEASE_GIT_SHA="${{ github.sha }}" \
               ${RELEASE_VIDEO_PROJECT_ID:+RELEASE_VIDEO_PROJECT_ID="$RELEASE_VIDEO_PROJECT_ID"}; then
+            run_sidecar=".pdd/release-videos/${tag}/pds_run.json"
+            if [ -s "$run_sidecar" ]; then
+              echo "::notice::release-video PDS recovery metadata saved at $run_sidecar"
+              cat "$run_sidecar"
+            fi
             echo "::warning::release video step failed; see diagnostics above for Claude script generation vs PDS publish. Release notes left unchanged."
             exit 0
           fi
           resp=".pdd/release-videos/${tag}/pds_response.json"
+          run_sidecar=".pdd/release-videos/${tag}/pds_run.json"
           youtube_url=$(grep -oE 'https?://(www\.)?(youtube\.com|youtu\.be)/[^"]+' "$resp" 2>/dev/null | head -1 || true)
           if [ -z "$youtube_url" ]; then
+            if [ -s "$run_sidecar" ]; then
+              echo "::notice::release-video PDS recovery metadata saved at $run_sidecar"
+              cat "$run_sidecar"
+            fi
             echo "No YouTube URL in PDS response ($resp); release notes unchanged."
             exit 0
           fi
@@ -306,6 +317,14 @@ jobs:
                 echo "::warning::failed to update release notes with video link."
               fi ;;
           esac
+
+      - name: Upload release video recovery artifacts
+        if: env.HAS_PDS == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-video-${{ github.ref_name }}
+          path: .pdd/release-videos/${{ github.ref_name }}/
+          if-no-files-found: ignore
 
       - name: Post release notes to Discord
         env:

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ help:
 	@echo "  make publish                 - Build & upload current version to PyPI"
 	@echo "  make publish-public          - Copy artifacts to public repo only"
 	@echo "  make release-video           - Generate and upload a YouTube video for the current release tag"
+	@echo "  make release-video-status RELEASE_TAG=vX.Y.Z - Show persisted PDS release-video run metadata"
 	@echo "  make release-video-discord-backfill RELEASE_TAG=vX.Y.Z RELEASE_VIDEO_YOUTUBE_URL=url - Post recovered video follow-up to Discord"
 	@echo "  make release-local           - Run release with local SOPS release secrets"
 	@echo "  make check-release-claude-oauth-config-local - Verify local SOPS Claude OAuth rotation slots"
@@ -94,6 +95,7 @@ RELEASE_VIDEO_DRY_RUN ?= 0
 RELEASE_VIDEO_PROJECT_ID ?=
 RELEASE_VIDEO_SCRIPT_PATH ?=
 RELEASE_VIDEO_IDEMPOTENCY_KEY ?=
+RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE ?=
 RELEASE_VIDEO_ATTEMPT_ID ?=
 RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT ?= 0
 RELEASE_VIDEO_FORCE_REGENERATE ?= 0
@@ -121,7 +123,7 @@ ifeq ($(CI),true)
 SKIP_MAKEFILE_REGEN := 1
 endif
 
-RELEASE_MAKE_GOALS := release release-video release-video-discord-backfill release-local release-sops release-infisical check-release-video-config check-release-video-config-local check-release-video-config-sops check-release-video-config-infisical check-release-claude-oauth-config check-release-claude-oauth-config-local check-release-claude-oauth-config-sops
+RELEASE_MAKE_GOALS := release release-video release-video-status release-video-discord-backfill release-local release-sops release-infisical check-release-video-config check-release-video-config-local check-release-video-config-sops check-release-video-config-infisical check-release-claude-oauth-config check-release-claude-oauth-config-local check-release-claude-oauth-config-sops
 ifneq ($(filter $(RELEASE_MAKE_GOALS),$(MAKECMDGOALS)),)
 SKIP_MAKEFILE_REGEN := 1
 endif
@@ -142,7 +144,7 @@ TEST_OUTPUTS := $(patsubst $(PDD_DIR)/%.py,$(TESTS_DIR)/test_%.py,$(PY_OUTPUTS))
 # All Example files in context directory (recursive)
 EXAMPLE_FILES := $(shell find $(CONTEXT_DIR) -name "*_example.py" 2>/dev/null)
 
-.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release release-local release-sops release-infisical release-video release-video-discord-backfill check-release-remote check-release-branch check-release-clean check-release-video-config check-release-video-config-local check-release-video-config-sops check-release-video-config-infisical check-release-claude-oauth-config check-release-claude-oauth-config-local check-release-claude-oauth-config-sops
+.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release release-local release-sops release-infisical release-video release-video-status release-video-discord-backfill check-release-remote check-release-branch check-release-clean check-release-video-config check-release-video-config-local check-release-video-config-sops check-release-video-config-infisical check-release-claude-oauth-config check-release-claude-oauth-config-local check-release-claude-oauth-config-sops
 
 all: $(PY_OUTPUTS) $(MAKEFILE_OUTPUT) $(CSV_OUTPUTS) $(EXAMPLE_OUTPUTS) $(TEST_OUTPUTS)
 
@@ -842,6 +844,7 @@ release-video:
 	export PDS_API_URL="$${PDS_API_URL:-$(PDS_API_URL)}"; \
 	RELEASE_TAG="$(RELEASE_TAG)" RELEASE_GIT_SHA="$(RELEASE_GIT_SHA)" \
 	RELEASE_VIDEO_IDEMPOTENCY_KEY="$(RELEASE_VIDEO_IDEMPOTENCY_KEY)" \
+	RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE="$(RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE)" \
 	RELEASE_VIDEO_ATTEMPT_ID="$(RELEASE_VIDEO_ATTEMPT_ID)" \
 	RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT="$(RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT)" \
 	RELEASE_VIDEO_FORCE_REGENERATE="$(RELEASE_VIDEO_FORCE_REGENERATE)" \
@@ -856,6 +859,22 @@ release-video:
 		--platform "$(RELEASE_VIDEO_PLATFORM)" \
 		--privacy "$(RELEASE_VIDEO_PRIVACY)" \
 		$$DRY_RUN_FLAG
+
+release-video-status:
+	@if [ -z "$(RELEASE_TAG)" ]; then \
+		echo "RELEASE_TAG is required, for example make release-video-status RELEASE_TAG=vX.Y.Z" >&2; \
+		exit 1; \
+	fi; \
+	RELEASE_PDS_TOKEN="$${PDS_TOKEN:-}"; \
+	if [ -z "$$RELEASE_PDS_TOKEN" ]; then RELEASE_PDS_TOKEN="$${PDS_RELEASE_TOKEN:-}"; fi; \
+	if [ -n "$$RELEASE_PDS_TOKEN" ]; then export PDS_TOKEN="$$RELEASE_PDS_TOKEN"; export PDS_PROFILE=; fi; \
+	export PDS_API_URL="$${PDS_API_URL:-$(PDS_API_URL)}"; \
+	python scripts/release_video.py \
+		--status \
+		--status-query \
+		--tag "$(RELEASE_TAG)" \
+		--output-dir "$(RELEASE_VIDEO_OUTPUT_DIR)" \
+		--pds-cli "$(PDS_CLI)"
 
 release-video-discord-backfill:
 	@python scripts/backfill_release_video_discord.py \

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE ?=
 RELEASE_VIDEO_ATTEMPT_ID ?=
 RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT ?= 0
 RELEASE_VIDEO_FORCE_REGENERATE ?= 0
+RELEASE_VIDEO_STATUS_QUERY ?= 0
 RELEASE_VIDEO_YOUTUBE_URL ?=
 CLAUDE_CLI ?= claude
 PDS_CLI ?= pds
@@ -108,6 +109,11 @@ SOPS_RELEASE_ENV_FILE ?= $(firstword $(wildcard ../secrets/pdd_cloud/shared.prod
 SOPS_RELEASE_CLAUDE_ENV_FILES ?= $(wildcard ../secrets/pdd_cloud/shared.staging.sops.env ../secrets/pdd_cloud/shared.staging2.sops.env ../secrets/pdd_cloud/shared.prod.sops.env ../pdd_cloud/secrets/pdd_cloud/shared.staging.sops.env ../pdd_cloud/secrets/pdd_cloud/shared.staging2.sops.env ../pdd_cloud/secrets/pdd_cloud/shared.prod.sops.env secrets/pdd_cloud/shared.staging.sops.env secrets/pdd_cloud/shared.staging2.sops.env secrets/pdd_cloud/shared.prod.sops.env)
 SOPS_RELEASE_ENV_RUNNER := python scripts/sops_release_env.py --sops "$(SOPS)" --release-env-file "$(SOPS_RELEASE_ENV_FILE)" $(foreach file,$(SOPS_RELEASE_CLAUDE_ENV_FILES),--claude-env-file "$(file)")
 REQUIRE_CLAUDE_OAUTH_SLOTS ?= 1
+
+RELEASE_VIDEO_STATUS_QUERY_FLAG :=
+ifeq ($(RELEASE_VIDEO_STATUS_QUERY),1)
+RELEASE_VIDEO_STATUS_QUERY_FLAG := --status-query
+endif
 
 # Python files
 PY_PROMPTS := $(shell find $(PROMPTS_DIR) -name "*_python.prompt")
@@ -865,16 +871,19 @@ release-video-status:
 		echo "RELEASE_TAG is required, for example make release-video-status RELEASE_TAG=vX.Y.Z" >&2; \
 		exit 1; \
 	fi; \
-	RELEASE_PDS_TOKEN="$${PDS_TOKEN:-}"; \
-	if [ -z "$$RELEASE_PDS_TOKEN" ]; then RELEASE_PDS_TOKEN="$${PDS_RELEASE_TOKEN:-}"; fi; \
-	if [ -n "$$RELEASE_PDS_TOKEN" ]; then export PDS_TOKEN="$$RELEASE_PDS_TOKEN"; export PDS_PROFILE=; fi; \
-	export PDS_API_URL="$${PDS_API_URL:-$(PDS_API_URL)}"; \
+	if [ "$(RELEASE_VIDEO_STATUS_QUERY)" = "1" ]; then \
+		RELEASE_PDS_TOKEN="$${PDS_TOKEN:-}"; \
+		if [ -z "$$RELEASE_PDS_TOKEN" ]; then RELEASE_PDS_TOKEN="$${PDS_RELEASE_TOKEN:-}"; fi; \
+		if [ -n "$$RELEASE_PDS_TOKEN" ]; then export PDS_TOKEN="$$RELEASE_PDS_TOKEN"; export PDS_PROFILE=; fi; \
+		export PDS_API_URL="$${PDS_API_URL:-$(PDS_API_URL)}"; \
+	fi; \
+	STATUS_QUERY_ARGS="$(RELEASE_VIDEO_STATUS_QUERY_FLAG)"; \
 	python scripts/release_video.py \
 		--status \
-		--status-query \
 		--tag "$(RELEASE_TAG)" \
 		--output-dir "$(RELEASE_VIDEO_OUTPUT_DIR)" \
-		--pds-cli "$(PDS_CLI)"
+		--pds-cli "$(PDS_CLI)" \
+		$$STATUS_QUERY_ARGS
 
 release-video-discord-backfill:
 	@python scripts/backfill_release_video_discord.py \

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -17,6 +17,14 @@ from typing import Any
 
 SEMVER_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
 YOUTUBE_URL_RE = re.compile(r"https?://(?:www\.)?(?:youtube\.com|youtu\.be)/[^\s\"'<>]+")
+IDEMPOTENCY_PROVENANCE_RE = re.compile(r"[^a-z0-9._-]+")
+PDS_RUN_HANDLE_LINE_RE = re.compile(
+    r"^\[pds\]\s+release-video run handle:\s+(?P<fields>.+)$",
+    flags=re.IGNORECASE | re.MULTILINE,
+)
+PDS_RUN_HANDLE_FIELD_RE = re.compile(
+    r"\b(?P<key>runId|projectId|status|attemptId)=(?P<value>[^\s]+)"
+)
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_RELEASE_VIDEO_PROMPT = REPO_ROOT / "pdd" / "prompts" / "release_video_script_LLM.prompt"
 DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
@@ -84,10 +92,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
         validate_release_video_idempotency_options(args)
+        repo = Path(args.repo).resolve()
+        if args.status:
+            return print_release_video_status(args, repo)
         if args.preflight:
             return preflight_release_video(args)
 
-        repo = Path(args.repo).resolve()
         tag = resolve_release_tag(repo, args.tag or os.environ.get("RELEASE_TAG"))
         git_sha = args.git_sha or os.environ.get("RELEASE_GIT_SHA") or git(
             repo,
@@ -116,6 +126,7 @@ def main(argv: list[str] | None = None) -> int:
         release_notes_path = output_dir / "release_notes.md"
         script_path = output_dir / "release_video_script.md"
         response_path = output_dir / "pds_response.json"
+        run_metadata_path = output_dir / "pds_run.json"
 
         context_path.write_text(context, encoding="utf8")
         release_notes_path.write_text(release_notes_from_context(context), encoding="utf8")
@@ -147,6 +158,7 @@ def main(argv: list[str] | None = None) -> int:
             script_path=script_path,
             release_notes_path=release_notes_path,
             changelog_path=Path(args.changelog),
+            run_metadata_path=run_metadata_path,
         )
         response_path.write_text(json.dumps(response, indent=2, sort_keys=True) + "\n", encoding="utf8")
 
@@ -233,6 +245,15 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         help="Full PDS idempotency key. Defaults to RELEASE_VIDEO_IDEMPOTENCY_KEY.",
     )
     parser.add_argument(
+        "--idempotency-provenance",
+        default=os.environ.get("RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE", ""),
+        help=(
+            "Execution provenance namespace for default PDS idempotency keys. "
+            "Defaults to github-actions on GitHub Actions, ci on generic CI, "
+            "and local otherwise."
+        ),
+    )
+    parser.add_argument(
         "--idempotency-attempt-id",
         default=os.environ.get("RELEASE_VIDEO_ATTEMPT_ID", ""),
         help=(
@@ -245,6 +266,16 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--preflight",
         action="store_true",
         help="Check local release-video configuration without creating artifacts.",
+    )
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        help="Print persisted PDS release-video run metadata for the release tag.",
+    )
+    parser.add_argument(
+        "--status-query",
+        action="store_true",
+        help="With --status, query PDS status using the persisted run id.",
     )
     return parser.parse_args(argv)
 
@@ -259,6 +290,69 @@ def validate_release_video_idempotency_options(args: argparse.Namespace) -> None
     if full_key and attempt_id:
         raise ReleaseVideoError(
             "Use either a full release-video idempotency key or an attempt id, not both."
+        )
+
+
+def print_release_video_status(args: argparse.Namespace, repo: Path) -> int:
+    """Print the locally persisted PDS run handle for a release tag."""
+    tag = resolve_release_tag(repo, args.tag or os.environ.get("RELEASE_TAG"))
+    run_metadata_path = Path(args.output_dir) / safe_path_part(tag) / "pds_run.json"
+    try:
+        raw = run_metadata_path.read_text(encoding="utf8")
+    except OSError as exc:
+        raise ReleaseVideoError(
+            f"No persisted PDS run metadata found for {tag}: {run_metadata_path}"
+        ) from exc
+    if not raw.strip():
+        raise ReleaseVideoError(
+            f"Persisted PDS run metadata is empty for {tag}: {run_metadata_path}"
+        )
+    try:
+        metadata = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ReleaseVideoError(
+            f"Persisted PDS run metadata is not valid JSON: {run_metadata_path}: {exc}"
+        ) from exc
+    if not isinstance(metadata, dict):
+        raise ReleaseVideoError(
+            f"Persisted PDS run metadata is not a JSON object: {run_metadata_path}"
+        )
+
+    print(json.dumps(metadata, indent=2, sort_keys=True))
+    recover_command = str(metadata.get("recoverCommand") or "").strip()
+    watch_command = str(metadata.get("watchCommand") or "").strip()
+    if recover_command:
+        print(f"recover: {recover_command}")
+    if watch_command:
+        print(f"watch: {watch_command}")
+    if args.status_query:
+        query_pds_release_video_status(args, repo, metadata)
+    return 0
+
+
+def query_pds_release_video_status(
+    args: argparse.Namespace,
+    repo: Path,
+    metadata: dict[str, Any],
+) -> None:
+    run_id = str(metadata.get("runId") or "").strip()
+    if not run_id:
+        raise ReleaseVideoError("Persisted PDS run metadata does not include runId.")
+    command = split_command(args.pds_cli)
+    ensure_command_exists(command[0], "PDS CLI")
+    completed = run(
+        [*command, "release-video", "status", "--run-id", run_id, "--json"],
+        cwd=repo,
+        timeout=None,
+        check=False,
+    )
+    if completed.stdout.strip():
+        print(completed.stdout.rstrip())
+    if completed.stderr.strip():
+        print(completed.stderr.rstrip(), file=sys.stderr)
+    if completed.returncode != 0:
+        raise ReleaseVideoError(
+            f"PDS release-video status failed: {process_details(completed)}"
         )
 
 
@@ -815,6 +909,7 @@ def create_release_video(
     script_path: Path,
     release_notes_path: Path,
     changelog_path: Path,
+    run_metadata_path: Path,
 ) -> dict[str, Any]:
     command = split_command(args.pds_cli)
     ensure_command_exists(command[0], "PDS CLI")
@@ -827,6 +922,7 @@ def create_release_video(
         git_sha=git_sha,
         full_key=args.idempotency_key,
         attempt_id=args.idempotency_attempt_id,
+        provenance=args.idempotency_provenance,
     )
     pds_args = [
         "release-video",
@@ -868,13 +964,39 @@ def create_release_video(
     if args.dry_run:
         pds_args.append("--dry-run")
 
-    completed = run(command + pds_args, cwd=repo, timeout=None)
+    completed = run(command + pds_args, cwd=repo, timeout=None, check=False)
+    persisted_run_metadata_path = persist_pds_run_metadata_from_output(
+        completed=completed,
+        path=run_metadata_path,
+        pds_cli=args.pds_cli,
+        tag=tag,
+        idempotency_key=idempotency_key,
+        attempt_id=args.idempotency_attempt_id,
+        provenance=release_video_idempotency_provenance(args.idempotency_provenance),
+    )
+    if persisted_run_metadata_path:
+        print(
+            f"release-video: persisted PDS run metadata to {persisted_run_metadata_path}",
+            file=sys.stderr,
+        )
+    if completed.returncode != 0:
+        message = (
+            f"{shlex.join(command + pds_args)} failed: "
+            f"{process_details(completed)}"
+        )
+        hint = pds_failure_hint(completed)
+        if hint:
+            message += f" {hint}"
+        if persisted_run_metadata_path:
+            message += f" PDS run metadata saved to {persisted_run_metadata_path}."
+        raise ReleaseVideoError(message)
     try:
         parsed = json.loads(completed.stdout)
     except json.JSONDecodeError as exc:
-        raise ReleaseVideoError(
-            f"PDS CLI did not return JSON: {exc}. Output: {completed.stdout[:2000]}"
-        ) from exc
+        message = f"PDS CLI did not return JSON: {exc}. Output: {completed.stdout[:2000]}"
+        if persisted_run_metadata_path:
+            message += f" PDS run metadata saved to {persisted_run_metadata_path}."
+        raise ReleaseVideoError(message) from exc
     if not isinstance(parsed, dict):
         raise ReleaseVideoError("PDS CLI returned JSON that was not an object.")
     return parsed
@@ -886,6 +1008,7 @@ def release_video_idempotency_key(
     git_sha: str,
     full_key: str | None,
     attempt_id: str | None,
+    provenance: str | None,
 ) -> str:
     full_key = str(full_key or "").strip()
     attempt_id = str(attempt_id or "").strip()
@@ -894,12 +1017,214 @@ def release_video_idempotency_key(
             "Use either a full release-video idempotency key or an attempt id, not both."
         )
 
-    default_key = f"pdd-release-video:{tag}:{git_sha}"
     if full_key:
         return full_key
+    default_key = (
+        f"pdd-release-video:{tag}:{git_sha}:"
+        f"{release_video_idempotency_provenance(provenance)}"
+    )
     if attempt_id:
         return f"{default_key}:retry-{attempt_id}"
     return default_key
+
+
+def release_video_idempotency_provenance(explicit_provenance: str | None) -> str:
+    provenance = str(explicit_provenance or "").strip()
+    if not provenance:
+        if os.environ.get("GITHUB_ACTIONS", "").strip().lower() == "true":
+            provenance = "github-actions"
+        elif os.environ.get("CI", "").strip():
+            provenance = "ci"
+        else:
+            provenance = "local"
+    sanitized = IDEMPOTENCY_PROVENANCE_RE.sub("-", provenance.lower()).strip("-._")
+    return sanitized or "local"
+
+
+def persist_pds_run_metadata_from_output(
+    *,
+    completed: subprocess.CompletedProcess[str],
+    path: Path,
+    pds_cli: str,
+    tag: str,
+    idempotency_key: str,
+    attempt_id: str | None,
+    provenance: str,
+) -> Path | None:
+    metadata = extract_pds_run_metadata(completed.stdout, completed.stderr)
+    if not metadata:
+        return None
+    metadata = enrich_pds_run_metadata(
+        metadata,
+        pds_cli=pds_cli,
+        tag=tag,
+        idempotency_key=idempotency_key,
+        attempt_id=attempt_id,
+        provenance=provenance,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf8")
+    return path
+
+
+def extract_pds_run_metadata(*texts: str) -> dict[str, str] | None:
+    for text in texts:
+        metadata = extract_pds_run_metadata_from_json_text(text)
+        if metadata:
+            return metadata
+    for text in texts:
+        metadata = extract_pds_run_metadata_from_compat_lines(text)
+        if metadata:
+            return metadata
+    return None
+
+
+def extract_pds_run_metadata_from_json_text(text: str) -> dict[str, str] | None:
+    for value in iter_json_values(text):
+        metadata = extract_pds_run_metadata_from_json_value(value)
+        if metadata:
+            return metadata
+    return None
+
+
+def iter_json_values(text: str):
+    decoder = json.JSONDecoder()
+    index = 0
+    while index < len(text):
+        json_starts = (
+            text.find("{", index),
+            text.find("[", index),
+        )
+        next_object = min(
+            (position for position in json_starts if position >= 0),
+            default=-1,
+        )
+        if next_object < 0:
+            return
+        try:
+            value, end = decoder.raw_decode(text[next_object:])
+        except json.JSONDecodeError:
+            index = next_object + 1
+            continue
+        yield value
+        index = next_object + end
+
+
+def extract_pds_run_metadata_from_json_value(value: Any) -> dict[str, str] | None:
+    if isinstance(value, dict):
+        metadata = pds_run_metadata_from_mapping(value)
+        if metadata:
+            return metadata
+        for nested in value.values():
+            metadata = extract_pds_run_metadata_from_json_value(nested)
+            if metadata:
+                return metadata
+    elif isinstance(value, list):
+        for nested in value:
+            metadata = extract_pds_run_metadata_from_json_value(nested)
+            if metadata:
+                return metadata
+    return None
+
+
+def pds_run_metadata_from_mapping(mapping: dict[str, Any]) -> dict[str, str] | None:
+    run_value = mapping.get("run")
+    project_value = mapping.get("project")
+    run = run_value if isinstance(run_value, dict) else {}
+    project = project_value if isinstance(project_value, dict) else {}
+    metadata = {
+        "runId": first_string(mapping, "runId", "run_id")
+        or first_string(run, "runId", "run_id", "id"),
+        "projectId": first_string(mapping, "projectId", "project_id")
+        or first_string(project, "projectId", "project_id", "id"),
+        "status": first_string(mapping, "status", "state")
+        or first_string(run, "status", "state"),
+        "attemptId": first_string(mapping, "attemptId", "attempt_id"),
+        "recoverCommand": first_string(mapping, "recoverCommand", "recover_command"),
+        "watchCommand": first_string(mapping, "watchCommand", "watch_command"),
+    }
+    if not metadata["runId"]:
+        return None
+    return {key: value for key, value in metadata.items() if value}
+
+
+def first_string(mapping: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def extract_pds_run_metadata_from_compat_lines(text: str) -> dict[str, str] | None:
+    match = PDS_RUN_HANDLE_LINE_RE.search(text)
+    if not match:
+        return None
+    metadata = {
+        field_match.group("key"): field_match.group("value")
+        for field_match in PDS_RUN_HANDLE_FIELD_RE.finditer(match.group("fields"))
+    }
+    recover_command = extract_pds_command_line(text, "[pds] recover:")
+    watch_command = extract_pds_command_line(text, "[pds] watch:")
+    if recover_command:
+        metadata["recoverCommand"] = recover_command
+    if watch_command:
+        metadata["watchCommand"] = watch_command
+    return metadata if metadata.get("runId") else None
+
+
+def extract_pds_command_line(text: str, prefix: str) -> str | None:
+    for line in text.splitlines():
+        if line.startswith(prefix):
+            command = line.removeprefix(prefix).strip()
+            if command:
+                return command
+    return None
+
+
+def enrich_pds_run_metadata(
+    metadata: dict[str, str],
+    *,
+    pds_cli: str,
+    tag: str,
+    idempotency_key: str,
+    attempt_id: str | None,
+    provenance: str,
+) -> dict[str, str]:
+    enriched = {
+        key: str(value).strip()
+        for key, value in metadata.items()
+        if str(value).strip()
+    }
+    run_id = enriched.get("runId", "")
+    if str(attempt_id or "").strip() and "attemptId" not in enriched:
+        enriched["attemptId"] = str(attempt_id).strip()
+    enriched.setdefault("tag", tag)
+    enriched.setdefault("idempotencyKey", idempotency_key)
+    enriched.setdefault("idempotencyProvenance", provenance)
+    if run_id:
+        pds_base = shlex.join(split_command(pds_cli))
+        enriched.setdefault(
+            "recoverCommand",
+            f"{pds_base} release-video status --run-id {shlex.quote(run_id)} --json",
+        )
+        enriched.setdefault(
+            "watchCommand",
+            f"{pds_base} jobs watch --run-id {shlex.quote(run_id)} --jsonl",
+        )
+    return enriched
+
+
+def pds_failure_hint(completed: subprocess.CompletedProcess[str]) -> str:
+    combined = f"{completed.stderr}\n{completed.stdout}".lower()
+    if "request_hash_mismatch" not in combined:
+        return ""
+    return (
+        "PDS reported request_hash_mismatch: the same idempotency key was "
+        "reused with a different request body. Retry with a distinct "
+        "RELEASE_VIDEO_ATTEMPT_ID, RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE, or "
+        "explicit RELEASE_VIDEO_IDEMPOTENCY_KEY."
+    )
 
 
 def find_youtube_url(value: Any) -> str | None:

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -91,10 +91,10 @@ class ReleaseVideoError(RuntimeError):
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
-        validate_release_video_idempotency_options(args)
         repo = Path(args.repo).resolve()
         if args.status:
             return print_release_video_status(args, repo)
+        validate_release_video_idempotency_options(args)
         if args.preflight:
             return preflight_release_video(args)
 
@@ -295,7 +295,7 @@ def validate_release_video_idempotency_options(args: argparse.Namespace) -> None
 
 def print_release_video_status(args: argparse.Namespace, repo: Path) -> int:
     """Print the locally persisted PDS run handle for a release tag."""
-    tag = resolve_release_tag(repo, args.tag or os.environ.get("RELEASE_TAG"))
+    tag = resolve_status_release_tag(repo, args.tag or os.environ.get("RELEASE_TAG"))
     run_metadata_path = Path(args.output_dir) / safe_path_part(tag) / "pds_run.json"
     try:
         raw = run_metadata_path.read_text(encoding="utf8")
@@ -330,6 +330,16 @@ def print_release_video_status(args: argparse.Namespace, repo: Path) -> int:
     return 0
 
 
+def resolve_status_release_tag(repo: Path, explicit_tag: str | None) -> str:
+    if explicit_tag:
+        if not SEMVER_TAG_RE.match(explicit_tag):
+            raise ReleaseVideoError(
+                f"Release tag must look like vN.N.N, got {explicit_tag!r}."
+            )
+        return explicit_tag
+    return resolve_release_tag(repo, None)
+
+
 def query_pds_release_video_status(
     args: argparse.Namespace,
     repo: Path,
@@ -340,6 +350,9 @@ def query_pds_release_video_status(
         raise ReleaseVideoError("Persisted PDS run metadata does not include runId.")
     command = split_command(args.pds_cli)
     ensure_command_exists(command[0], "PDS CLI")
+    project_id = str(metadata.get("projectId") or "").strip()
+    if project_id:
+        command.extend(["--project", project_id])
     completed = run(
         [*command, "release-video", "status", "--run-id", run_id, "--json"],
         cwd=repo,
@@ -973,6 +986,7 @@ def create_release_video(
         idempotency_key=idempotency_key,
         attempt_id=args.idempotency_attempt_id,
         provenance=release_video_idempotency_provenance(args.idempotency_provenance),
+        project_id=project_id,
     )
     if persisted_run_metadata_path:
         print(
@@ -1031,9 +1045,9 @@ def release_video_idempotency_key(
 def release_video_idempotency_provenance(explicit_provenance: str | None) -> str:
     provenance = str(explicit_provenance or "").strip()
     if not provenance:
-        if os.environ.get("GITHUB_ACTIONS", "").strip().lower() == "true":
+        if env_flag("GITHUB_ACTIONS"):
             provenance = "github-actions"
-        elif os.environ.get("CI", "").strip():
+        elif env_flag("CI"):
             provenance = "ci"
         else:
             provenance = "local"
@@ -1050,6 +1064,7 @@ def persist_pds_run_metadata_from_output(
     idempotency_key: str,
     attempt_id: str | None,
     provenance: str,
+    project_id: str | None,
 ) -> Path | None:
     metadata = extract_pds_run_metadata(completed.stdout, completed.stderr)
     if not metadata:
@@ -1061,6 +1076,7 @@ def persist_pds_run_metadata_from_output(
         idempotency_key=idempotency_key,
         attempt_id=attempt_id,
         provenance=provenance,
+        project_id=project_id,
     )
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf8")
@@ -1190,6 +1206,7 @@ def enrich_pds_run_metadata(
     idempotency_key: str,
     attempt_id: str | None,
     provenance: str,
+    project_id: str | None,
 ) -> dict[str, str]:
     enriched = {
         key: str(value).strip()
@@ -1202,17 +1219,43 @@ def enrich_pds_run_metadata(
     enriched.setdefault("tag", tag)
     enriched.setdefault("idempotencyKey", idempotency_key)
     enriched.setdefault("idempotencyProvenance", provenance)
+    if str(project_id or "").strip() and "projectId" not in enriched:
+        enriched["projectId"] = str(project_id).strip()
     if run_id:
-        pds_base = shlex.join(split_command(pds_cli))
-        enriched.setdefault(
-            "recoverCommand",
-            f"{pds_base} release-video status --run-id {shlex.quote(run_id)} --json",
+        pds_command = split_command(pds_cli)
+        if enriched.get("projectId"):
+            pds_command.extend(["--project", enriched["projectId"]])
+        pds_base = shlex.join(pds_command)
+        recover_command = (
+            f"{pds_base} release-video status --run-id {shlex.quote(run_id)} --json"
         )
-        enriched.setdefault(
-            "watchCommand",
-            f"{pds_base} jobs watch --run-id {shlex.quote(run_id)} --jsonl",
-        )
+        watch_command = f"{pds_base} jobs watch --run-id {shlex.quote(run_id)} --jsonl"
+        if should_replace_recovery_command(
+            enriched.get("recoverCommand", ""),
+            enriched.get("projectId", ""),
+        ):
+            enriched["recoverCommand"] = recover_command
+        if should_replace_recovery_command(
+            enriched.get("watchCommand", ""),
+            enriched.get("projectId", ""),
+        ):
+            enriched["watchCommand"] = watch_command
     return enriched
+
+
+def should_replace_recovery_command(command: str, project_id: str) -> bool:
+    if not command:
+        return True
+    if not project_id:
+        return False
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return True
+    return not any(
+        part == "--project" and index + 1 < len(parts) and parts[index + 1] == project_id
+        for index, part in enumerate(parts)
+    )
 
 
 def pds_failure_hint(completed: subprocess.CompletedProcess[str]) -> str:

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -412,6 +412,50 @@ def test_release_video_default_idempotency_key_separates_local_and_ci_provenance
     )
 
 
+def test_release_video_falsey_ci_env_uses_local_idempotency_provenance(tmp_path: Path):
+    repo = init_release_repo(tmp_path)
+    existing_script = tmp_path / "existing_release_video_script.md"
+    existing_script.write_text(reusable_script_text(), encoding="utf8")
+
+    for falsey_value in ("false", "0", "no", "off"):
+        capture = tmp_path / f"pds-capture-{falsey_value}.json"
+        subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--repo",
+                str(repo),
+                "--tag",
+                "v1.1.0",
+                "--git-sha",
+                "abc123def456",
+                "--script-path",
+                str(existing_script),
+                "--pds-cli",
+                str(
+                    pds_stub(
+                        tmp_path,
+                        {
+                            "ok": True,
+                            "summary": {"youtubeUrl": f"https://youtu.be/{falsey_value}"},
+                        },
+                    )
+                ),
+                "--output-dir",
+                str(tmp_path / f"videos-{falsey_value}"),
+            ],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            env=release_video_env({"PDS_STUB_CAPTURE": str(capture), "CI": falsey_value}),
+            check=True,
+        )
+
+        assert pds_idempotency_key(capture) == (
+            "pdd-release-video:v1.1.0:abc123def456:local"
+        )
+
+
 def test_release_video_env_full_idempotency_key_overrides_default(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     capture = tmp_path / "pds-capture.json"
@@ -728,9 +772,32 @@ def test_release_video_makefile_passes_recovery_env_vars():
 def test_release_video_makefile_has_status_target():
     makefile_text = (ROOT / "Makefile").read_text(encoding="utf8")
 
+    default = subprocess.run(
+        ["make", "-n", "release-video-status", "RELEASE_TAG=v0.0.289"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    with_query = subprocess.run(
+        [
+            "make",
+            "-n",
+            "release-video-status",
+            "RELEASE_TAG=v0.0.289",
+            "RELEASE_VIDEO_STATUS_QUERY=1",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "RELEASE_VIDEO_STATUS_QUERY ?= 0" in makefile_text
     assert "release-video-status:" in makefile_text
     assert "--status" in makefile_text
-    assert "--status-query" in makefile_text
+    assert "--status-query" not in default.stdout
+    assert "--status-query" in with_query.stdout
     assert 'RELEASE_TAG is required' in makefile_text
 
 
@@ -1368,6 +1435,58 @@ def test_release_video_persists_structured_pds_run_handle_sidecar(tmp_path: Path
     assert str(sidecar) in result.stderr
 
 
+def test_release_video_persists_explicit_project_when_pds_run_lacks_project_id(
+    tmp_path: Path,
+):
+    repo = init_release_repo(tmp_path)
+    capture = tmp_path / "pds-capture.json"
+    output_dir = tmp_path / "videos"
+    existing_script = tmp_path / "existing_release_video_script.md"
+    existing_script.write_text(reusable_script_text(), encoding="utf8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--git-sha",
+            "abc123def456",
+            "--script-path",
+            str(existing_script),
+            "--project-id",
+            "fixed-release-project",
+            "--pds-cli",
+            str(
+                pds_output_stub(
+                    tmp_path,
+                    stderr=json.dumps(
+                        {"runId": "agent_run_fixed_project", "status": "running"}
+                    )
+                    + "\n",
+                    exit_code=1,
+                )
+            ),
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    assert result.returncode == 1
+    sidecar = output_dir / "v1.1.0" / "pds_run.json"
+    persisted = json.loads(sidecar.read_text(encoding="utf8"))
+    assert persisted["projectId"] == "fixed-release-project"
+    assert "--project fixed-release-project" in persisted["recoverCommand"]
+    assert "--project fixed-release-project" in persisted["watchCommand"]
+
+
 def test_release_video_persists_compatibility_run_handle_sidecar(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     capture = tmp_path / "pds-capture.json"
@@ -1467,6 +1586,86 @@ def test_release_video_status_prints_persisted_run_sidecar(tmp_path: Path):
     assert result.stderr == ""
 
 
+def test_release_video_status_ignores_create_idempotency_conflict_env(tmp_path: Path):
+    repo = init_release_repo(tmp_path)
+    output_dir = tmp_path / "videos"
+    sidecar = output_dir / "v1.1.0" / "pds_run.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "runId": "agent_run_status_env",
+                "projectId": "pdd-v1-1-0-release",
+                "status": "running",
+            }
+        ),
+        encoding="utf8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--output-dir",
+            str(output_dir),
+            "--status",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env(
+            {
+                "RELEASE_VIDEO_IDEMPOTENCY_KEY": "manual-key",
+                "RELEASE_VIDEO_ATTEMPT_ID": "retry-operator",
+            }
+        ),
+        check=True,
+    )
+
+    assert "agent_run_status_env" in result.stdout
+    assert result.stderr == ""
+
+
+def test_release_video_status_explicit_tag_does_not_require_local_git_tag(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo-without-tags"
+    repo.mkdir()
+    output_dir = tmp_path / "videos"
+    sidecar = output_dir / "v9.9.9" / "pds_run.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps({"runId": "agent_run_no_local_tag", "status": "running"}),
+        encoding="utf8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v9.9.9",
+            "--output-dir",
+            str(output_dir),
+            "--status",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env(),
+        check=True,
+    )
+
+    assert "agent_run_no_local_tag" in result.stdout
+    assert result.stderr == ""
+
+
 def test_release_video_status_query_uses_persisted_run_id(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     output_dir = tmp_path / "videos"
@@ -1515,6 +1714,8 @@ def test_release_video_status_query_uses_persisted_run_id(tmp_path: Path):
     )
 
     assert pds_capture_argv(capture) == [
+        "--project",
+        "pdd-v1-1-0-release",
         "release-video",
         "status",
         "--run-id",

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -332,7 +332,7 @@ def test_release_video_default_idempotency_key_uses_tag_and_git_sha(tmp_path: Pa
         check=True,
     )
 
-    assert pds_idempotency_key(capture) == "pdd-release-video:v1.1.0:abc123def456"
+    assert pds_idempotency_key(capture) == "pdd-release-video:v1.1.0:abc123def456:local"
 
 
 def test_release_video_default_idempotency_key_separates_local_and_ci_provenance(
@@ -496,7 +496,7 @@ def test_release_video_attempt_id_adds_retry_suffix(tmp_path: Path):
 
     assert (
         pds_idempotency_key(capture)
-        == "pdd-release-video:v1.1.0:abc123def456:retry-20260620-001"
+        == "pdd-release-video:v1.1.0:abc123def456:local:retry-20260620-001"
     )
 
 
@@ -543,7 +543,7 @@ def test_release_video_env_attempt_id_adds_retry_suffix(tmp_path: Path):
 
     assert (
         pds_idempotency_key(capture)
-        == "pdd-release-video:v1.1.0:abc123def456:retry-ops-retry"
+        == "pdd-release-video:v1.1.0:abc123def456:local:retry-ops-retry"
     )
 
 
@@ -693,9 +693,15 @@ def test_release_video_makefile_passes_idempotency_env_vars():
     makefile_text = (ROOT / "Makefile").read_text(encoding="utf8")
 
     assert "RELEASE_VIDEO_IDEMPOTENCY_KEY ?=" in makefile_text
+    assert "RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE ?=" in makefile_text
     assert "RELEASE_VIDEO_ATTEMPT_ID ?=" in makefile_text
     assert (
         'RELEASE_VIDEO_IDEMPOTENCY_KEY="$(RELEASE_VIDEO_IDEMPOTENCY_KEY)"'
+        in makefile_text
+    )
+    assert (
+        'RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE='
+        '"$(RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE)"'
         in makefile_text
     )
     assert (
@@ -717,6 +723,15 @@ def test_release_video_makefile_passes_recovery_env_vars():
         'RELEASE_VIDEO_FORCE_REGENERATE="$(RELEASE_VIDEO_FORCE_REGENERATE)"'
         in makefile_text
     )
+
+
+def test_release_video_makefile_has_status_target():
+    makefile_text = (ROOT / "Makefile").read_text(encoding="utf8")
+
+    assert "release-video-status:" in makefile_text
+    assert "--status" in makefile_text
+    assert "--status-query" in makefile_text
+    assert 'RELEASE_TAG is required' in makefile_text
 
 
 def test_release_video_can_select_existing_pds_project(tmp_path: Path):
@@ -1254,6 +1269,47 @@ def test_release_video_publish_requires_youtube_url(tmp_path: Path):
     assert "did not return a YouTube URL" in result.stderr
 
 
+def test_release_video_request_hash_mismatch_reports_idempotency_hint(tmp_path: Path):
+    repo = init_release_repo(tmp_path)
+    capture = tmp_path / "pds-capture.json"
+    existing_script = tmp_path / "existing_release_video_script.md"
+    existing_script.write_text(reusable_script_text(), encoding="utf8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--git-sha",
+            "abc123def456",
+            "--script-path",
+            str(existing_script),
+            "--pds-cli",
+            str(
+                pds_output_stub(
+                    tmp_path,
+                    stderr='{"error":"request_hash_mismatch"}\n',
+                    exit_code=1,
+                )
+            ),
+            "--output-dir",
+            str(tmp_path / "videos"),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "request_hash_mismatch" in result.stderr
+    assert "same idempotency key was reused with a different request body" in result.stderr
+
+
 def test_release_video_persists_structured_pds_run_handle_sidecar(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     capture = tmp_path / "pds-capture.json"
@@ -1363,6 +1419,110 @@ def test_release_video_persists_compatibility_run_handle_sidecar(tmp_path: Path)
     assert persisted["status"] == "running"
     assert "jobs watch --run-id agent_run_line456 --jsonl" in persisted["watchCommand"]
     assert str(sidecar) in result.stderr
+
+
+def test_release_video_status_prints_persisted_run_sidecar(tmp_path: Path):
+    repo = init_release_repo(tmp_path)
+    output_dir = tmp_path / "videos"
+    sidecar = output_dir / "v1.1.0" / "pds_run.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "runId": "agent_run_status789",
+                "projectId": "pdd-v1-1-0-release",
+                "status": "running",
+                "recoverCommand": (
+                    "pds release-video status --run-id agent_run_status789 --json"
+                ),
+            }
+        ),
+        encoding="utf8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--output-dir",
+            str(output_dir),
+            "--status",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env(),
+        check=True,
+    )
+
+    assert "agent_run_status789" in result.stdout
+    assert (
+        "recover: pds release-video status --run-id agent_run_status789 --json"
+        in result.stdout
+    )
+    assert result.stderr == ""
+
+
+def test_release_video_status_query_uses_persisted_run_id(tmp_path: Path):
+    repo = init_release_repo(tmp_path)
+    output_dir = tmp_path / "videos"
+    capture = tmp_path / "pds-status-capture.json"
+    sidecar = output_dir / "v1.1.0" / "pds_run.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "runId": "agent_run_status_query",
+                "projectId": "pdd-v1-1-0-release",
+                "status": "running",
+            }
+        ),
+        encoding="utf8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--output-dir",
+            str(output_dir),
+            "--status",
+            "--status-query",
+            "--pds-cli",
+            str(
+                pds_output_stub(
+                    tmp_path,
+                    stdout=json.dumps(
+                        {"runId": "agent_run_status_query", "status": "succeeded"}
+                    )
+                    + "\n",
+                )
+            ),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=True,
+    )
+
+    assert pds_capture_argv(capture) == [
+        "release-video",
+        "status",
+        "--run-id",
+        "agent_run_status_query",
+        "--json",
+    ]
+    assert '"status": "succeeded"' in result.stdout
+    assert result.stderr == ""
 
 
 def test_release_video_dry_run_does_not_require_youtube_url(tmp_path: Path):

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -23,10 +23,13 @@ def release_video_env(extra: dict | None = None) -> dict:
         "RELEASE_VIDEO_ATTEMPT_ID",
         "RELEASE_VIDEO_CLAUDE_TOOLS",
         "RELEASE_VIDEO_IDEMPOTENCY_KEY",
+        "RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE",
         "RELEASE_VIDEO_PROMPT_TEMPLATE",
         "RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT",
         "RELEASE_VIDEO_FORCE_REGENERATE",
         "RELEASE_VIDEO_SCRIPT_PATH",
+        "CI",
+        "GITHUB_ACTIONS",
     ):
         env.pop(key, None)
     if extra:
@@ -149,6 +152,30 @@ import sys
 capture = pathlib.Path(os.environ["PDS_STUB_CAPTURE"])
 capture.write_text(json.dumps({{"argv": sys.argv[1:]}}, indent=2), encoding="utf8")
 print(json.dumps({response_literal}))
+""",
+    )
+
+
+def pds_output_stub(
+    tmp_path: Path,
+    *,
+    stdout: str = "",
+    stderr: str = "",
+    exit_code: int = 0,
+) -> Path:
+    return write_executable(
+        tmp_path / "pds-output-stub.py",
+        f"""#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+capture = pathlib.Path(os.environ["PDS_STUB_CAPTURE"])
+capture.write_text(json.dumps({{"argv": sys.argv[1:]}}, indent=2), encoding="utf8")
+sys.stdout.write({stdout!r})
+sys.stderr.write({stderr!r})
+raise SystemExit({exit_code})
 """,
     )
 
@@ -306,6 +333,83 @@ def test_release_video_default_idempotency_key_uses_tag_and_git_sha(tmp_path: Pa
     )
 
     assert pds_idempotency_key(capture) == "pdd-release-video:v1.1.0:abc123def456"
+
+
+def test_release_video_default_idempotency_key_separates_local_and_ci_provenance(
+    tmp_path: Path,
+):
+    repo = init_release_repo(tmp_path)
+    existing_script = tmp_path / "existing_release_video_script.md"
+    existing_script.write_text(reusable_script_text(), encoding="utf8")
+
+    local_capture = tmp_path / "local-pds-capture.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--git-sha",
+            "abc123def456",
+            "--script-path",
+            str(existing_script),
+            "--pds-cli",
+            str(
+                pds_stub(
+                    tmp_path,
+                    {"ok": True, "summary": {"youtubeUrl": "https://youtu.be/local"}},
+                )
+            ),
+            "--output-dir",
+            str(tmp_path / "local-videos"),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(local_capture)}),
+        check=True,
+    )
+
+    ci_capture = tmp_path / "ci-pds-capture.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--git-sha",
+            "abc123def456",
+            "--script-path",
+            str(existing_script),
+            "--pds-cli",
+            str(
+                pds_stub(
+                    tmp_path,
+                    {"ok": True, "summary": {"youtubeUrl": "https://youtu.be/ci"}},
+                )
+            ),
+            "--output-dir",
+            str(tmp_path / "ci-videos"),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env(
+            {"PDS_STUB_CAPTURE": str(ci_capture), "GITHUB_ACTIONS": "true"}
+        ),
+        check=True,
+    )
+
+    assert pds_idempotency_key(local_capture) == (
+        "pdd-release-video:v1.1.0:abc123def456:local"
+    )
+    assert pds_idempotency_key(ci_capture) == (
+        "pdd-release-video:v1.1.0:abc123def456:github-actions"
+    )
 
 
 def test_release_video_env_full_idempotency_key_overrides_default(tmp_path: Path):
@@ -1148,6 +1252,117 @@ def test_release_video_publish_requires_youtube_url(tmp_path: Path):
 
     assert result.returncode == 1
     assert "did not return a YouTube URL" in result.stderr
+
+
+def test_release_video_persists_structured_pds_run_handle_sidecar(tmp_path: Path):
+    repo = init_release_repo(tmp_path)
+    capture = tmp_path / "pds-capture.json"
+    output_dir = tmp_path / "videos"
+    existing_script = tmp_path / "existing_release_video_script.md"
+    existing_script.write_text(reusable_script_text(), encoding="utf8")
+    structured_run = {
+        "runId": "agent_run_json123",
+        "projectId": "pdd-v1-1-0-release",
+        "status": "running",
+        "attemptId": "attempt-json123",
+    }
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--git-sha",
+            "abc123def456",
+            "--script-path",
+            str(existing_script),
+            "--pds-cli",
+            str(
+                pds_output_stub(
+                    tmp_path,
+                    stderr=json.dumps(structured_run) + "\n",
+                    exit_code=1,
+                )
+            ),
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    assert result.returncode == 1
+    sidecar = output_dir / "v1.1.0" / "pds_run.json"
+    assert sidecar.exists()
+    persisted = json.loads(sidecar.read_text(encoding="utf8"))
+    assert persisted["runId"] == "agent_run_json123"
+    assert persisted["projectId"] == "pdd-v1-1-0-release"
+    assert persisted["status"] == "running"
+    assert persisted["attemptId"] == "attempt-json123"
+    assert (
+        "release-video status --run-id agent_run_json123 --json"
+        in persisted["recoverCommand"]
+    )
+    assert str(sidecar) in result.stderr
+
+
+def test_release_video_persists_compatibility_run_handle_sidecar(tmp_path: Path):
+    repo = init_release_repo(tmp_path)
+    capture = tmp_path / "pds-capture.json"
+    output_dir = tmp_path / "videos"
+    existing_script = tmp_path / "existing_release_video_script.md"
+    existing_script.write_text(reusable_script_text(), encoding="utf8")
+    compat_output = (
+        "[pds] release-video run handle: "
+        "runId=agent_run_line456 projectId=pdd-v1-1-0-release status=running\n"
+        "[pds] recover: pds release-video status --run-id agent_run_line456 --json\n"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--git-sha",
+            "abc123def456",
+            "--script-path",
+            str(existing_script),
+            "--pds-cli",
+            str(
+                pds_output_stub(
+                    tmp_path,
+                    stdout=compat_output,
+                    exit_code=1,
+                )
+            ),
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    assert result.returncode == 1
+    sidecar = output_dir / "v1.1.0" / "pds_run.json"
+    assert sidecar.exists()
+    persisted = json.loads(sidecar.read_text(encoding="utf8"))
+    assert persisted["runId"] == "agent_run_line456"
+    assert persisted["projectId"] == "pdd-v1-1-0-release"
+    assert persisted["status"] == "running"
+    assert "jobs watch --run-id agent_run_line456 --jsonl" in persisted["watchCommand"]
+    assert str(sidecar) in result.stderr
 
 
 def test_release_video_dry_run_does_not_require_youtube_url(tmp_path: Path):


### PR DESCRIPTION
Fixes #1746
Fixes #1751

## Summary
- Namespace generated release-video idempotency keys by provenance (`local`, `github-actions`, or generic `ci`) while preserving explicit full keys and retry attempt suffixes.
- Persist recoverable PDS run metadata to `.pdd/release-videos/<tag>/pds_run.json` from structured JSON or the compatibility `[pds] release-video run handle: ...` line before raising terminal failures.
- Add `make release-video-status RELEASE_TAG=vX.Y.Z`, which reads the sidecar and queries PDS status by persisted run id, plus CI artifact/log surfacing for recovery metadata.

## TDD Evidence
Red first commit: `test(release-video): cover idempotency provenance and PDS run sidecars`

Initial focused run:
```text
python -m pytest -vv tests/test_release_video.py -k 'provenance or structured_pds_run_handle_sidecar or compatibility_run_handle_sidecar'
3 failed, 30 deselected
- default key lacked `:local`
- structured run sidecar was absent
- compatibility run sidecar was absent
```

## Validation
```text
python -m pytest -vv tests/test_release_video.py
37 passed

python -m py_compile scripts/release_video.py
passed

make -n release-video-status RELEASE_TAG=v0.0.289
expanded expected --status --status-query command without live execution
```

No live release, provider, SOPS, PyPI, GitHub release, or PDS workflow was run.