### PR TITLE
fix(release-video): normalize label-only visual cues

### DIFF
--- a/pdd/prompts/release_video_script_LLM.prompt
+++ b/pdd/prompts/release_video_script_LLM.prompt
@@ -36,7 +36,8 @@ Business-value requirements:
 Visual requirements:
 - Use the PDS script format exactly:
   - Every spoken narration block starts with `NARRATOR:` on its own line.
-  - Every non-spoken visual cue starts with `VISUAL:` on its own line.
+  - Every non-spoken visual cue is written on one line as `VISUAL: <cue text>`.
+- Do not put `VISUAL:` by itself with the cue text on the next line.
 - Visual cues must be detailed enough for an automated video generator to create relevant scenes.
 - For every `VISUAL:` cue, include specific screen/UI/content direction, not generic phrases.
 - Prefer visuals that reveal the product and workflow: terminal commands, before/after output, GitHub release page, changelog snippets, failing/passing checks, audit files, config snippets, PR/issue references, diagrams of the workflow, and short code/doc excerpts.

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -2363,6 +2363,9 @@ def prepare_release_video_script(raw_script: str, *, source: str) -> dict[str, A
     candidate, duplicate_changed = collapse_duplicate_narrator_labels(candidate)
     if duplicate_changed:
         changes.append("collapsed_duplicate_narrator_labels")
+    candidate, visual_changed = collapse_label_only_visual_cues(candidate)
+    if visual_changed:
+        changes.append("collapsed_label_only_visual_cues")
     normalized = normalize_release_video_script(candidate)
     normalized, duplicate_changed_after = collapse_duplicate_narrator_labels(normalized)
     if duplicate_changed_after and "collapsed_duplicate_narrator_labels" not in changes:
@@ -2571,6 +2574,50 @@ def collapse_duplicate_narrator_labels(script: str) -> tuple[str, bool]:
         blank_after_pending_label = False
 
     return trim_repeated_blank_lines(normalized), changed
+
+
+def collapse_label_only_visual_cues(script: str) -> tuple[str, bool]:
+    """Collapse safe label-only visual blocks into same-line VISUAL cues."""
+    lines = script.splitlines()
+    normalized: list[str] = []
+    changed = False
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        if is_visual_label_only(line):
+            cue_index = next_nonblank_line_index(lines, index + 1)
+            if cue_index is not None and is_collapsible_visual_cue_line(lines[cue_index]):
+                append_spaced(normalized, f"VISUAL: {clean_visual_cue(lines[cue_index])}")
+                index = cue_index + 1
+                changed = True
+                continue
+        normalized.append(line)
+        index += 1
+
+    if not changed:
+        return script, False
+    return trim_repeated_blank_lines(normalized), True
+
+
+def next_nonblank_line_index(lines: list[str], start: int) -> int | None:
+    """Return the next nonblank line index at or after start."""
+    for index in range(start, len(lines)):
+        if lines[index].strip():
+            return index
+    return None
+
+
+def is_collapsible_visual_cue_line(line: str) -> bool:
+    """Return whether a line can safely become cue text after VISUAL:."""
+    stripped = line.strip()
+    return bool(
+        stripped
+        and not re.match(r"^#{1,6}\s+\S", stripped)
+        and not is_release_video_script_line(line)
+        and not is_model_wrapper_line(line)
+        and not is_markdown_fence_line(line)
+    )
 
 
 def validate_release_video_script(
@@ -2813,7 +2860,22 @@ def is_release_video_script_line(line: str) -> bool:
         re.match(r"^#{1,2}\s+\S", stripped)
         or is_narrator_label(line)
         or inline_narrator_label_body(line) is not None
+        or is_visual_label_only(line)
         or visual_cue_text(line)
+    )
+
+
+def is_visual_label_only(line: str) -> bool:
+    """Return whether a line is only a visual label with no cue text."""
+    stripped = line.strip()
+    return bool(
+        re.match(
+            r"^(?:\*\*)?"
+            r"(?:VISUAL|Visual direction|Scene|Shot|On[- ]screen):"
+            r"\s*(?:\*\*)?$",
+            stripped,
+            flags=re.IGNORECASE,
+        )
     )
 
 

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -2366,6 +2366,9 @@ def prepare_release_video_script(raw_script: str, *, source: str) -> dict[str, A
     candidate, visual_changed = collapse_label_only_visual_cues(candidate)
     if visual_changed:
         changes.append("collapsed_label_only_visual_cues")
+    candidate, wrapped_visual_changed = collapse_wrapped_visual_cues(candidate)
+    if wrapped_visual_changed:
+        changes.append("collapsed_wrapped_visual_cues")
     normalized = normalize_release_video_script(candidate)
     normalized, duplicate_changed_after = collapse_duplicate_narrator_labels(normalized)
     if duplicate_changed_after and "collapsed_duplicate_narrator_labels" not in changes:
@@ -2620,6 +2623,53 @@ def collect_visual_cue_paragraph(lines: list[str], start: int) -> tuple[list[str
             cue_lines.append(visual)
             index += 1
         break
+    return cue_lines, index
+
+
+def collapse_wrapped_visual_cues(script: str) -> tuple[str, bool]:
+    """Collapse safe continuation lines into their preceding VISUAL cue."""
+    lines = script.splitlines()
+    normalized: list[str] = []
+    changed = False
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        visual = visual_cue_text(line)
+        if visual:
+            continuation_lines, next_index = collect_visual_cue_continuation(
+                lines,
+                index + 1,
+            )
+            if continuation_lines:
+                cue = " ".join([visual, *continuation_lines])
+                append_spaced(normalized, f"VISUAL: {cue}")
+                index = next_index
+                changed = True
+                continue
+        normalized.append(line)
+        index += 1
+
+    if not changed:
+        return script, False
+    return trim_repeated_blank_lines(normalized), True
+
+
+def collect_visual_cue_continuation(
+    lines: list[str],
+    start: int,
+) -> tuple[list[str], int]:
+    """Collect safe visual cue continuation lines until the next block boundary."""
+    cue_lines: list[str] = []
+    index = start
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            break
+        if not is_collapsible_visual_cue_line(line):
+            break
+        cue_lines.append(clean_visual_cue(line))
+        index += 1
     return cue_lines, index
 
 

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -2586,10 +2586,11 @@ def collapse_label_only_visual_cues(script: str) -> tuple[str, bool]:
     while index < len(lines):
         line = lines[index]
         if is_visual_label_only(line):
-            cue_index = next_nonblank_line_index(lines, index + 1)
-            if cue_index is not None and is_collapsible_visual_cue_line(lines[cue_index]):
-                append_spaced(normalized, f"VISUAL: {clean_visual_cue(lines[cue_index])}")
-                index = cue_index + 1
+            cue_lines, next_index = collect_visual_cue_paragraph(lines, index + 1)
+            if cue_lines:
+                cue = " ".join(cue_lines)
+                append_spaced(normalized, f"VISUAL: {cue}")
+                index = next_index
                 changed = True
                 continue
         normalized.append(line)
@@ -2600,12 +2601,26 @@ def collapse_label_only_visual_cues(script: str) -> tuple[str, bool]:
     return trim_repeated_blank_lines(normalized), True
 
 
-def next_nonblank_line_index(lines: list[str], start: int) -> int | None:
-    """Return the next nonblank line index at or after start."""
-    for index in range(start, len(lines)):
-        if lines[index].strip():
-            return index
-    return None
+def collect_visual_cue_paragraph(lines: list[str], start: int) -> tuple[list[str], int]:
+    """Collect cue paragraph lines after a label-only visual marker."""
+    cue_lines: list[str] = []
+    index = start
+    while index < len(lines) and not lines[index].strip():
+        index += 1
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            break
+        if is_collapsible_visual_cue_line(line):
+            cue_lines.append(clean_visual_cue(line))
+            index += 1
+            continue
+        visual = visual_cue_text(line)
+        if visual and not cue_lines:
+            cue_lines.append(visual)
+            index += 1
+        break
+    return cue_lines, index
 
 
 def is_collapsible_visual_cue_line(line: str) -> bool:
@@ -2634,6 +2649,7 @@ def validate_release_video_script(
         "hasVisual": any(visual_cue_text(line) for line in script.splitlines()),
         "hasNoModelWrapperText": not has_unstripped_model_wrapper_text(script),
         "hasNoDuplicateNarratorLabels": not has_duplicate_narrator_labels(script),
+        "hasNoLabelOnlyVisualCues": not has_label_only_visual_cues(script),
         "hasNoMarkdownFences": not has_markdown_fence_line(script),
     }
     errors = [name for name, passed in checks.items() if not passed]
@@ -2662,6 +2678,11 @@ def has_duplicate_narrator_labels(script: str) -> bool:
         if line.strip():
             previous_pending_label = False
     return False
+
+
+def has_label_only_visual_cues(script: str) -> bool:
+    """Return whether the script still contains empty visual cue labels."""
+    return any(is_visual_label_only(line) for line in script.splitlines())
 
 
 def has_markdown_fence_line(script: str) -> bool:

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -322,6 +322,10 @@ def test_release_video_generates_script_and_invokes_pds_publish(tmp_path: Path):
     assert "what changed, why it matters, and the practical business value" in claude_prompt
     assert "## Release hook (0:00 - 0:12)" in claude_prompt
     assert "Every spoken narration block starts with `NARRATOR:` on its own line." in claude_prompt
+    assert (
+        "Every non-spoken visual cue is written on one line as `VISUAL: <cue text>`."
+        in claude_prompt
+    )
     assert "release video automation" in claude_prompt
     claude_argv = json.loads((repo / "claude_argv.json").read_text(encoding="utf8"))
     assert claude_argv[claude_argv.index("--model") + 1] == "claude-opus-4-8"
@@ -411,6 +415,88 @@ Let me know if you want a punchier version.
     assert validation["checks"]["hasNoModelWrapperText"] is True
     assert validation["checks"]["hasNoDuplicateNarratorLabels"] is True
     assert validation["errors"] == []
+
+
+def test_release_video_normalizes_label_only_visual_blocks():
+    release_video = load_release_video_module()
+    script = """# PDD v1.1.0 Release Video
+
+## Opening
+
+NARRATOR:
+PDD v1.1.0 makes release-video recovery easier to audit by preserving the
+generated script, the normalized script, and the validation evidence before
+the PDS create step receives anything.
+
+VISUAL:
+
+show the release context, normalized script, and pds_run.json side by side with callout labels for raw output, final script, and validation state.
+
+## Recovery
+
+NARRATOR:
+Operators can compare the raw model output with the final script and quickly
+see which sanitation steps ran, which reduces guesswork during release
+recovery and keeps publishing diagnostics reproducible.
+
+VISUAL:
+zoom into release_video_script_validation.json highlighting checks.hasVisual true and the collapsed visual-label change entry.
+"""
+
+    artifacts = release_video.prepare_release_video_script(script, source="test")
+
+    assert "\nVISUAL:\n" not in artifacts["script"]
+    assert (
+        "\nVISUAL: show the release context, normalized script, and pds_run.json"
+        in artifacts["script"]
+    )
+    assert "\nVISUAL: zoom into release_video_script_validation.json" in artifacts["script"]
+    assert artifacts["validation"]["checks"]["hasVisual"] is True
+    assert "collapsed_label_only_visual_cues" in artifacts["validation"]["changes"]
+    assert artifacts["validation"]["errors"] == []
+
+
+def test_release_video_does_not_swallow_unsafe_label_only_visual_blocks():
+    release_video = load_release_video_module()
+    script = """# PDD v1.1.0 Release Video
+
+## Opening
+
+NARRATOR:
+The wrapper must avoid converting structural lines or wrapper prose into visual
+cues when a model emits an empty visual label without useful cue text after it.
+
+VISUAL:
+
+## Recovery
+
+VISUAL:
+
+NARRATOR:
+This narration remains a narrator block instead of becoming a visual cue,
+because the line after the empty visual label is another script label.
+
+VISUAL:
+
+Here is the release video script you asked for:
+
+VISUAL:
+
+show the validation JSON beside the final PDS create command with a highlighted
+hasVisual check and a callout for the normalized script artifact.
+"""
+
+    artifacts = release_video.prepare_release_video_script(script, source="test")
+
+    assert "\nVISUAL: ## Recovery" not in artifacts["script"]
+    assert "\nVISUAL: NARRATOR:" not in artifacts["script"]
+    assert "\nVISUAL: Here is the release video script" not in artifacts["script"]
+    assert (
+        "\nVISUAL: show the validation JSON beside the final PDS create command"
+        in artifacts["script"]
+    )
+    assert artifacts["validation"]["checks"]["hasVisual"] is True
+    assert artifacts["validation"]["checks"]["hasNoModelWrapperText"] is False
 
 
 def test_release_video_preserves_exact_raw_claude_output_artifact(tmp_path: Path):

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -456,6 +456,79 @@ zoom into release_video_script_validation.json highlighting checks.hasVisual tru
     assert artifacts["validation"]["errors"] == []
 
 
+def test_release_video_normalizes_wrapped_label_only_visual_cue_paragraph():
+    release_video = load_release_video_module()
+    script = """# PDD v1.1.0 Release Video
+
+## Opening
+
+NARRATOR:
+PDD v1.1.0 keeps release-video recovery auditable by preserving the raw model
+output, normalized script, validation JSON, and PDS run state before the
+publish command can hand the script to downstream video generation.
+
+VISUAL:
+show a split screen with release_video_script.raw.md on the left and the final
+release_video_script.md on the right, with callouts for raw output, collapsed
+visual cue paragraph, validation changes, and the PDS create command.
+
+## Recovery
+
+NARRATOR:
+The normalized script must keep the entire visual direction together so the
+video generator receives one complete storyboard cue instead of dropping the
+wrapped continuation text.
+
+VISUAL: show release_video_script_validation.json with checks.hasVisual true.
+"""
+
+    artifacts = release_video.prepare_release_video_script(script, source="test")
+
+    assert (
+        "\nVISUAL: show a split screen with release_video_script.raw.md on the left "
+        "and the final release_video_script.md on the right, with callouts for raw "
+        "output, collapsed visual cue paragraph, validation changes, and the PDS "
+        "create command."
+        in artifacts["script"]
+    )
+    assert "\nrelease_video_script.md on the right" not in artifacts["script"]
+    assert "\nvisual cue paragraph, validation changes" not in artifacts["script"]
+    assert artifacts["validation"]["checks"]["hasVisual"] is True
+    assert artifacts["validation"]["errors"] == []
+
+
+def test_release_video_validation_rejects_leftover_label_only_visual_cues():
+    release_video = load_release_video_module()
+    script = """# PDD v1.1.0 Release Video
+
+## Opening
+
+NARRATOR:
+The release-video wrapper must not let empty storyboard labels reach PDS just
+because a later scene contains one valid visual cue. Empty visual labels can
+become blank scenes or parser failures downstream, so validation has to keep
+the normalized script contract strict before create runs.
+
+VISUAL:
+
+## Recovery
+
+NARRATOR:
+The recovery workflow still includes enough narration and a concrete valid
+visual later in the script to satisfy all other validation checks, isolating
+the failure to the leftover label-only visual cue.
+
+VISUAL: show the validation JSON with hasNoLabelOnlyVisualCues highlighted false.
+"""
+
+    artifacts = release_video.prepare_release_video_script(script, source="test")
+
+    assert "\nVISUAL:\n" in artifacts["script"]
+    assert artifacts["validation"]["checks"]["hasVisual"] is True
+    assert artifacts["validation"]["checks"]["hasNoLabelOnlyVisualCues"] is False
+    assert "hasNoLabelOnlyVisualCues" in artifacts["validation"]["errors"]
+
+
 def test_release_video_does_not_swallow_unsafe_label_only_visual_blocks():
     release_video = load_release_video_module()
     script = """# PDD v1.1.0 Release Video

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -497,6 +497,34 @@ VISUAL: show release_video_script_validation.json with checks.hasVisual true.
     assert artifacts["validation"]["errors"] == []
 
 
+def test_release_video_normalizes_wrapped_same_line_visual_cue_continuation():
+    release_video = load_release_video_module()
+    script = """Hook: PDD v1.1.0 turns release-video recovery into an operator-visible
+path instead of a best-effort publish step that can fail without enough context.
+
+Narration: The release wrapper now keeps generated scripts, validation evidence,
+PDS run handles, status query diagnostics, and recovery commands together before
+the publish request reaches PDS. Maintainers can reattach to the same run, see
+whether a running sidecar is stale, and retry with a stable idempotency key
+without regenerating the release story or losing the incident trail.
+
+Visual direction: show the changelog, generated script, pds_run.json, status
+query output, and final YouTube receipt side by side.
+"""
+
+    artifacts = release_video.prepare_release_video_script(script, source="test")
+
+    assert (
+        "\nVISUAL: show the changelog, generated script, pds_run.json, status "
+        "query output, and final YouTube receipt side by side."
+        in artifacts["script"]
+    )
+    assert "\nNARRATOR:\nquery output" not in artifacts["script"]
+    assert "collapsed_wrapped_visual_cues" in artifacts["validation"]["changes"]
+    assert artifacts["validation"]["checks"]["hasVisual"] is True
+    assert artifacts["validation"]["errors"] == []
+
+
 def test_release_video_validation_rejects_leftover_label_only_visual_cues():
     release_video = load_release_video_module()
     script = """# PDD v1.1.0 Release Video


### PR DESCRIPTION
## Summary
- Collapse safe label-only `VISUAL:` blocks into `VISUAL: <cue>` before release-video validation.
- Keep headings, narrator labels, blank-only visual blocks, markdown fences, and model wrapper text from being consumed as visual cue text.
- Update the release-video script prompt to require same-line visual cues.

## Investigation
- Grep showed the parser/contract mismatch is concentrated in `scripts/release_video.py` and `pdd/prompts/release_video_script_LLM.prompt`: `validate_release_video_script()` sets `hasVisual` from `visual_cue_text(line)`, and `visual_cue_text()` only accepted same-line labels or bracket cues.
- Sibling label-normalization code exists for narrator labels (`collapse_duplicate_narrator_labels`, inline/bold narrator helpers), but those cases are already covered and intentionally separate from the visual cue contract.
- Prior relevant commits reviewed: `cf4ef581f` introduced PDS-native video script parsing including `visual_cue_text`; `5b850aac8` / `d0dca48e3` added script validation/sanitization and `hasVisual`; `ffb053ad3` and `f31424018` show the established narrator-label normalization pattern followed here.

## Tests
- `conda run -n pdd pytest -q tests/test_release_video.py -k visual`
- `conda run -n pdd pytest -q tests/test_release_video.py::test_release_video_generates_script_and_invokes_pds_publish`
- `conda run -n pdd pylint scripts/release_video.py tests/test_release_video.py` (fails on existing baseline warnings in these large files; no new helper docstring issues remain)