### PR TITLE
test(stories): add cross-unit PRD generate-sync story

### DIFF
--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -16,6 +16,15 @@ features called out by the issue and the workflow documentation:
 These are intentionally single-dev-unit stories. Cross-dev-unit stories are a
 follow-up phase.
 
+The cross-dev-unit follow-up covers documented PDD workflows that naturally span
+more than one dev unit:
+
+- PRD-backed `pdd generate` output handed to `pdd sync`
+
+Cross-dev-unit stories use both `pdd-story-prompts` and `pdd-story-dev-units`
+metadata so the same story is attributed to every linked dev unit while still
+counting as one global regression oracle.
+
 ## Verification
 
 This backfill uses the existing PDD user-story file model:
@@ -53,4 +62,6 @@ Final local verification:
 ```bash
 python -m py_compile tests/test_story_backfill_top_flows.py
 python -c "import importlib.util; spec=importlib.util.spec_from_file_location('story_checks','tests/test_story_backfill_top_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_top_flow_story_backfill_artifacts_are_complete(); print('story backfill checks passed')"
+python -m py_compile tests/test_story_backfill_cross_unit_flows.py
+python -c "import importlib.util; spec=importlib.util.spec_from_file_location('cross_story_checks','tests/test_story_backfill_cross_unit_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_cross_unit_story_backfill_artifacts_are_complete(); print('cross-unit story checks passed')"
 ```

--- a/tests/test_story_backfill_cross_unit_flows.py
+++ b/tests/test_story_backfill_cross_unit_flows.py
@@ -1,0 +1,144 @@
+"""Deterministic checks for cross-dev-unit user-story backfill."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STORIES_DIR = REPO_ROOT / "user_stories"
+CONTRACTS_DIR = STORIES_DIR / "contracts"
+PACKAGE_PROMPTS_DIR = REPO_ROOT / "pdd" / "prompts"
+
+STORY_PROMPTS_METADATA_RE = re.compile(
+    r"<!--\s*pdd-story-prompts:\s*(?P<values>.*?)\s*-->",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+STORY_DEV_UNITS_METADATA_RE = re.compile(
+    r"<!--\s*pdd-story-dev-units:\s*(?P<values>.*?)\s*-->",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+CONTRACT_HEADER_RE = re.compile(
+    r"<!--\s*pdd-story-contract\b(?P<attrs>.*?)-->",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+CONTRACT_ATTR_RE = re.compile(
+    r"(?P<key>[a-z0-9_-]+)\s*=\s*\"(?P<val>[^\"]*)\"",
+    flags=re.IGNORECASE,
+)
+
+REQUIRED_CONTRACT_SECTIONS = (
+    "## Covers",
+    "## Context",
+    "## Acceptance Criteria",
+    "## Oracle",
+    "## Non-Oracle",
+    "## Negative Cases",
+    "## Non-Goals",
+    "## Candidate Prompts",
+    "## Notes",
+)
+
+CROSS_UNIT_STORIES = {
+    "pdd_prd_generate_sync": {
+        "metadata_prompts": [
+            "prompts/commands/generate_python.prompt",
+            "prompts/agentic_architecture_python.prompt",
+            "prompts/sync_main_python.prompt",
+            "prompts/commands/maintenance_python.prompt",
+        ],
+        "dev_units": [
+            "generate_python.prompt",
+            "agentic_architecture_python.prompt",
+            "sync_main_python.prompt",
+            "maintenance_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5", "R6"},
+        "must_contain": (
+            "documented PRD workflow",
+            "counted once globally",
+        ),
+    },
+}
+
+
+def _story_path(story_id: str) -> Path:
+    return STORIES_DIR / f"story__{story_id}.md"
+
+
+def _contract_path(story_id: str) -> Path:
+    return CONTRACTS_DIR / f"{story_id}.contract.md"
+
+
+def _parse_metadata(pattern: re.Pattern[str], story_text: str) -> list[str]:
+    match = pattern.search(story_text)
+    if not match:
+        return []
+    raw = match.group("values").strip()
+    return [entry.strip() for entry in raw.split(",") if entry.strip()]
+
+
+def _story_content_hash(story_text: str) -> str:
+    without_prompt_meta = STORY_PROMPTS_METADATA_RE.sub("", story_text)
+    without_meta = STORY_DEV_UNITS_METADATA_RE.sub("", without_prompt_meta)
+    lines = [line.rstrip() for line in without_meta.strip().splitlines()]
+    normalized = "\n".join(line for line in lines if line.strip())
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _parse_contract_header(contract_text: str) -> dict[str, str]:
+    match = CONTRACT_HEADER_RE.search(contract_text)
+    assert match, "contract must include pdd-story-contract header"
+    return {
+        attr.group("key").lower(): attr.group("val")
+        for attr in CONTRACT_ATTR_RE.finditer(match.group("attrs"))
+    }
+
+
+def _covered_rule_ids(contract_text: str) -> set[str]:
+    return set(re.findall(r"^\s*-\s+(R\d+):", contract_text, flags=re.MULTILINE))
+
+
+def _prompt_package_path(metadata_prompt: str) -> Path:
+    assert metadata_prompt.startswith("prompts/")
+    return PACKAGE_PROMPTS_DIR / metadata_prompt.removeprefix("prompts/")
+
+
+def test_cross_unit_story_backfill_artifacts_are_complete() -> None:
+    assert len(CROSS_UNIT_STORIES) == len(set(CROSS_UNIT_STORIES))
+
+    for story_id, expected in CROSS_UNIT_STORIES.items():
+        story_path = _story_path(story_id)
+        contract_path = _contract_path(story_id)
+
+        assert story_path.exists(), f"{story_id} story is missing"
+        assert contract_path.exists(), f"{story_id} contract is missing"
+
+        story_text = story_path.read_text(encoding="utf-8")
+        contract_text = contract_path.read_text(encoding="utf-8")
+
+        prompt_refs = _parse_metadata(STORY_PROMPTS_METADATA_RE, story_text)
+        dev_units = _parse_metadata(STORY_DEV_UNITS_METADATA_RE, story_text)
+        assert prompt_refs == expected["metadata_prompts"]
+        assert dev_units == expected["dev_units"]
+        assert len(prompt_refs) >= 2
+        assert len(dev_units) >= 2
+
+        for prompt_ref in prompt_refs:
+            assert _prompt_package_path(prompt_ref).exists()
+            assert f"`{prompt_ref}`" in contract_text
+
+        header = _parse_contract_header(contract_text)
+        assert header["derived-from-story"] == f"../story__{story_id}.md"
+        assert header["story-hash"] == _story_content_hash(story_text)
+        assert header["issue-ref"] == "https://github.com/promptdriven/pdd/issues/1769"
+
+        for section in REQUIRED_CONTRACT_SECTIONS:
+            assert section in contract_text
+
+        assert expected["covers"] <= _covered_rule_ids(contract_text)
+
+        for phrase in expected["must_contain"]:
+            assert phrase in contract_text

--- a/user_stories/contracts/pdd_prd_generate_sync.contract.md
+++ b/user_stories/contracts/pdd_prd_generate_sync.contract.md
@@ -1,0 +1,77 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_prd_generate_sync.md" story-hash="50dfcb910ae19ae4" issue-ref="https://github.com/promptdriven/pdd/issues/1769" -->
+
+# Contract: PRD generate output can be synced into a module
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_prd_generate_sync.md`), not this contract.
+
+## Covers
+
+- R1: A GitHub issue or PRD source routes `pdd generate` to the architecture workflow.
+- R2: The architecture workflow produces reviewable project configuration and prompt files.
+- R3: Generated prompt files remain valid inputs to `pdd sync <module>`.
+- R4: Sync preserves the selected module boundary instead of treating the PRD as a global rewrite.
+- R5: The handoff records enough evidence for reviewers to connect the synced module back to the original request.
+- R6: The cross-dev-unit story is attributed to generate, architecture, sync, and maintenance command prompts without being counted as four stories.
+
+## Context
+
+The documented PRD workflow says `pdd generate <issue-url>` creates
+`architecture.json`, `.pddrc`, and prompt files, then the user can run
+`pdd sync my_module` on generated prompts. This crosses the generate command,
+agentic architecture workflow, sync implementation, and maintenance command
+surface.
+
+## Acceptance Criteria
+
+1. Given a GitHub issue containing a PRD, when the user runs `pdd generate <issue-url>`, then PDD routes to the architecture workflow rather than ordinary single-prompt generation.
+2. Given the architecture workflow succeeds, when the user reviews the output, then the output includes project configuration and prompt files suitable for later sync.
+3. Given a generated prompt/module exists, when the user runs `pdd sync <module>`, then PDD syncs that module through the normal single-module sync path.
+4. Given the sync target is one module, when PDD materializes code, then it does not silently widen the request to every generated module.
+5. Given reviewers inspect the resulting PR, when they trace the synced module, then they can identify the original PRD request and the prompt files that shaped the code.
+6. Given this story is reported in coverage, when generate and sync dev units are listed separately, then this story is shown under each linked unit but counted once globally.
+
+## Oracle
+
+These details matter for pass/fail:
+- issue/PRD routing to the architecture workflow
+- architecture output includes prompt files and project configuration
+- sync accepts a generated module target after architecture generation
+- single-module sync scope is preserved
+- evidence links the generated/synced artifacts to the request
+- cross-unit story metadata lists every participating dev unit
+
+## Non-Oracle
+
+These details should not matter:
+- exact generated module names or architecture content
+- exact provider/model used by generation or sync
+- exact console styling or progress wording
+- internal helper names below the documented command boundaries
+
+## Negative Cases
+
+- A PRD issue must not be handled as a normal prompt-file generation request.
+- `pdd sync <module>` must not ignore the requested module and regenerate the whole project.
+- The generated prompt handoff must not lose the issue/request reference needed for review.
+- Coverage must not count this one cross-unit story once per linked prompt.
+
+## Non-Goals
+
+- This story does not verify the semantic quality of generated application code.
+- This story does not cover incremental PRD mode.
+- This story does not prescribe the internal architecture step sequence.
+
+## Candidate Prompts
+
+- `prompts/commands/generate_python.prompt` - owns the public `pdd generate` command surface.
+- `prompts/agentic_architecture_python.prompt` - owns the PRD/issue architecture workflow.
+- `prompts/sync_main_python.prompt` - owns single-module sync behavior.
+- `prompts/commands/maintenance_python.prompt` - owns the public `pdd sync` command surface.
+- `prompts/sync_orchestration_python.prompt` - related sync orchestration support.
+
+## Notes
+
+This story is a cross-dev-unit regression oracle for the documented PRD
+generate-to-sync workflow in `docs/TUTORIALS.md`.

--- a/user_stories/story__pdd_prd_generate_sync.md
+++ b/user_stories/story__pdd_prd_generate_sync.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/generate_python.prompt, prompts/agentic_architecture_python.prompt, prompts/sync_main_python.prompt, prompts/commands/maintenance_python.prompt -->
+<!-- pdd-story-dev-units: generate_python.prompt, agentic_architecture_python.prompt, sync_main_python.prompt, maintenance_python.prompt -->
+
+# User Story: PRD generate output can be synced into a module
+
+## Story
+
+As a maintainer starting from a product request, I want PDD to turn the request into prompt files and then sync a selected module from those prompts, so that the first generated implementation is still traceable to the original request.


### PR DESCRIPTION
## Summary

Adds the first cross-dev-unit story regression backfill for the documented PRD workflow where `pdd generate <issue-url>` creates prompts/project configuration and `pdd sync <module>` materializes one selected module.

This targets EPIC PR #1800 and exercises issue #1769's cross-dev-unit story model with both `pdd-story-prompts` and `pdd-story-dev-units` metadata.

## Verification

```bash
python -m py_compile tests/test_story_backfill_cross_unit_flows.py
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('cross_story_checks','tests/test_story_backfill_cross_unit_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_cross_unit_story_backfill_artifacts_are_complete(); print('cross-unit story checks passed')"
```

Refs #1769
Part of #1800