### PR TITLE
fix(release): use GLM for PDS release-video pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
       #                                with vars.RELEASE_VIDEO_PROJECT_ID set to
       #                                that same authorized fixed project.
       #   vars.PDS_CLI_PACKAGE         install spec for the @promptdriven/pds
-      #                                CLI. Defaults to @promptdriven/pds@0.1.6
+      #                                CLI. Defaults to @promptdriven/pds@0.1.7
       #                                so release-video recovery/status support
       #                                is available even when the repo variable
       #                                is unset.
@@ -244,7 +244,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PDS_TOKEN: ${{ secrets.PDS_TOKEN }}
           PDS_API_URL: ${{ vars.PDS_API_URL || 'https://video.promptdriven.ai' }}
-          PDS_CLI_PACKAGE: ${{ vars.PDS_CLI_PACKAGE || '@promptdriven/pds@0.1.6' }}
+          PDS_CLI_PACKAGE: ${{ vars.PDS_CLI_PACKAGE || '@promptdriven/pds@0.1.7' }}
           PDS_CLI: ${{ vars.PDS_CLI || 'pds --timeout 120s' }}
           CLAUDE_CODE_OAUTH_TOKEN_1: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_1 }}
           CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}

--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,9 @@ RELEASE_VIDEO_METADATA_CONFLICT ?=
 RELEASE_VIDEO_STATUS_QUERY ?= 0
 RELEASE_VIDEO_YOUTUBE_URL ?=
 RELEASE_VIDEO_PDS_CREATE_TIMEOUT ?= 1800
+RELEASE_VIDEO_PDS_CLAUDE_MODEL ?= glm-5.2
 CLAUDE_CLI ?= claude
-PDS_CLI ?= npx -y @promptdriven/pds@0.1.6 --timeout 120s
+PDS_CLI ?= npx -y @promptdriven/pds@0.1.7 --timeout 120s
 PDS_API_URL ?= https://video.promptdriven.ai
 SOPS ?= sops
 SOPS_RELEASE_ENV_FILE ?= $(firstword $(wildcard ../secrets/pdd_cloud/shared.prod.sops.env ../pdd_cloud/secrets/pdd_cloud/shared.prod.sops.env secrets/pdd_cloud/shared.prod.sops.env) ../secrets/pdd_cloud/shared.prod.sops.env)
@@ -775,6 +776,7 @@ check-release-video-config:
 	python scripts/release_video.py \
 		--preflight \
 		--pds-cli "$(PDS_CLI)" \
+		--pds-claude-model "$(RELEASE_VIDEO_PDS_CLAUDE_MODEL)" \
 		--project-id "$(RELEASE_VIDEO_PROJECT_ID)"
 
 check-release-claude-oauth-config:
@@ -865,6 +867,7 @@ release-video:
 		--claude-cli "$(CLAUDE_CLI)" \
 		--script-path "$(RELEASE_VIDEO_SCRIPT_PATH)" \
 		--pds-cli "$(PDS_CLI)" \
+		--pds-claude-model "$(RELEASE_VIDEO_PDS_CLAUDE_MODEL)" \
 		--project-id "$(RELEASE_VIDEO_PROJECT_ID)" \
 		--preset "$(RELEASE_VIDEO_PRESET)" \
 		--target "$(RELEASE_VIDEO_TARGET)" \

--- a/docs/contributors/pdd-cli-release-process.md
+++ b/docs/contributors/pdd-cli-release-process.md
@@ -5,7 +5,7 @@
 Local release-video targets default to:
 
 ```bash
-npx -y @promptdriven/pds@0.1.6 --timeout 120s
+npx -y @promptdriven/pds@0.1.7 --timeout 120s
 ```
 
 That avoids silently picking up an older globally installed `pds` binary and
@@ -17,13 +17,19 @@ resolved CLI version:
 make check-release-video-config
 ```
 
-The release workflow also installs `@promptdriven/pds@0.1.6` by default when
+Release-video creation sends `--claude-model glm-5.2` to PDS by default for
+non-vision pipeline stages such as specs and compositions. Override with
+`RELEASE_VIDEO_PDS_CLAUDE_MODEL=<model>` only when intentionally changing the
+downstream PDS model; the local script-generation `CLAUDE_MODEL` remains a
+separate setting.
+
+The release workflow also installs `@promptdriven/pds@0.1.7` by default when
 `PDS_CLI_PACKAGE` is unset and runs the same preflight before creating the
-video. If the GitHub repo variable is pinned below `0.1.6`, update it outside
+video. If the GitHub repo variable is pinned below `0.1.7`, update it outside
 the PR:
 
 ```bash
-gh variable set PDS_CLI_PACKAGE --repo promptdriven/pdd --body '@promptdriven/pds@0.1.6'
+gh variable set PDS_CLI_PACKAGE --repo promptdriven/pdd --body '@promptdriven/pds@0.1.7'
 ```
 
 ## Release-Video Metadata Recovery

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -75,7 +75,8 @@ SENSITIVE_FIELD_NAMES = {
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_RELEASE_VIDEO_PROMPT = REPO_ROOT / "pdd" / "prompts" / "release_video_script_LLM.prompt"
 DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
-MIN_PDS_CLI_VERSION = (0, 1, 6)
+DEFAULT_PDS_CLAUDE_MODEL = "glm-5.2"
+MIN_PDS_CLI_VERSION = (0, 1, 7)
 MIN_PDS_CLI_VERSION_TEXT = ".".join(str(part) for part in MIN_PDS_CLI_VERSION)
 PDS_VERSION_RE = re.compile(r"(?<!\d)(?P<version>\d+\.\d+\.\d+)(?!\d)")
 PDS_VERSION_PROBE_TIMEOUT_SECONDS = 10.0
@@ -278,6 +279,18 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     )
     parser.add_argument("--claude-cli", default=os.environ.get("CLAUDE_CLI", "claude"))
     parser.add_argument("--claude-model", default=os.environ.get("CLAUDE_MODEL", DEFAULT_CLAUDE_MODEL))
+    parser.add_argument(
+        "--pds-claude-model",
+        default=os.environ.get(
+            "RELEASE_VIDEO_PDS_CLAUDE_MODEL",
+            DEFAULT_PDS_CLAUDE_MODEL,
+        ),
+        help=(
+            "Claude Code model passed to PDS for non-vision release-video "
+            "pipeline stages. Set RELEASE_VIDEO_PDS_CLAUDE_MODEL='' to use "
+            "the server default."
+        ),
+    )
     parser.add_argument(
         "--claude-tools",
         default=os.environ.get("RELEASE_VIDEO_CLAUDE_TOOLS", ""),
@@ -1845,6 +1858,9 @@ def add_optional_pds_create_args(
     metadata_conflict = release_video_metadata_conflict(args)
     if metadata_conflict:
         pds_args.extend(["--metadata-conflict", metadata_conflict])
+    pds_claude_model = str(getattr(args, "pds_claude_model", "") or "").strip()
+    if pds_claude_model:
+        pds_args.extend(["--claude-model", pds_claude_model])
     if args.force_regenerate:
         pds_args.append("--force-regenerate")
     if args.dry_run:

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -1852,7 +1852,7 @@ def test_release_video_makefile_pds_cli_default_avoids_stale_global_cli():
     makefile_text = (ROOT / "Makefile").read_text(encoding="utf8")
 
     assert (
-        "PDS_CLI ?= npx -y @promptdriven/pds@0.1.6 --timeout 120s"
+        "PDS_CLI ?= npx -y @promptdriven/pds@0.1.7 --timeout 120s"
         in makefile_text
     )
 
@@ -1864,7 +1864,7 @@ def test_release_video_workflow_defaults_and_preflights_recovery_capable_pds_cli
 
     assert (
         "PDS_CLI_PACKAGE: "
-        "${{ vars.PDS_CLI_PACKAGE || '@promptdriven/pds@0.1.6' }}"
+        "${{ vars.PDS_CLI_PACKAGE || '@promptdriven/pds@0.1.7' }}"
         in workflow_text
     )
     assert "make check-release-video-config" in workflow_text
@@ -2330,7 +2330,7 @@ def test_release_video_preflight_warns_for_project_scoped_profile(tmp_path: Path
             str(SCRIPT),
             "--preflight",
             "--pds-cli",
-            str(pds_version_stub(tmp_path, "0.1.6\n")),
+            str(pds_version_stub(tmp_path, "0.1.7\n")),
         ],
         cwd=tmp_path,
         text=True,
@@ -2379,7 +2379,7 @@ def test_release_video_preflight_allows_env_token_without_printing_it(tmp_path: 
             str(SCRIPT),
             "--preflight",
             "--pds-cli",
-            str(pds_version_stub(tmp_path, "0.1.6\n")),
+            str(pds_version_stub(tmp_path, "0.1.7\n")),
         ],
         cwd=tmp_path,
         text=True,
@@ -2414,7 +2414,7 @@ def test_release_video_preflight_with_env_token_and_project_reports_fixed_projec
             "--project-id",
             "fixed-project-123",
             "--pds-cli",
-            str(pds_version_stub(tmp_path, "0.1.6\n")),
+            str(pds_version_stub(tmp_path, "0.1.7\n")),
         ],
         cwd=repo,
         text=True,
@@ -2434,7 +2434,7 @@ def test_release_video_preflight_reports_redacted_pds_cli_command_and_version(
     tmp_path: Path,
 ):
     pds_cli = (
-        f"{pds_version_stub(tmp_path, '@promptdriven/pds 0.1.6\\n')} "
+        f"{pds_version_stub(tmp_path, '@promptdriven/pds 0.1.7\\n')} "
         "--token secret-preflight-token"
     )
 
@@ -2455,13 +2455,13 @@ def test_release_video_preflight_reports_redacted_pds_cli_command_and_version(
 
     assert "release-video preflight: PDS CLI command:" in result.stdout
     assert "--token '[redacted]'" in result.stdout
-    assert "release-video preflight: PDS CLI version: 0.1.6" in result.stdout
+    assert "release-video preflight: PDS CLI version: 0.1.7" in result.stdout
     assert "secret-preflight-token" not in result.stdout + result.stderr
 
 
 def test_release_video_preflight_rejects_stale_pds_cli_version(tmp_path: Path):
     pds_cli = (
-        f"{pds_version_stub(tmp_path, '@promptdriven/pds 0.1.5\\n')} "
+        f"{pds_version_stub(tmp_path, '@promptdriven/pds 0.1.6\\n')} "
         "--token secret-preflight-token"
     )
 
@@ -2481,7 +2481,7 @@ def test_release_video_preflight_rejects_stale_pds_cli_version(tmp_path: Path):
     )
 
     assert result.returncode == 1
-    assert "PDS CLI 0.1.5 is older than required 0.1.6" in result.stderr
+    assert "PDS CLI 0.1.6 is older than required 0.1.7" in result.stderr
     assert "--token '[redacted]'" in result.stdout
     assert "secret-preflight-token" not in result.stdout + result.stderr
 

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -29,6 +29,7 @@ def release_video_env(extra: dict | None = None) -> dict:
         "RELEASE_VIDEO_BOOTSTRAP_SELECTED_PROJECT",
         "RELEASE_VIDEO_FORCE_REGENERATE",
         "RELEASE_VIDEO_METADATA_CONFLICT",
+        "RELEASE_VIDEO_PDS_CLAUDE_MODEL",
         "RELEASE_VIDEO_PDS_CREATE_TIMEOUT",
         "RELEASE_VIDEO_SCRIPT_PATH",
         "PDS_API_URL",
@@ -337,6 +338,7 @@ def test_release_video_generates_script_and_invokes_pds_publish(tmp_path: Path):
     assert pds_call[pds_call.index("--privacy") + 1] == "unlisted"
     assert pds_call[pds_call.index("--release-tag") + 1] == "v1.1.0"
     assert pds_call[pds_call.index("--repo-name") + 1] == "promptdriven/pdd"
+    assert pds_call[pds_call.index("--claude-model") + 1] == "glm-5.2"
     idempotency_key = pds_call[pds_call.index("--idempotency-key") + 1]
     assert idempotency_key.startswith("pdd-release-video:v1.1.0:")
 


### PR DESCRIPTION
## Summary
- Forward `--claude-model glm-5.2` from PDD release tooling into `pds release-video create` by default.
- Add `RELEASE_VIDEO_PDS_CLAUDE_MODEL` / `--pds-claude-model` so downstream PDS specs/compositions can be overridden independently from local script generation.
- Require/default `@promptdriven/pds@0.1.7`, because published `0.1.6` rejects `release-video create --claude-model`.
- Document the split between local `CLAUDE_MODEL` and downstream PDS model selection.

## Root Cause
PDS/GVS source already supports a release-video `--claude-model` request override and applies it to non-vision pipeline steps such as specs and compositions. PDD's release-video wrapper had its own `--claude-model`, but that only controlled local script generation. The wrapper never forwarded a PDS model override, and the Makefile/workflow had no downstream PDS model variable, so production v0.0.291 release-video attempts omitted the override and PDS fell back to the default Opus/Anthropic provider path.

This should use GLM for downstream specs/compositions. The default is now `glm-5.2`.

## Merge Dependency
Do not merge this until `@promptdriven/pds@0.1.7` is published to npm. `@promptdriven/pds@0.1.6` rejects `release-video create --claude-model`; this PR now makes `0.1.7` the minimum/default CLI version so preflight catches stale CLIs.

Fixes #1783.

## Tests
- RED: `pytest tests/test_release_video.py -k 'generates_script_and_invokes_pds_publish' -q` at test-only commit `df46ee5e8` failed with `ValueError: '--claude-model' is not in list`.
- GREEN: `pytest tests/test_release_video.py -k 'generates_script_and_invokes_pds_publish' -q`
- GREEN: `pytest tests/test_release_video.py -k 'pds_cli_default or workflow_defaults or preflight or generates_script_and_invokes_pds_publish' -q`
- GREEN: `pytest tests/test_release_video.py -q`
- GREEN: `git diff --check`
- NOTE: `pylint scripts/release_video.py tests/test_release_video.py` still reports existing broad file-level style warnings/errors in these large files; this patch improves the score from 8.97 to 8.99 and does not introduce the existing failures.
