### PR TITLE
test(stories): verify pdd change backfill story

### DIFF
--- a/tests/test_story_backfill_top_flows.py
+++ b/tests/test_story_backfill_top_flows.py
@@ -38,6 +38,12 @@ REQUIRED_CONTRACT_SECTIONS = (
 )
 
 TOP_FLOW_STORIES = {
+    "pdd_change": {
+        "metadata_prompt": "prompts/commands/modify_python.prompt",
+        "package_prompt": "commands/modify_python.prompt",
+        "covers": {"R1", "R2", "R3", "R4"},
+        "must_contain": ("agentic change", "contract sidecar"),
+    },
     "pdd_fix": {
         "metadata_prompt": "prompts/commands/fix_python.prompt",
         "package_prompt": "commands/fix_python.prompt",

--- a/user_stories/contracts/pdd_change.contract.md
+++ b/user_stories/contracts/pdd_change.contract.md
@@ -1,4 +1,4 @@
-<!-- pdd-story-contract derived-from-story="../story__pdd_change.md" story-hash="<auto>" issue-ref="https://github.com/promptdriven/pdd/pull/1501#issuecomment-4662232582" -->
+<!-- pdd-story-contract derived-from-story="../story__pdd_change.md" story-hash="3d3e24afdcf4ac7e" issue-ref="https://github.com/promptdriven/pdd/pull/1501#issuecomment-4662232582" -->
 
 # Contract: pdd change
 


### PR DESCRIPTION
## Summary

Adds deterministic verification for the existing single-dev-unit `pdd change`
user story as part of the #1703 top-flow backfill.

This sub PR targets parent EPIC PR #1800, not `main`.

## Changes

- Aligns `user_stories/contracts/pdd_change.contract.md` with the current
  `story-hash` for `user_stories/story__pdd_change.md`.
- Extends deterministic story-backfill checks to cover the `pdd change` story,
  contract, rule IDs, and linked prompt.

## Verification

No LLM/API-backed PDD commands were run.

```bash
python -m py_compile tests/test_story_backfill_top_flows.py
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('story_checks','tests/test_story_backfill_top_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_top_flow_story_backfill_artifacts_are_complete(); print('story backfill checks passed')"
```

Refs #1703
Parent PR: #1800
