### PR TITLE
test(stories): carry cross-unit workflow stories into epic branch

### DIFF
--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -24,6 +24,7 @@ more than one dev unit:
   and reviewable PR creation
 - Bug-report `pdd bug` reproduction handed to `pdd fix` verification
 - Story-mode `pdd test` artifacts surfaced through `pdd checkup coverage`
+- Code-to-prompt `pdd update` results finalized through metadata synchronization
 
 Cross-dev-unit stories use both `pdd-story-prompts` and `pdd-story-dev-units`
 metadata so the same story is attributed to every linked dev unit while still

--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -23,6 +23,7 @@ more than one dev unit:
 - Feature-request `pdd change` output carried through story/contract artifacts
   and reviewable PR creation
 - Bug-report `pdd bug` reproduction handed to `pdd fix` verification
+- Story-mode `pdd test` artifacts surfaced through `pdd checkup coverage`
 
 Cross-dev-unit stories use both `pdd-story-prompts` and `pdd-story-dev-units`
 metadata so the same story is attributed to every linked dev unit while still

--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -22,6 +22,7 @@ more than one dev unit:
 - PRD-backed `pdd generate` output handed to `pdd sync`
 - Feature-request `pdd change` output carried through story/contract artifacts
   and reviewable PR creation
+- Bug-report `pdd bug` reproduction handed to `pdd fix` verification
 
 Cross-dev-unit stories use both `pdd-story-prompts` and `pdd-story-dev-units`
 metadata so the same story is attributed to every linked dev unit while still

--- a/tests/test_story_backfill_cross_unit_flows.py
+++ b/tests/test_story_backfill_cross_unit_flows.py
@@ -63,6 +63,27 @@ CROSS_UNIT_STORIES = {
             "failing tests",
         ),
     },
+    "pdd_story_test_coverage": {
+        "metadata_prompts": [
+            "prompts/commands/generate_python.prompt",
+            "prompts/agentic_test_orchestrator_python.prompt",
+            "prompts/user_story_tests_python.prompt",
+            "prompts/coverage_contracts_python.prompt",
+            "prompts/commands/checkup_python.prompt",
+        ],
+        "dev_units": [
+            "generate_python.prompt",
+            "agentic_test_orchestrator_python.prompt",
+            "user_story_tests_python.prompt",
+            "coverage_contracts_python.prompt",
+            "checkup_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5", "R6"},
+        "must_contain": (
+            "story-mode test workflow",
+            "coverage matrix",
+        ),
+    },
     "pdd_feature_change_pr": {
         "metadata_prompts": [
             "prompts/commands/modify_python.prompt",

--- a/tests/test_story_backfill_cross_unit_flows.py
+++ b/tests/test_story_backfill_cross_unit_flows.py
@@ -42,6 +42,27 @@ REQUIRED_CONTRACT_SECTIONS = (
 )
 
 CROSS_UNIT_STORIES = {
+    "pdd_bug_fix_verification": {
+        "metadata_prompts": [
+            "prompts/commands/analysis_python.prompt",
+            "prompts/agentic_bug_orchestrator_python.prompt",
+            "prompts/commands/fix_python.prompt",
+            "prompts/agentic_e2e_fix_orchestrator_python.prompt",
+            "prompts/agentic_common_python.prompt",
+        ],
+        "dev_units": [
+            "analysis_python.prompt",
+            "agentic_bug_orchestrator_python.prompt",
+            "fix_python.prompt",
+            "agentic_e2e_fix_orchestrator_python.prompt",
+            "agentic_common_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5", "R6"},
+        "must_contain": (
+            "bug-to-fix workflow",
+            "failing tests",
+        ),
+    },
     "pdd_feature_change_pr": {
         "metadata_prompts": [
             "prompts/commands/modify_python.prompt",

--- a/tests/test_story_backfill_cross_unit_flows.py
+++ b/tests/test_story_backfill_cross_unit_flows.py
@@ -84,6 +84,27 @@ CROSS_UNIT_STORIES = {
             "coverage matrix",
         ),
     },
+    "pdd_update_metadata_sync": {
+        "metadata_prompts": [
+            "prompts/commands/modify_python.prompt",
+            "prompts/update_main_python.prompt",
+            "prompts/agentic_update_python.prompt",
+            "prompts/metadata_sync_python.prompt",
+            "prompts/operation_log_python.prompt",
+        ],
+        "dev_units": [
+            "modify_python.prompt",
+            "update_main_python.prompt",
+            "agentic_update_python.prompt",
+            "metadata_sync_python.prompt",
+            "operation_log_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5", "R6"},
+        "must_contain": (
+            "code-to-prompt update workflow",
+            "fingerprint",
+        ),
+    },
     "pdd_feature_change_pr": {
         "metadata_prompts": [
             "prompts/commands/modify_python.prompt",

--- a/user_stories/contracts/pdd_bug_fix_verification.contract.md
+++ b/user_stories/contracts/pdd_bug_fix_verification.contract.md
@@ -1,0 +1,78 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_bug_fix_verification.md" story-hash="29c6a547ae8cc133" issue-ref="https://github.com/promptdriven/pdd/issues/1769" -->
+
+# Contract: Bug report becomes a verified fix
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_bug_fix_verification.md`), not this contract.
+
+## Covers
+
+- R1: Bug issue URLs route through `pdd bug` to create a reproducible failing test or test plan.
+- R2: The bug workflow distinguishes code bugs from prompt defects before the fix loop runs.
+- R3: `pdd fix` consumes the failing tests and protected context as repair constraints.
+- R4: The fix workflow iterates until local verification passes or a clear failure is reported.
+- R5: Post-fix evidence preserves test results, CI status when enabled, and workflow comments.
+- R6: The cross-dev-unit story is attributed to analysis, bug orchestration, fix command, E2E fix orchestration, and shared agentic utilities without duplicate global counting.
+
+## Context
+
+The documented bug workflow starts with `pdd bug <issue-url>` to create failing
+tests, then uses `pdd fix <issue-url>` to repair code until tests pass locally
+and, when enabled, through post-push CI. This crosses the analysis command,
+bug orchestrator, fix command, E2E fix orchestrator, and shared agentic
+comment/evidence utilities.
+
+## Acceptance Criteria
+
+1. Given a GitHub bug issue, when the user runs `pdd bug <issue-url>`, then PDD routes to the agentic bug workflow and captures the observed failure as executable or planned regression evidence.
+2. Given the root cause indicates a prompt defect, when the bug workflow classifies the defect, then it records that the prompt must be fixed before generating downstream tests.
+3. Given failing tests exist for the bug, when the user runs `pdd fix <issue-url>`, then PDD uses those tests as constraints for the repair loop.
+4. Given tests fail after a repair attempt, when the fix loop continues, then the workflow reports the failure and attempts another bounded repair rather than declaring success.
+5. Given local verification passes, when the workflow finishes, then the PR evidence identifies the tests and any CI validation or skipped CI choice.
+6. Given coverage reports this story, when bug and fix dev units are listed separately, then this story appears under each linked unit but is counted once globally.
+
+## Oracle
+
+These details matter for pass/fail:
+- `pdd bug` routes issue URLs to bug reproduction
+- failing tests or explicit test plan evidence are created before repair
+- prompt-defect classification is not lost
+- `pdd fix` uses tests as constraints and verifies before success
+- post-fix evidence includes local checks and CI status or skip reason
+- cross-unit metadata lists every participating dev unit
+
+## Non-Oracle
+
+These details should not matter:
+- exact generated test code
+- exact repair patch content
+- exact provider/model used
+- exact comment formatting beyond status and evidence semantics
+
+## Negative Cases
+
+- `pdd fix` must not declare success while the captured failing tests still fail.
+- A prompt defect must not be treated as only a generated-code bug when the workflow has enough evidence to classify it.
+- CI failures must not be hidden when CI validation is enabled.
+- Coverage must not count this one cross-unit story once for each linked prompt.
+
+## Non-Goals
+
+- This story does not prescribe the exact unit tests produced by `pdd bug`.
+- This story does not cover feature-request handling through `pdd change`.
+- This story does not require live CI in deterministic local verification.
+
+## Candidate Prompts
+
+- `prompts/commands/analysis_python.prompt` - owns the public `pdd bug` command surface.
+- `prompts/agentic_bug_orchestrator_python.prompt` - owns bug workflow orchestration.
+- `prompts/commands/fix_python.prompt` - owns the public `pdd fix` command surface.
+- `prompts/agentic_e2e_fix_orchestrator_python.prompt` - owns iterative fix verification.
+- `prompts/agentic_common_python.prompt` - owns shared agentic comments and runner behavior.
+- `prompts/agentic_bug_python.prompt` - related bug workflow behavior.
+
+## Notes
+
+This story is a cross-dev-unit regression oracle for the documented
+bug-to-fix workflow in `docs/TUTORIALS.md` and `docs/prompting_guide.md`.

--- a/user_stories/contracts/pdd_story_test_coverage.contract.md
+++ b/user_stories/contracts/pdd_story_test_coverage.contract.md
@@ -1,0 +1,78 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_story_test_coverage.md" story-hash="8fdc178d30078079" issue-ref="https://github.com/promptdriven/pdd/issues/1769" -->
+
+# Contract: Story tests appear in coverage
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_story_test_coverage.md`), not this contract.
+
+## Covers
+
+- R1: `pdd test --issue <source> <prompt...>` creates or updates story artifacts linked to every supplied prompt.
+- R2: Existing `story__*.md` files can refresh prompt-link metadata through story mode.
+- R3: Story contracts retain rule coverage and candidate prompt context for reviewers.
+- R4: `pdd checkup coverage` includes story evidence in the rule-to-evidence matrix.
+- R5: Cross-dev-unit stories are attributed to each linked prompt while counted once globally.
+- R6: Coverage output exposes unresolved, stale, or missing evidence without treating cross-unit metadata as separate stories.
+
+## Context
+
+The documented story-mode test workflow uses `pdd test` with prompt files or an
+existing `story__*.md` file to generate or refresh user-story artifacts. Coverage
+then reads story/contract evidence through `pdd checkup coverage`. This crosses
+the generate/test command surface, agentic test workflow, story utility module,
+coverage engine, and checkup delegation command.
+
+## Acceptance Criteria
+
+1. Given an issue source and two or more prompt files, when the user runs `pdd test --issue <source> <prompt...>`, then PDD writes a story linked to every supplied prompt.
+2. Given an existing `story__*.md` file, when the user runs `pdd test <story-file>`, then PDD refreshes prompt-link metadata rather than treating the story as code input.
+3. Given a story contract lists covered rules, when coverage scans the prompt, then the matching story appears as evidence for those rule IDs.
+4. Given a story links multiple prompts, when coverage scans each prompt, then the story is attributed to each prompt without creating multiple global story identities.
+5. Given evidence is stale, missing, or unresolved, when coverage renders output, then reviewers can see that status instead of receiving a silent pass.
+6. Given the story lane summary groups by story slug, when this cross-unit story appears, then it is reported once with its linked dev-unit scope.
+
+## Oracle
+
+These details matter for pass/fail:
+- story-mode routing in `pdd test`
+- prompt metadata is written or refreshed for every linked prompt
+- story contract rule coverage feeds the coverage matrix
+- missing/stale evidence remains visible
+- global metrics deduplicate by story identity
+- cross-unit metadata lists every participating dev unit
+
+## Non-Oracle
+
+These details should not matter:
+- exact LLM-authored story wording
+- exact terminal table styling
+- exact provider/model used for story generation
+- exact order of unrelated coverage rows
+
+## Negative Cases
+
+- A story file must not be handled as a normal prompt/code unit-test input.
+- A multi-prompt story must not be reported as separate unrelated stories.
+- Missing or stale evidence must not be hidden by the cross-unit grouping.
+- Coverage must not count this one cross-unit story once for each linked prompt.
+
+## Non-Goals
+
+- This story does not verify the generated executable test contents.
+- This story does not cover live model availability.
+- This story does not prescribe the exact coverage table formatting.
+
+## Candidate Prompts
+
+- `prompts/commands/generate_python.prompt` - owns the public `pdd test` command surface.
+- `prompts/agentic_test_orchestrator_python.prompt` - owns issue-driven test workflow orchestration.
+- `prompts/user_story_tests_python.prompt` - owns story metadata and traceability.
+- `prompts/coverage_contracts_python.prompt` - owns deterministic rule-to-evidence coverage.
+- `prompts/commands/checkup_python.prompt` - delegates `pdd checkup coverage`.
+- `prompts/agentic_test_step6_coverage_LLM.prompt` - related test-plan coverage step.
+
+## Notes
+
+This story is a cross-dev-unit regression oracle for the documented
+story-mode test workflow and issue #1769 coverage requirements.

--- a/user_stories/contracts/pdd_update_metadata_sync.contract.md
+++ b/user_stories/contracts/pdd_update_metadata_sync.contract.md
@@ -1,0 +1,78 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_update_metadata_sync.md" story-hash="e8f082eb49aef36a" issue-ref="https://github.com/promptdriven/pdd/issues/1769" -->
+
+# Contract: Code changes update the prompt source
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_update_metadata_sync.md`), not this contract.
+
+## Covers
+
+- R1: `pdd update` routes repository-wide and file-specific update modes without ambiguous option combinations.
+- R2: Accepted code behavior is back-propagated into the prompt source of truth.
+- R3: Agentic update is used where available and legacy update paths remain explicit fallbacks.
+- R4: Metadata synchronization runs when requested and can fail the command if required metadata cannot be refreshed.
+- R5: Successful updates clear stale run reports and finalize prompt/code fingerprints.
+- R6: The cross-dev-unit story is attributed to modify command, update engine, agentic update, metadata sync, and operation logging without duplicate global counting.
+
+## Context
+
+The documented update workflow asks maintainers to decide when implementation
+knowledge belongs in the prompt. `pdd update` back-propagates accepted code
+behavior into prompt files, and metadata/fingerprint finalization keeps the
+prompt-code state auditable. This crosses the modify command surface, update
+engine, agentic update path, metadata synchronization, and operation log.
+
+## Acceptance Criteria
+
+1. Given a repository-wide or file-specific update request, when the user runs `pdd update`, then PDD validates the selected mode before running update logic.
+2. Given a code change reflects accepted behavior, when update succeeds, then the corresponding prompt is updated rather than leaving the accepted behavior only in generated code.
+3. Given agentic update is available, when the update path uses it, then legacy fallback remains explicit and does not hide failures.
+4. Given `--sync-metadata` is requested, when metadata synchronization fails, then the update command reports failure rather than silently succeeding.
+5. Given an update succeeds without redirected output, when finalization runs, then stale run reports are cleared and a fresh prompt/code fingerprint is recorded.
+6. Given coverage reports this story, when update and metadata dev units are listed separately, then this story appears under each linked unit but is counted once globally.
+
+## Oracle
+
+These details matter for pass/fail:
+- update-mode validation before work starts
+- accepted code behavior is copied back to prompts
+- agentic and fallback update paths are distinguishable
+- metadata synchronization failure is surfaced
+- stale run-report cleanup and fingerprint finalization happen after successful update
+- cross-unit metadata lists every participating dev unit
+
+## Non-Oracle
+
+These details should not matter:
+- exact prompt prose produced by the updater
+- exact provider/model selected
+- exact progress table styling
+- exact ordering of unrelated repository-mode candidates
+
+## Negative Cases
+
+- Ambiguous update modes must not proceed to prompt modification.
+- Accepted behavior must not remain only in generated code after a successful update.
+- Metadata synchronization failure must not be swallowed as success.
+- Coverage must not count this one cross-unit story once for each linked prompt.
+
+## Non-Goals
+
+- This story does not verify semantic correctness of every generated prompt edit.
+- This story does not cover `pdd change` feature workflow.
+- This story does not require live model calls in deterministic local verification.
+
+## Candidate Prompts
+
+- `prompts/commands/modify_python.prompt` - owns the public `pdd update` command surface.
+- `prompts/update_main_python.prompt` - owns update routing and prompt back-propagation.
+- `prompts/agentic_update_python.prompt` - owns agentic update behavior.
+- `prompts/metadata_sync_python.prompt` - owns metadata synchronization.
+- `prompts/operation_log_python.prompt` - owns fingerprint and run-report metadata.
+- `prompts/detect_change_main_python.prompt` - related change detection support.
+
+## Notes
+
+This story is a cross-dev-unit regression oracle for the documented
+code-to-prompt update workflow in `docs/prompting_guide.md`.

--- a/user_stories/story__pdd_bug_fix_verification.md
+++ b/user_stories/story__pdd_bug_fix_verification.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/analysis_python.prompt, prompts/agentic_bug_orchestrator_python.prompt, prompts/commands/fix_python.prompt, prompts/agentic_e2e_fix_orchestrator_python.prompt, prompts/agentic_common_python.prompt -->
+<!-- pdd-story-dev-units: analysis_python.prompt, agentic_bug_orchestrator_python.prompt, fix_python.prompt, agentic_e2e_fix_orchestrator_python.prompt, agentic_common_python.prompt -->
+
+# User Story: Bug report becomes a verified fix
+
+## Story
+
+As a maintainer responding to a bug report, I want PDD to capture the failure as tests and then repair the affected code until the checks pass, so that the fix is enforced by durable regression evidence.

--- a/user_stories/story__pdd_story_test_coverage.md
+++ b/user_stories/story__pdd_story_test_coverage.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/generate_python.prompt, prompts/agentic_test_orchestrator_python.prompt, prompts/user_story_tests_python.prompt, prompts/coverage_contracts_python.prompt, prompts/commands/checkup_python.prompt -->
+<!-- pdd-story-dev-units: generate_python.prompt, agentic_test_orchestrator_python.prompt, user_story_tests_python.prompt, coverage_contracts_python.prompt, checkup_python.prompt -->
+
+# User Story: Story tests appear in coverage
+
+## Story
+
+As a reviewer checking prompt coverage, I want PDD story-mode test artifacts to appear in coverage reports for every prompt they protect, so that cross-module user outcomes are visible without inflating the story count.

--- a/user_stories/story__pdd_update_metadata_sync.md
+++ b/user_stories/story__pdd_update_metadata_sync.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/modify_python.prompt, prompts/update_main_python.prompt, prompts/agentic_update_python.prompt, prompts/metadata_sync_python.prompt, prompts/operation_log_python.prompt -->
+<!-- pdd-story-dev-units: modify_python.prompt, update_main_python.prompt, agentic_update_python.prompt, metadata_sync_python.prompt, operation_log_python.prompt -->
+
+# User Story: Code changes update the prompt source
+
+## Story
+
+As a maintainer who made or reviewed a code change, I want PDD to back-propagate the changed behavior into the prompt and refresh metadata, so that future regeneration keeps the accepted behavior instead of drifting away.


### PR DESCRIPTION
## Summary

Carries the five verified cross-dev-unit workflow story sub-PRs into the actual issue #1698 EPIC integration branch after PR #1800 was closed as integrated.

Included story sub-PRs:
- #1808 - PRD `pdd generate` output handed to `pdd sync`
- #1809 - feature-request `pdd change` output carried through story/contract artifacts and PR creation
- #1810 - bug-report `pdd bug` reproduction handed to `pdd fix`
- #1811 - story-mode `pdd test` artifacts surfaced through `pdd checkup coverage`
- #1812 - code-to-prompt `pdd update` results finalized through metadata sync

This keeps the work out of `main` and targets only `codex/issue-1698-story-regression-epic`.

## Verification

```bash
python -m py_compile tests/test_story_backfill_top_flows.py
python -m py_compile tests/test_story_backfill_cross_unit_flows.py
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('story_checks','tests/test_story_backfill_top_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_top_flow_story_backfill_artifacts_are_complete(); print('story backfill checks passed')"
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('cross_story_checks','tests/test_story_backfill_cross_unit_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_cross_unit_story_backfill_artifacts_are_complete(); print('cross-unit story checks passed')"
```

Refs #1769
Refs #1775
Refs #1800
Part of #1698