### PR TITLE
test(stories): add cross-unit story coverage story

### DIFF
--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -23,6 +23,7 @@ more than one dev unit:
 - Feature-request `pdd change` output carried through story/contract artifacts
   and reviewable PR creation
 - Bug-report `pdd bug` reproduction handed to `pdd fix` verification
+- Story-mode `pdd test` artifacts surfaced through `pdd checkup coverage`
 
 Cross-dev-unit stories use both `pdd-story-prompts` and `pdd-story-dev-units`
 metadata so the same story is attributed to every linked dev unit while still

--- a/tests/test_story_backfill_cross_unit_flows.py
+++ b/tests/test_story_backfill_cross_unit_flows.py
@@ -63,6 +63,27 @@ CROSS_UNIT_STORIES = {
             "failing tests",
         ),
     },
+    "pdd_story_test_coverage": {
+        "metadata_prompts": [
+            "prompts/commands/generate_python.prompt",
+            "prompts/agentic_test_orchestrator_python.prompt",
+            "prompts/user_story_tests_python.prompt",
+            "prompts/coverage_contracts_python.prompt",
+            "prompts/commands/checkup_python.prompt",
+        ],
+        "dev_units": [
+            "generate_python.prompt",
+            "agentic_test_orchestrator_python.prompt",
+            "user_story_tests_python.prompt",
+            "coverage_contracts_python.prompt",
+            "checkup_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5", "R6"},
+        "must_contain": (
+            "story-mode test workflow",
+            "coverage matrix",
+        ),
+    },
     "pdd_feature_change_pr": {
         "metadata_prompts": [
             "prompts/commands/modify_python.prompt",

--- a/user_stories/contracts/pdd_story_test_coverage.contract.md
+++ b/user_stories/contracts/pdd_story_test_coverage.contract.md
@@ -1,0 +1,78 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_story_test_coverage.md" story-hash="8fdc178d30078079" issue-ref="https://github.com/promptdriven/pdd/issues/1769" -->
+
+# Contract: Story tests appear in coverage
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_story_test_coverage.md`), not this contract.
+
+## Covers
+
+- R1: `pdd test --issue <source> <prompt...>` creates or updates story artifacts linked to every supplied prompt.
+- R2: Existing `story__*.md` files can refresh prompt-link metadata through story mode.
+- R3: Story contracts retain rule coverage and candidate prompt context for reviewers.
+- R4: `pdd checkup coverage` includes story evidence in the rule-to-evidence matrix.
+- R5: Cross-dev-unit stories are attributed to each linked prompt while counted once globally.
+- R6: Coverage output exposes unresolved, stale, or missing evidence without treating cross-unit metadata as separate stories.
+
+## Context
+
+The documented story-mode test workflow uses `pdd test` with prompt files or an
+existing `story__*.md` file to generate or refresh user-story artifacts. Coverage
+then reads story/contract evidence through `pdd checkup coverage`. This crosses
+the generate/test command surface, agentic test workflow, story utility module,
+coverage engine, and checkup delegation command.
+
+## Acceptance Criteria
+
+1. Given an issue source and two or more prompt files, when the user runs `pdd test --issue <source> <prompt...>`, then PDD writes a story linked to every supplied prompt.
+2. Given an existing `story__*.md` file, when the user runs `pdd test <story-file>`, then PDD refreshes prompt-link metadata rather than treating the story as code input.
+3. Given a story contract lists covered rules, when coverage scans the prompt, then the matching story appears as evidence for those rule IDs.
+4. Given a story links multiple prompts, when coverage scans each prompt, then the story is attributed to each prompt without creating multiple global story identities.
+5. Given evidence is stale, missing, or unresolved, when coverage renders output, then reviewers can see that status instead of receiving a silent pass.
+6. Given the story lane summary groups by story slug, when this cross-unit story appears, then it is reported once with its linked dev-unit scope.
+
+## Oracle
+
+These details matter for pass/fail:
+- story-mode routing in `pdd test`
+- prompt metadata is written or refreshed for every linked prompt
+- story contract rule coverage feeds the coverage matrix
+- missing/stale evidence remains visible
+- global metrics deduplicate by story identity
+- cross-unit metadata lists every participating dev unit
+
+## Non-Oracle
+
+These details should not matter:
+- exact LLM-authored story wording
+- exact terminal table styling
+- exact provider/model used for story generation
+- exact order of unrelated coverage rows
+
+## Negative Cases
+
+- A story file must not be handled as a normal prompt/code unit-test input.
+- A multi-prompt story must not be reported as separate unrelated stories.
+- Missing or stale evidence must not be hidden by the cross-unit grouping.
+- Coverage must not count this one cross-unit story once for each linked prompt.
+
+## Non-Goals
+
+- This story does not verify the generated executable test contents.
+- This story does not cover live model availability.
+- This story does not prescribe the exact coverage table formatting.
+
+## Candidate Prompts
+
+- `prompts/commands/generate_python.prompt` - owns the public `pdd test` command surface.
+- `prompts/agentic_test_orchestrator_python.prompt` - owns issue-driven test workflow orchestration.
+- `prompts/user_story_tests_python.prompt` - owns story metadata and traceability.
+- `prompts/coverage_contracts_python.prompt` - owns deterministic rule-to-evidence coverage.
+- `prompts/commands/checkup_python.prompt` - delegates `pdd checkup coverage`.
+- `prompts/agentic_test_step6_coverage_LLM.prompt` - related test-plan coverage step.
+
+## Notes
+
+This story is a cross-dev-unit regression oracle for the documented
+story-mode test workflow and issue #1769 coverage requirements.

--- a/user_stories/story__pdd_story_test_coverage.md
+++ b/user_stories/story__pdd_story_test_coverage.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/generate_python.prompt, prompts/agentic_test_orchestrator_python.prompt, prompts/user_story_tests_python.prompt, prompts/coverage_contracts_python.prompt, prompts/commands/checkup_python.prompt -->
+<!-- pdd-story-dev-units: generate_python.prompt, agentic_test_orchestrator_python.prompt, user_story_tests_python.prompt, coverage_contracts_python.prompt, checkup_python.prompt -->
+
+# User Story: Story tests appear in coverage
+
+## Story
+
+As a reviewer checking prompt coverage, I want PDD story-mode test artifacts to appear in coverage reports for every prompt they protect, so that cross-module user outcomes are visible without inflating the story count.


### PR DESCRIPTION
## Summary

Adds a cross-dev-unit story regression backfill for story-mode `pdd test` and deterministic `pdd checkup coverage`, covering story metadata, contract evidence, coverage attribution, and global deduplication.

This targets EPIC PR #1800 and exercises issue #1769's cross-dev-unit story model with both `pdd-story-prompts` and `pdd-story-dev-units` metadata.

## Verification

```bash
python -m py_compile tests/test_story_backfill_cross_unit_flows.py
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('cross_story_checks','tests/test_story_backfill_cross_unit_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_cross_unit_story_backfill_artifacts_are_complete(); print('cross-unit story checks passed')"
```

Refs #1769
Part of #1800