### PR TITLE
fix(release-video): enforce recovery-capable PDS CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,8 +221,10 @@ jobs:
       #                                with vars.RELEASE_VIDEO_PROJECT_ID set to
       #                                that same authorized fixed project.
       #   vars.PDS_CLI_PACKAGE         install spec for the @promptdriven/pds
-      #                                CLI, for example @promptdriven/pds@latest
-      #                                or a pinned version.
+      #                                CLI. Defaults to @promptdriven/pds@0.1.6
+      #                                so release-video recovery/status support
+      #                                is available even when the repo variable
+      #                                is unset.
       #   vars.PDS_CLI                 optional pds command. Defaults to a
       #                                longer timeout because release-video
       #                                create can exceed the CLI's 30s default
@@ -242,7 +244,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PDS_TOKEN: ${{ secrets.PDS_TOKEN }}
           PDS_API_URL: ${{ vars.PDS_API_URL || 'https://video.promptdriven.ai' }}
-          PDS_CLI_PACKAGE: ${{ vars.PDS_CLI_PACKAGE }}
+          PDS_CLI_PACKAGE: ${{ vars.PDS_CLI_PACKAGE || '@promptdriven/pds@0.1.6' }}
           PDS_CLI: ${{ vars.PDS_CLI || 'pds --timeout 120s' }}
           CLAUDE_CODE_OAUTH_TOKEN_1: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_1 }}
           CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
@@ -270,6 +272,11 @@ jobs:
           fi
           if ! npm install -g "$PDS_CLI_PACKAGE"; then
             echo "::warning::pds CLI install from PDS_CLI_PACKAGE failed; skipping release video."
+            exit 0
+          fi
+          if ! make check-release-video-config \
+              ${RELEASE_VIDEO_PROJECT_ID:+RELEASE_VIDEO_PROJECT_ID="$RELEASE_VIDEO_PROJECT_ID"}; then
+            echo "::warning::release video preflight failed; skipping release video."
             exit 0
           fi
           if ! command -v claude >/dev/null 2>&1; then

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,9 @@ RELEASE_VIDEO_FORCE_REGENERATE ?= 0
 RELEASE_VIDEO_METADATA_CONFLICT ?=
 RELEASE_VIDEO_STATUS_QUERY ?= 0
 RELEASE_VIDEO_YOUTUBE_URL ?=
+RELEASE_VIDEO_PDS_CREATE_TIMEOUT ?= 1800
 CLAUDE_CLI ?= claude
-PDS_CLI ?= pds
+PDS_CLI ?= npx -y @promptdriven/pds@0.1.6 --timeout 120s
 PDS_API_URL ?= https://video.promptdriven.ai
 SOPS ?= sops
 SOPS_RELEASE_ENV_FILE ?= $(firstword $(wildcard ../secrets/pdd_cloud/shared.prod.sops.env ../pdd_cloud/secrets/pdd_cloud/shared.prod.sops.env secrets/pdd_cloud/shared.prod.sops.env) ../secrets/pdd_cloud/shared.prod.sops.env)
@@ -769,6 +770,8 @@ check-release-video-config:
 	if [ -z "$$RELEASE_PDS_TOKEN" ]; then RELEASE_PDS_TOKEN="$${PDS_RELEASE_TOKEN:-}"; fi; \
 	if [ -n "$$RELEASE_PDS_TOKEN" ]; then export PDS_TOKEN="$$RELEASE_PDS_TOKEN"; export PDS_PROFILE=; fi; \
 	export PDS_API_URL="$${PDS_API_URL:-$(PDS_API_URL)}"; \
+	RELEASE_VIDEO="$(RELEASE_VIDEO)" \
+	RELEASE_VIDEO_PDS_CREATE_TIMEOUT="$(RELEASE_VIDEO_PDS_CREATE_TIMEOUT)" \
 	python scripts/release_video.py \
 		--preflight \
 		--pds-cli "$(PDS_CLI)" \
@@ -856,6 +859,7 @@ release-video:
 	RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT="$(RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT)" \
 	RELEASE_VIDEO_FORCE_REGENERATE="$(RELEASE_VIDEO_FORCE_REGENERATE)" \
 	RELEASE_VIDEO_METADATA_CONFLICT="$(RELEASE_VIDEO_METADATA_CONFLICT)" \
+	RELEASE_VIDEO_PDS_CREATE_TIMEOUT="$(RELEASE_VIDEO_PDS_CREATE_TIMEOUT)" \
 	python scripts/release_video.py \
 		--output-dir "$(RELEASE_VIDEO_OUTPUT_DIR)" \
 		--claude-cli "$(CLAUDE_CLI)" \

--- a/docs/contributors/pdd-cli-release-process.md
+++ b/docs/contributors/pdd-cli-release-process.md
@@ -1,5 +1,31 @@
 # PDD CLI Release Process
 
+## Release-Video PDS CLI
+
+Local release-video targets default to:
+
+```bash
+npx -y @promptdriven/pds@0.1.6 --timeout 120s
+```
+
+That avoids silently picking up an older globally installed `pds` binary and
+keeps the PDS wait path bounded before recovery/status metadata is needed. Run
+the local preflight before a release to print the redacted PDS command and the
+resolved CLI version:
+
+```bash
+make check-release-video-config
+```
+
+The release workflow also installs `@promptdriven/pds@0.1.6` by default when
+`PDS_CLI_PACKAGE` is unset and runs the same preflight before creating the
+video. If the GitHub repo variable is pinned below `0.1.6`, update it outside
+the PR:
+
+```bash
+gh variable set PDS_CLI_PACKAGE --repo promptdriven/pdd --body '@promptdriven/pds@0.1.6'
+```
+
 ## Release-Video Metadata Recovery
 
 When PDS reports a recoverable project metadata mismatch such as

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -140,6 +140,21 @@ class ReleaseVideoError(RuntimeError):
     """Raised for actionable release-video failures."""
 
 
+class ReleaseVideoProcessTimeout(ReleaseVideoError):
+    """Raised when a release-video subprocess times out with captured output."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        completed: subprocess.CompletedProcess[str],
+        timeout: float | None,
+    ) -> None:
+        super().__init__(message)
+        self.completed = completed
+        self.timeout = timeout
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
@@ -1111,18 +1126,15 @@ def preflight_pds_cli(args: argparse.Namespace, repo: Path) -> None:
 
     version, diagnostic = probe_pds_cli_version(str(args.pds_cli or ""), repo)
     if diagnostic:
-        print(
+        raise ReleaseVideoError(
             "release-video preflight: could not determine PDS CLI version: "
-            f"{diagnostic}",
-            file=sys.stderr,
+            f"{diagnostic}. Use @promptdriven/pds@{MIN_PDS_CLI_VERSION_TEXT} "
+            f"or newer. Command: {redacted_command}"
         )
-        return
     if version is None:
-        print(
+        raise ReleaseVideoError(
             "release-video preflight: could not determine PDS CLI version.",
-            file=sys.stderr,
         )
-        return
 
     print(f"release-video preflight: PDS CLI version: {version}")
     if pds_cli_version_tuple(version) < MIN_PDS_CLI_VERSION:
@@ -1205,8 +1217,17 @@ def run(
             check=False,
         )
     except subprocess.TimeoutExpired as exc:
-        raise ReleaseVideoError(
-            f"{rendered_command} timed out after {timeout:g} seconds"
+        timeout_text = f"{timeout:g}" if timeout is not None else "unknown"
+        completed = subprocess.CompletedProcess(
+            command,
+            124,
+            stdout=timeout_output_text(getattr(exc, "stdout", None)),
+            stderr=timeout_output_text(getattr(exc, "stderr", None)),
+        )
+        raise ReleaseVideoProcessTimeout(
+            f"{rendered_command} timed out after {timeout_text} seconds",
+            completed=completed,
+            timeout=timeout,
         ) from exc
     except FileNotFoundError as exc:
         raise ReleaseVideoError(f"Executable not found: {command[0]}") from exc
@@ -1218,6 +1239,15 @@ def run(
             f"{rendered_command} failed: {redact_secret_text(details[:2000])}"
         )
     return completed
+
+
+def timeout_output_text(output: str | bytes | None) -> str:
+    """Return captured timeout output as text for metadata extraction."""
+    if output is None:
+        return ""
+    if isinstance(output, bytes):
+        return output.decode("utf8", errors="replace")
+    return str(output)
 
 
 def git(repo: Path, *args: str, check: bool = True) -> str:
@@ -1732,25 +1762,37 @@ def create_release_video(
     ]
     if project_name:
         pds_args[2:2] = ["--project-name", project_name]
-    changelog_full_path = repo / changelog_path
-    if changelog_full_path.exists():
-        pds_args.extend(["--changelog", str(changelog_full_path)])
-    if args.bootstrap_selected_project:
-        pds_args.append("--bootstrap-selected-project")
-    metadata_conflict = release_video_metadata_conflict(args)
-    if metadata_conflict:
-        pds_args.extend(["--metadata-conflict", metadata_conflict])
-    if args.force_regenerate:
-        pds_args.append("--force-regenerate")
-    if args.dry_run:
-        pds_args.append("--dry-run")
-
-    completed = run(
-        command + pds_args,
-        cwd=repo,
-        timeout=pds_create_process_timeout(args),
-        check=False,
+    add_optional_pds_create_args(
+        pds_args,
+        args,
+        repo,
+        changelog_path,
     )
+
+    try:
+        completed = run(
+            command + pds_args,
+            cwd=repo,
+            timeout=pds_create_process_timeout(args),
+            check=False,
+        )
+    except ReleaseVideoProcessTimeout as exc:
+        persisted_run_metadata_path = persist_timed_out_pds_run_metadata(
+            timeout=exc,
+            path=run_metadata_path,
+            args=args,
+            tag=tag,
+            idempotency_key=idempotency_key,
+            project_id=project_id,
+        )
+        message = str(exc)
+        if persisted_run_metadata_path:
+            print(
+                f"release-video: persisted PDS run metadata to {persisted_run_metadata_path}",
+                file=sys.stderr,
+            )
+            message += f" PDS run metadata saved to {persisted_run_metadata_path}."
+        raise ReleaseVideoError(message) from exc
     persisted_run_metadata_path = persist_pds_run_metadata_from_output(
         completed=completed,
         path=run_metadata_path,
@@ -1786,6 +1828,49 @@ def create_release_video(
             message += f" PDS run metadata saved to {persisted_run_metadata_path}."
         raise ReleaseVideoError(message) from exc
     return parsed
+
+
+def add_optional_pds_create_args(
+    pds_args: list[str],
+    args: argparse.Namespace,
+    repo: Path,
+    changelog_path: Path,
+) -> None:
+    """Append optional PDS release-video create flags in-place."""
+    changelog_full_path = repo / changelog_path
+    if changelog_full_path.exists():
+        pds_args.extend(["--changelog", str(changelog_full_path)])
+    if args.bootstrap_selected_project:
+        pds_args.append("--bootstrap-selected-project")
+    metadata_conflict = release_video_metadata_conflict(args)
+    if metadata_conflict:
+        pds_args.extend(["--metadata-conflict", metadata_conflict])
+    if args.force_regenerate:
+        pds_args.append("--force-regenerate")
+    if args.dry_run:
+        pds_args.append("--dry-run")
+
+
+def persist_timed_out_pds_run_metadata(
+    *,
+    timeout: ReleaseVideoProcessTimeout,
+    path: Path,
+    args: argparse.Namespace,
+    tag: str,
+    idempotency_key: str,
+    project_id: str | None,
+) -> Path | None:
+    """Persist a PDS run sidecar from partial output captured on timeout."""
+    return persist_pds_run_metadata_from_output(
+        completed=timeout.completed,
+        path=path,
+        pds_cli=args.pds_cli,
+        tag=tag,
+        idempotency_key=idempotency_key,
+        attempt_id=args.idempotency_attempt_id,
+        provenance=release_video_idempotency_provenance(args.idempotency_provenance),
+        project_id=project_id,
+    )
 
 
 def parse_pds_create_response(stdout: str) -> dict[str, Any]:

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -75,6 +75,11 @@ SENSITIVE_FIELD_NAMES = {
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_RELEASE_VIDEO_PROMPT = REPO_ROOT / "pdd" / "prompts" / "release_video_script_LLM.prompt"
 DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
+MIN_PDS_CLI_VERSION = (0, 1, 6)
+MIN_PDS_CLI_VERSION_TEXT = ".".join(str(part) for part in MIN_PDS_CLI_VERSION)
+PDS_VERSION_RE = re.compile(r"(?<!\d)(?P<version>\d+\.\d+\.\d+)(?!\d)")
+PDS_VERSION_PROBE_TIMEOUT_SECONDS = 10.0
+DEFAULT_PDS_CREATE_TIMEOUT_SECONDS = 1800.0
 CLAUDE_OAUTH_TOKEN_ENV_VARS = (
     "CLAUDE_CODE_OAUTH_TOKEN_1",
     "CLAUDE_CODE_OAUTH_TOKEN_2",
@@ -281,6 +286,20 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         ),
     )
     parser.add_argument("--pds-cli", default=os.environ.get("PDS_CLI", "pds"))
+    parser.add_argument(
+        "--pds-create-timeout",
+        type=float,
+        default=float(
+            os.environ.get(
+                "RELEASE_VIDEO_PDS_CREATE_TIMEOUT",
+                DEFAULT_PDS_CREATE_TIMEOUT_SECONDS,
+            )
+        ),
+        help=(
+            "Maximum seconds to allow the PDS release-video create process. "
+            "Set to 0 to rely only on the PDS CLI timeout/recovery behavior."
+        ),
+    )
     parser.add_argument(
         "--project-id",
         default=os.environ.get("RELEASE_VIDEO_PROJECT_ID", ""),
@@ -997,6 +1016,8 @@ def preflight_release_video(args: argparse.Namespace) -> int:
         print("release-video preflight: skipped because RELEASE_VIDEO=0.")
         return 0
 
+    preflight_pds_cli(args, Path(args.repo).resolve())
+
     project_id = str(args.project_id or "").strip()
     if project_id:
         print(f"release-video preflight: using explicit PDS project {project_id}.")
@@ -1083,6 +1104,85 @@ def read_pds_config(path: Path) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def preflight_pds_cli(args: argparse.Namespace, repo: Path) -> None:
+    """Print and validate the PDS CLI command used by release-video."""
+    redacted_command = redact_command_text(str(args.pds_cli or ""))
+    print(f"release-video preflight: PDS CLI command: {redacted_command}")
+
+    version, diagnostic = probe_pds_cli_version(str(args.pds_cli or ""), repo)
+    if diagnostic:
+        print(
+            "release-video preflight: could not determine PDS CLI version: "
+            f"{diagnostic}",
+            file=sys.stderr,
+        )
+        return
+    if version is None:
+        print(
+            "release-video preflight: could not determine PDS CLI version.",
+            file=sys.stderr,
+        )
+        return
+
+    print(f"release-video preflight: PDS CLI version: {version}")
+    if pds_cli_version_tuple(version) < MIN_PDS_CLI_VERSION:
+        raise ReleaseVideoError(
+            f"PDS CLI {version} is older than required "
+            f"{MIN_PDS_CLI_VERSION_TEXT}. Use @promptdriven/pds@"
+            f"{MIN_PDS_CLI_VERSION_TEXT} or newer. Command: {redacted_command}"
+        )
+
+
+def probe_pds_cli_version(
+    pds_cli: str,
+    repo: Path,
+) -> tuple[str | None, str | None]:
+    """Return the PDS CLI semantic version, or a redacted diagnostic."""
+    command = split_command(pds_cli)
+    if not command:
+        return None, "PDS_CLI is empty"
+    try:
+        ensure_command_exists(command[0], "PDS CLI")
+        completed = run(
+            [*command, "--version"],
+            cwd=repo,
+            timeout=PDS_VERSION_PROBE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except ReleaseVideoError as exc:
+        return None, redact_secret_text(str(exc))
+
+    combined = "\n".join(
+        part.strip()
+        for part in (completed.stdout, completed.stderr)
+        if part and part.strip()
+    )
+    if completed.returncode != 0:
+        return None, redacted_process_details(completed)
+    version = extract_pds_cli_version(combined)
+    if not version:
+        diagnostic = truncate(redact_secret_text(combined), 300) or "empty output"
+        return None, f"could not parse --version output: {diagnostic}"
+    return version, None
+
+
+def extract_pds_cli_version(text: str) -> str | None:
+    """Extract the first semantic version from PDS CLI version output."""
+    match = PDS_VERSION_RE.search(text)
+    if not match:
+        return None
+    return match.group("version")
+
+
+def pds_cli_version_tuple(version: str) -> tuple[int, int, int]:
+    """Return a comparable major/minor/patch tuple for a PDS CLI version."""
+    match = PDS_VERSION_RE.search(version)
+    if not match:
+        return (0, 0, 0)
+    major, minor, patch = match.group("version").split(".")
+    return (int(major), int(minor), int(patch))
+
+
 def run(
     command: list[str],
     *,
@@ -1092,6 +1192,7 @@ def run(
     env: dict[str, str] | None = None,
     check: bool = True,
 ) -> subprocess.CompletedProcess[str]:
+    rendered_command = redact_command_text(shlex.join(command))
     try:
         completed = subprocess.run(
             command,
@@ -1105,7 +1206,7 @@ def run(
         )
     except subprocess.TimeoutExpired as exc:
         raise ReleaseVideoError(
-            f"{shlex.join(command)} timed out after {timeout:g} seconds"
+            f"{rendered_command} timed out after {timeout:g} seconds"
         ) from exc
     except FileNotFoundError as exc:
         raise ReleaseVideoError(f"Executable not found: {command[0]}") from exc
@@ -1113,7 +1214,9 @@ def run(
         stderr = completed.stderr.strip()
         stdout = completed.stdout.strip()
         details = stderr or stdout or f"exit code {completed.returncode}"
-        raise ReleaseVideoError(f"{shlex.join(command)} failed: {details[:2000]}")
+        raise ReleaseVideoError(
+            f"{rendered_command} failed: {redact_secret_text(details[:2000])}"
+        )
     return completed
 
 
@@ -1565,6 +1668,14 @@ def resolve_prompt_template_path(prompt_template: Path, cwd: Path) -> Path:
     raise ReleaseVideoError(f"Release-video prompt template not found. Tried:\n{tried}")
 
 
+def pds_create_process_timeout(args: argparse.Namespace) -> float | None:
+    """Return the configured PDS create subprocess timeout."""
+    timeout = float(
+        getattr(args, "pds_create_timeout", DEFAULT_PDS_CREATE_TIMEOUT_SECONDS)
+    )
+    return timeout if timeout > 0 else None
+
+
 def create_release_video(
     *,
     args: argparse.Namespace,
@@ -1634,7 +1745,12 @@ def create_release_video(
     if args.dry_run:
         pds_args.append("--dry-run")
 
-    completed = run(command + pds_args, cwd=repo, timeout=None, check=False)
+    completed = run(
+        command + pds_args,
+        cwd=repo,
+        timeout=pds_create_process_timeout(args),
+        check=False,
+    )
     persisted_run_metadata_path = persist_pds_run_metadata_from_output(
         completed=completed,
         path=run_metadata_path,

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -29,6 +29,7 @@ def release_video_env(extra: dict | None = None) -> dict:
         "RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT",
         "RELEASE_VIDEO_FORCE_REGENERATE",
         "RELEASE_VIDEO_METADATA_CONFLICT",
+        "RELEASE_VIDEO_PDS_CREATE_TIMEOUT",
         "RELEASE_VIDEO_SCRIPT_PATH",
         "PDS_API_URL",
         "PDS_PROFILE",
@@ -41,6 +42,14 @@ def release_video_env(extra: dict | None = None) -> dict:
     if extra:
         env.update(extra)
     return env
+
+
+def test_release_video_env_scrubs_pds_create_timeout(monkeypatch):
+    monkeypatch.setenv("RELEASE_VIDEO_PDS_CREATE_TIMEOUT", "1")
+
+    env = release_video_env()
+
+    assert "RELEASE_VIDEO_PDS_CREATE_TIMEOUT" not in env
 
 
 def run(command, cwd: Path, **kwargs):
@@ -2288,6 +2297,57 @@ def test_release_video_preflight_rejects_stale_pds_cli_version(tmp_path: Path):
     assert "secret-preflight-token" not in result.stdout + result.stderr
 
 
+def test_release_video_preflight_rejects_unknown_pds_cli_version(tmp_path: Path):
+    pds_cli = (
+        f"{pds_version_stub(tmp_path, 'pds development build\\n')} "
+        "--token secret-preflight-token"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--preflight",
+            "--pds-cli",
+            pds_cli,
+        ],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        env=release_video_env(),
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "could not determine PDS CLI version" in result.stderr
+    assert "could not parse --version output" in result.stderr
+    assert "--token '[redacted]'" in result.stdout
+    assert "secret-preflight-token" not in result.stdout + result.stderr
+
+
+def test_release_video_preflight_skip_allows_unknown_pds_cli_version(
+    tmp_path: Path,
+):
+    pds_cli = pds_version_stub(tmp_path, "pds development build\n")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--preflight",
+            "--pds-cli",
+            str(pds_cli),
+        ],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"RELEASE_VIDEO": "0"}),
+        check=True,
+    )
+
+    assert "release-video preflight: skipped because RELEASE_VIDEO=0." in result.stdout
+
+
 def test_release_video_publish_requires_youtube_url(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     capture = tmp_path / "pds-capture.json"
@@ -2594,6 +2654,77 @@ def test_release_video_create_uses_configured_pds_process_timeout(
 
     assert response["summary"]["youtubeUrl"] == "https://youtu.be/timeout"
     assert observed_timeouts == [42.0]
+
+
+def test_release_video_create_timeout_persists_partial_pds_run_metadata(
+    tmp_path: Path,
+    monkeypatch,
+):
+    release_video = load_release_video_module()
+    repo = init_release_repo(tmp_path)
+    script_path = tmp_path / "release_video_script.md"
+    release_notes_path = tmp_path / "release_notes.md"
+    run_metadata_path = tmp_path / "pds_run.json"
+    script_path.write_text(reusable_script_text(), encoding="utf8")
+    release_notes_path.write_text("Release notes\n", encoding="utf8")
+    timed_out_run = {
+        "runId": "agent_run_timeout123",
+        "projectId": "pdd-v1-1-0-release",
+        "status": "running",
+    }
+
+    def fake_subprocess_run(command, **kwargs):
+        raise subprocess.TimeoutExpired(
+            command,
+            kwargs["timeout"],
+            output=json.dumps(timed_out_run) + "\n",
+            stderr="[pds] still waiting\n",
+        )
+
+    monkeypatch.setattr(release_video.subprocess, "run", fake_subprocess_run)
+
+    try:
+        release_video.create_release_video(
+            args=SimpleNamespace(
+                pds_cli=sys.executable,
+                project_id="",
+                project_name="",
+                idempotency_key="",
+                idempotency_attempt_id="",
+                idempotency_provenance="local-test",
+                preset="release-notes",
+                target="publish",
+                platform="youtube",
+                privacy="unlisted",
+                bootstrap_selected_project=False,
+                metadata_conflict="",
+                force_regenerate=False,
+                dry_run=False,
+                pds_create_timeout=0.01,
+            ),
+            repo=repo,
+            tag="v1.1.0",
+            git_sha="abc123def456",
+            repo_url="https://github.com/promptdriven/pdd",
+            repo_name="promptdriven/pdd",
+            script_path=script_path,
+            release_notes_path=release_notes_path,
+            changelog_path=Path("CHANGELOG.md"),
+            run_metadata_path=run_metadata_path,
+        )
+    except release_video.ReleaseVideoError as exc:
+        error = str(exc)
+    else:
+        raise AssertionError("expected release-video timeout to fail")
+
+    assert "timed out after 0.01 seconds" in error
+    assert str(run_metadata_path) in error
+    persisted = json.loads(run_metadata_path.read_text(encoding="utf8"))
+    assert persisted["runId"] == "agent_run_timeout123"
+    assert persisted["projectId"] == "pdd-v1-1-0-release"
+    assert "release-video status --run-id agent_run_timeout123 --json" in persisted[
+        "recoverCommand"
+    ]
 
 
 def test_release_video_persists_structured_pds_run_handle_sidecar(tmp_path: Path):

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -192,6 +193,17 @@ capture.write_text(json.dumps({{"argv": sys.argv[1:]}}, indent=2), encoding="utf
 sys.stdout.write({stdout!r})
 sys.stderr.write({stderr!r})
 raise SystemExit({exit_code})
+""",
+    )
+
+
+def pds_version_stub(tmp_path: Path, version_output: str) -> Path:
+    return write_executable(
+        tmp_path / "pds-version-stub.py",
+        f"""#!/usr/bin/env python3
+import sys
+
+sys.stdout.write({version_output!r})
 """,
     )
 
@@ -1638,6 +1650,24 @@ def test_release_video_makefile_passes_recovery_env_vars():
     )
 
 
+def test_release_video_makefile_pds_cli_default_avoids_stale_global_cli():
+    makefile_text = (ROOT / "Makefile").read_text(encoding="utf8")
+
+    assert "PDS_CLI ?= npx -y @promptdriven/pds@0.1.6 --timeout 120s" in makefile_text
+
+
+def test_release_video_workflow_defaults_and_preflights_recovery_capable_pds_cli():
+    workflow_text = (ROOT / ".github" / "workflows" / "release.yml").read_text(
+        encoding="utf8"
+    )
+
+    assert (
+        "PDS_CLI_PACKAGE: ${{ vars.PDS_CLI_PACKAGE || '@promptdriven/pds@0.1.6' }}"
+        in workflow_text
+    )
+    assert "make check-release-video-config" in workflow_text
+
+
 def test_release_video_metadata_conflict_recovery_is_documented():
     doc_text = (
         ROOT / "docs" / "contributors" / "pdd-cli-release-process.md"
@@ -2184,6 +2214,62 @@ def test_release_video_preflight_with_env_token_and_project_reports_fixed_projec
     assert "env-secret-token" not in result.stdout + result.stderr
 
 
+def test_release_video_preflight_reports_redacted_pds_cli_command_and_version(
+    tmp_path: Path,
+):
+    pds_cli = (
+        f"{pds_version_stub(tmp_path, '@promptdriven/pds 0.1.6\\n')} "
+        "--token secret-preflight-token"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--preflight",
+            "--pds-cli",
+            pds_cli,
+        ],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        env=release_video_env(),
+        check=True,
+    )
+
+    assert "release-video preflight: PDS CLI command:" in result.stdout
+    assert "--token '[redacted]'" in result.stdout
+    assert "release-video preflight: PDS CLI version: 0.1.6" in result.stdout
+    assert "secret-preflight-token" not in result.stdout + result.stderr
+
+
+def test_release_video_preflight_rejects_stale_pds_cli_version(tmp_path: Path):
+    pds_cli = (
+        f"{pds_version_stub(tmp_path, '@promptdriven/pds 0.1.5\\n')} "
+        "--token secret-preflight-token"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--preflight",
+            "--pds-cli",
+            pds_cli,
+        ],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        env=release_video_env(),
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "PDS CLI 0.1.5 is older than required 0.1.6" in result.stderr
+    assert "--token '[redacted]'" in result.stdout
+    assert "secret-preflight-token" not in result.stdout + result.stderr
+
+
 def test_release_video_publish_requires_youtube_url(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     capture = tmp_path / "pds-capture.json"
@@ -2430,6 +2516,63 @@ def test_release_video_create_failure_redacts_pds_cli_command_secrets(tmp_path: 
     assert "secret-create-auth" not in result.stderr
     assert "--token '[redacted]'" in result.stderr
     assert "--authorization '[redacted]'" in result.stderr
+
+
+def test_release_video_create_uses_configured_pds_process_timeout(
+    tmp_path: Path,
+    monkeypatch,
+):
+    release_video = load_release_video_module()
+    repo = init_release_repo(tmp_path)
+    script_path = tmp_path / "release_video_script.md"
+    release_notes_path = tmp_path / "release_notes.md"
+    run_metadata_path = tmp_path / "pds_run.json"
+    script_path.write_text(reusable_script_text(), encoding="utf8")
+    release_notes_path.write_text("Release notes\n", encoding="utf8")
+    observed_timeouts = []
+
+    def fake_run(command, *, cwd, input_text=None, timeout=None, env=None, check=True):
+        observed_timeouts.append(timeout)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps({"summary": {"youtubeUrl": "https://youtu.be/timeout"}}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(release_video, "run", fake_run)
+
+    response = release_video.create_release_video(
+        args=SimpleNamespace(
+            pds_cli=sys.executable,
+            project_id="",
+            project_name="",
+            idempotency_key="",
+            idempotency_attempt_id="",
+            idempotency_provenance="local-test",
+            preset="release-notes",
+            target="publish",
+            platform="youtube",
+            privacy="unlisted",
+            bootstrap_selected_project=False,
+            metadata_conflict="",
+            force_regenerate=False,
+            dry_run=False,
+            pds_create_timeout=42.0,
+        ),
+        repo=repo,
+        tag="v1.1.0",
+        git_sha="abc123def456",
+        repo_url="https://github.com/promptdriven/pdd",
+        repo_name="promptdriven/pdd",
+        script_path=script_path,
+        release_notes_path=release_notes_path,
+        changelog_path=Path("CHANGELOG.md"),
+        run_metadata_path=run_metadata_path,
+    )
+
+    assert response["summary"]["youtubeUrl"] == "https://youtu.be/timeout"
+    assert observed_timeouts == [42.0]
 
 
 def test_release_video_persists_structured_pds_run_handle_sidecar(tmp_path: Path):

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -1653,7 +1653,10 @@ def test_release_video_makefile_passes_recovery_env_vars():
 def test_release_video_makefile_pds_cli_default_avoids_stale_global_cli():
     makefile_text = (ROOT / "Makefile").read_text(encoding="utf8")
 
-    assert "PDS_CLI ?= npx -y @promptdriven/pds@0.1.6 --timeout 120s" in makefile_text
+    assert (
+        "PDS_CLI ?= npx -y @promptdriven/pds@0.1.6 --timeout 120s"
+        in makefile_text
+    )
 
 
 def test_release_video_workflow_defaults_and_preflights_recovery_capable_pds_cli():
@@ -1662,7 +1665,8 @@ def test_release_video_workflow_defaults_and_preflights_recovery_capable_pds_cli
     )
 
     assert (
-        "PDS_CLI_PACKAGE: ${{ vars.PDS_CLI_PACKAGE || '@promptdriven/pds@0.1.6' }}"
+        "PDS_CLI_PACKAGE: "
+        "${{ vars.PDS_CLI_PACKAGE || '@promptdriven/pds@0.1.6' }}"
         in workflow_text
     )
     assert "make check-release-video-config" in workflow_text
@@ -2123,7 +2127,13 @@ def test_release_video_preflight_warns_for_project_scoped_profile(tmp_path: Path
     env.pop("RELEASE_VIDEO_PROJECT_ID", None)
 
     result = subprocess.run(
-        [sys.executable, str(SCRIPT), "--preflight"],
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--preflight",
+            "--pds-cli",
+            str(pds_version_stub(tmp_path, "0.1.6\n")),
+        ],
         cwd=tmp_path,
         text=True,
         capture_output=True,
@@ -2166,7 +2176,13 @@ def test_release_video_preflight_allows_env_token_without_printing_it(tmp_path: 
     env.pop("RELEASE_VIDEO_PROJECT_ID", None)
 
     result = subprocess.run(
-        [sys.executable, str(SCRIPT), "--preflight"],
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--preflight",
+            "--pds-cli",
+            str(pds_version_stub(tmp_path, "0.1.6\n")),
+        ],
         cwd=tmp_path,
         text=True,
         capture_output=True,
@@ -2199,6 +2215,8 @@ def test_release_video_preflight_with_env_token_and_project_reports_fixed_projec
             "--preflight",
             "--project-id",
             "fixed-project-123",
+            "--pds-cli",
+            str(pds_version_stub(tmp_path, "0.1.6\n")),
         ],
         cwd=repo,
         text=True,
@@ -2531,12 +2549,15 @@ def test_release_video_create_uses_configured_pds_process_timeout(
     release_notes_path.write_text("Release notes\n", encoding="utf8")
     observed_timeouts = []
 
-    def fake_run(command, *, cwd, input_text=None, timeout=None, env=None, check=True):
+    def fake_run(command, **kwargs):
+        timeout = kwargs["timeout"]
         observed_timeouts.append(timeout)
         return subprocess.CompletedProcess(
             command,
             0,
-            stdout=json.dumps({"summary": {"youtubeUrl": "https://youtu.be/timeout"}}),
+            stdout=json.dumps(
+                {"summary": {"youtubeUrl": "https://youtu.be/timeout"}}
+            ),
             stderr="",
         )
 


### PR DESCRIPTION
## Summary
- default local release-video PDS CLI to `npx -y @promptdriven/pds@0.1.6 --timeout 120s`
- default the release workflow PDS package to `@promptdriven/pds@0.1.6` and run release-video preflight after install
- add PDS CLI preflight command/version reporting, stale-version rejection, redaction, and a configurable process timeout for create
- document the release-video PDS CLI default and repo variable command

Fixes #1782.

## Tests
- `pytest -q tests/test_release_video.py -k "pds_cli or preflight or makefile or workflow"`
- `pytest -q tests/test_release_video.py::test_release_video_create_uses_configured_pds_process_timeout`
- `pytest -q tests/test_release_video.py`
- `make -n check-release-video-config RELEASE_VIDEO=0`
- `make -n release-video RELEASE_TAG=v1.2.3 RELEASE_GIT_SHA=abc123 RELEASE_VIDEO=0`

## Notes
`pylint scripts/release_video.py tests/test_release_video.py` still exits nonzero on existing broad style debt in these large files.