### PR TITLE
fix(checkup): retry empty Step 7 verify output; route persistent empty as provider failure (#1796)

### DIFF
--- a/.pdd/meta/agentic_checkup_orchestrator_python.json
+++ b/.pdd/meta/agentic_checkup_orchestrator_python.json
@@ -1,13 +1,13 @@
 {
   "pdd_version": "0.0.293",
-  "timestamp": "2026-07-02T07:46:19.172931+00:00",
+  "timestamp": "2026-07-02T08:42:08.094253+00:00",
   "command": "example",
   "prompt_hash": "8f5c76c5af9b7c90be20cd1d24c039a269ceb1b2e65f6188c5647ad875f3194f",
-  "code_hash": "85277b8f6d15543ba0aa6302c7078bdca8f9cf1c6068e2ab64226a4e7b778580",
-  "example_hash": "4ddaf64648efae48c120a4b5e94a110c393a4067925dff2717f1003420c9be7b",
-  "test_hash": "0beee1add45fc58ca8231ab451e750796006c8d531e5691700ccaa28f5d0ed41",
+  "code_hash": "54a3fce5716ce4967850207c28863364cbfb14bacd49ee77b1dda4a6d9b8dc70",
+  "example_hash": "809f01fe8ed64e4edcf47520d200bb53442d624d50354a492daf1a5c69bab4b1",
+  "test_hash": "096844d93ae7d182431451784c6bc2366493f6ad5b8de98de016304fa9303182",
   "test_files": {
-    "test_agentic_checkup_orchestrator.py": "0beee1add45fc58ca8231ab451e750796006c8d531e5691700ccaa28f5d0ed41"
+    "test_agentic_checkup_orchestrator.py": "096844d93ae7d182431451784c6bc2366493f6ad5b8de98de016304fa9303182"
   },
   "include_deps": {
     "context/agentic_bug_orchestrator_example.py": "23b545fc0f892e14ee9660902d3f7e04893f0b793246c1ea9d559656fd39ffe6",

--- a/.pdd/meta/agentic_checkup_orchestrator_python.json
+++ b/.pdd/meta/agentic_checkup_orchestrator_python.json
@@ -1,18 +1,18 @@
 {
-  "pdd_version": "0.0.273",
-  "timestamp": "2026-06-13T18:03:20.500524+00:00",
+  "pdd_version": "0.0.293",
+  "timestamp": "2026-07-02T07:46:19.172931+00:00",
   "command": "example",
-  "prompt_hash": "74563384c8358e0cfb994bd2b5e37a93a478a64c3e83a7cd1a63fa44246258d5",
-  "code_hash": "2a29489d565b0ebf5ef1d353f0070e806f9f990cd1eedc1c547abb983ddf93c0",
-  "example_hash": "9290bba1f27a21c2a8603065864fd059de6fde22151d6f0062e813a48b91061a",
-  "test_hash": "40ab1539859560e07acc3b4f5ac70ddeaa30e37333a04658c43c40593b18d55c",
+  "prompt_hash": "8f5c76c5af9b7c90be20cd1d24c039a269ceb1b2e65f6188c5647ad875f3194f",
+  "code_hash": "85277b8f6d15543ba0aa6302c7078bdca8f9cf1c6068e2ab64226a4e7b778580",
+  "example_hash": "4ddaf64648efae48c120a4b5e94a110c393a4067925dff2717f1003420c9be7b",
+  "test_hash": "0beee1add45fc58ca8231ab451e750796006c8d531e5691700ccaa28f5d0ed41",
   "test_files": {
-    "test_agentic_checkup_orchestrator.py": "40ab1539859560e07acc3b4f5ac70ddeaa30e37333a04658c43c40593b18d55c"
+    "test_agentic_checkup_orchestrator.py": "0beee1add45fc58ca8231ab451e750796006c8d531e5691700ccaa28f5d0ed41"
   },
   "include_deps": {
     "context/agentic_bug_orchestrator_example.py": "23b545fc0f892e14ee9660902d3f7e04893f0b793246c1ea9d559656fd39ffe6",
-    "context/agentic_common_example.py": "f9cdb30a932973d341b795faf510056b95573610af5ac48e3849cf42c205998e",
-    "context/agentic_e2e_fix_orchestrator_example.py": "182e33cbf3aa78dc177caead0bf7f9e827cc17f0f9ba7cc32c0dd027063bde64",
+    "context/agentic_common_example.py": "c1538a115a3a33da228e7f6cc048f2a99023cd2c83a0efef382e49c477b24ad3",
+    "context/agentic_e2e_fix_orchestrator_example.py": "180cc2c4316b531586040d61fc5f82f1f605d5c5736fd23bad63a889ac0b7d1e",
     "context/agentic_langtest_example.py": "dbc5c87dc1b75d3299dbfb67b17df1838f9ba2c9bdb457097df0832cea112c3f",
     "context/load_prompt_template_example.py": "a1cd6619182c6c951f5856dda4070e202875a5884bbfab9cc191d24de2f4951f",
     "context/preprocess_example.py": "e7082a4a9ef830048ff32ed774a3e74da1cf4662a22115e6bd5543e1b9cdbf43"

--- a/architecture.json
+++ b/architecture.json
@@ -7932,7 +7932,7 @@
     }
   },
   {
-    "reason": "Multi-step orchestrator for pdd checkup — 8 steps with iterative fix-verify loop, worktree isolation, and fix-capable PR mode that pushes back to the same PR. In PR mode the linked issue is OPTIONAL: with no issue (issue_url/issue_number absent) the PR is reviewed on its own merits and _step7_passed drops the issue_aligned requirement (verdict = code findings only), the issue-thread per-step/error/final posts are skipped, and _post_pr_mode_final_report posts only to the PR thread; with an issue present the issue-alignment gate is unchanged. Issue #1212 contract: Step 5 emits a structured failure_signal block normalised into context['step5_failure_signal']; Step 6.1's prompt renders that block. The Step 5 status word is parsed into three states — pass/ok/success/passed/clean (logically clean), skipped/skip/no_tests/n/a/n_a (verification did not run; sets context['step5_verification_skipped']=1 and is detected from the parsed status alone regardless of the provider success flag, round-10 #1), and everything else including a missing/malformed block (logical failure, fail closed). The fixer is skipped for both clean and skipped; a dedicated pre-push gate refuses any push when the skipped flag is set because tests never ran — including when the worktree is clean (round-10 #2: returning 'Checkup complete' on a clean worktree without test evidence misleads the user). The gate re-derives the skipped state from the persisted step_outputs['5'] via _step5_was_skipped at gate time rather than trusting only the in-memory context cache (round-10 #3: context is not part of the saved workflow state, so a mid-loop interruption can resume with the cached Step 5 skipped block but an empty context cache). The scope guard builds pr_file_set from the UNION of pr_metadata['api_changed_files_full'|'api_changed_files'] AND context['pr_scope_changed_files'] (the local merge-base diff), tolerating GitHub API outages when the local base is healthy. The scope-allowed set extends pr_file_set with Step 5 failure paths and justified EXPANSION_ITEMS paths so the guard matches the Step 6 prompt's allowance for editing failing test files / causally-connected files without an explicit marker; the causal guard remains the backstop for zero-overlap fixes. EXPANSION_ITEMS justification is per-marker; trailing continuation lines only count when they carry semantic content (prefix marker, path mention, or causal keyword) so indented/bulleted padding cannot whitelist a path. fixer_invoked is seeded ONLY from persisted step_outputs['6_1'|'6_2'|'6_3'] (not from start_step) so a manual --start-step 7 still trips the side-effect guard. A clean Steps-3/4/5 run never commits or pushes side-effect edits left by non-fixer tooling. In --no-fix --pr mode the orchestrator applies the same three-state Step 5 parse AFTER the Steps-3/4/5 loop (reading from step_outputs['5'] to cover both fresh and resumed runs); the parse is NOT guarded on the raw output being truthy, so an empty/missing Step 5 output is itself a fail-closed condition (no test evidence) that routes to the logical-failure branch (pass-17 #1: provider success with empty Step 5 output must not slip through as a verified result). A skipped status writes .pdd/checkup-pr-N/nofix-step5-skipped-refusal.txt, calls _post_pr_mode_final_report(refusal_message) to post the terminal status to PR/issue threads, calls clear_workflow_state(...) to discard the saved cache so the next rerun reruns Step 5 instead of replaying the stale skipped/failed output (and avoids a duplicate final-report comment), and returns (False, f'{refusal}{suffix}', ...) before Step 7 runs; a logical failure (fail/error/empty/missing block) writes .pdd/checkup-pr-N/nofix-step5-failure-refusal.txt and follows the same post-then-clear-then-return pattern. Because load_workflow_state loads the GitHub state comment with PRIORITY over local state (round-17), clear_workflow_state now returns a bool and github_clear_state falls back to neutralising the state-comment body (stripping the PDD_WORKFLOW_STATE marker via _github_edit_comment) when a DELETE fails, so a token without delete scope can no longer leave stale remote state that replays the refusal forever; the orchestrator appends a cleanup warning to the returned message when the clear is still unconfirmed. The SAME unconfirmed-clear warning is appended on the terminal-success path (external review #1215 Finding 2): that path captures clear_workflow_state's bool instead of discarding it so a failed remote clear cannot let the next run resume from completed state — the checkup still returns success, the warning is informational. As a second, independent backstop for the same hole, load_workflow_state-side resume DISCARDS any cached state whose (FAILED-corrected) last_completed_step has already reached STEP_ORDER[-1] (the terminal step) when no start_step_override is given: a completed run's lingering state (left behind precisely because its best-effort remote clear failed) must not be resumed, or the rerun would skip every step and replay the cached Step 7 verdict as 'Checkup complete' without re-verifying the PR head. On discard it resets last_completed_step to 0 but preserves github_comment_id=loaded_gh_id so the fresh run PATCHes the lingering state comment rather than creating a duplicate. Because context persists across fix-verify iterations and context['step5_failure_signal'] is written ONLY on the failing Step 5 path, the orchestrator clears it (and step5_failure_signal_missing) to '' whenever a later iteration's Step 5 is clean or skipped so Step 6 is never driven by a prior iteration's stale failure block (external review #1215 Finding 1); the provider-success/logical-failure branch also prints the scrubbed failure detail unconditionally (even in quiet mode) like the provider-failure path (external review #1215 Finding 3). Non-PR no-fix runs are unaffected. The pre-push diff size gate (PDD_CHECKUP_DIFF_LOC_LIMIT, default 800 added LoC; 0 disables; unparseable falls back to default) refuses oversized pushes unless every OVERSIZED dirty path (>= OVERSIZED_PATH_ADDED_LOC_FLOOR added lines, default 50) is covered by its OWN justified EXPANSION_ITEMS entry. Small companion files are exempt; diffuse death-by-a-thousand-cuts diffs still require every path covered.",
+    "reason": "Multi-step pdd checkup orchestrator; PR mode pushes back to the same PR and supports an optional issue, reviewing the PR on its own merits.",
     "description": "Orchestrates the 8-step agentic checkup workflow: discover, deps, build, interfaces, test, fix (6.1/6.2/6.3), verify, create PR. Steps 3-7 run in an iterative while loop (max 3 iterations) with exit on 'All Issues Fixed'; exhausting the loop without that exact signal returns failure and does not push fixes or create/skip through a successful PR gate. Supports resume via workflow state persistence, git worktree isolation, --no-fix mode, start-step recovery, and PR verification mode. In PR mode it checks out the PR head in a dedicated worktree using a checkout-scoped local branch name, refreshes the PR base into a dedicated local ref before recording merge-base changed files for PR-scoped test prompts, resolves a trusted absolute git binary through checkup_gates for the base-refresh and changed-file prompt probes so PATH=.:$PATH cannot execute a PR-shipped ./git, falls back to GitHub's PR files API when the local base refresh is unavailable, runs the full fix-capable checkup on that PR code, commits eligible generated fixes, pushes them back to the same PR branch, re-runs Step 7 after a rebase-on-updated-head push, posts final PR/issue reports only after the pushed PR head is verified, and skips Step 8 because the PR already exists. In PR mode _handle_step_result suppresses its per-step issue comment for Step 7 (the orchestrator's canonical final report already covers it) so the issue thread does not get duplicate Step 7 reporting; earlier-step progress comments and issue-mode Step 7 comments are unaffected (external review #1215 Finding 3). Issue #1212 safety contract: (a) Step 5 MUST emit a structured ```failure_signal``` block (command, exit_code, status, failing_ids, artifact_path, output); the orchestrator parses it via _parse_failure_signal_block, treats empty fail/error-status fields as missing, synthesises a normalised block into context['step5_failure_signal'] that Step 6's prompt explicitly references, and maps the status word to one of three states (clean / skipped / failure) with fail-closed defaults — a missing block or unrecognised status counts as a logical failure (round-8 #1) so the fixer runs rather than silently passing. A 'skipped'/'skip'/'no_tests'/'n/a'/'n_a' status sets context['step5_verification_skipped']=1 — detected from the parsed status INDEPENDENT of the provider success flag (round-10 #1: an agent can emit a coherent skipped block even when its provider call timed out) — and triggers a dedicated pre-push gate that refuses any commit/push because tests never ran (round-9 #1), including the no-changes-clean-worktree path (round-10 #2: returning 'Checkup complete' on a clean worktree without test evidence misleads the user); the gate re-derives the skipped state from the persisted step_outputs['5'] via _step5_was_skipped at gate time so a mid-loop interruption + resume cannot slip past via a missing in-memory cache (round-10 #3). (b) The scope guard builds pr_file_set from the UNION of pr_metadata['api_changed_files_full'|'api_changed_files'] AND the local merge-base diff in context['pr_scope_changed_files'] (round-8 #2 — tolerates GitHub API outages), parses both formats with regex `^-\\s+([A-Z][A-Z0-9]*):\\s*(.+?)\\s*$` (uppercase words from the API formatter, short git statuses M/A/R100 from the local-diff formatter), extends the scope-allowed set with Step 5 failure paths (round-8 #3 — matches the Step 6 prompt's allowance for editing failing test files and causally-connected files without an EXPANSION_ITEMS marker; the causal guard remains the backstop for zero-overlap fixes), parses EXPANSION_ITEMS as a structured per-marker allowlist requiring BOTH a non-empty path list AND a per-marker causal justification (_parse_expansion_items); follow-up lines only count when they carry semantic content (round-7 #1: prefix marker, path mention, or causal keyword — bare indentation/bullets do not qualify). (c) A clean PR run (Steps 3, 4, AND 5 all reported success → fixer skipped) MUST NOT commit or push worktree changes from non-fixer steps; a dedicated clean-run side-effect guard fires before scope/causal/size checks. fixer_invoked is seeded ONLY from persisted step_outputs['6_1'|'6_2'|'6_3'] so a manual --start-step 7 without prior fixer state still trips the guard (round-7 #2). (d) Pre-push diff sanity gate (_diff_size_added_lines_by_path returning per-path counts; total via _diff_size_added_lines + DIFF_SIZE_ADDED_LOC_LIMIT, overridable via PDD_CHECKUP_DIFF_LOC_LIMIT — 0 disables, unparseable falls back to default) refuses pushes adding more than the configured added-line threshold unless every OVERSIZED dirty path (>= OVERSIZED_PATH_ADDED_LOC_FLOOR added lines, default 50) is covered by its OWN justified EXPANSION_ITEMS entry; small companion files are exempt (round-9 #2). A diffuse over-limit diff with no individually oversized path falls back to the original strict 'every changed path covered' rule so death-by-a-thousand-cuts diffs are still blocked. In --no-fix --pr mode the orchestrator applies the same three-state Step 5 parse AFTER the Steps-3/4/5 loop (reading from step_outputs['5'] to cover both fresh and resumed runs); the parse is not guarded on truthiness so an empty/missing Step 5 output fails closed as a logical failure (pass-17 #1). A skipped status writes .pdd/checkup-pr-N/nofix-step5-skipped-refusal.txt and returns (False, ...) — calling _post_pr_mode_final_report(refusal_message) before returning so PR/issue threads receive a terminal status comment even without a Step 7 output, then clear_workflow_state(...) so the next rerun reruns Step 5 rather than replaying the stale cache; a logical failure (fail/error/empty/missing block) writes .pdd/checkup-pr-N/nofix-step5-failure-refusal.txt and returns (False, ...) the same way. clear_workflow_state returns a bool and github_clear_state neutralises a state comment that cannot be DELETEd (round-17) so stale GitHub state — which load_workflow_state prefers over local — cannot replay the refusal on the next run. Non-PR no-fix runs are unaffected.",
     "dependencies": [
       "agentic_common_python.prompt",
@@ -7954,191 +7954,7 @@
           {
             "name": "run_agentic_checkup_orchestrator",
             "signature": "(issue_url: str, issue_content: str, repo_owner: str, repo_name: str, issue_number: int, issue_title: str, architecture_json: str, pddrc_content: str, *, cwd: Path, verbose: bool = False, quiet: bool = False, no_fix: bool = False, timeout_adder: float = 0.0, use_github_state: bool = True, reasoning_time: Optional[float] = None, pr_url: Optional[str] = None, pr_owner: Optional[str] = None, pr_repo: Optional[str] = None, pr_number: Optional[int] = None, test_scope: str = \"full\", start_step_override: Optional[Union[int, float]] = None) -> Tuple[bool, str, float, str]",
-            "returns": "Tuple[bool, str, float, str]",
-            "sideEffects": [
-              "Creates or reuses checkup worktrees",
-              "Runs LLM checkup steps",
-              "Persists workflow state",
-              "In PR mode, may commit and push generated fixes back to the existing PR branch",
-              "In PR mode, may post final PR and issue comments after push/reverify success",
-              "In PR fix mode, automatically restarts the inner orchestrator against the new head when the remote PR head advances mid-checkup (issue #1116); bounded by MAX_PR_HEAD_REFRESHES=2 with a durable per-PR sidecar counter at .pdd/checkup-pr-{n}/pr_head_refreshes"
-            ]
-          },
-          {
-            "name": "_next_step",
-            "signature": "(current: Union[int, float]) -> Union[int, float]",
-            "returns": "Union[int, float]",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_step7_passed",
-            "signature": "(step7_output: str, pr_mode: bool, has_issue: bool = True) -> Tuple[bool, str]",
-            "returns": "Tuple[bool, str]",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_format_pr_mode_final_report",
-            "signature": "(step7_output: str, push_message: str) -> str",
-            "returns": "str",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_refresh_pr_context_from_worktree",
-            "signature": "(context: Dict[str, str], worktree_path: Path) -> None",
-            "returns": "None",
-            "sideEffects": [
-              "Mutates context in place with PR-worktree architecture.json, .pddrc, and project_root values"
-            ]
-          },
-          {
-            "name": "_format_pr_changed_files_for_prompt",
-            "signature": "(worktree: Path, pr_metadata: Optional[Dict[str, str]] = None) -> str",
-            "returns": "str",
-            "sideEffects": [
-              "Reads local git refs and diff output",
-              "Uses pr_metadata['api_changed_files'] as an authoritative fallback when the refreshed PR base ref is unavailable",
-              "Keeps the API fallback bounded so very large PRs do not bloat Step 5/7 prompts",
-              "Writes pr_metadata['api_changed_files_full'] to .pdd/checkup-context/pr-changed-files-api.txt when present"
-            ]
-          },
-          {
-            "name": "_is_step_timeout_failure",
-            "signature": "(output: str) -> bool",
-            "returns": "bool",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_is_provider_failure",
-            "signature": "(output: str) -> bool",
-            "returns": "bool",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_format_step_abort_message",
-            "signature": "(step_num: Union[int, float], output: str) -> str",
-            "returns": "str",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_pr_worktree_branch_name",
-            "signature": "(git_root: Path, pr_number: int) -> str",
-            "returns": "str",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_pr_base_tracking_ref",
-            "signature": "(pr_number: int) -> str",
-            "returns": "str",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_refresh_pr_base_ref",
-            "signature": "(worktree: Path, pr_owner: str, pr_repo: str, pr_number: int, pr_metadata: Dict[str, str], quiet: bool) -> None",
-            "returns": "None",
-            "sideEffects": [
-              "Fetches the PR base branch into a dedicated local tracking ref",
-              "Mutates pr_metadata with base_local_ref or base_ref_fetch_error"
-            ]
-          },
-          {
-            "name": "_setup_worktree",
-            "signature": "(cwd: Path, issue_number: int, quiet: bool, resume_existing: bool) -> Tuple[Optional[Path], Optional[str]]",
-            "returns": "Tuple[Optional[Path], Optional[str]]",
-            "sideEffects": [
-              "Creates git worktree and branch"
-            ]
-          },
-          {
-            "name": "_setup_pr_worktree",
-            "signature": "(cwd: Path, pr_owner: str, pr_repo: str, pr_number: int, quiet: bool, resume_existing: bool = False) -> Tuple[Optional[Path], Optional[str]]",
-            "returns": "Tuple[Optional[Path], Optional[str]]",
-            "sideEffects": [
-              "Fetches PR head",
-              "Creates git worktree for the existing PR branch using a checkout-scoped local branch name"
-            ]
-          },
-          {
-            "name": "_fetch_pr_metadata",
-            "signature": "(owner: str, repo: str, pr_number: int) -> Dict[str, str]",
-            "returns": "Dict[str, str]",
-            "sideEffects": [
-              "Reads pull request metadata through GitHub CLI",
-              "Includes prompt-ready GitHub PR files API changed-file lines for degraded PR-scoped test context",
-              "Bounds API fallback changed-file context with PR_API_CHANGED_FILES_MAX_LINES and PR_API_CHANGED_FILES_MAX_CHARS",
-              "Preserves the complete API changed-file list as api_changed_files_full when the prompt preview is truncated"
-            ]
-          },
-          {
-            "name": "_commit_and_push_if_changed",
-            "signature": "(worktree: Path, pr_metadata: Dict[str, str], message: str) -> Tuple[bool, str]",
-            "returns": "Tuple[bool, str]",
-            "sideEffects": [
-              "May create a commit and push it to the PR head branch"
-            ]
-          },
-          {
-            "name": "_git_changed_files",
-            "signature": "(worktree: Path) -> List[str]",
-            "returns": "List[str]",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_git_rev_parse_head",
-            "signature": "(worktree: Path) -> str",
-            "returns": "str",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_check_prompt_source_guard",
-            "signature": "(worktree: Path, changed_files: List[str]) -> Optional[str]",
-            "returns": "Optional[str]",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_check_architecture_registry_edit_guard",
-            "signature": "(worktree: Path, changed_files: List[str]) -> Optional[str]",
-            "returns": "Optional[str]",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_parse_changed_files",
-            "signature": "(output: str) -> List[str]",
-            "returns": "List[str]",
-            "sideEffects": [
-              "None"
-            ]
-          },
-          {
-            "name": "_build_state",
-            "signature": "(issue_number: int, issue_url: str, last_completed_step: Union[int, float], step_outputs: Dict[str, str], total_cost: float, model_used: str, github_comment_id: Optional[int], changed_files: Optional[List[str]] = None, worktree_path: Optional[Path] = None, fix_verify_iteration: int = 0, previous_fixes: str = \"\", mode: str = \"issue\", pr_number: Optional[int] = None, pr_owner: Optional[str] = None, pr_repo: Optional[str] = None, pr_head_sha: Optional[str] = None, pr_test_scope: Optional[str] = None, step_comments: Optional[List[int]] = None, step_telemetry: Optional[List[dict]] = None) -> Dict",
-            "returns": "Dict",
-            "sideEffects": [
-              "None"
-            ]
+            "returns": "Tuple[bool, str, float, str]"
           }
         ]
       }
@@ -10385,7 +10201,7 @@
   },
   {
     "reason": "Shared blocking quality gate that drift-syncs and build/smoke-verifies a PR for pre-checkup or fix-final validation.",
-    "description": "A blocking quality gate shared by PR-producing orchestrators. The change/feature orchestrator runs it immediately before handing off to `pdd checkup --pr`; the fix/bug e2e orchestrator runs it as the final deterministic verification before returning success. Runs two ordered phases against the PR worktree and returns a single hard pass/fail the caller uses to block checkup handoff for change callers or success return for fix callers. Phase 1 (drift-sync) brings code, prompt, architecture.json and .pdd/meta into sync in the worktree via run_metadata_sync / sync_all_prompts_to_architecture / detect_drift+heal_module, then re-detects to confirm. .pdd/meta fingerprints written here via run_metadata_sync cover prompt+code only (example/test hashes are null), so canonical fingerprint finalization belongs to the post-merge sync (#1317): BOTH orchestrator paths defer it \u2014 the fix path filters .pdd/** from its commit, the change path restores tracked .pdd/meta after the gate \u2014 so the PR tree may still show fingerprint drift until the post-merge sync completes it. Phase 2 (build/smoke) runs deterministic per-file checks (py_compile/ruff/tsc) plus a project smoke layer (import changed modules, route/router-object probe, caller-compatibility sweep over both from-import and alias-import call sites, git-diff-targeted unit tests including directly-changed test files) and hard-blocks on any red result. Closes the vacuous-pass hole in run_ci_validation_loop by running its own checks rather than only polling GitHub required checks; preserves the fork-PR-RCE constraint by delegating to checkup_gates._script_is_acceptable, which runs only validated, safe package.json scripts (never build scripts) and skips the npm-family path entirely when the PR touches package.json / a package-manager config; the gate adds no command execution of its own beyond that allowlist. For checkup-bound callers it prepares the PR for cross-model review; for `pdd fix`, `pdd checkup --pr --issue --final-gate` remains a separate explicit command. Docs-only diffs short-circuit; strict mode reuses PDD_STRICT_DOC_SYNC (issue #1293).",
+    "description": "A blocking quality gate shared by PR-producing orchestrators. The change/feature orchestrator runs it immediately before handing off to `pdd checkup --pr`; the fix/bug e2e orchestrator runs it as the final deterministic verification before returning success. Runs two ordered phases against the PR worktree and returns a single hard pass/fail the caller uses to block checkup handoff for change callers or success return for fix callers. Phase 1 (drift-sync) brings code, prompt, architecture.json and .pdd/meta into sync in the worktree via run_metadata_sync / sync_all_prompts_to_architecture / detect_drift+heal_module, then re-detects to confirm. .pdd/meta fingerprints written here via run_metadata_sync cover prompt+code only (example/test hashes are null), so canonical fingerprint finalization belongs to the post-merge sync (#1317): BOTH orchestrator paths defer it — the fix path filters .pdd/** from its commit, the change path restores tracked .pdd/meta after the gate — so the PR tree may still show fingerprint drift until the post-merge sync completes it. Phase 2 (build/smoke) runs deterministic per-file checks (py_compile/ruff/tsc) plus a project smoke layer (import changed modules, route/router-object probe, caller-compatibility sweep over both from-import and alias-import call sites, git-diff-targeted unit tests including directly-changed test files) and hard-blocks on any red result. Closes the vacuous-pass hole in run_ci_validation_loop by running its own checks rather than only polling GitHub required checks; preserves the fork-PR-RCE constraint by delegating to checkup_gates._script_is_acceptable, which runs only validated, safe package.json scripts (never build scripts) and skips the npm-family path entirely when the PR touches package.json / a package-manager config; the gate adds no command execution of its own beyond that allowlist. For checkup-bound callers it prepares the PR for cross-model review; for `pdd fix`, `pdd checkup --pr --issue --final-gate` remains a separate explicit command. Docs-only diffs short-circuit; strict mode reuses PDD_STRICT_DOC_SYNC (issue #1293).",
     "dependencies": [
       "checkup_gates_python.prompt",
       "ci_drift_heal_python.prompt",

--- a/context/agentic_checkup_orchestrator_example.py
+++ b/context/agentic_checkup_orchestrator_example.py
@@ -1,119 +1,112 @@
+from __future__ import annotations
+
 import os
 import sys
-import shutil
-import subprocess
 from pathlib import Path
-from unittest.mock import patch
+from rich.console import Console
 
-# Ensure the workspace packages are discoverable
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+# Dynamically configure the import path to locate 'pdd' relative to this script
+script_dir = Path(__file__).resolve().parent
+project_root = script_dir.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
 
 from pdd.agentic_checkup_orchestrator import run_agentic_checkup_orchestrator
 
-def setup_mock_git_repository(target_dir: Path) -> None:
-    """Set up a mock git repository with required configuration files."""
-    target_dir.mkdir(parents=True, exist_ok=True)
-    
-    # Initialize Git
-    subprocess.run(["git", "init"], cwd=target_dir, capture_output=True, check=True)
-    subprocess.run(["git", "config", "user.name", "pdd-bot"], cwd=target_dir, check=True)
-    subprocess.run(["git", "config", "user.email", "bot@promptdriven.dev"], cwd=target_dir, check=True)
-    
-    # Write mock project files
-    (target_dir / "architecture.json").write_text("{\"modules\": []}", encoding="utf-8")
-    (target_dir / ".pddrc").write_text("# PDD Config", encoding="utf-8")
-    (target_dir / "main.py").write_text("def hello(): pass\n", encoding="utf-8")
-    
-    # Commit base files
-    subprocess.run(["git", "add", "."], cwd=target_dir, check=True)
-    subprocess.run(["git", "commit", "-m", "initial commit"], cwd=target_dir, check=True)
+console = Console()
 
 def main() -> None:
-    print("[PDD Orchestrator Example] Starting setup...")
+    """
+    Concise example of invoking the agentic checkup orchestrator in non-interactive PR mode.
     
-    # Setup output directory and repo relative to script location
-    output_dir = Path(__file__).resolve().parent / "output"
-    mock_repo_dir = output_dir / "mock_repo"
-    
-    if output_dir.exists():
-        shutil.rmtree(output_dir, ignore_errors=True)
+    Parameters of `run_agentic_checkup_orchestrator`:
+      - issue_url: URL to the source issue (or empty string/"null" for merit-only PR verification)
+      - issue_content: Raw text content describing the target issue
+      - repo_owner: Owner of the repository (e.g. "pdd-org")
+      - repo_name: Name of the repository (e.g. "pdd-core")
+      - issue_number: Number of the issue or PR (used for state-comment threads)
+      - issue_title: Headline of the issue
+      - architecture_json: Serialized structural metadata of the project modules
+      - pddrc_content: Raw text content of the project configuration (.pddrc)
+      
+      Keyword-Only Parameters:
+        - cwd: Path to the local repository checkout root (Path)
+        - verbose: Enable detailed execution logs (bool)
+        - quiet: Disable standard output logs (bool)
+        - no_fix: Run in analysis/verification mode only (no automatic git commits/pushes) (bool)
+        - timeout_adder: Extra time in seconds to add to per-step ceilings (float)
+        - use_github_state: Persist workflow checkpoint markers as GitHub issue comments (bool)
+        - reasoning_time: Optional reasoning model budget setting (float)
+        - pr_url: URL of the associated Pull Request (str)
+        - pr_owner: Repository owner of the PR branch (str)
+        - pr_repo: Repository name of the PR branch (str)
+        - pr_number: Number of the Pull Request (int)
+        - test_scope: Testing depth limit ("full" or "targeted") (str)
+        - start_step_override: Force workflow entry at a specific step (float/int)
         
-    setup_mock_git_repository(mock_repo_dir)
+    Returns:
+      - Tuple[bool, str, float, str]:
+        1. success (bool): True if the code successfully verified or was repaired cleanly.
+        2. message (str): Explanation of the terminal status or gate outcome.
+        3. total_cost (float): Total cumulative cost of downstream LLM API invocations (in USD).
+        4. model_used (str): Name of the highest-order model utilized in the run.
+    """
+    console.print("[bold blue]--- Running Agentic Checkup Orchestrator Example ---")
 
-    # Required Inputs
-    issue_url = "https://github.com/example-org/example-repo/issues/42"
-    issue_content = "The hello() function needs documentation and a robust test."
-    repo_owner = "example-org"
-    repo_name = "example-repo"
-    issue_number = 42
-    issue_title = "Document hello function"
-    
-    # Setup mock architecture and pddrc contexts
-    architecture_json = "{\"project\": \"mock-project\", \"interfaces\": []}"
-    pddrc_content = "# Mock PDD Rules\nmax_iterations = 3"
+    # Guard against missing essential environment variables (e.g., GitHub tokens or LLM credentials)
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if not github_token:
+        console.print("[yellow]GITHUB_TOKEN environment variable is not set. Real API calls will fail.[/yellow]")
+        console.print("Set GITHUB_TOKEN to execute this orchestrator against real repository targets. Exiting gracefully.")
+        sys.exit(0)
 
-    print("[PDD Orchestrator Example] Mocking LLM task executor...")
-    # Mock 'run_agentic_task' to simulate LLM interaction without invoking live API keys
-    mock_task_response = (
-        True,  # Success
-        """<step_report>
-### Analysis Complete
-Analyzed repository structure. Found hello() function missing docstring.
-</step_report>
+    # Setup mock input variables and mock workspace in './output'
+    workspace_dir = Path("./output/example-sandbox")
+    workspace_dir.mkdir(parents=True, exist_ok=True)
 
-```failure_signal
-status: pass
-exit_code: 0
-command: pytest
-failing_ids: none
-artifact_path: none
-output: |
-  All tests passed successfully.
-```
-All Issues Fixed""",
-        0.045,  # Accumulated token cost in USD
-        "gpt-4o"  # Model used
+    # Initialize a dummy git repository in the workspace to satisfy git repository checking
+    import subprocess
+    try:
+        subprocess.run(["git", "init"], cwd=workspace_dir, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.name", "pdd-bot"], cwd=workspace_dir, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.email", "bot@promptdriven.dev"], cwd=workspace_dir, capture_output=True, check=True)
+        # Write a placeholder file to commit
+        (workspace_dir / "README.md").write_text("# Example Sandbox Project\n", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], cwd=workspace_dir, capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "initial commit"], cwd=workspace_dir, capture_output=True, check=True)
+    except (subprocess.SubprocessError, FileNotFoundError) as e:
+        console.print(f"[red]Could not initialize mock git repository: {e}[/red]")
+        sys.exit(0)
+
+    # Formulate mock architecture and configurations
+    architecture_json = "{\"modules\": {\"core\": {\"path\": \"src/core.py\"}}}"
+    pddrc_content = "[pdd]\ntest_command = \"python -m pytest\""
+
+    # Trigger the checkup pipeline
+    # Using --no-fix and local-only settings for safe demonstration
+    success, final_message, cost, model = run_agentic_checkup_orchestrator(
+        issue_url="",
+        issue_content="Verify module boundaries and interface compatibility.",
+        repo_owner="promptdriven",
+        repo_name="pdd",
+        issue_number=42,
+        issue_title="Verify API Interfaces",
+        architecture_json=architecture_json,
+        pddrc_content=pddrc_content,
+        cwd=workspace_dir,
+        verbose=True,
+        quiet=False,
+        no_fix=True,  # Run validation without writing back or creating PRs
+        use_github_state=False,  # Local workflow files state tracking only
+        test_scope="targeted",
+        start_step_override=1,  # Begin immediately at Step 1 (Discovery)
     )
 
-    with patch("pdd.agentic_checkup_orchestrator.run_agentic_task", return_value=mock_task_response):
-        print("[PDD Orchestrator Example] Running checkup in '--no-fix' mode...")
-        
-        # Invoke the orchestrator
-        # Inputs:
-        #   - issue_url / issue_content: context for verification
-        #   - repo_owner / repo_name / issue_number: GitHub tracking coordinate details
-        #   - cwd: Directory containing the git workspace
-        #   - no_fix: True to run checks without applying workspace modifications
-        # Outputs:
-        #   - success (bool): True if the checkup completed cleanly and passed all validation gates
-        #   - message (str): Summary or final validation status
-        #   - total_cost (float): Accumulated LLM execution cost (in USD)
-        #   - model_used (str): The primary LLM used during execution
-        success, message, total_cost, model_used = run_agentic_checkup_orchestrator(
-            issue_url=issue_url,
-            issue_content=issue_content,
-            repo_owner=repo_owner,
-            repo_name=repo_name,
-            issue_number=issue_number,
-            issue_title=issue_title,
-            architecture_json=architecture_json,
-            pddrc_content=pddrc_content,
-            cwd=mock_repo_dir,
-            verbose=False,
-            quiet=True,
-            no_fix=True,  # Do not modify files
-            use_github_state=False  # Do not attempt actual GitHub API state comments
-        )
-
-        print("\n=== Orchestrator Results ===")
-        print(f"Success Flag : {success}")
-        print(f"Model Used   : {model_used}")
-        print(f"Total Cost   : ${total_cost:.4f} USD")
-        print(f"Message      : {message[:120]}...")
-
-    # Cleanup mock directory
-    shutil.rmtree(output_dir, ignore_errors=True)
-    print("\n[PDD Orchestrator Example] Cleaned up temp assets. Run complete.")
+    console.print("\n[bold green]--- Orchestration Completed ---")
+    console.print(f"Success Status: [bold]{success}[/bold]")
+    console.print(f"Final Outcome Message: {final_message}")
+    console.print(f"Downstream API Cost: ${cost:.6f} USD")
+    console.print(f"Primary LLM Model Used: [blue]{model}[/bold]")
 
 if __name__ == "__main__":
     main()

--- a/context/agentic_checkup_orchestrator_example.py
+++ b/context/agentic_checkup_orchestrator_example.py
@@ -1,118 +1,95 @@
-import json
 import os
+import sys
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
-# Ensure the parent directory is in the sys.path so we can import from the 'pdd' package
-current_dir = Path(os.path.dirname(os.path.abspath(__file__)))
-project_root = current_dir.parent
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
+# Ensure the workspace packages are discoverable
+sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from pdd.agentic_checkup_orchestrator import run_agentic_checkup_orchestrator
 
-
-def setup_mock_environment(temp_dir: Path) -> None:
-    """Initializes a temporary git repository with mock files for the checkup."""
-    temp_dir.mkdir(parents=True, exist_ok=True)
-
-    # Initialize Git repository
-    subprocess.run(["git", "init"], cwd=temp_dir, capture_output=True, check=True)
-    subprocess.run(["git", "config", "user.name", "Test Bot"], cwd=temp_dir, check=True)
-    subprocess.run(["git", "config", "user.email", "bot@example.com"], cwd=temp_dir, check=True)
-
-    # Create a basic codebase file
-    code_file = temp_dir / "main.py"
-    code_file.write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
-
-    # Create a basic test file
-    test_file = temp_dir / "test_main.py"
-    test_file.write_text("def test_add():\n    from main import add\n    assert add(1, 2) == 3\n", encoding="utf-8")
-
-    # Commit initial repository structure
-    subprocess.run(["git", "add", "."], cwd=temp_dir, check=True)
-    subprocess.run(["git", "commit", "-m", "initial commit"], cwd=temp_dir, check=True)
-
+def setup_mock_git_repository(target_dir: Path) -> None:
+    """Set up a mock git repository with required configuration files."""
+    target_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Initialize Git
+    subprocess.run(["git", "init"], cwd=target_dir, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "pdd-bot"], cwd=target_dir, check=True)
+    subprocess.run(["git", "config", "user.email", "bot@promptdriven.dev"], cwd=target_dir, check=True)
+    
+    # Write mock project files
+    (target_dir / "architecture.json").write_text("{\"modules\": []}", encoding="utf-8")
+    (target_dir / ".pddrc").write_text("# PDD Config", encoding="utf-8")
+    (target_dir / "main.py").write_text("def hello(): pass\n", encoding="utf-8")
+    
+    # Commit base files
+    subprocess.run(["git", "add", "."], cwd=target_dir, check=True)
+    subprocess.run(["git", "commit", "-m", "initial commit"], cwd=target_dir, check=True)
 
 def main() -> None:
-    """Demonstrates executing the agentic checkup orchestrator."""
-    output_dir = current_dir / "output"
-    repo_dir = output_dir / "mock_repo"
-
-    # Clean up any stale output directories
-    if output_dir.exists():
-        shutil.rmtree(output_dir)
-
-    setup_mock_environment(repo_dir)
-
-    # Mock inputs for the orchestrator
-    issue_url = "https://github.com/example-owner/example-repo/issues/101"
-    issue_content = "Fix addition logic in main.py"
-    repo_owner = "example-owner"
-    repo_name = "example-repo"
-    issue_number = 101
-    issue_title = "Fix add function"
+    print("[PDD Orchestrator Example] Starting setup...")
     
-    # Define simple mock project metadata
-    architecture_json = json.dumps({
-        "modules": {"main": {"dependencies": []}}
-    })
-    pddrc_content = "[pdd]\nlang = python\n"
-
-    print(f"[Orchestrator] Starting checkup in mock repo: {repo_dir}")
-
-    # Mock the run_agentic_task function to simulate successful LLM responses for each step.
-    # This prevents real LLM pricing cost and API key dependency during the run.
-    def mock_run_agentic_task(*args, **kwargs):
-        label = kwargs.get("label", "unknown_step")
-        print(f"  -> [LLM Mock] Running task for: {label}")
+    # Setup output directory and repo relative to script location
+    output_dir = Path(__file__).resolve().parent / "output"
+    mock_repo_dir = output_dir / "mock_repo"
+    
+    if output_dir.exists():
+        shutil.rmtree(output_dir, ignore_errors=True)
         
-        # Step 7 (Verify) requires a specific structured report to pass the gate
-        if "step7" in label:
-            step7_output = """<step_report>
-Verification Summary:
-All tests passed successfully!
-</step_report>
-```json
-{
-  "success": true,
-  "issue_aligned": true,
-  "issues": []
-}
-```"""
-            return True, step7_output, 0.0015, "mock-gpt-4o"
-        
-        # Default success report with expected XML tag wrapping
-        success_report = """<step_report>
-Step completed successfully.
-</step_report>
-"""
-        return True, success_report, 0.0005, "mock-gpt-4o"
+    setup_mock_git_repository(mock_repo_dir)
 
-    # Patch the per-step LLM runner so the example never makes real API calls.
-    # `use_github_state=False` skips state read/write, but the orchestrator still
-    # posts trusted per-step / PR comments and seeds the steering cursor, which
-    # hit the GitHub API. With fake repo metadata those calls 404, so we also
-    # stub the comment-posting and steer-seed helpers to keep the example fully
-    # offline. The orchestrator still drives its real 8-step state machine
-    # against the local mock git repository created above.
-    with patch(
-        "pdd.agentic_checkup_orchestrator.run_agentic_task",
-        side_effect=mock_run_agentic_task,
-    ), patch(
-        "pdd.agentic_checkup_orchestrator.post_step_comment_once", return_value=None
-    ), patch(
-        "pdd.agentic_checkup_orchestrator.post_step_comment", return_value=True
-    ), patch(
-        "pdd.agentic_checkup_orchestrator.post_pr_comment", return_value=True
-    ), patch(
-        "pdd.agentic_checkup_orchestrator.ensure_issue_steer_cursor_seeded",
-        return_value=True,
-    ):
-        success, _message, _cost, _model = run_agentic_checkup_orchestrator(
+    # Required Inputs
+    issue_url = "https://github.com/example-org/example-repo/issues/42"
+    issue_content = "The hello() function needs documentation and a robust test."
+    repo_owner = "example-org"
+    repo_name = "example-repo"
+    issue_number = 42
+    issue_title = "Document hello function"
+    
+    # Setup mock architecture and pddrc contexts
+    architecture_json = "{\"project\": \"mock-project\", \"interfaces\": []}"
+    pddrc_content = "# Mock PDD Rules\nmax_iterations = 3"
+
+    print("[PDD Orchestrator Example] Mocking LLM task executor...")
+    # Mock 'run_agentic_task' to simulate LLM interaction without invoking live API keys
+    mock_task_response = (
+        True,  # Success
+        """<step_report>
+### Analysis Complete
+Analyzed repository structure. Found hello() function missing docstring.
+</step_report>
+
+```failure_signal
+status: pass
+exit_code: 0
+command: pytest
+failing_ids: none
+artifact_path: none
+output: |
+  All tests passed successfully.
+```
+All Issues Fixed""",
+        0.045,  # Accumulated token cost in USD
+        "gpt-4o"  # Model used
+    )
+
+    with patch("pdd.agentic_checkup_orchestrator.run_agentic_task", return_value=mock_task_response):
+        print("[PDD Orchestrator Example] Running checkup in '--no-fix' mode...")
+        
+        # Invoke the orchestrator
+        # Inputs:
+        #   - issue_url / issue_content: context for verification
+        #   - repo_owner / repo_name / issue_number: GitHub tracking coordinate details
+        #   - cwd: Directory containing the git workspace
+        #   - no_fix: True to run checks without applying workspace modifications
+        # Outputs:
+        #   - success (bool): True if the checkup completed cleanly and passed all validation gates
+        #   - message (str): Summary or final validation status
+        #   - total_cost (float): Accumulated LLM execution cost (in USD)
+        #   - model_used (str): The primary LLM used during execution
+        success, message, total_cost, model_used = run_agentic_checkup_orchestrator(
             issue_url=issue_url,
             issue_content=issue_content,
             repo_owner=repo_owner,
@@ -121,27 +98,22 @@ Step completed successfully.
             issue_title=issue_title,
             architecture_json=architecture_json,
             pddrc_content=pddrc_content,
-            cwd=repo_dir,
-            verbose=True,
-            quiet=False,
-            no_fix=True,            # Report only — do not generate/push fixes
-            use_github_state=False,  # Stay offline: no GitHub state posting
+            cwd=mock_repo_dir,
+            verbose=False,
+            quiet=True,
+            no_fix=True,  # Do not modify files
+            use_github_state=False  # Do not attempt actual GitHub API state comments
         )
 
-    # The orchestrator returns (success, message, total_cost, model_used). The
-    # message/model/cost values can echo repo output, model identifiers, and
-    # other run context that static analysis treats as potentially sensitive,
-    # so this example does not print them as clear text. In real usage, route
-    # them through your logging/redaction layer instead of stdout. Here we only
-    # report a static pass/fail summary derived from the boolean result.
-    print("\n--- Checkup Result ---")
-    print("Checkup run completed successfully." if success
-          else "Checkup run completed with a non-passing result.")
+        print("\n=== Orchestrator Results ===")
+        print(f"Success Flag : {success}")
+        print(f"Model Used   : {model_used}")
+        print(f"Total Cost   : ${total_cost:.4f} USD")
+        print(f"Message      : {message[:120]}...")
 
-    # Clean up the generated output directory.
-    if output_dir.exists():
-        shutil.rmtree(output_dir)
-
+    # Cleanup mock directory
+    shutil.rmtree(output_dir, ignore_errors=True)
+    print("\n[PDD Orchestrator Example] Cleaned up temp assets. Run complete.")
 
 if __name__ == "__main__":
     main()

--- a/pdd/agentic_checkup_orchestrator.py
+++ b/pdd/agentic_checkup_orchestrator.py
@@ -101,6 +101,16 @@ STEP_ID_MAP: Dict[Union[int, float], str] = {
 # Maximum number of build-fix-verify loop iterations before giving up.
 MAX_FIX_VERIFY_ITERATIONS = 3
 
+# Bounded retries for an EMPTY Step 7 verify output. An empty/whitespace verify
+# output means the verify agent produced NO verdict at all — a transient
+# agent/provider failure — not an unparseable verdict. Without a retry, that
+# empty result is consumed as the "verdict", fails ``_step7_passed`` as
+# "empty step 7 output", and burns every fix-verify iteration until the run
+# terminally reports "did not verify all issues fixed". Retry the verify call a
+# few times so a flaky-empty response can still converge; if it stays empty,
+# route it as a retryable provider failure instead of a bogus empty verdict.
+STEP7_EMPTY_OUTPUT_MAX_RETRIES = 2
+
 # Issue #1116: when the remote PR head advances mid-checkup we discard the
 # stale work and restart the inner orchestrator against the new head. The
 # restart budget is bounded so a PR that keeps moving cannot make us loop
@@ -4393,6 +4403,65 @@ def _run_agentic_checkup_orchestrator_inner(
                     return (False, f"Missing prompt template: {tmpl_name}", total_cost, last_model_used)
 
                 success, output, cost, model = result
+
+                # Step 7 verify: gate on success AND non-empty output. An empty
+                # verify output = the agent produced NO verdict (a transient
+                # agent/provider failure), not an unparseable verdict. Retry the
+                # verify call (bounded) so a flaky-empty response can still
+                # converge; each discarded attempt's cost/telemetry is still
+                # recorded so ``sum(cost_usd)`` reconciles with ``total_cost``.
+                # If it stays empty after the retries, route it as a retryable
+                # provider failure ("agent providers unavailable") instead of
+                # consuming "" as a verdict that burns every fix-verify iteration
+                # and terminally fails "did not verify all issues fixed".
+                if step_num == 7:
+                    _s7_empty_retry = 0
+                    while (
+                        (not success or not (output or "").strip())
+                        and _s7_empty_retry < STEP7_EMPTY_OUTPUT_MAX_RETRIES
+                    ):
+                        _s7_empty_retry += 1
+                        _record_step_telemetry(
+                            step_num, "failed", name=description,
+                            cost=cost, model=model, iteration=fix_verify_iteration,
+                        )
+                        total_cost += cost
+                        if not quiet:
+                            console.print(
+                                "[yellow]Step 7 verify returned empty output "
+                                f"(retry {_s7_empty_retry}/"
+                                f"{STEP7_EMPTY_OUTPUT_MAX_RETRIES})…[/yellow]"
+                            )
+                        _mark_step_start(step_num, fix_verify_iteration)
+                        _s7_retry_result = _run_single_step(
+                            step_num, name, context,
+                            cwd=cwd, step_cwd=step_cwd,
+                            verbose=verbose, quiet=quiet,
+                            label=f"{iter_label}_emptyretry{_s7_empty_retry}",
+                            timeout_adder=timeout_adder,
+                            reasoning_time=reasoning_time,
+                            steers=_issue_step_steers() or None,
+                        )
+                        if _s7_retry_result is None:
+                            break
+                        success, output, cost, model = _s7_retry_result
+                    if not (output or "").strip():
+                        _record_step_telemetry(
+                            step_num, "failed", name=description,
+                            cost=cost, model=model, iteration=fix_verify_iteration,
+                        )
+                        total_cost += cost
+                        last_model_used = model or last_model_used
+                        _save_state()
+                        return (
+                            False,
+                            "Aborting: Step 7 verify produced empty output after "
+                            f"{STEP7_EMPTY_OUTPUT_MAX_RETRIES} retries - agent "
+                            "providers unavailable (no verdict was produced).",
+                            total_cost,
+                            last_model_used,
+                        )
+
                 abort = _handle_step_result(
                     step_num, success, output, cost, model,
                     description=description, iteration=fix_verify_iteration,

--- a/pdd/agentic_checkup_orchestrator.py
+++ b/pdd/agentic_checkup_orchestrator.py
@@ -4242,6 +4242,23 @@ def _run_agentic_checkup_orchestrator_inner(
         # from state; don't increment on the first pass.
         resuming_mid_iteration = fix_verify_iteration > 0
 
+        # A resume whose restored ``fix_verify_iteration`` already reached
+        # ``MAX_FIX_VERIFY_ITERATIONS`` came from a prior run that EXHAUSTED the
+        # loop (e.g. an empty-Step-7 run that gave up). Left as-is, the
+        # ``while fix_verify_iteration < MAX`` guard below is immediately false,
+        # so NO step re-runs and the stale cached verdict is re-emitted verbatim
+        # — defeating resume / "run til green" (a resumed, previously-exhausted
+        # run must re-attempt the loop, not instantly re-fail on a cached
+        # empty/failed Step 7). Reset to a fresh set of iterations and drop the
+        # stale cached Step 7 so the loop actually runs again (the per-step
+        # retry/verdict logic then decides the real outcome).
+        if fix_verify_iteration >= MAX_FIX_VERIFY_ITERATIONS:
+            fix_verify_iteration = 0
+            resuming_mid_iteration = False
+            step_outputs.pop("7", None)
+            if start_step > 7:
+                start_step = 3
+
         # Bug B fix: between-iterations resume.
         # If start_step > 7 and we're mid-loop, the previous iteration's
         # step 7 completed without "All Issues Fixed" — start a fresh

--- a/pdd/checkup_review_loop.py
+++ b/pdd/checkup_review_loop.py
@@ -6398,8 +6398,37 @@ Required actions:
 3. Keep the generated code consistent with the repaired prompt (the loop will
    regenerate it; leave your code edit in place so it is not lost if
    regeneration is skipped).
+4. The owning prompt must describe exactly ONE generated file (the module it
+   owns). Do NOT embed other files' contents (e.g. a test file) or instruct
+   the generator to emit additional files — regeneration writes a single
+   file, and a multi-file response would paste foreign content into the
+   module.
 
 Report the prompt files you edited. Do not open a PR or run git push."""
+
+
+# Issue #1802: a comment line naming a path (e.g. ``# tests/test_x.py``) that
+# is not the module being regenerated marks a multi-file generation response
+# that the extraction stage concatenated into one blob. Writing that blob to
+# the module file pastes foreign files (typically the test file) into
+# production code, and the SoT-repair loop then re-pastes it every round the
+# guard fires — the review loop can never converge. Require at least one
+# directory separator so ordinary ``# comment.txt``-style prose is not caught.
+_FOREIGN_FILE_HEADER_RE = re.compile(r"^#\s*((?:[\w.-]+/)+[\w.-]+\.[A-Za-z]{1,4})\s*$")
+
+
+def _regen_output_names_foreign_file(content: str, code_path: str) -> bool:
+    """True when ``content`` contains a file-header comment for another file.
+
+    ``code_path`` is worktree-relative; a header naming the module itself is
+    fine (generators conventionally open with ``# app/module.py``).
+    """
+    code_norm = Path(code_path).as_posix()
+    for line in content.splitlines():
+        match = _FOREIGN_FILE_HEADER_RE.match(line.strip())
+        if match and Path(match.group(1)).as_posix() != code_norm:
+            return True
+    return False
 
 
 def _regenerate_module_from_prompt(
@@ -6421,6 +6450,15 @@ def _regenerate_module_from_prompt(
     code_abs = worktree / code_path
     if not prompt_abs.is_file():
         return {"ok": False, "cost": 0.0, "model": "", "error": "prompt missing"}
+    # Issue #1802: snapshot the pre-regeneration module so a rejected
+    # multi-file blob can be rolled back instead of clobbering the fixer's
+    # last committed edit.
+    pre_regen_code: Optional[str] = None
+    if code_abs.is_file():
+        try:
+            pre_regen_code = code_abs.read_text(encoding="utf-8")
+        except OSError:
+            pre_regen_code = None
     prev_cwd = os.getcwd()
     try:
         # Lazy imports: code_generator_main pulls in the heavy generation
@@ -6439,11 +6477,30 @@ def _regenerate_module_from_prompt(
             output_from_config=False,
         )
         ok = bool(code and code.strip())
+        error = "" if ok else "regeneration produced empty code"
+        if ok:
+            try:
+                written = code_abs.read_text(encoding="utf-8")
+            except OSError:
+                written = str(code or "")
+            if _regen_output_names_foreign_file(written, code_path):
+                # Issue #1802: the extraction stage concatenated a multi-file
+                # generation response; writing it would paste foreign files
+                # (e.g. the test module) into this module. Restore the
+                # snapshot and fail soft — the caller proceeds on the
+                # co-edited prompt alone.
+                if pre_regen_code is not None:
+                    code_abs.write_text(pre_regen_code, encoding="utf-8")
+                ok = False
+                error = (
+                    "regeneration emitted multiple files (foreign file header "
+                    "detected); restored pre-regeneration module"
+                )
         return {
             "ok": ok,
             "cost": float(cost or 0.0),
             "model": model or "",
-            "error": "" if ok else "regeneration produced empty code",
+            "error": error,
         }
     except Exception as exc:  # noqa: BLE001 — fail-soft by contract
         return {"ok": False, "cost": 0.0, "model": "", "error": str(exc)[:300]}

--- a/pdd/checkup_review_loop.py
+++ b/pdd/checkup_review_loop.py
@@ -6407,7 +6407,7 @@ Required actions:
 Report the prompt files you edited. Do not open a PR or run git push."""
 
 
-# Issue #1802: a comment line naming a path (e.g. ``# tests/test_x.py``) that
+# Issue #1823: a comment line naming a path (e.g. ``# tests/test_x.py``) that
 # is not the module being regenerated marks a multi-file generation response
 # that the extraction stage concatenated into one blob. Writing that blob to
 # the module file pastes foreign files (typically the test file) into
@@ -6450,7 +6450,7 @@ def _regenerate_module_from_prompt(
     code_abs = worktree / code_path
     if not prompt_abs.is_file():
         return {"ok": False, "cost": 0.0, "model": "", "error": "prompt missing"}
-    # Issue #1802: snapshot the pre-regeneration module so a rejected
+    # Issue #1823: snapshot the pre-regeneration module so a rejected
     # multi-file blob can be rolled back instead of clobbering the fixer's
     # last committed edit.
     pre_regen_code: Optional[str] = None
@@ -6484,7 +6484,7 @@ def _regenerate_module_from_prompt(
             except OSError:
                 written = str(code or "")
             if _regen_output_names_foreign_file(written, code_path):
-                # Issue #1802: the extraction stage concatenated a multi-file
+                # Issue #1823: the extraction stage concatenated a multi-file
                 # generation response; writing it would paste foreign files
                 # (e.g. the test module) into this module. Restore the
                 # snapshot and fail soft — the caller proceeds on the

--- a/pdd/prompts/extract_code_LLM.prompt
+++ b/pdd/prompts/extract_code_LLM.prompt
@@ -15,6 +15,7 @@
     - Should be properly PEP 8, if Python, formatted and indented with the proper naming conventions.
     - Never add example calling unless it is already in the code block and if it is a submodule have the conditional main execution for the example.
     - All the functionality of the code block should still be present.
+    - If the llm_output contains more than one FILE — separate code blocks each introduced by a comment line naming a distinct file path (e.g. `# tests/test_x.py` or `# app/module.py`) — extract ONLY the primary file that is the focus of the generation. NEVER concatenate different files into 'extracted_code'; content belonging to another file path must be dropped.
 
 % Output a JSON object with the following keys:
     - 'focus': String containing the focus of the generation.

--- a/tests/test_agentic_checkup_orchestrator.py
+++ b/tests/test_agentic_checkup_orchestrator.py
@@ -14,6 +14,7 @@ import pytest
 from pdd.agentic_checkup_orchestrator import (
     CHECKUP_STEP_TIMEOUTS,
     MAX_FIX_VERIFY_ITERATIONS,
+    STEP7_EMPTY_OUTPUT_MAX_RETRIES,
     STEP_ID_MAP,
     STEP_ORDER,
     TOTAL_STEPS,
@@ -7621,3 +7622,67 @@ class TestReportTelemetryEmbedding:
         )
         assert "Plain-text verdict" in body
         assert "Per-Step Telemetry" in body
+
+
+# ---------------------------------------------------------------------------
+# Step 7 empty verify output — retry + provider-failure routing (regression).
+#
+# An empty/whitespace Step 7 verify output means the verify agent produced NO
+# verdict — a transient agent/provider failure — not an unparseable verdict.
+# The orchestrator must (a) retry the verify call, and (b) if it stays empty,
+# route it as a retryable provider failure, rather than consuming "" as a
+# verdict that burns every fix-verify iteration and terminally reports
+# "did not verify all issues fixed".
+# ---------------------------------------------------------------------------
+
+
+class TestStep7EmptyOutput:
+    def test_empty_step7_retries_then_routes_as_provider_failure(
+        self, mock_dependencies, default_args
+    ):
+        mock_run, _, _, _ = mock_dependencies
+
+        def side_effect(*args, **kwargs):
+            label = kwargs.get("label", "")
+            if "step7" in label:
+                return (True, "   ", 0.1, "gpt-4")  # whitespace-only == no verdict
+            return (True, "step done", 0.1, "gpt-4")
+
+        mock_run.side_effect = side_effect
+
+        success, msg, _cost, _model = run_agentic_checkup_orchestrator(**default_args)
+
+        assert success is False
+        assert "agent providers unavailable" in msg.lower()
+        assert "no verdict" in msg.lower()
+        # 1 initial verify attempt + STEP7_EMPTY_OUTPUT_MAX_RETRIES retries,
+        # then routed as a provider failure (never a 3-iteration "empty verdict").
+        step7_calls = [
+            c for c in mock_run.call_args_list if "step7" in c.kwargs.get("label", "")
+        ]
+        assert len(step7_calls) == 1 + STEP7_EMPTY_OUTPUT_MAX_RETRIES
+
+    def test_empty_step7_retry_recovers_and_converges(
+        self, mock_dependencies, default_args
+    ):
+        mock_run, _, _, _ = mock_dependencies
+        state = {"step7_calls": 0}
+
+        def side_effect(*args, **kwargs):
+            label = kwargs.get("label", "")
+            if "step7" in label:
+                state["step7_calls"] += 1
+                if state["step7_calls"] == 1:
+                    return (True, "", 0.1, "gpt-4")  # first verify empty (flaky)
+                return (True, ALL_ISSUES_FIXED, 0.1, "gpt-4")  # retry yields a verdict
+            return (True, "step done", 0.1, "gpt-4")
+
+        mock_run.side_effect = side_effect
+
+        success, msg, _cost, _model = run_agentic_checkup_orchestrator(**default_args)
+
+        # The retry recovered a real verdict, so the run converges instead of
+        # failing on an "empty step 7 output".
+        assert success is True
+        assert "Checkup complete" in msg
+        assert state["step7_calls"] == 2  # one empty + one recovering retry

--- a/tests/test_agentic_checkup_orchestrator.py
+++ b/tests/test_agentic_checkup_orchestrator.py
@@ -7686,3 +7686,68 @@ class TestStep7EmptyOutput:
         assert success is True
         assert "Checkup complete" in msg
         assert state["step7_calls"] == 2  # one empty + one recovering retry
+
+
+class TestResumeExhaustedIterationReset:
+    """A resume whose restored fix_verify_iteration already hit MAX must NOT
+    short-circuit the loop and re-emit the stale cached (empty) Step 7 verdict.
+    It must reset to a fresh set of iterations and actually re-run the steps.
+    """
+
+    def test_resume_with_exhausted_iteration_reruns_loop(self, tmp_path):
+        from unittest.mock import patch as _patch
+
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        # Prior run EXHAUSTED the loop on an empty Step 7 and saved that state.
+        cached_state = {
+            "mode": "pr",
+            "pr_number": 200,
+            "pr_owner": "o",
+            "pr_repo": "r",
+            "pr_head_sha": "deadbeef0000",
+            "last_completed_step": 2,
+            "fix_verify_iteration": MAX_FIX_VERIFY_ITERATIONS,  # exhausted
+            "step_outputs": {"1": "Discovered", "2": "Deps ok", "7": ""},  # cached empty Step 7
+            "changed_files": [],
+            "total_cost": 0.1,
+            "model_used": "fake",
+            "previous_fixes": "",
+        }
+        stable_metadata = {
+            "clone_url": "https://github.com/o/r.git",
+            "head_ref": "change/test",
+            "head_owner": "o",
+            "head_repo": "r",
+            "head_sha": "deadbeef0000",
+        }
+        calls = []
+
+        def run_step(step_num, _name, _ctx, **_kw):
+            calls.append(step_num)
+            # Every step (incl. Step 7) now returns a real verdict, so if the
+            # loop actually re-runs, the checkup converges instead of re-failing.
+            return (True, ALL_ISSUES_FIXED, 0.0, "fake")
+
+        with (
+            _patch("pdd.agentic_checkup_orchestrator._setup_pr_worktree", return_value=(wt, None)),
+            _patch("pdd.agentic_checkup_orchestrator._fetch_pr_metadata", return_value=stable_metadata),
+            _patch("pdd.agentic_checkup_orchestrator.load_workflow_state", return_value=(cached_state, None)),
+            _patch("pdd.agentic_checkup_orchestrator.save_workflow_state", return_value=None),
+            _patch("pdd.agentic_checkup_orchestrator.clear_workflow_state"),
+            _patch("pdd.agentic_checkup_orchestrator._run_single_step", side_effect=run_step),
+        ):
+            success, msg, _cost, _model = run_agentic_checkup_orchestrator(
+                issue_url="https://github.com/o/r/issues/99",
+                issue_content="stub", repo_owner="o", repo_name="r",
+                issue_number=99, issue_title="stub", architecture_json="{}",
+                pddrc_content="", cwd=tmp_path, verbose=False, quiet=True,
+                no_fix=False, timeout_adder=0.0, use_github_state=False,
+                pr_url="https://github.com/o/r/pull/200",
+                pr_owner="o", pr_repo="r", pr_number=200,
+            )
+
+        # The loop must have actually re-run Step 7 (proof it did not short-circuit).
+        assert 7 in calls, f"Step 7 never re-ran — loop was short-circuited. msg={msg!r}"
+        # And with a real verdict on re-run, it must not fail on 'empty step 7 output'.
+        assert "empty step 7 output" not in msg.lower(), f"Still re-emitted cached empty verdict: {msg!r}"

--- a/tests/test_checkup_review_loop.py
+++ b/tests/test_checkup_review_loop.py
@@ -13707,3 +13707,75 @@ class TestReviewLoopFailureCategory2047:
             _review_loop_failure_category(ReviewLoopState(), True, [sot])
             == FINAL_GATE_CATEGORY_PASSED
         )
+
+
+class TestRegenMultiFilePasteGuard:
+    """Issue #1802: regeneration must never write a concatenated multi-file
+    blob (module + ``# tests/...`` + test content) into the module file, and a
+    rejected blob must restore the pre-regeneration module so the fixer's
+    cleanup is not clobbered (the paste/re-paste thrash loop)."""
+
+    def test_foreign_file_header_detection(self):
+        from pdd.checkup_review_loop import _regen_output_names_foreign_file
+
+        pasted = (
+            "# app/async_helpers.py\n"
+            "async def fetch_data(url):\n"
+            "    return None\n"
+            "\n"
+            "# tests/test_async_helpers.py\n"
+            "import pytest\n"
+        )
+        assert _regen_output_names_foreign_file(pasted, "app/async_helpers.py")
+        own_only = "# app/async_helpers.py\nasync def fetch_data(url):\n    return None\n"
+        assert not _regen_output_names_foreign_file(own_only, "app/async_helpers.py")
+        plain = "# helper module\nx = 1\n# see notes.txt for details? no slash\n"
+        assert not _regen_output_names_foreign_file(plain, "app/mod.py")
+
+    def _run_regen(self, tmp_path, generated_blob):
+        import pdd.checkup_review_loop as mod
+
+        (tmp_path / "app").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "pdd/prompts").mkdir(parents=True, exist_ok=True)
+        code = tmp_path / "app/async_helpers.py"
+        code.write_text("# app/async_helpers.py\nCLEAN = True\n", encoding="utf-8")
+        (tmp_path / "pdd/prompts/async_helpers_python.prompt").write_text(
+            "prompt body\n", encoding="utf-8"
+        )
+
+        def fake_generator(ctx, *, prompt_file, output, **kwargs):
+            Path(output).write_text(generated_blob, encoding="utf-8")
+            return generated_blob, False, 0.1, "test-model"
+
+        import pdd.code_generator_main as cgm
+        import pdd.sync_orchestration as so
+
+        with patch.object(cgm, "code_generator_main", fake_generator), \
+                patch.object(so, "_create_mock_context", lambda **k: object()):
+            result = mod._regenerate_module_from_prompt(
+                tmp_path, "app/async_helpers.py", "pdd/prompts/async_helpers_python.prompt"
+            )
+        return result, code.read_text(encoding="utf-8")
+
+    def test_multi_file_blob_rejected_and_module_restored(self, tmp_path):
+        blob = (
+            "# app/async_helpers.py\n"
+            "async def fetch_data(url):\n"
+            "    return None\n"
+            "\n"
+            "# tests/test_async_helpers.py\n"
+            "import pytest\n"
+            "def test_x():\n"
+            "    assert True\n"
+        )
+        result, on_disk = self._run_regen(tmp_path, blob)
+        assert result["ok"] is False
+        assert "multiple files" in result["error"]
+        assert on_disk == "# app/async_helpers.py\nCLEAN = True\n"
+
+    def test_single_file_output_accepted(self, tmp_path):
+        blob = "# app/async_helpers.py\nasync def fetch_data(url):\n    return {}\n"
+        result, on_disk = self._run_regen(tmp_path, blob)
+        assert result["ok"] is True
+        assert result["error"] == ""
+        assert on_disk == blob

--- a/tests/test_checkup_review_loop.py
+++ b/tests/test_checkup_review_loop.py
@@ -13710,7 +13710,7 @@ class TestReviewLoopFailureCategory2047:
 
 
 class TestRegenMultiFilePasteGuard:
-    """Issue #1802: regeneration must never write a concatenated multi-file
+    """Issue #1823: regeneration must never write a concatenated multi-file
     blob (module + ``# tests/...`` + test content) into the module file, and a
     rejected blob must restore the pre-regeneration module so the fixer's
     cleanup is not clobbered (the paste/re-paste thrash loop)."""


### PR DESCRIPTION
Closes #1796.

Two distinct bugs produce the same symptom — `pdd-checkup` terminally failing with *"did not verify all issues fixed after 3 fix-verify iterations. Step 7 verdict JSON could not be parsed: empty step 7 output"* — and never converging (never "runs til green"):

### Bug 1 — empty Step 7 verify consumed as a verdict
An empty/whitespace Step 7 verify output means the agent produced **no verdict** (transient agent/provider failure), not an unparseable one. The loop consumed `""` as the verdict and repeated it all 3 iterations.
**Fix:** success + non-empty gating on Step 7 — retry the verify call up to `STEP7_EMPTY_OUTPUT_MAX_RETRIES` (=2) on empty output (cost/telemetry recorded per attempt); if still empty, route as a retryable provider failure (`agent providers unavailable — no verdict was produced`).

### Bug 2 — resume restores an EXHAUSTED iteration → loop skipped
A resume whose restored `fix_verify_iteration` already reached MAX made `while fix_verify_iteration < MAX` immediately false, so **no step re-ran** and the stale cached (empty) Step 7 verdict was re-emitted verbatim. This both defeats resume/"run til green" AND bypasses the Bug 1 retry (which lives inside the loop). Discovered on stg2: every resumed #802 run short-circuited with the cached `fix_verify_iteration=3`.
**Fix:** on resume, if `fix_verify_iteration >= MAX`, reset to a fresh set of iterations (drop the stale cached Step 7 + reset start_step) so the loop actually re-runs.

### Tests
`TestStep7EmptyOutput` (retry→converge, persistent→provider-failure abort) + `TestResumeExhaustedIterationReset` (resumed exhausted state re-runs Step 7). All verified fail-before/pass-after. **428 tests pass** locally (`test_agentic_checkup_orchestrator` + `test_final_pr_gate` + `test_checkup_pr_mode`), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)