### PR TITLE
EPIC: backfill story regression top PDD flows (#1703)

### DIFF
--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -34,3 +34,23 @@ required contract sections, rule coverage, and prompt links.
 Sub PRs target this EPIC branch and are merged here after deterministic local
 verification. The EPIC PR itself must not be merged into `main` until the full
 issue is reviewed and ready.
+
+Completed sub PRs:
+
+- #1801 — `pdd sync`: aligned the existing story contract hash and added the
+  deterministic top-flow story check.
+- #1802 — `pdd fix`: aligned the existing story contract hash and extended the
+  top-flow story check.
+- #1803 — `pdd change`: aligned the existing story contract hash and extended
+  the top-flow story check.
+- #1804 — `pdd generate`: added the missing story, contract, and top-flow story
+  check coverage.
+- #1806 — `pdd update`: added the missing story, contract, and top-flow story
+  check coverage.
+
+Final local verification:
+
+```bash
+python -m py_compile tests/test_story_backfill_top_flows.py
+python -c "import importlib.util; spec=importlib.util.spec_from_file_location('story_checks','tests/test_story_backfill_top_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_top_flow_story_backfill_artifacts_are_complete(); print('story backfill checks passed')"
+```

--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -20,6 +20,8 @@ The cross-dev-unit follow-up covers documented PDD workflows that naturally span
 more than one dev unit:
 
 - PRD-backed `pdd generate` output handed to `pdd sync`
+- Feature-request `pdd change` output carried through story/contract artifacts
+  and reviewable PR creation
 
 Cross-dev-unit stories use both `pdd-story-prompts` and `pdd-story-dev-units`
 metadata so the same story is attributed to every linked dev unit while still

--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -1,0 +1,36 @@
+# Story Regression Backfill
+
+Tracking document for issue #1703, the backfill phase of EPIC #1698.
+
+## Scope
+
+The first regression-story backfill covers the top single-dev-unit PDD workflow
+features called out by the issue and the workflow documentation:
+
+- `pdd generate`
+- `pdd sync`
+- `pdd fix`
+- `pdd change`
+- `pdd update`
+
+These are intentionally single-dev-unit stories. Cross-dev-unit stories are a
+follow-up phase.
+
+## Verification
+
+This backfill uses the existing PDD user-story file model:
+
+- human stories in `user_stories/story__*.md`
+- generated-style contract sidecars in `user_stories/contracts/*.contract.md`
+- `pdd-story-prompts` metadata linking each story to the owning prompt
+- `story-hash` metadata aligned with the human story text
+
+No LLM-backed PDD commands are required to verify this branch. Verification is
+deterministic and local: tests inspect the PDD story metadata, contract headers,
+required contract sections, rule coverage, and prompt links.
+
+## Sub PRs
+
+Sub PRs target this EPIC branch and are merged here after deterministic local
+verification. The EPIC PR itself must not be merged into `main` until the full
+issue is reviewed and ready.

--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -16,6 +16,15 @@ features called out by the issue and the workflow documentation:
 These are intentionally single-dev-unit stories. Cross-dev-unit stories are a
 follow-up phase.
 
+The cross-dev-unit follow-up covers documented PDD workflows that naturally span
+more than one dev unit:
+
+- PRD-backed `pdd generate` output handed to `pdd sync`
+
+Cross-dev-unit stories use both `pdd-story-prompts` and `pdd-story-dev-units`
+metadata so the same story is attributed to every linked dev unit while still
+counting as one global regression oracle.
+
 ## Verification
 
 This backfill uses the existing PDD user-story file model:
@@ -53,4 +62,6 @@ Final local verification:
 ```bash
 python -m py_compile tests/test_story_backfill_top_flows.py
 python -c "import importlib.util; spec=importlib.util.spec_from_file_location('story_checks','tests/test_story_backfill_top_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_top_flow_story_backfill_artifacts_are_complete(); print('story backfill checks passed')"
+python -m py_compile tests/test_story_backfill_cross_unit_flows.py
+python -c "import importlib.util; spec=importlib.util.spec_from_file_location('cross_story_checks','tests/test_story_backfill_cross_unit_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_cross_unit_story_backfill_artifacts_are_complete(); print('cross-unit story checks passed')"
 ```

--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -24,6 +24,7 @@ more than one dev unit:
   and reviewable PR creation
 - Bug-report `pdd bug` reproduction handed to `pdd fix` verification
 - Story-mode `pdd test` artifacts surfaced through `pdd checkup coverage`
+- Code-to-prompt `pdd update` results finalized through metadata synchronization
 
 Cross-dev-unit stories use both `pdd-story-prompts` and `pdd-story-dev-units`
 metadata so the same story is attributed to every linked dev unit while still

--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -23,6 +23,7 @@ more than one dev unit:
 - Feature-request `pdd change` output carried through story/contract artifacts
   and reviewable PR creation
 - Bug-report `pdd bug` reproduction handed to `pdd fix` verification
+- Story-mode `pdd test` artifacts surfaced through `pdd checkup coverage`
 
 Cross-dev-unit stories use both `pdd-story-prompts` and `pdd-story-dev-units`
 metadata so the same story is attributed to every linked dev unit while still

--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -22,6 +22,7 @@ more than one dev unit:
 - PRD-backed `pdd generate` output handed to `pdd sync`
 - Feature-request `pdd change` output carried through story/contract artifacts
   and reviewable PR creation
+- Bug-report `pdd bug` reproduction handed to `pdd fix` verification
 
 Cross-dev-unit stories use both `pdd-story-prompts` and `pdd-story-dev-units`
 metadata so the same story is attributed to every linked dev unit while still

--- a/tests/test_story_backfill_cross_unit_flows.py
+++ b/tests/test_story_backfill_cross_unit_flows.py
@@ -1,0 +1,144 @@
+"""Deterministic checks for cross-dev-unit user-story backfill."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STORIES_DIR = REPO_ROOT / "user_stories"
+CONTRACTS_DIR = STORIES_DIR / "contracts"
+PACKAGE_PROMPTS_DIR = REPO_ROOT / "pdd" / "prompts"
+
+STORY_PROMPTS_METADATA_RE = re.compile(
+    r"<!--\s*pdd-story-prompts:\s*(?P<values>.*?)\s*-->",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+STORY_DEV_UNITS_METADATA_RE = re.compile(
+    r"<!--\s*pdd-story-dev-units:\s*(?P<values>.*?)\s*-->",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+CONTRACT_HEADER_RE = re.compile(
+    r"<!--\s*pdd-story-contract\b(?P<attrs>.*?)-->",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+CONTRACT_ATTR_RE = re.compile(
+    r"(?P<key>[a-z0-9_-]+)\s*=\s*\"(?P<val>[^\"]*)\"",
+    flags=re.IGNORECASE,
+)
+
+REQUIRED_CONTRACT_SECTIONS = (
+    "## Covers",
+    "## Context",
+    "## Acceptance Criteria",
+    "## Oracle",
+    "## Non-Oracle",
+    "## Negative Cases",
+    "## Non-Goals",
+    "## Candidate Prompts",
+    "## Notes",
+)
+
+CROSS_UNIT_STORIES = {
+    "pdd_prd_generate_sync": {
+        "metadata_prompts": [
+            "prompts/commands/generate_python.prompt",
+            "prompts/agentic_architecture_python.prompt",
+            "prompts/sync_main_python.prompt",
+            "prompts/commands/maintenance_python.prompt",
+        ],
+        "dev_units": [
+            "generate_python.prompt",
+            "agentic_architecture_python.prompt",
+            "sync_main_python.prompt",
+            "maintenance_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5", "R6"},
+        "must_contain": (
+            "documented PRD workflow",
+            "counted once globally",
+        ),
+    },
+}
+
+
+def _story_path(story_id: str) -> Path:
+    return STORIES_DIR / f"story__{story_id}.md"
+
+
+def _contract_path(story_id: str) -> Path:
+    return CONTRACTS_DIR / f"{story_id}.contract.md"
+
+
+def _parse_metadata(pattern: re.Pattern[str], story_text: str) -> list[str]:
+    match = pattern.search(story_text)
+    if not match:
+        return []
+    raw = match.group("values").strip()
+    return [entry.strip() for entry in raw.split(",") if entry.strip()]
+
+
+def _story_content_hash(story_text: str) -> str:
+    without_prompt_meta = STORY_PROMPTS_METADATA_RE.sub("", story_text)
+    without_meta = STORY_DEV_UNITS_METADATA_RE.sub("", without_prompt_meta)
+    lines = [line.rstrip() for line in without_meta.strip().splitlines()]
+    normalized = "\n".join(line for line in lines if line.strip())
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _parse_contract_header(contract_text: str) -> dict[str, str]:
+    match = CONTRACT_HEADER_RE.search(contract_text)
+    assert match, "contract must include pdd-story-contract header"
+    return {
+        attr.group("key").lower(): attr.group("val")
+        for attr in CONTRACT_ATTR_RE.finditer(match.group("attrs"))
+    }
+
+
+def _covered_rule_ids(contract_text: str) -> set[str]:
+    return set(re.findall(r"^\s*-\s+(R\d+):", contract_text, flags=re.MULTILINE))
+
+
+def _prompt_package_path(metadata_prompt: str) -> Path:
+    assert metadata_prompt.startswith("prompts/")
+    return PACKAGE_PROMPTS_DIR / metadata_prompt.removeprefix("prompts/")
+
+
+def test_cross_unit_story_backfill_artifacts_are_complete() -> None:
+    assert len(CROSS_UNIT_STORIES) == len(set(CROSS_UNIT_STORIES))
+
+    for story_id, expected in CROSS_UNIT_STORIES.items():
+        story_path = _story_path(story_id)
+        contract_path = _contract_path(story_id)
+
+        assert story_path.exists(), f"{story_id} story is missing"
+        assert contract_path.exists(), f"{story_id} contract is missing"
+
+        story_text = story_path.read_text(encoding="utf-8")
+        contract_text = contract_path.read_text(encoding="utf-8")
+
+        prompt_refs = _parse_metadata(STORY_PROMPTS_METADATA_RE, story_text)
+        dev_units = _parse_metadata(STORY_DEV_UNITS_METADATA_RE, story_text)
+        assert prompt_refs == expected["metadata_prompts"]
+        assert dev_units == expected["dev_units"]
+        assert len(prompt_refs) >= 2
+        assert len(dev_units) >= 2
+
+        for prompt_ref in prompt_refs:
+            assert _prompt_package_path(prompt_ref).exists()
+            assert f"`{prompt_ref}`" in contract_text
+
+        header = _parse_contract_header(contract_text)
+        assert header["derived-from-story"] == f"../story__{story_id}.md"
+        assert header["story-hash"] == _story_content_hash(story_text)
+        assert header["issue-ref"] == "https://github.com/promptdriven/pdd/issues/1769"
+
+        for section in REQUIRED_CONTRACT_SECTIONS:
+            assert section in contract_text
+
+        assert expected["covers"] <= _covered_rule_ids(contract_text)
+
+        for phrase in expected["must_contain"]:
+            assert phrase in contract_text

--- a/tests/test_story_backfill_cross_unit_flows.py
+++ b/tests/test_story_backfill_cross_unit_flows.py
@@ -63,6 +63,27 @@ CROSS_UNIT_STORIES = {
             "failing tests",
         ),
     },
+    "pdd_story_test_coverage": {
+        "metadata_prompts": [
+            "prompts/commands/generate_python.prompt",
+            "prompts/agentic_test_orchestrator_python.prompt",
+            "prompts/user_story_tests_python.prompt",
+            "prompts/coverage_contracts_python.prompt",
+            "prompts/commands/checkup_python.prompt",
+        ],
+        "dev_units": [
+            "generate_python.prompt",
+            "agentic_test_orchestrator_python.prompt",
+            "user_story_tests_python.prompt",
+            "coverage_contracts_python.prompt",
+            "checkup_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5", "R6"},
+        "must_contain": (
+            "story-mode test workflow",
+            "coverage matrix",
+        ),
+    },
     "pdd_feature_change_pr": {
         "metadata_prompts": [
             "prompts/commands/modify_python.prompt",

--- a/tests/test_story_backfill_cross_unit_flows.py
+++ b/tests/test_story_backfill_cross_unit_flows.py
@@ -42,6 +42,27 @@ REQUIRED_CONTRACT_SECTIONS = (
 )
 
 CROSS_UNIT_STORIES = {
+    "pdd_feature_change_pr": {
+        "metadata_prompts": [
+            "prompts/commands/modify_python.prompt",
+            "prompts/agentic_change_orchestrator_python.prompt",
+            "prompts/agentic_change_python.prompt",
+            "prompts/user_story_tests_python.prompt",
+            "prompts/generate_story_contract_LLM.prompt",
+        ],
+        "dev_units": [
+            "modify_python.prompt",
+            "agentic_change_orchestrator_python.prompt",
+            "agentic_change_python.prompt",
+            "user_story_tests_python.prompt",
+            "generate_story_contract_LLM.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5", "R6"},
+        "must_contain": (
+            "issue-driven feature workflow",
+            "contract sidecar",
+        ),
+    },
     "pdd_prd_generate_sync": {
         "metadata_prompts": [
             "prompts/commands/generate_python.prompt",

--- a/tests/test_story_backfill_cross_unit_flows.py
+++ b/tests/test_story_backfill_cross_unit_flows.py
@@ -42,6 +42,27 @@ REQUIRED_CONTRACT_SECTIONS = (
 )
 
 CROSS_UNIT_STORIES = {
+    "pdd_bug_fix_verification": {
+        "metadata_prompts": [
+            "prompts/commands/analysis_python.prompt",
+            "prompts/agentic_bug_orchestrator_python.prompt",
+            "prompts/commands/fix_python.prompt",
+            "prompts/agentic_e2e_fix_orchestrator_python.prompt",
+            "prompts/agentic_common_python.prompt",
+        ],
+        "dev_units": [
+            "analysis_python.prompt",
+            "agentic_bug_orchestrator_python.prompt",
+            "fix_python.prompt",
+            "agentic_e2e_fix_orchestrator_python.prompt",
+            "agentic_common_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5", "R6"},
+        "must_contain": (
+            "bug-to-fix workflow",
+            "failing tests",
+        ),
+    },
     "pdd_feature_change_pr": {
         "metadata_prompts": [
             "prompts/commands/modify_python.prompt",

--- a/tests/test_story_backfill_cross_unit_flows.py
+++ b/tests/test_story_backfill_cross_unit_flows.py
@@ -84,6 +84,27 @@ CROSS_UNIT_STORIES = {
             "coverage matrix",
         ),
     },
+    "pdd_update_metadata_sync": {
+        "metadata_prompts": [
+            "prompts/commands/modify_python.prompt",
+            "prompts/update_main_python.prompt",
+            "prompts/agentic_update_python.prompt",
+            "prompts/metadata_sync_python.prompt",
+            "prompts/operation_log_python.prompt",
+        ],
+        "dev_units": [
+            "modify_python.prompt",
+            "update_main_python.prompt",
+            "agentic_update_python.prompt",
+            "metadata_sync_python.prompt",
+            "operation_log_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5", "R6"},
+        "must_contain": (
+            "code-to-prompt update workflow",
+            "fingerprint",
+        ),
+    },
     "pdd_feature_change_pr": {
         "metadata_prompts": [
             "prompts/commands/modify_python.prompt",

--- a/tests/test_story_backfill_top_flows.py
+++ b/tests/test_story_backfill_top_flows.py
@@ -1,0 +1,113 @@
+"""Deterministic checks for the top-flow user-story backfill."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STORIES_DIR = REPO_ROOT / "user_stories"
+CONTRACTS_DIR = STORIES_DIR / "contracts"
+PACKAGE_PROMPTS_DIR = REPO_ROOT / "pdd" / "prompts"
+
+STORY_PROMPTS_METADATA_RE = re.compile(
+    r"<!--\s*pdd-story-prompts:\s*(?P<prompts>.*?)\s*-->",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+CONTRACT_HEADER_RE = re.compile(
+    r"<!--\s*pdd-story-contract\b(?P<attrs>.*?)-->",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+CONTRACT_ATTR_RE = re.compile(
+    r"(?P<key>[a-z0-9_-]+)\s*=\s*\"(?P<val>[^\"]*)\"",
+    flags=re.IGNORECASE,
+)
+
+REQUIRED_CONTRACT_SECTIONS = (
+    "## Covers",
+    "## Context",
+    "## Acceptance Criteria",
+    "## Oracle",
+    "## Non-Oracle",
+    "## Negative Cases",
+    "## Non-Goals",
+    "## Candidate Prompts",
+    "## Notes",
+)
+
+TOP_FLOW_STORIES = {
+    "pdd_sync": {
+        "metadata_prompt": "prompts/commands/maintenance_python.prompt",
+        "package_prompt": "commands/maintenance_python.prompt",
+        "covers": {"R1", "R2", "R3", "R4"},
+        "must_contain": ("project-wide/global synchronization", "single-module"),
+    },
+}
+
+
+def _story_path(story_id: str) -> Path:
+    return STORIES_DIR / f"story__{story_id}.md"
+
+
+def _contract_path(story_id: str) -> Path:
+    return CONTRACTS_DIR / f"{story_id}.contract.md"
+
+
+def _parse_story_prompts(story_text: str) -> list[str]:
+    match = STORY_PROMPTS_METADATA_RE.search(story_text)
+    if not match:
+        return []
+    raw = match.group("prompts").strip()
+    return [entry.strip() for entry in raw.split(",") if entry.strip()]
+
+
+def _story_content_hash(story_text: str) -> str:
+    without_meta = STORY_PROMPTS_METADATA_RE.sub("", story_text)
+    lines = [line.rstrip() for line in without_meta.strip().splitlines()]
+    normalized = "\n".join(line for line in lines if line.strip())
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _parse_contract_header(contract_text: str) -> dict[str, str]:
+    match = CONTRACT_HEADER_RE.search(contract_text)
+    assert match, "contract must include pdd-story-contract header"
+    return {
+        attr.group("key").lower(): attr.group("val")
+        for attr in CONTRACT_ATTR_RE.finditer(match.group("attrs"))
+    }
+
+
+def _covered_rule_ids(contract_text: str) -> set[str]:
+    return set(re.findall(r"^\s*-\s+(R\d+):", contract_text, flags=re.MULTILINE))
+
+
+def test_top_flow_story_backfill_artifacts_are_complete() -> None:
+    for story_id, expected in TOP_FLOW_STORIES.items():
+        story_path = _story_path(story_id)
+        contract_path = _contract_path(story_id)
+
+        assert story_path.exists(), f"{story_id} story is missing"
+        assert contract_path.exists(), f"{story_id} contract is missing"
+
+        story_text = story_path.read_text(encoding="utf-8")
+        contract_text = contract_path.read_text(encoding="utf-8")
+
+        prompt_refs = _parse_story_prompts(story_text)
+        assert prompt_refs == [expected["metadata_prompt"]]
+        assert (PACKAGE_PROMPTS_DIR / expected["package_prompt"]).exists()
+
+        header = _parse_contract_header(contract_text)
+        assert header["derived-from-story"] == f"../story__{story_id}.md"
+        assert header["story-hash"] == _story_content_hash(story_text)
+        assert header["issue-ref"]
+
+        for section in REQUIRED_CONTRACT_SECTIONS:
+            assert section in contract_text
+
+        assert expected["covers"] <= _covered_rule_ids(contract_text)
+        assert f"`{expected['metadata_prompt']}`" in contract_text
+
+        for phrase in expected["must_contain"]:
+            assert phrase in contract_text

--- a/tests/test_story_backfill_top_flows.py
+++ b/tests/test_story_backfill_top_flows.py
@@ -62,6 +62,12 @@ TOP_FLOW_STORIES = {
         "covers": {"R1", "R2", "R3", "R4"},
         "must_contain": ("project-wide/global synchronization", "single-module"),
     },
+    "pdd_update": {
+        "metadata_prompt": "prompts/commands/modify_python.prompt",
+        "package_prompt": "commands/modify_python.prompt",
+        "covers": {"R1", "R2", "R3", "R4", "R5"},
+        "must_contain": ("Repository-wide update", "fingerprint finalization"),
+    },
 }
 
 

--- a/tests/test_story_backfill_top_flows.py
+++ b/tests/test_story_backfill_top_flows.py
@@ -38,6 +38,12 @@ REQUIRED_CONTRACT_SECTIONS = (
 )
 
 TOP_FLOW_STORIES = {
+    "pdd_change": {
+        "metadata_prompt": "prompts/commands/modify_python.prompt",
+        "package_prompt": "commands/modify_python.prompt",
+        "covers": {"R1", "R2", "R3", "R4"},
+        "must_contain": ("agentic change", "contract sidecar"),
+    },
     "pdd_fix": {
         "metadata_prompt": "prompts/commands/fix_python.prompt",
         "package_prompt": "commands/fix_python.prompt",

--- a/tests/test_story_backfill_top_flows.py
+++ b/tests/test_story_backfill_top_flows.py
@@ -38,6 +38,12 @@ REQUIRED_CONTRACT_SECTIONS = (
 )
 
 TOP_FLOW_STORIES = {
+    "pdd_fix": {
+        "metadata_prompt": "prompts/commands/fix_python.prompt",
+        "package_prompt": "commands/fix_python.prompt",
+        "covers": {"R1", "R2", "R3", "R4"},
+        "must_contain": ("agentic E2E fix workflow", "user-story-driven prompt fixes"),
+    },
     "pdd_sync": {
         "metadata_prompt": "prompts/commands/maintenance_python.prompt",
         "package_prompt": "commands/maintenance_python.prompt",

--- a/tests/test_story_backfill_top_flows.py
+++ b/tests/test_story_backfill_top_flows.py
@@ -50,6 +50,12 @@ TOP_FLOW_STORIES = {
         "covers": {"R1", "R2", "R3", "R4"},
         "must_contain": ("agentic E2E fix workflow", "user-story-driven prompt fixes"),
     },
+    "pdd_generate": {
+        "metadata_prompt": "prompts/commands/generate_python.prompt",
+        "package_prompt": "commands/generate_python.prompt",
+        "covers": {"R1", "R2", "R3", "R4", "R5"},
+        "must_contain": ("standard prompt-file generation", "incremental PRD"),
+    },
     "pdd_sync": {
         "metadata_prompt": "prompts/commands/maintenance_python.prompt",
         "package_prompt": "commands/maintenance_python.prompt",

--- a/user_stories/contracts/pdd_bug_fix_verification.contract.md
+++ b/user_stories/contracts/pdd_bug_fix_verification.contract.md
@@ -1,0 +1,78 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_bug_fix_verification.md" story-hash="29c6a547ae8cc133" issue-ref="https://github.com/promptdriven/pdd/issues/1769" -->
+
+# Contract: Bug report becomes a verified fix
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_bug_fix_verification.md`), not this contract.
+
+## Covers
+
+- R1: Bug issue URLs route through `pdd bug` to create a reproducible failing test or test plan.
+- R2: The bug workflow distinguishes code bugs from prompt defects before the fix loop runs.
+- R3: `pdd fix` consumes the failing tests and protected context as repair constraints.
+- R4: The fix workflow iterates until local verification passes or a clear failure is reported.
+- R5: Post-fix evidence preserves test results, CI status when enabled, and workflow comments.
+- R6: The cross-dev-unit story is attributed to analysis, bug orchestration, fix command, E2E fix orchestration, and shared agentic utilities without duplicate global counting.
+
+## Context
+
+The documented bug workflow starts with `pdd bug <issue-url>` to create failing
+tests, then uses `pdd fix <issue-url>` to repair code until tests pass locally
+and, when enabled, through post-push CI. This crosses the analysis command,
+bug orchestrator, fix command, E2E fix orchestrator, and shared agentic
+comment/evidence utilities.
+
+## Acceptance Criteria
+
+1. Given a GitHub bug issue, when the user runs `pdd bug <issue-url>`, then PDD routes to the agentic bug workflow and captures the observed failure as executable or planned regression evidence.
+2. Given the root cause indicates a prompt defect, when the bug workflow classifies the defect, then it records that the prompt must be fixed before generating downstream tests.
+3. Given failing tests exist for the bug, when the user runs `pdd fix <issue-url>`, then PDD uses those tests as constraints for the repair loop.
+4. Given tests fail after a repair attempt, when the fix loop continues, then the workflow reports the failure and attempts another bounded repair rather than declaring success.
+5. Given local verification passes, when the workflow finishes, then the PR evidence identifies the tests and any CI validation or skipped CI choice.
+6. Given coverage reports this story, when bug and fix dev units are listed separately, then this story appears under each linked unit but is counted once globally.
+
+## Oracle
+
+These details matter for pass/fail:
+- `pdd bug` routes issue URLs to bug reproduction
+- failing tests or explicit test plan evidence are created before repair
+- prompt-defect classification is not lost
+- `pdd fix` uses tests as constraints and verifies before success
+- post-fix evidence includes local checks and CI status or skip reason
+- cross-unit metadata lists every participating dev unit
+
+## Non-Oracle
+
+These details should not matter:
+- exact generated test code
+- exact repair patch content
+- exact provider/model used
+- exact comment formatting beyond status and evidence semantics
+
+## Negative Cases
+
+- `pdd fix` must not declare success while the captured failing tests still fail.
+- A prompt defect must not be treated as only a generated-code bug when the workflow has enough evidence to classify it.
+- CI failures must not be hidden when CI validation is enabled.
+- Coverage must not count this one cross-unit story once for each linked prompt.
+
+## Non-Goals
+
+- This story does not prescribe the exact unit tests produced by `pdd bug`.
+- This story does not cover feature-request handling through `pdd change`.
+- This story does not require live CI in deterministic local verification.
+
+## Candidate Prompts
+
+- `prompts/commands/analysis_python.prompt` - owns the public `pdd bug` command surface.
+- `prompts/agentic_bug_orchestrator_python.prompt` - owns bug workflow orchestration.
+- `prompts/commands/fix_python.prompt` - owns the public `pdd fix` command surface.
+- `prompts/agentic_e2e_fix_orchestrator_python.prompt` - owns iterative fix verification.
+- `prompts/agentic_common_python.prompt` - owns shared agentic comments and runner behavior.
+- `prompts/agentic_bug_python.prompt` - related bug workflow behavior.
+
+## Notes
+
+This story is a cross-dev-unit regression oracle for the documented
+bug-to-fix workflow in `docs/TUTORIALS.md` and `docs/prompting_guide.md`.

--- a/user_stories/contracts/pdd_change.contract.md
+++ b/user_stories/contracts/pdd_change.contract.md
@@ -1,4 +1,4 @@
-<!-- pdd-story-contract derived-from-story="../story__pdd_change.md" story-hash="<auto>" issue-ref="https://github.com/promptdriven/pdd/pull/1501#issuecomment-4662232582" -->
+<!-- pdd-story-contract derived-from-story="../story__pdd_change.md" story-hash="3d3e24afdcf4ac7e" issue-ref="https://github.com/promptdriven/pdd/pull/1501#issuecomment-4662232582" -->
 
 # Contract: pdd change
 

--- a/user_stories/contracts/pdd_feature_change_pr.contract.md
+++ b/user_stories/contracts/pdd_feature_change_pr.contract.md
@@ -1,0 +1,79 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_feature_change_pr.md" story-hash="116740a5ec1b111d" issue-ref="https://github.com/promptdriven/pdd/issues/1769" -->
+
+# Contract: Feature request becomes a verified PDD change PR
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_feature_change_pr.md`), not this contract.
+
+## Covers
+
+- R1: GitHub feature issues route through `pdd change` rather than manual patch mode.
+- R2: The change workflow identifies and updates the prompt/dev units that own the requested behavior.
+- R3: Generated user-story artifacts include both the human story and contract sidecar.
+- R4: Step comments and final status make degraded-vs-failed workflow state visible to reviewers.
+- R5: The created PR includes enough evidence for reviewers to connect issue, prompts, stories, and verification.
+- R6: The cross-dev-unit story is attributed to change command, orchestration, shared agentic utilities, story generation, and contract generation without duplicate global counting.
+
+## Context
+
+The documented feature workflow starts from `pdd change <issue-url>`, updates
+the prompt source of truth, adds or updates user stories for product-level
+behavior, verifies the result, and opens a PR. This crosses the command layer,
+agentic change orchestration, shared agentic GitHub comments, and story/contract
+generation.
+
+## Acceptance Criteria
+
+1. Given a GitHub feature issue, when the user runs `pdd change <issue-url>`, then PDD routes to the issue-driven agentic change workflow with GitHub-state and restart controls.
+2. Given the workflow determines the affected dev units, when it edits the repository, then prompt changes remain the durable source of truth rather than only patching generated code.
+3. Given the change creates or updates a user story, when artifacts are staged, then the human story and generated contract sidecar travel together.
+4. Given a recoverable agentic step fails, when the workflow reports status, then reviewers can distinguish degraded continuation from a terminal failure.
+5. Given the workflow completes, when the PR is created, then its evidence links the issue, changed prompts, story files, contract files, and verification commands.
+6. Given coverage reports this story, when each linked dev unit is listed, then this story appears under every linked unit but is counted once globally.
+
+## Oracle
+
+These details matter for pass/fail:
+- issue URL routing to agentic change
+- prompt-source updates rather than code-only patches
+- paired story and contract sidecar artifacts
+- visible workflow status semantics
+- PR evidence connecting issue, prompts, stories, and verification
+- cross-unit metadata lists every participating dev unit
+
+## Non-Oracle
+
+These details should not matter:
+- exact prompt prose chosen by the workflow
+- exact generated PR body wording beyond evidence presence
+- exact provider/model selected
+- exact console colors or progress formatting
+
+## Negative Cases
+
+- A feature issue must not silently route to manual change mode.
+- The workflow must not stage a story without its contract sidecar when one was generated.
+- A recoverable step failure must not be reported as a terminal workflow abort.
+- Coverage must not count this one cross-unit story once for each linked prompt.
+
+## Non-Goals
+
+- This story does not prescribe the exact prompt patch.
+- This story does not cover `pdd bug` or `pdd fix`.
+- This story does not verify downstream CI provider behavior.
+
+## Candidate Prompts
+
+- `prompts/commands/modify_python.prompt` - owns the public `pdd change` command surface.
+- `prompts/agentic_change_orchestrator_python.prompt` - owns the multi-step change workflow.
+- `prompts/agentic_change_python.prompt` - owns change workflow behavior.
+- `prompts/user_story_tests_python.prompt` - owns story generation/linking support.
+- `prompts/generate_story_contract_LLM.prompt` - owns generated contract sidecars.
+- `prompts/agentic_common_python.prompt` - related shared issue/PR status support.
+
+## Notes
+
+This story is a cross-dev-unit regression oracle for the documented
+issue-driven feature workflow in `docs/TUTORIALS.md` and
+`docs/prompting_guide.md`.

--- a/user_stories/contracts/pdd_fix.contract.md
+++ b/user_stories/contracts/pdd_fix.contract.md
@@ -1,4 +1,4 @@
-<!-- pdd-story-contract derived-from-story="../story__pdd_fix.md" story-hash="<auto>" issue-ref="https://github.com/promptdriven/pdd/pull/1501#issuecomment-4662232582" -->
+<!-- pdd-story-contract derived-from-story="../story__pdd_fix.md" story-hash="b587af4ac2bc2176" issue-ref="https://github.com/promptdriven/pdd/pull/1501#issuecomment-4662232582" -->
 
 # Contract: pdd fix
 

--- a/user_stories/contracts/pdd_generate.contract.md
+++ b/user_stories/contracts/pdd_generate.contract.md
@@ -1,0 +1,80 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_generate.md" story-hash="de0a7b28c908d6af" issue-ref="https://github.com/promptdriven/pdd/issues/1703" -->
+
+# Contract: pdd generate
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_generate.md`), not this contract.
+
+## Covers
+
+- R1: Standard prompt-file generation creates code from an explicit prompt or template request.
+- R2: Agentic issue generation routes GitHub issue URLs to the architecture workflow.
+- R3: Incremental PRD generation requires explicit `--incremental --experimental-prd` opt-in.
+- R4: Mode-specific guardrails reject ambiguous or unsupported flag combinations.
+- R5: Estimate mode previews standard generation cost without writing outputs or running providers.
+
+## Context
+
+The `pdd generate` command is implemented by
+`prompts/commands/generate_python.prompt`. It owns the top-level generate
+surface for standard prompt-file generation, template-based generation, GitHub
+issue architecture generation, incremental PRD propagation, snapshot context,
+prompt-checkup gating, and estimate-mode routing.
+
+## Acceptance Criteria
+
+1. Given a prompt file and no template, when the user runs `pdd generate`, then the command validates the request and invokes standard code generation with the resolved prompt, output, environment, snapshot, and prompt-checkup options.
+2. Given a template name and no prompt file, when the user runs `pdd generate --template <name>`, then the command resolves the template and invokes standard generation without requiring a separate prompt file.
+3. Given both a prompt file and `--template`, when the user runs `pdd generate`, then the command rejects the ambiguous request before any generation workflow starts.
+4. Given a GitHub issue URL without incremental PRD flags, when the user runs `pdd generate <issue-url>`, then the command routes to the agentic architecture workflow and forwards project-root, prompt-skip, GitHub-state, and output-directory choices.
+5. Given a PRD-like source or issue URL with `--incremental --experimental-prd`, when the user runs `pdd generate`, then the command routes to incremental PRD propagation and distinguishes dry-run output from files actually written.
+6. Given `--incremental` on a PRD-like source without `--experimental-prd`, when the user runs the command, then PDD raises a usage error that tells the user how to opt in explicitly.
+7. Given global estimate mode for standard prompt-file generation, when the user runs `pdd --estimate generate`, then PDD returns an estimate payload without writing command outputs, evidence manifests, or cost rows for a real run.
+
+## Oracle
+
+These details matter for pass/fail:
+- standard prompt-file and template routing
+- prompt-file/template mutual exclusion
+- GitHub issue URL routing to architecture generation
+- explicit incremental PRD opt-in and dry-run labeling
+- mode-specific rejection for unsupported flags such as standard-mode `--project-root`, non-PRD `--dry-run`, and unsupported `--snapshot-context`
+- estimate mode staying side-effect-free for standard generation
+- prompt-checkup gate forwarding before downstream generation
+
+## Non-Oracle
+
+These details should not matter:
+- exact generated code or architecture content
+- exact console color/style
+- exact model/provider selected during real generation
+- exact wording of non-user-facing helper messages
+- internal function names below the public workflow boundary
+
+## Negative Cases
+
+- A request with both a prompt file and `--template` must not proceed to generation.
+- `--dry-run` must not be accepted outside incremental PRD mode.
+- A PRD-like source with `--incremental` must not silently route to PRD propagation without `--experimental-prd`.
+- Agentic or incremental multi-step generation must not claim support for standard estimate mode.
+- Mode-specific flags such as `--project-root` and `--snapshot-context` must not be silently ignored on unsupported paths.
+
+## Non-Goals
+
+- This story does not verify the generated artifact contents.
+- This story does not cover `pdd test` or `pdd example`.
+- This story does not prescribe the internal architecture workflow step sequence.
+
+## Candidate Prompts
+
+- `prompts/commands/generate_python.prompt` — primary owner of the `pdd generate` CLI.
+- `prompts/code_generator_main_python.prompt` — related standard prompt-file generation workflow.
+- `prompts/agentic_architecture_python.prompt` — related GitHub issue architecture workflow.
+- `prompts/incremental_prd_architecture_python.prompt` — related incremental PRD workflow.
+- `prompts/prompt_gate_python.prompt` — related prompt-checkup gate support.
+
+## Notes
+
+This story seeds the #1703 top-flow regression backfill for the documented
+`pdd generate` entry point.

--- a/user_stories/contracts/pdd_prd_generate_sync.contract.md
+++ b/user_stories/contracts/pdd_prd_generate_sync.contract.md
@@ -1,0 +1,77 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_prd_generate_sync.md" story-hash="50dfcb910ae19ae4" issue-ref="https://github.com/promptdriven/pdd/issues/1769" -->
+
+# Contract: PRD generate output can be synced into a module
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_prd_generate_sync.md`), not this contract.
+
+## Covers
+
+- R1: A GitHub issue or PRD source routes `pdd generate` to the architecture workflow.
+- R2: The architecture workflow produces reviewable project configuration and prompt files.
+- R3: Generated prompt files remain valid inputs to `pdd sync <module>`.
+- R4: Sync preserves the selected module boundary instead of treating the PRD as a global rewrite.
+- R5: The handoff records enough evidence for reviewers to connect the synced module back to the original request.
+- R6: The cross-dev-unit story is attributed to generate, architecture, sync, and maintenance command prompts without being counted as four stories.
+
+## Context
+
+The documented PRD workflow says `pdd generate <issue-url>` creates
+`architecture.json`, `.pddrc`, and prompt files, then the user can run
+`pdd sync my_module` on generated prompts. This crosses the generate command,
+agentic architecture workflow, sync implementation, and maintenance command
+surface.
+
+## Acceptance Criteria
+
+1. Given a GitHub issue containing a PRD, when the user runs `pdd generate <issue-url>`, then PDD routes to the architecture workflow rather than ordinary single-prompt generation.
+2. Given the architecture workflow succeeds, when the user reviews the output, then the output includes project configuration and prompt files suitable for later sync.
+3. Given a generated prompt/module exists, when the user runs `pdd sync <module>`, then PDD syncs that module through the normal single-module sync path.
+4. Given the sync target is one module, when PDD materializes code, then it does not silently widen the request to every generated module.
+5. Given reviewers inspect the resulting PR, when they trace the synced module, then they can identify the original PRD request and the prompt files that shaped the code.
+6. Given this story is reported in coverage, when generate and sync dev units are listed separately, then this story is shown under each linked unit but counted once globally.
+
+## Oracle
+
+These details matter for pass/fail:
+- issue/PRD routing to the architecture workflow
+- architecture output includes prompt files and project configuration
+- sync accepts a generated module target after architecture generation
+- single-module sync scope is preserved
+- evidence links the generated/synced artifacts to the request
+- cross-unit story metadata lists every participating dev unit
+
+## Non-Oracle
+
+These details should not matter:
+- exact generated module names or architecture content
+- exact provider/model used by generation or sync
+- exact console styling or progress wording
+- internal helper names below the documented command boundaries
+
+## Negative Cases
+
+- A PRD issue must not be handled as a normal prompt-file generation request.
+- `pdd sync <module>` must not ignore the requested module and regenerate the whole project.
+- The generated prompt handoff must not lose the issue/request reference needed for review.
+- Coverage must not count this one cross-unit story once per linked prompt.
+
+## Non-Goals
+
+- This story does not verify the semantic quality of generated application code.
+- This story does not cover incremental PRD mode.
+- This story does not prescribe the internal architecture step sequence.
+
+## Candidate Prompts
+
+- `prompts/commands/generate_python.prompt` - owns the public `pdd generate` command surface.
+- `prompts/agentic_architecture_python.prompt` - owns the PRD/issue architecture workflow.
+- `prompts/sync_main_python.prompt` - owns single-module sync behavior.
+- `prompts/commands/maintenance_python.prompt` - owns the public `pdd sync` command surface.
+- `prompts/sync_orchestration_python.prompt` - related sync orchestration support.
+
+## Notes
+
+This story is a cross-dev-unit regression oracle for the documented PRD
+generate-to-sync workflow in `docs/TUTORIALS.md`.

--- a/user_stories/contracts/pdd_story_test_coverage.contract.md
+++ b/user_stories/contracts/pdd_story_test_coverage.contract.md
@@ -1,0 +1,78 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_story_test_coverage.md" story-hash="8fdc178d30078079" issue-ref="https://github.com/promptdriven/pdd/issues/1769" -->
+
+# Contract: Story tests appear in coverage
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_story_test_coverage.md`), not this contract.
+
+## Covers
+
+- R1: `pdd test --issue <source> <prompt...>` creates or updates story artifacts linked to every supplied prompt.
+- R2: Existing `story__*.md` files can refresh prompt-link metadata through story mode.
+- R3: Story contracts retain rule coverage and candidate prompt context for reviewers.
+- R4: `pdd checkup coverage` includes story evidence in the rule-to-evidence matrix.
+- R5: Cross-dev-unit stories are attributed to each linked prompt while counted once globally.
+- R6: Coverage output exposes unresolved, stale, or missing evidence without treating cross-unit metadata as separate stories.
+
+## Context
+
+The documented story-mode test workflow uses `pdd test` with prompt files or an
+existing `story__*.md` file to generate or refresh user-story artifacts. Coverage
+then reads story/contract evidence through `pdd checkup coverage`. This crosses
+the generate/test command surface, agentic test workflow, story utility module,
+coverage engine, and checkup delegation command.
+
+## Acceptance Criteria
+
+1. Given an issue source and two or more prompt files, when the user runs `pdd test --issue <source> <prompt...>`, then PDD writes a story linked to every supplied prompt.
+2. Given an existing `story__*.md` file, when the user runs `pdd test <story-file>`, then PDD refreshes prompt-link metadata rather than treating the story as code input.
+3. Given a story contract lists covered rules, when coverage scans the prompt, then the matching story appears as evidence for those rule IDs.
+4. Given a story links multiple prompts, when coverage scans each prompt, then the story is attributed to each prompt without creating multiple global story identities.
+5. Given evidence is stale, missing, or unresolved, when coverage renders output, then reviewers can see that status instead of receiving a silent pass.
+6. Given the story lane summary groups by story slug, when this cross-unit story appears, then it is reported once with its linked dev-unit scope.
+
+## Oracle
+
+These details matter for pass/fail:
+- story-mode routing in `pdd test`
+- prompt metadata is written or refreshed for every linked prompt
+- story contract rule coverage feeds the coverage matrix
+- missing/stale evidence remains visible
+- global metrics deduplicate by story identity
+- cross-unit metadata lists every participating dev unit
+
+## Non-Oracle
+
+These details should not matter:
+- exact LLM-authored story wording
+- exact terminal table styling
+- exact provider/model used for story generation
+- exact order of unrelated coverage rows
+
+## Negative Cases
+
+- A story file must not be handled as a normal prompt/code unit-test input.
+- A multi-prompt story must not be reported as separate unrelated stories.
+- Missing or stale evidence must not be hidden by the cross-unit grouping.
+- Coverage must not count this one cross-unit story once for each linked prompt.
+
+## Non-Goals
+
+- This story does not verify the generated executable test contents.
+- This story does not cover live model availability.
+- This story does not prescribe the exact coverage table formatting.
+
+## Candidate Prompts
+
+- `prompts/commands/generate_python.prompt` - owns the public `pdd test` command surface.
+- `prompts/agentic_test_orchestrator_python.prompt` - owns issue-driven test workflow orchestration.
+- `prompts/user_story_tests_python.prompt` - owns story metadata and traceability.
+- `prompts/coverage_contracts_python.prompt` - owns deterministic rule-to-evidence coverage.
+- `prompts/commands/checkup_python.prompt` - delegates `pdd checkup coverage`.
+- `prompts/agentic_test_step6_coverage_LLM.prompt` - related test-plan coverage step.
+
+## Notes
+
+This story is a cross-dev-unit regression oracle for the documented
+story-mode test workflow and issue #1769 coverage requirements.

--- a/user_stories/contracts/pdd_sync.contract.md
+++ b/user_stories/contracts/pdd_sync.contract.md
@@ -1,4 +1,4 @@
-<!-- pdd-story-contract derived-from-story="../story__pdd_sync.md" story-hash="<auto>" issue-ref="https://github.com/promptdriven/pdd/pull/1501#issuecomment-4662232582" -->
+<!-- pdd-story-contract derived-from-story="../story__pdd_sync.md" story-hash="db8793f0c80a101b" issue-ref="https://github.com/promptdriven/pdd/pull/1501#issuecomment-4662232582" -->
 
 # Contract: pdd sync
 

--- a/user_stories/contracts/pdd_update.contract.md
+++ b/user_stories/contracts/pdd_update.contract.md
@@ -1,0 +1,80 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_update.md" story-hash="9c6a941b9c3e3f96" issue-ref="https://github.com/promptdriven/pdd/issues/1703" -->
+
+# Contract: pdd update
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_update.md`), not this contract.
+
+## Covers
+
+- R1: Repository-wide update scans changed code/prompt pairs and updates prompts in batch.
+- R2: Single-code regeneration mode derives or creates the prompt path for a changed code file.
+- R3: Git and manual true-update modes update an existing prompt from modified code.
+- R4: CLI validation rejects ambiguous update modes and incompatible options before work starts.
+- R5: Metadata synchronization and fingerprint finalization keep prompt/code state consistent after successful updates.
+
+## Context
+
+The `pdd update` command is exposed through
+`prompts/commands/modify_python.prompt` and implemented by
+`prompts/update_main_python.prompt`. It back-propagates code changes into the
+authoritative prompt, either for a single target or across a repository.
+
+## Acceptance Criteria
+
+1. Given no file arguments or `--all`, when the user runs `pdd update`, then the command scans the repository for changed code/prompt pairs, filters unsupported files, updates eligible prompts, and reports per-pair status.
+2. Given one modified code file, when the user runs `pdd update <code-file>`, then the command resolves or creates the corresponding prompt path and performs regeneration-mode prompt update.
+3. Given two files with `--git`, when the user runs `pdd update --git <prompt> <modified-code>`, then the command updates the prompt by comparing the modified code against Git history.
+4. Given three files without `--git`, when the user runs `pdd update <prompt> <modified-code> <original-code>`, then the command updates the prompt from the explicit original/modified code pair.
+5. Given incompatible options such as `--all` with file paths, `--output` in repo mode, or file-mode-only arguments with repo-mode filters, when the user invokes the command, then PDD rejects the request before running update logic.
+6. Given `--sync-metadata`, when an update succeeds, then PDD runs metadata synchronization and exits non-zero if any required metadata stage fails.
+7. Given a successful single-file or regeneration update without redirected output, when the command returns, then PDD clears stale run reports and finalizes the affected prompt/code fingerprint unless a documented skip condition applies.
+
+## Oracle
+
+These details matter for pass/fail:
+- routing among repo-wide, regeneration, git true-update, and manual true-update modes
+- option validation before update logic
+- agentic-first update with legacy fallback where available
+- per-target `.pddrc` runtime config resolution in repo mode
+- metadata-sync failure causing non-zero exit when requested
+- default fingerprint finalization after successful single-file/regeneration updates
+- stale run-report cleanup before writing fresh fingerprints
+
+## Non-Oracle
+
+These details should not matter:
+- exact prompt prose produced by the updater
+- exact model/provider selected during real update
+- exact progress bar or Rich table styling
+- exact ordering of repo-mode pairs beyond deterministic reporting where required
+- internal helper names below the public workflow boundary
+
+## Negative Cases
+
+- Two file arguments must not be accepted without `--git`.
+- Three file arguments must not be accepted with `--git`.
+- Repo mode must not accept `--output`, `--git`, or file paths.
+- File modes must not accept repo-only filters such as `--extensions`, `--directory`, non-default `--base-branch`, `--dry-run`, or `--budget`.
+- A metadata-sync failure must not be swallowed as a successful `pdd update --sync-metadata` run.
+- A fresh fingerprint must not be written while a stale run report for the same prompt/code identity remains.
+
+## Non-Goals
+
+- This story does not verify the exact updated prompt contents.
+- This story does not cover `pdd change` or `pdd sync`.
+- This story does not prescribe the internal agent implementation.
+
+## Candidate Prompts
+
+- `prompts/commands/modify_python.prompt` — primary owner of the `pdd update` CLI surface.
+- `prompts/update_main_python.prompt` — primary owner of update routing and metadata finalization behavior.
+- `prompts/agentic_update_python.prompt` — related agentic update implementation.
+- `prompts/metadata_sync_python.prompt` — related metadata synchronization support.
+- `prompts/operation_log_python.prompt` — related fingerprint and run-report metadata support.
+
+## Notes
+
+This story seeds the #1703 top-flow regression backfill for the documented
+`pdd update` command.

--- a/user_stories/contracts/pdd_update_metadata_sync.contract.md
+++ b/user_stories/contracts/pdd_update_metadata_sync.contract.md
@@ -1,0 +1,78 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_update_metadata_sync.md" story-hash="e8f082eb49aef36a" issue-ref="https://github.com/promptdriven/pdd/issues/1769" -->
+
+# Contract: Code changes update the prompt source
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_update_metadata_sync.md`), not this contract.
+
+## Covers
+
+- R1: `pdd update` routes repository-wide and file-specific update modes without ambiguous option combinations.
+- R2: Accepted code behavior is back-propagated into the prompt source of truth.
+- R3: Agentic update is used where available and legacy update paths remain explicit fallbacks.
+- R4: Metadata synchronization runs when requested and can fail the command if required metadata cannot be refreshed.
+- R5: Successful updates clear stale run reports and finalize prompt/code fingerprints.
+- R6: The cross-dev-unit story is attributed to modify command, update engine, agentic update, metadata sync, and operation logging without duplicate global counting.
+
+## Context
+
+The documented update workflow asks maintainers to decide when implementation
+knowledge belongs in the prompt. `pdd update` back-propagates accepted code
+behavior into prompt files, and metadata/fingerprint finalization keeps the
+prompt-code state auditable. This crosses the modify command surface, update
+engine, agentic update path, metadata synchronization, and operation log.
+
+## Acceptance Criteria
+
+1. Given a repository-wide or file-specific update request, when the user runs `pdd update`, then PDD validates the selected mode before running update logic.
+2. Given a code change reflects accepted behavior, when update succeeds, then the corresponding prompt is updated rather than leaving the accepted behavior only in generated code.
+3. Given agentic update is available, when the update path uses it, then legacy fallback remains explicit and does not hide failures.
+4. Given `--sync-metadata` is requested, when metadata synchronization fails, then the update command reports failure rather than silently succeeding.
+5. Given an update succeeds without redirected output, when finalization runs, then stale run reports are cleared and a fresh prompt/code fingerprint is recorded.
+6. Given coverage reports this story, when update and metadata dev units are listed separately, then this story appears under each linked unit but is counted once globally.
+
+## Oracle
+
+These details matter for pass/fail:
+- update-mode validation before work starts
+- accepted code behavior is copied back to prompts
+- agentic and fallback update paths are distinguishable
+- metadata synchronization failure is surfaced
+- stale run-report cleanup and fingerprint finalization happen after successful update
+- cross-unit metadata lists every participating dev unit
+
+## Non-Oracle
+
+These details should not matter:
+- exact prompt prose produced by the updater
+- exact provider/model selected
+- exact progress table styling
+- exact ordering of unrelated repository-mode candidates
+
+## Negative Cases
+
+- Ambiguous update modes must not proceed to prompt modification.
+- Accepted behavior must not remain only in generated code after a successful update.
+- Metadata synchronization failure must not be swallowed as success.
+- Coverage must not count this one cross-unit story once for each linked prompt.
+
+## Non-Goals
+
+- This story does not verify semantic correctness of every generated prompt edit.
+- This story does not cover `pdd change` feature workflow.
+- This story does not require live model calls in deterministic local verification.
+
+## Candidate Prompts
+
+- `prompts/commands/modify_python.prompt` - owns the public `pdd update` command surface.
+- `prompts/update_main_python.prompt` - owns update routing and prompt back-propagation.
+- `prompts/agentic_update_python.prompt` - owns agentic update behavior.
+- `prompts/metadata_sync_python.prompt` - owns metadata synchronization.
+- `prompts/operation_log_python.prompt` - owns fingerprint and run-report metadata.
+- `prompts/detect_change_main_python.prompt` - related change detection support.
+
+## Notes
+
+This story is a cross-dev-unit regression oracle for the documented
+code-to-prompt update workflow in `docs/prompting_guide.md`.

--- a/user_stories/story__pdd_bug_fix_verification.md
+++ b/user_stories/story__pdd_bug_fix_verification.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/analysis_python.prompt, prompts/agentic_bug_orchestrator_python.prompt, prompts/commands/fix_python.prompt, prompts/agentic_e2e_fix_orchestrator_python.prompt, prompts/agentic_common_python.prompt -->
+<!-- pdd-story-dev-units: analysis_python.prompt, agentic_bug_orchestrator_python.prompt, fix_python.prompt, agentic_e2e_fix_orchestrator_python.prompt, agentic_common_python.prompt -->
+
+# User Story: Bug report becomes a verified fix
+
+## Story
+
+As a maintainer responding to a bug report, I want PDD to capture the failure as tests and then repair the affected code until the checks pass, so that the fix is enforced by durable regression evidence.

--- a/user_stories/story__pdd_feature_change_pr.md
+++ b/user_stories/story__pdd_feature_change_pr.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/modify_python.prompt, prompts/agentic_change_orchestrator_python.prompt, prompts/agentic_change_python.prompt, prompts/user_story_tests_python.prompt, prompts/generate_story_contract_LLM.prompt -->
+<!-- pdd-story-dev-units: modify_python.prompt, agentic_change_orchestrator_python.prompt, agentic_change_python.prompt, user_story_tests_python.prompt, generate_story_contract_LLM.prompt -->
+
+# User Story: Feature request becomes a verified PDD change PR
+
+## Story
+
+As a maintainer implementing a feature request, I want PDD to convert the issue into prompt changes, story evidence, and a reviewable pull request, so that reviewers can validate both the requested behavior and the prompt source of truth.

--- a/user_stories/story__pdd_generate.md
+++ b/user_stories/story__pdd_generate.md
@@ -1,0 +1,9 @@
+<!-- pdd-story-prompts: prompts/commands/generate_python.prompt -->
+
+# User Story: pdd generate
+
+## Story
+
+As a maintainer turning prompts or product descriptions into project artifacts,
+I want PDD to route my generate request to the right generation workflow,
+so that code, architecture, and previews are produced or rejected predictably.

--- a/user_stories/story__pdd_prd_generate_sync.md
+++ b/user_stories/story__pdd_prd_generate_sync.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/generate_python.prompt, prompts/agentic_architecture_python.prompt, prompts/sync_main_python.prompt, prompts/commands/maintenance_python.prompt -->
+<!-- pdd-story-dev-units: generate_python.prompt, agentic_architecture_python.prompt, sync_main_python.prompt, maintenance_python.prompt -->
+
+# User Story: PRD generate output can be synced into a module
+
+## Story
+
+As a maintainer starting from a product request, I want PDD to turn the request into prompt files and then sync a selected module from those prompts, so that the first generated implementation is still traceable to the original request.

--- a/user_stories/story__pdd_story_test_coverage.md
+++ b/user_stories/story__pdd_story_test_coverage.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/generate_python.prompt, prompts/agentic_test_orchestrator_python.prompt, prompts/user_story_tests_python.prompt, prompts/coverage_contracts_python.prompt, prompts/commands/checkup_python.prompt -->
+<!-- pdd-story-dev-units: generate_python.prompt, agentic_test_orchestrator_python.prompt, user_story_tests_python.prompt, coverage_contracts_python.prompt, checkup_python.prompt -->
+
+# User Story: Story tests appear in coverage
+
+## Story
+
+As a reviewer checking prompt coverage, I want PDD story-mode test artifacts to appear in coverage reports for every prompt they protect, so that cross-module user outcomes are visible without inflating the story count.

--- a/user_stories/story__pdd_update.md
+++ b/user_stories/story__pdd_update.md
@@ -1,0 +1,9 @@
+<!-- pdd-story-prompts: prompts/commands/modify_python.prompt -->
+
+# User Story: pdd update
+
+## Story
+
+As a maintainer whose generated code has changed,
+I want PDD to update the authoritative prompt through the right update mode,
+so that prompt, code, and metadata stay aligned for future syncs.

--- a/user_stories/story__pdd_update_metadata_sync.md
+++ b/user_stories/story__pdd_update_metadata_sync.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/modify_python.prompt, prompts/update_main_python.prompt, prompts/agentic_update_python.prompt, prompts/metadata_sync_python.prompt, prompts/operation_log_python.prompt -->
+<!-- pdd-story-dev-units: modify_python.prompt, update_main_python.prompt, agentic_update_python.prompt, metadata_sync_python.prompt, operation_log_python.prompt -->
+
+# User Story: Code changes update the prompt source
+
+## Story
+
+As a maintainer who made or reviewed a code change, I want PDD to back-propagate the changed behavior into the prompt and refresh metadata, so that future regeneration keeps the accepted behavior instead of drifting away.


### PR DESCRIPTION
## Summary

Parent EPIC PR for #1703. This PR collects verified single-dev-unit user-story
backfill sub PRs for the top documented PDD workflow features: generate, sync,
fix, change, and update.

Sub PRs targeted `epic/issue-1703-story-regression-backfill` and were merged
into this PR branch after deterministic local verification. This parent PR must
not be merged into `main` until reviewed.

## Completed Sub PRs

- #1801 — `pdd sync`: aligned the existing story contract hash and added the
  deterministic top-flow story check.
- #1802 — `pdd fix`: aligned the existing story contract hash and extended the
  top-flow story check.
- #1803 — `pdd change`: aligned the existing story contract hash and extended
  the top-flow story check.
- #1804 — `pdd generate`: added the missing story, contract, and top-flow story
  check coverage.
- #1806 — `pdd update`: added the missing story, contract, and top-flow story
  check coverage.

## Verification

No LLM/provider-key-backed PDD commands were used for this backfill.
Verification is deterministic and local: tests inspect the PDD user-story files,
prompt metadata, contract headers, required contract sections, rule IDs, and
story-hash alignment.

```bash
python -m py_compile tests/test_story_backfill_top_flows.py
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('story_checks','tests/test_story_backfill_top_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_top_flow_story_backfill_artifacts_are_complete(); print('story backfill checks passed')"
```

Refs #1703
Part of #1698
