### PR TITLE
test(stories): add unit-like CLI validation stories

### DIFF
--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -30,6 +30,13 @@ Cross-dev-unit stories use both `pdd-story-prompts` and `pdd-story-dev-units`
 metadata so the same story is attributed to every linked dev unit while still
 counting as one global regression oracle.
 
+The unit-test-like story follow-up adds smaller regression oracles for behavior
+that should feel as stable and focused as Python unit tests:
+
+- CLI mode and option guardrails
+- deterministic contract-rule checking
+- deterministic coverage evidence reporting
+
 ## Verification
 
 This backfill uses the existing PDD user-story file model:
@@ -69,4 +76,6 @@ python -m py_compile tests/test_story_backfill_top_flows.py
 python -c "import importlib.util; spec=importlib.util.spec_from_file_location('story_checks','tests/test_story_backfill_top_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_top_flow_story_backfill_artifacts_are_complete(); print('story backfill checks passed')"
 python -m py_compile tests/test_story_backfill_cross_unit_flows.py
 python -c "import importlib.util; spec=importlib.util.spec_from_file_location('cross_story_checks','tests/test_story_backfill_cross_unit_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_cross_unit_story_backfill_artifacts_are_complete(); print('cross-unit story checks passed')"
+python -m py_compile tests/test_story_backfill_unit_like_flows.py
+python -c "import importlib.util; spec=importlib.util.spec_from_file_location('unit_story_checks','tests/test_story_backfill_unit_like_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_unit_like_story_backfill_artifacts_are_complete(); print('unit-like story checks passed')"
 ```

--- a/tests/test_story_backfill_unit_like_flows.py
+++ b/tests/test_story_backfill_unit_like_flows.py
@@ -1,0 +1,179 @@
+"""Deterministic checks for unit-test-like user-story backfill."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STORIES_DIR = REPO_ROOT / "user_stories"
+CONTRACTS_DIR = STORIES_DIR / "contracts"
+PACKAGE_PROMPTS_DIR = REPO_ROOT / "pdd" / "prompts"
+ISSUE_REF = "https://github.com/promptdriven/pdd/issues/1698"
+
+STORY_PROMPTS_METADATA_RE = re.compile(
+    r"<!--\s*pdd-story-prompts:\s*(?P<values>.*?)\s*-->",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+STORY_DEV_UNITS_METADATA_RE = re.compile(
+    r"<!--\s*pdd-story-dev-units:\s*(?P<values>.*?)\s*-->",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+CONTRACT_HEADER_RE = re.compile(
+    r"<!--\s*pdd-story-contract\b(?P<attrs>.*?)-->",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+CONTRACT_ATTR_RE = re.compile(
+    r"(?P<key>[a-z0-9_-]+)\s*=\s*\"(?P<val>[^\"]*)\"",
+    flags=re.IGNORECASE,
+)
+
+REQUIRED_CONTRACT_SECTIONS = (
+    "## Covers",
+    "## Context",
+    "## Acceptance Criteria",
+    "## Oracle",
+    "## Non-Oracle",
+    "## Negative Cases",
+    "## Non-Goals",
+    "## Candidate Prompts",
+    "## Notes",
+)
+
+UNIT_LIKE_STORIES = {
+    "pdd_checkup_coverage_evidence": {
+        "metadata_prompts": [
+            "prompts/commands/checkup_python.prompt",
+            "prompts/coverage_contracts_python.prompt",
+            "prompts/contract_ir_python.prompt",
+        ],
+        "dev_units": [
+            "checkup_python.prompt",
+            "coverage_contracts_python.prompt",
+            "contract_ir_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5"},
+        "must_contain": (
+            "Coverage reporting",
+            "rule-to-evidence matrix",
+        ),
+    },
+    "pdd_cli_mode_guardrails": {
+        "metadata_prompts": [
+            "prompts/core/cli_python.prompt",
+            "prompts/commands/generate_python.prompt",
+            "prompts/commands/modify_python.prompt",
+            "prompts/commands/maintenance_python.prompt",
+        ],
+        "dev_units": [
+            "cli_python.prompt",
+            "generate_python.prompt",
+            "modify_python.prompt",
+            "maintenance_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5"},
+        "must_contain": (
+            "unit-test-like CLI regression",
+            "invalid option combinations",
+        ),
+    },
+    "pdd_contracts_check_gate": {
+        "metadata_prompts": [
+            "prompts/commands/contracts_python.prompt",
+            "prompts/contract_check_python.prompt",
+            "prompts/contract_ir_python.prompt",
+        ],
+        "dev_units": [
+            "contracts_python.prompt",
+            "contract_check_python.prompt",
+            "contract_ir_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5"},
+        "must_contain": (
+            "deterministic contract-rule checker",
+            "malformed or duplicate rule IDs",
+        ),
+    },
+}
+
+
+def _story_path(story_id: str) -> Path:
+    return STORIES_DIR / f"story__{story_id}.md"
+
+
+def _contract_path(story_id: str) -> Path:
+    return CONTRACTS_DIR / f"{story_id}.contract.md"
+
+
+def _parse_metadata(pattern: re.Pattern[str], story_text: str) -> list[str]:
+    match = pattern.search(story_text)
+    if not match:
+        return []
+    raw = match.group("values").strip()
+    return [entry.strip() for entry in raw.split(",") if entry.strip()]
+
+
+def _story_content_hash(story_text: str) -> str:
+    without_prompt_meta = STORY_PROMPTS_METADATA_RE.sub("", story_text)
+    without_meta = STORY_DEV_UNITS_METADATA_RE.sub("", without_prompt_meta)
+    lines = [line.rstrip() for line in without_meta.strip().splitlines()]
+    normalized = "\n".join(line for line in lines if line.strip())
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _parse_contract_header(contract_text: str) -> dict[str, str]:
+    match = CONTRACT_HEADER_RE.search(contract_text)
+    assert match, "contract must include pdd-story-contract header"
+    return {
+        attr.group("key").lower(): attr.group("val")
+        for attr in CONTRACT_ATTR_RE.finditer(match.group("attrs"))
+    }
+
+
+def _covered_rule_ids(contract_text: str) -> set[str]:
+    return set(re.findall(r"^\s*-\s+(R\d+):", contract_text, flags=re.MULTILINE))
+
+
+def _prompt_package_path(metadata_prompt: str) -> Path:
+    assert metadata_prompt.startswith("prompts/")
+    return PACKAGE_PROMPTS_DIR / metadata_prompt.removeprefix("prompts/")
+
+
+def test_unit_like_story_backfill_artifacts_are_complete() -> None:
+    assert len(UNIT_LIKE_STORIES) == len(set(UNIT_LIKE_STORIES))
+
+    for story_id, expected in UNIT_LIKE_STORIES.items():
+        story_path = _story_path(story_id)
+        contract_path = _contract_path(story_id)
+
+        assert story_path.exists(), f"{story_id} story is missing"
+        assert contract_path.exists(), f"{story_id} contract is missing"
+
+        story_text = story_path.read_text(encoding="utf-8")
+        contract_text = contract_path.read_text(encoding="utf-8")
+
+        prompt_refs = _parse_metadata(STORY_PROMPTS_METADATA_RE, story_text)
+        dev_units = _parse_metadata(STORY_DEV_UNITS_METADATA_RE, story_text)
+        assert prompt_refs == expected["metadata_prompts"]
+        assert dev_units == expected["dev_units"]
+        assert len(prompt_refs) >= 2
+        assert len(dev_units) >= 2
+
+        for prompt_ref in prompt_refs:
+            assert _prompt_package_path(prompt_ref).exists()
+            assert f"`{prompt_ref}`" in contract_text
+
+        header = _parse_contract_header(contract_text)
+        assert header["derived-from-story"] == f"../story__{story_id}.md"
+        assert header["story-hash"] == _story_content_hash(story_text)
+        assert header["issue-ref"] == ISSUE_REF
+
+        for section in REQUIRED_CONTRACT_SECTIONS:
+            assert section in contract_text
+
+        assert expected["covers"] <= _covered_rule_ids(contract_text)
+
+        for phrase in expected["must_contain"]:
+            assert phrase in contract_text

--- a/user_stories/contracts/pdd_checkup_coverage_evidence.contract.md
+++ b/user_stories/contracts/pdd_checkup_coverage_evidence.contract.md
@@ -1,0 +1,72 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_checkup_coverage_evidence.md" story-hash="df12c306985649b5" issue-ref="https://github.com/promptdriven/pdd/issues/1698" -->
+
+# Contract: Coverage reports show rule evidence
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_checkup_coverage_evidence.md`), not this contract.
+
+## Covers
+
+- R1: `pdd checkup coverage TARGET` delegates to deterministic coverage analysis.
+- R2: The rule-to-evidence matrix reports story, test, waiver, and missing evidence per rule.
+- R3: JSON output remains machine-readable for CI and agent review.
+- R4: Legacy prompts without contract rules are handled without false failures.
+- R5: Cross-unit stories are attributed without being double-counted in global metrics.
+
+## Context
+
+Coverage reporting turns contract rules into a deterministic coverage matrix.
+For a regression suite that behaves like Python unit tests, reviewers need this
+local command to expose evidence gaps without relying on a live model.
+
+## Acceptance Criteria
+
+1. Given a prompt with contract rules and linked stories, when coverage runs, then each rule row lists the matching story evidence.
+2. Given a test explicitly names a rule ID, when coverage runs with a tests directory, then that test appears as evidence for the rule.
+3. Given a waiver covers a rule, when coverage runs, then the waiver status and expiry are visible.
+4. Given a rule has no story, test, or waiver, when coverage runs, then the gap is reported instead of passing silently.
+5. Given `--json` is requested, when coverage runs, then output is structured enough for CI to consume.
+6. Given a prompt has no contract rules, when coverage runs, then it is treated as legacy-safe rather than a hard error.
+
+## Oracle
+
+These details matter for pass/fail:
+- command delegation to deterministic coverage analysis
+- rule-to-evidence matrix contents
+- missing evidence remains visible
+- JSON output can be consumed by CI
+- legacy prompts without contract rules do not fail spuriously
+- cross-unit stories are not double-counted
+
+## Non-Oracle
+
+These details should not matter:
+- exact Rich table styling
+- exact ordering of unrelated rule rows
+- model/provider configuration
+- implementation helper names
+
+## Negative Cases
+
+- A missing story/test/waiver must not be hidden by an aggregate percentage.
+- A test that does not name a rule ID must not count as rule evidence.
+- Expired or malformed waivers must not count as clean coverage.
+- Cross-unit stories must not inflate global coverage counts.
+
+## Non-Goals
+
+- This story does not prescribe a hosted dashboard.
+- This story does not require live provider credentials.
+- This story does not verify the semantic correctness of every story body.
+
+## Candidate Prompts
+
+- `prompts/commands/checkup_python.prompt` - owns `pdd checkup coverage` delegation.
+- `prompts/coverage_contracts_python.prompt` - owns the deterministic rule-to-evidence matrix.
+- `prompts/contract_ir_python.prompt` - owns contract rule parsing.
+
+## Notes
+
+This story protects deterministic coverage reporting as the suite's equivalent
+of a local unit-test coverage gate.

--- a/user_stories/contracts/pdd_cli_mode_guardrails.contract.md
+++ b/user_stories/contracts/pdd_cli_mode_guardrails.contract.md
@@ -1,0 +1,71 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_cli_mode_guardrails.md" story-hash="7aa444b31df66e23" issue-ref="https://github.com/promptdriven/pdd/issues/1698" -->
+
+# Contract: CLI mode guardrails reject ambiguous requests
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_cli_mode_guardrails.md`), not this contract.
+
+## Covers
+
+- R1: Shared CLI parsing preserves Click usage errors and abort semantics.
+- R2: Generate-mode guardrails reject mutually exclusive prompt/template, dry-run, estimate, and PRD options.
+- R3: Modify-mode guardrails reject manual, issue-driven, CSV, change, and update combinations that cannot be routed safely.
+- R4: Maintenance-mode guardrails reject sync options that are valid only for other sync modes.
+- R5: A rejected request exits before any provider, file mutation, or GitHub workflow starts.
+
+## Context
+
+This is a unit-test-like CLI regression story for behavior that should be as
+stable as ordinary Python argument-validation unit tests. It spans the shared
+CLI entry point and the generate, modify, and maintenance command groups.
+
+## Acceptance Criteria
+
+1. Given mutually exclusive options, when the user invokes a PDD command, then PDD raises a usage error before downstream workflow code runs.
+2. Given a generate request mixes prompt-file, template, PRD, and dry-run modes incompatibly, when parsing completes, then no files are written and no model call starts.
+3. Given a modify request mixes issue-driven and manual/CSV modes incompatibly, when parsing completes, then no prompt or code file is changed.
+4. Given a sync request uses durable, snapshot, or compression options on an unsupported sync path, when parsing completes, then PDD rejects the request instead of silently ignoring the option.
+5. Given Click raises `UsageError`, `Abort`, or `Exit`, when the command wrapper handles it, then the original Click semantics are preserved.
+
+## Oracle
+
+These details matter for pass/fail:
+- invalid option combinations are rejected before side effects
+- Click usage and abort exceptions are not swallowed
+- generated files, prompt files, and GitHub state remain untouched on parse failure
+- mode-specific guardrails stay attached to the correct command families
+- rejected requests report actionable command-line feedback
+
+## Non-Oracle
+
+These details should not matter:
+- exact color or Rich formatting of the usage output
+- exact helper names in the command modules
+- provider/model defaults that would have been used after validation
+- ordering of unrelated command options in help text
+
+## Negative Cases
+
+- A typo in mode flags must not silently fall through to a default workflow.
+- An invalid generate request must not create output, evidence, or cost rows.
+- An invalid modify request must not stage partial prompt/story artifacts.
+- An invalid sync request must not ignore unsupported durability or context flags.
+
+## Non-Goals
+
+- This story does not verify generated code content.
+- This story does not cover every option on every command.
+- This story does not require live provider credentials.
+
+## Candidate Prompts
+
+- `prompts/core/cli_python.prompt` - owns shared CLI wiring and Click exception handling.
+- `prompts/commands/generate_python.prompt` - owns generate and test mode guardrails.
+- `prompts/commands/modify_python.prompt` - owns change and update mode guardrails.
+- `prompts/commands/maintenance_python.prompt` - owns sync mode guardrails.
+
+## Notes
+
+This story protects unit-test-like CLI behavior: invalid inputs should fail
+fast, locally, and without side effects.

--- a/user_stories/contracts/pdd_contracts_check_gate.contract.md
+++ b/user_stories/contracts/pdd_contracts_check_gate.contract.md
@@ -1,0 +1,70 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_contracts_check_gate.md" story-hash="8e7cc7402eb25238" issue-ref="https://github.com/promptdriven/pdd/issues/1698" -->
+
+# Contract: Contract checks catch malformed prompt rules
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_contracts_check_gate.md`), not this contract.
+
+## Covers
+
+- R1: `pdd contracts check TARGET` accepts prompt files and directories with an optional stories directory.
+- R2: The deterministic checker reports malformed or duplicate rule IDs.
+- R3: The checker reports unknown story coverage references and missing coverage for required rules.
+- R4: Cross-module `## Covers` references are parsed without confusing prompt names and rule IDs.
+- R5: Clean prompts exit successfully without requiring LLM calls.
+
+## Context
+
+The deterministic contract-rule checker is the closest story-regression analogue
+to Python unit tests for prompt obligations: it parses local files, checks known
+failure modes, and exits without provider access.
+
+## Acceptance Criteria
+
+1. Given a prompt with sequential contract rules and valid story coverage, when `pdd contracts check` runs, then it exits successfully.
+2. Given duplicate, malformed, or non-sequential rule IDs, when the checker runs, then it reports the exact contract-rule issue.
+3. Given a story covers an unknown rule ID, when the checker runs with the stories directory, then it reports the unknown reference.
+4. Given a cross-module cover reference such as `prompts/foo.prompt#R3`, when parsing covers entries, then the checker attributes the reference to the right prompt and rule.
+5. Given a target directory, when the checker runs, then it aggregates deterministic results without invoking an LLM.
+
+## Oracle
+
+These details matter for pass/fail:
+- file and directory targets are accepted
+- malformed or duplicate rule IDs are reported
+- unknown story references are reported
+- cross-module coverage references retain prompt and rule identity
+- clean inputs exit successfully without provider calls
+
+## Non-Oracle
+
+These details should not matter:
+- exact table styling
+- exact order of unrelated clean files in directory output
+- wording of non-actionable helper text
+- downstream generation behavior
+
+## Negative Cases
+
+- A duplicate rule ID must not be silently treated as two valid obligations.
+- A story reference to an unknown rule must not count as coverage.
+- A malformed cross-module reference must not be attributed to the wrong prompt.
+- The checker must not require a model key for deterministic validation.
+
+## Non-Goals
+
+- This story does not verify generated implementation code.
+- This story does not prescribe all future contract-rule lint checks.
+- This story does not cover hosted dashboards.
+
+## Candidate Prompts
+
+- `prompts/commands/contracts_python.prompt` - owns the `pdd contracts check` CLI.
+- `prompts/contract_check_python.prompt` - owns deterministic contract validation.
+- `prompts/contract_ir_python.prompt` - owns rule and cover reference parsing.
+
+## Notes
+
+This story protects the contract gate as a local, fast, unit-test-like check for
+prompt rules.

--- a/user_stories/story__pdd_checkup_coverage_evidence.md
+++ b/user_stories/story__pdd_checkup_coverage_evidence.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/checkup_python.prompt, prompts/coverage_contracts_python.prompt, prompts/contract_ir_python.prompt -->
+<!-- pdd-story-dev-units: checkup_python.prompt, coverage_contracts_python.prompt, contract_ir_python.prompt -->
+
+# User Story: Coverage reports show rule evidence
+
+## Story
+
+As a maintainer reviewing prompt safety, I want `pdd checkup coverage` to show which rules have stories, tests, waivers, or gaps, so that missing regression evidence is visible before merge.

--- a/user_stories/story__pdd_cli_mode_guardrails.md
+++ b/user_stories/story__pdd_cli_mode_guardrails.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/core/cli_python.prompt, prompts/commands/generate_python.prompt, prompts/commands/modify_python.prompt, prompts/commands/maintenance_python.prompt -->
+<!-- pdd-story-dev-units: cli_python.prompt, generate_python.prompt, modify_python.prompt, maintenance_python.prompt -->
+
+# User Story: CLI mode guardrails reject ambiguous requests
+
+## Story
+
+As a developer running PDD commands, I want invalid option combinations to fail before any workflow starts, so that a typo cannot trigger the wrong generation, sync, change, or update path.

--- a/user_stories/story__pdd_contracts_check_gate.md
+++ b/user_stories/story__pdd_contracts_check_gate.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/contracts_python.prompt, prompts/contract_check_python.prompt, prompts/contract_ir_python.prompt -->
+<!-- pdd-story-dev-units: contracts_python.prompt, contract_check_python.prompt, contract_ir_python.prompt -->
+
+# User Story: Contract checks catch malformed prompt rules
+
+## Story
+
+As a prompt reviewer, I want deterministic contract checks to catch malformed, duplicate, missing, or unreferenced rules before generation, so that prompt obligations are testable like unit-test assertions.


### PR DESCRIPTION
## Summary

Adds the first unit-test-like story pack for the story regression EPIC. These stories cover behavior that should stay stable like Python unit tests:

- CLI mode guardrails reject ambiguous requests before side effects
- deterministic contract checks catch malformed prompt rules
- deterministic coverage reports expose rule evidence gaps

## Verification

```bash
python -m py_compile tests/test_story_backfill_unit_like_flows.py
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('unit_story_checks','tests/test_story_backfill_unit_like_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_unit_like_story_backfill_artifacts_are_complete(); print('unit-like story checks passed')"
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('cross_story_checks','tests/test_story_backfill_cross_unit_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_cross_unit_story_backfill_artifacts_are_complete(); print('cross-unit story checks passed')"
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('story_checks','tests/test_story_backfill_top_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_top_flow_story_backfill_artifacts_are_complete(); print('story backfill checks passed')"
```

Part of #1698
Refs #1769