### PR TITLE
test(stories): add cross-unit bug fix story

### DIFF
--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -22,6 +22,7 @@ more than one dev unit:
 - PRD-backed `pdd generate` output handed to `pdd sync`
 - Feature-request `pdd change` output carried through story/contract artifacts
   and reviewable PR creation
+- Bug-report `pdd bug` reproduction handed to `pdd fix` verification
 
 Cross-dev-unit stories use both `pdd-story-prompts` and `pdd-story-dev-units`
 metadata so the same story is attributed to every linked dev unit while still

--- a/tests/test_story_backfill_cross_unit_flows.py
+++ b/tests/test_story_backfill_cross_unit_flows.py
@@ -42,6 +42,27 @@ REQUIRED_CONTRACT_SECTIONS = (
 )
 
 CROSS_UNIT_STORIES = {
+    "pdd_bug_fix_verification": {
+        "metadata_prompts": [
+            "prompts/commands/analysis_python.prompt",
+            "prompts/agentic_bug_orchestrator_python.prompt",
+            "prompts/commands/fix_python.prompt",
+            "prompts/agentic_e2e_fix_orchestrator_python.prompt",
+            "prompts/agentic_common_python.prompt",
+        ],
+        "dev_units": [
+            "analysis_python.prompt",
+            "agentic_bug_orchestrator_python.prompt",
+            "fix_python.prompt",
+            "agentic_e2e_fix_orchestrator_python.prompt",
+            "agentic_common_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5", "R6"},
+        "must_contain": (
+            "bug-to-fix workflow",
+            "failing tests",
+        ),
+    },
     "pdd_feature_change_pr": {
         "metadata_prompts": [
             "prompts/commands/modify_python.prompt",

--- a/user_stories/contracts/pdd_bug_fix_verification.contract.md
+++ b/user_stories/contracts/pdd_bug_fix_verification.contract.md
@@ -1,0 +1,78 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_bug_fix_verification.md" story-hash="29c6a547ae8cc133" issue-ref="https://github.com/promptdriven/pdd/issues/1769" -->
+
+# Contract: Bug report becomes a verified fix
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_bug_fix_verification.md`), not this contract.
+
+## Covers
+
+- R1: Bug issue URLs route through `pdd bug` to create a reproducible failing test or test plan.
+- R2: The bug workflow distinguishes code bugs from prompt defects before the fix loop runs.
+- R3: `pdd fix` consumes the failing tests and protected context as repair constraints.
+- R4: The fix workflow iterates until local verification passes or a clear failure is reported.
+- R5: Post-fix evidence preserves test results, CI status when enabled, and workflow comments.
+- R6: The cross-dev-unit story is attributed to analysis, bug orchestration, fix command, E2E fix orchestration, and shared agentic utilities without duplicate global counting.
+
+## Context
+
+The documented bug workflow starts with `pdd bug <issue-url>` to create failing
+tests, then uses `pdd fix <issue-url>` to repair code until tests pass locally
+and, when enabled, through post-push CI. This crosses the analysis command,
+bug orchestrator, fix command, E2E fix orchestrator, and shared agentic
+comment/evidence utilities.
+
+## Acceptance Criteria
+
+1. Given a GitHub bug issue, when the user runs `pdd bug <issue-url>`, then PDD routes to the agentic bug workflow and captures the observed failure as executable or planned regression evidence.
+2. Given the root cause indicates a prompt defect, when the bug workflow classifies the defect, then it records that the prompt must be fixed before generating downstream tests.
+3. Given failing tests exist for the bug, when the user runs `pdd fix <issue-url>`, then PDD uses those tests as constraints for the repair loop.
+4. Given tests fail after a repair attempt, when the fix loop continues, then the workflow reports the failure and attempts another bounded repair rather than declaring success.
+5. Given local verification passes, when the workflow finishes, then the PR evidence identifies the tests and any CI validation or skipped CI choice.
+6. Given coverage reports this story, when bug and fix dev units are listed separately, then this story appears under each linked unit but is counted once globally.
+
+## Oracle
+
+These details matter for pass/fail:
+- `pdd bug` routes issue URLs to bug reproduction
+- failing tests or explicit test plan evidence are created before repair
+- prompt-defect classification is not lost
+- `pdd fix` uses tests as constraints and verifies before success
+- post-fix evidence includes local checks and CI status or skip reason
+- cross-unit metadata lists every participating dev unit
+
+## Non-Oracle
+
+These details should not matter:
+- exact generated test code
+- exact repair patch content
+- exact provider/model used
+- exact comment formatting beyond status and evidence semantics
+
+## Negative Cases
+
+- `pdd fix` must not declare success while the captured failing tests still fail.
+- A prompt defect must not be treated as only a generated-code bug when the workflow has enough evidence to classify it.
+- CI failures must not be hidden when CI validation is enabled.
+- Coverage must not count this one cross-unit story once for each linked prompt.
+
+## Non-Goals
+
+- This story does not prescribe the exact unit tests produced by `pdd bug`.
+- This story does not cover feature-request handling through `pdd change`.
+- This story does not require live CI in deterministic local verification.
+
+## Candidate Prompts
+
+- `prompts/commands/analysis_python.prompt` - owns the public `pdd bug` command surface.
+- `prompts/agentic_bug_orchestrator_python.prompt` - owns bug workflow orchestration.
+- `prompts/commands/fix_python.prompt` - owns the public `pdd fix` command surface.
+- `prompts/agentic_e2e_fix_orchestrator_python.prompt` - owns iterative fix verification.
+- `prompts/agentic_common_python.prompt` - owns shared agentic comments and runner behavior.
+- `prompts/agentic_bug_python.prompt` - related bug workflow behavior.
+
+## Notes
+
+This story is a cross-dev-unit regression oracle for the documented
+bug-to-fix workflow in `docs/TUTORIALS.md` and `docs/prompting_guide.md`.

--- a/user_stories/story__pdd_bug_fix_verification.md
+++ b/user_stories/story__pdd_bug_fix_verification.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/analysis_python.prompt, prompts/agentic_bug_orchestrator_python.prompt, prompts/commands/fix_python.prompt, prompts/agentic_e2e_fix_orchestrator_python.prompt, prompts/agentic_common_python.prompt -->
+<!-- pdd-story-dev-units: analysis_python.prompt, agentic_bug_orchestrator_python.prompt, fix_python.prompt, agentic_e2e_fix_orchestrator_python.prompt, agentic_common_python.prompt -->
+
+# User Story: Bug report becomes a verified fix
+
+## Story
+
+As a maintainer responding to a bug report, I want PDD to capture the failure as tests and then repair the affected code until the checks pass, so that the fix is enforced by durable regression evidence.


### PR DESCRIPTION
## Summary

Adds a cross-dev-unit story regression backfill for the documented bug workflow: `pdd bug <issue-url>` captures a failing behavior and `pdd fix <issue-url>` repairs it through verified tests/evidence.

This targets EPIC PR #1800 and exercises issue #1769's cross-dev-unit story model with both `pdd-story-prompts` and `pdd-story-dev-units` metadata.

## Verification

```bash
python -m py_compile tests/test_story_backfill_cross_unit_flows.py
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('cross_story_checks','tests/test_story_backfill_cross_unit_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_cross_unit_story_backfill_artifacts_are_complete(); print('cross-unit story checks passed')"
```

Refs #1769
Part of #1800