### PR TITLE
fix(change): resolve CSV code paths from prompt subdirs

### DIFF
--- a/pdd/process_csv_change.py
+++ b/pdd/process_csv_change.py
@@ -63,6 +63,72 @@ def resolve_prompt_path(prompt_name: str, csv_file: str, code_directory: str) ->
     # If we get here, file was not found
     return None
 
+def derive_code_file_stem(prompt_filename: str, default_language: str) -> Tuple[str, str, bool]:
+    """
+    Derive the generated code stem and language from a prompt filename.
+
+    Returns:
+        Tuple[file_stem, actual_language, language_from_suffix]
+    """
+    base_name, _ = os.path.splitext(prompt_filename)
+
+    if '_' not in base_name:
+        return base_name, default_language, False
+
+    parts = base_name.rsplit('_', 1)
+    if len(parts) == 2 and parts[1].isalpha():
+        return parts[0], parts[1].capitalize(), True
+
+    return base_name, default_language, False
+
+def resolve_code_path(
+    prompt_name: str,
+    resolved_prompt_path: str,
+    csv_file: str,
+    code_directory: str,
+    input_code_filename: str,
+) -> str:
+    """
+    Resolve the code path paired with a CSV prompt row.
+
+    Prefer the prompt's relative subpath under the CSV directory or code
+    directory, then fall back to the historical flat code_directory lookup.
+    """
+    abs_code_directory = os.path.abspath(code_directory)
+    abs_csv_dir = os.path.abspath(os.path.dirname(csv_file))
+    abs_prompt_path = os.path.abspath(resolved_prompt_path)
+
+    candidate_dirs: List[str] = []
+    for root in (abs_csv_dir, abs_code_directory):
+        try:
+            rel_prompt = os.path.relpath(abs_prompt_path, root)
+        except ValueError:
+            continue
+        if rel_prompt.startswith(os.pardir + os.sep) or rel_prompt == os.pardir:
+            continue
+        rel_dir = os.path.dirname(rel_prompt)
+        if rel_dir:
+            candidate_dirs.append(os.path.join(abs_code_directory, rel_dir))
+
+    prompt_dir_from_csv = os.path.dirname(prompt_name)
+    if prompt_dir_from_csv and not os.path.isabs(prompt_dir_from_csv):
+        candidate_dirs.append(os.path.join(abs_code_directory, prompt_dir_from_csv))
+
+    candidate_dirs.append(abs_code_directory)
+
+    checked_dirs = set()
+    fallback_path = os.path.join(abs_code_directory, input_code_filename)
+    for directory in candidate_dirs:
+        normalized_dir = os.path.abspath(directory)
+        if normalized_dir in checked_dirs:
+            continue
+        checked_dirs.add(normalized_dir)
+        candidate = os.path.join(normalized_dir, input_code_filename)
+        if os.path.exists(candidate) and os.path.isfile(candidate):
+            return candidate
+
+    return fallback_path
+
 def process_csv_change(
     csv_file: str,
     strength: float,
@@ -215,22 +281,16 @@ def process_csv_change(
                              console.print(f"[bold yellow]Warning:[/bold yellow] Prompt file '{prompt_filename}' does not end with '.prompt'. Attempting to parse language anyway (row {row_num}).")
                              # Keep base_name as is, don't assume .prompt was the only extension part
 
-                        file_stem = base_name
-                        actual_language = language # Default language
-                        language_from_suffix = False # Track if language came from suffix
+                        file_stem, actual_language, language_from_suffix = derive_code_file_stem(
+                            prompt_filename,
+                            language
+                        )
 
-                        # Check for _language suffix
-                        if '_' in base_name:
+                        if language_from_suffix:
+                            console.print(f"    [dim]Inferred language from filename:[/dim] {actual_language}")
+                        elif '_' in base_name:
                             parts = base_name.rsplit('_', 1)
-                            # Check if the suffix looks like a language identifier (simple check: alpha only)
-                            if len(parts) == 2 and parts[1].isalpha():
-                                file_stem = parts[0]
-                                # Use capitalize for consistency, matching get_extension examples
-                                actual_language = parts[1].capitalize()
-                                language_from_suffix = True # Set flag
-                                console.print(f"    [dim]Inferred language from filename:[/dim] {actual_language}")
-                            else:
-                                console.print(f"    [dim]Suffix '_{parts[1]}' not recognized as language, using default:[/dim] {language}")
+                            console.print(f"    [dim]Suffix '_{parts[1]}' not recognized as language, using default:[/dim] {language}")
                         else:
                             console.print(f"    [dim]Using default language:[/dim] {language}")
 
@@ -259,10 +319,15 @@ def process_csv_change(
                         # iii. add the suffix extension to the prompt_name (stem)
                         input_code_filename = file_stem + code_extension
 
-                        # iv. Construct code file path: place it directly in code_directory.
-                        input_code_path = os.path.join(code_directory, input_code_filename)
+                        # iv. Construct code file path, preserving prompt subdirectories when present.
+                        input_code_path = resolve_code_path(
+                            prompt_name=prompt_name_from_csv,
+                            resolved_prompt_path=resolved_prompt_path,
+                            csv_file=csv_file,
+                            code_directory=code_directory,
+                            input_code_filename=input_code_filename,
+                        )
                         console.print(f"  [dim]Derived target code path:[/dim] {input_code_path}")
-                        print(f"DEBUG: Attempting to access code file path: '{input_code_path}'") # Added log
 
 
                         # Read the input code from the input_code_path

--- a/pdd/prompts/process_csv_change_python.prompt
+++ b/pdd/prompts/process_csv_change_python.prompt
@@ -102,7 +102,7 @@
                 i.  remove the path and suffix _language.prompt from the prompt_name
                 ii. use the `get_extension` function to infer the extension of the input_code file, if it doesn't have a language suffix use the default input extension.
                 iii. add the suffix extension to the prompt_name
-                iv. change the directory to code_directory + path from prompt_name (Step i).
+                iv. resolve the input_code path under code_directory while preserving the prompt's relative subdirectory when present. For example, if the CSV points to prompts/pkg/widget_python.prompt, first try code_directory/prompts/pkg/widget.py, then fall back to the historical flat code_directory/widget.py lookup for compatibility.
             - Read the input_code from the input_code_name as a string
             - Read the change_instructions from the change_instructions column
         b. Call the change function with the input_prompt, input_code, change_prompt, strength, temperature, and time.

--- a/tests/test_process_csv_change.py
+++ b/tests/test_process_csv_change.py
@@ -871,6 +871,62 @@ def test_correct_prompt_path_resolution_integration(mock_change_fixture, tmp_pat
     assert "Inferred language from filename: Python" in captured.out
     assert "Overall Success Status: True" in captured.out
 
+def test_csv_change_resolves_code_path_from_prompt_subdirectory(
+    mock_change_fixture,
+    tmp_path,
+    capsys,
+):
+    """
+    CSV change should preserve the prompt's relative subdirectory when locating
+    the paired code file under code_directory.
+    """
+    prompts_dir = tmp_path / "prompts" / "pkg"
+    code_dir = tmp_path / "code"
+    nested_code_dir = code_dir / "prompts" / "pkg"
+    prompts_dir.mkdir(parents=True)
+    nested_code_dir.mkdir(parents=True)
+
+    prompt_rel = Path("prompts") / "pkg" / "widget_python.prompt"
+    prompt_path = tmp_path / prompt_rel
+    code_path = nested_code_dir / "widget.py"
+    csv_path = tmp_path / "changes.csv"
+
+    prompt_path.write_text("Original prompt content", encoding="utf-8")
+    code_path.write_text("def widget():\n    return 1\n", encoding="utf-8")
+    csv_path.write_text(
+        f"prompt_name,change_instructions\n{prompt_rel.as_posix()},Do the change\n",
+        encoding="utf-8",
+    )
+
+    mock_change_fixture.return_value = ("Modified prompt", 0.01, "test_model")
+
+    with patch("pdd.process_csv_change.get_extension", return_value=".py"):
+        success, list_of_jsons, total_cost, model_name = process_csv_change(
+            csv_file=str(csv_path),
+            strength=0.5,
+            temperature=0.5,
+            code_directory=str(code_dir),
+            language="python",
+            extension=".py",
+            budget=1.0,
+        )
+
+    assert success
+    assert list_of_jsons == [
+        {
+            "file_name": prompt_rel.as_posix(),
+            "modified_prompt": "Modified prompt",
+        }
+    ]
+    assert total_cost == 0.01
+    assert model_name == "test_model"
+    assert mock_change_fixture.call_args.kwargs["input_code"] == code_path.read_text(
+        encoding="utf-8"
+    )
+
+    captured = capsys.readouterr()
+    assert "Overall Success Status: True" in captured.out
+
 def test_extension_fallback_bug(mock_change_fixture, capsys):
     """
     Test the scenario where prompt suffix indicates Python, but get_extension fails,


### PR DESCRIPTION
## Summary
- preserve prompt-relative subdirectories when resolving CSV change code files
- keep the historical flat code_directory lookup as a fallback
- update the process_csv_change prompt source and add regression coverage

## Verification
- python -m pytest tests/test_process_csv_change.py -q
- python -m py_compile pdd/process_csv_change.py
- focused end-to-end CSV process_csv_change probe with real nested prompt/code files and mocked LLM call

Base is fix-epic-xdist-isolation, not main.