### PR TITLE
test(stories): add unit-like context control stories

### DIFF
--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -36,6 +36,9 @@ that should feel as stable and focused as Python unit tests:
 - CLI mode and option guardrails
 - deterministic contract-rule checking
 - deterministic coverage evidence reporting
+- preprocess include and snapshot reproducibility
+- context compression and test-packing manifests
+- side-effect-free estimate mode
 
 ## Verification
 

--- a/tests/test_story_backfill_unit_like_flows.py
+++ b/tests/test_story_backfill_unit_like_flows.py
@@ -43,6 +43,63 @@ REQUIRED_CONTRACT_SECTIONS = (
 )
 
 UNIT_LIKE_STORIES = {
+    "pdd_context_compression_manifest": {
+        "metadata_prompts": [
+            "prompts/content_selector_python.prompt",
+            "prompts/test_context_packer_python.prompt",
+            "prompts/pytest_slicer_python.prompt",
+            "prompts/llm_invoke_python.prompt",
+        ],
+        "dev_units": [
+            "content_selector_python.prompt",
+            "test_context_packer_python.prompt",
+            "pytest_slicer_python.prompt",
+            "llm_invoke_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5"},
+        "must_contain": (
+            "context compression",
+            "TestPackingManifest",
+        ),
+    },
+    "pdd_estimate_side_effect_free": {
+        "metadata_prompts": [
+            "prompts/commands/generate_python.prompt",
+            "prompts/code_generator_main_python.prompt",
+            "prompts/track_cost_python.prompt",
+            "prompts/llm_invoke_python.prompt",
+        ],
+        "dev_units": [
+            "generate_python.prompt",
+            "code_generator_main_python.prompt",
+            "track_cost_python.prompt",
+            "llm_invoke_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5"},
+        "must_contain": (
+            "Estimate mode",
+            "does not write",
+        ),
+    },
+    "pdd_preprocess_snapshot_reproducibility": {
+        "metadata_prompts": [
+            "prompts/preprocess_python.prompt",
+            "prompts/preprocess_main_python.prompt",
+            "prompts/context_snapshot_python.prompt",
+            "prompts/commands/context_python.prompt",
+        ],
+        "dev_units": [
+            "preprocess_python.prompt",
+            "preprocess_main_python.prompt",
+            "context_snapshot_python.prompt",
+            "context_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5"},
+        "must_contain": (
+            "Preprocess and snapshot behavior",
+            "dynamic context snapshots",
+        ),
+    },
     "pdd_checkup_coverage_evidence": {
         "metadata_prompts": [
             "prompts/commands/checkup_python.prompt",

--- a/user_stories/contracts/pdd_context_compression_manifest.contract.md
+++ b/user_stories/contracts/pdd_context_compression_manifest.contract.md
@@ -1,0 +1,71 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_context_compression_manifest.md" story-hash="aed7d941a928e1b1" issue-ref="https://github.com/promptdriven/pdd/issues/1698" -->
+
+# Contract: Context compression leaves an audit trail
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_context_compression_manifest.md`), not this contract.
+
+## Covers
+
+- R1: Context compression can select example, contract, and test context under a configured token budget.
+- R2: Failing tests are prioritized before lower-signal tests.
+- R3: Pytest slicing preserves the failing test and required fixtures when a file is too large.
+- R4: The TestPackingManifest lists selected and omitted tests with reasons.
+- R5: Compression fallback behavior is explicit when parsing, slicing, or ranking fails.
+
+## Context
+
+Context compression is useful only if it behaves like a reviewed, deterministic
+test-selection system. This story covers selection, slicing, manifest output,
+and explicit fallback reporting.
+
+## Acceptance Criteria
+
+1. Given test context compression is enabled and failing tests are known, when context is packed, then failing tests are selected first.
+2. Given a test file is too large, when slicing is possible, then the selected context includes the failing test and required fixtures rather than the whole file.
+3. Given the token budget is exhausted, when remaining tests are omitted, then the manifest explains the omission.
+4. Given near-duplicate tests are found, when deduplication runs, then the manifest records which test was kept and which was omitted.
+5. Given slicing or parsing fails, when fallback runs, then the fallback mode is visible instead of silently changing context.
+
+## Oracle
+
+These details matter for pass/fail:
+- failing tests are prioritized
+- selected and omitted context is explained
+- sliced tests keep required fixtures
+- fallback behavior is explicit
+- compressed context still reports the behavioral evidence sent to the model
+
+## Non-Oracle
+
+These details should not matter:
+- exact ranking score decimals
+- exact token-count library internals
+- cosmetic manifest formatting
+- unrelated provider/model choice
+
+## Negative Cases
+
+- A failing test must not be omitted merely because a lower-signal test was ranked first.
+- The manifest must not hide omitted tests.
+- A slicing failure must not silently drop all test context.
+- Compression must not mutate source tests.
+
+## Non-Goals
+
+- This story does not prescribe the final ranking formula weights.
+- This story does not require live model calls.
+- This story does not cover every possible test framework.
+
+## Candidate Prompts
+
+- `prompts/content_selector_python.prompt` - owns context selection.
+- `prompts/test_context_packer_python.prompt` - owns test context packing and manifests.
+- `prompts/pytest_slicer_python.prompt` - owns pytest slicing.
+- `prompts/llm_invoke_python.prompt` - carries packed context into model invocation.
+
+## Notes
+
+This story protects context compression as a transparent, unit-test-like
+selection step instead of an invisible cost optimization.

--- a/user_stories/contracts/pdd_estimate_side_effect_free.contract.md
+++ b/user_stories/contracts/pdd_estimate_side_effect_free.contract.md
@@ -1,0 +1,69 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_estimate_side_effect_free.md" story-hash="3fd5c07d4059d77b" issue-ref="https://github.com/promptdriven/pdd/issues/1698" -->
+
+# Contract: Estimate mode previews cost without changing files
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_estimate_side_effect_free.md`), not this contract.
+
+## Covers
+
+- R1: Global estimate mode routes supported standard generation requests to cost preview logic.
+- R2: Estimate mode returns prompt/model/cost information without invoking a real generation.
+- R3: Estimate mode does not write command outputs, evidence manifests, generated code, or cost rows.
+- R4: Unsupported agentic or multi-step paths reject estimate mode instead of pretending to estimate them.
+- R5: Normal generation remains unchanged when estimate mode is not requested.
+
+## Context
+
+Estimate mode should behave like a dry unit test for generation cost: it answers
+"what would this cost?" without mutating repository state or provider state.
+
+## Acceptance Criteria
+
+1. Given a standard prompt-file generation request and global estimate mode, when the command runs, then it returns an estimate payload.
+2. Given estimate mode is active, when the command completes, then no generated code, evidence manifest, or cost row is written.
+3. Given a path uses agentic or multi-step generation, when estimate mode is requested and unsupported, then PDD rejects it clearly.
+4. Given normal generation runs without estimate mode, when the command completes, then existing generation side effects remain available.
+5. Given estimate mode inspects model selection, when reporting cost, then it does not require a real provider completion.
+
+## Oracle
+
+These details matter for pass/fail:
+- supported standard generation can estimate
+- unsupported paths reject estimate mode
+- no generated outputs, evidence, or cost rows are written
+- estimate reporting includes enough information for budgeting
+- normal generation is unaffected
+
+## Non-Oracle
+
+These details should not matter:
+- exact dollar amount for a future model catalog update
+- cosmetic output formatting
+- provider-specific implementation details
+- exact internal helper names
+
+## Negative Cases
+
+- Estimate mode must not write generated code.
+- Estimate mode must not append a real run cost row.
+- Unsupported multi-step workflows must not return a misleading estimate.
+- Normal generation must not be accidentally converted into estimate behavior.
+
+## Non-Goals
+
+- This story does not guarantee exact billing for future provider pricing changes.
+- This story does not cover hosted billing dashboards.
+- This story does not require live model credentials.
+
+## Candidate Prompts
+
+- `prompts/commands/generate_python.prompt` - owns generate command estimate routing.
+- `prompts/code_generator_main_python.prompt` - owns standard prompt-file generation.
+- `prompts/track_cost_python.prompt` - owns cost accounting behavior.
+- `prompts/llm_invoke_python.prompt` - owns model invocation boundaries.
+
+## Notes
+
+This story protects estimate mode as a side-effect-free budgeting regression.

--- a/user_stories/contracts/pdd_preprocess_snapshot_reproducibility.contract.md
+++ b/user_stories/contracts/pdd_preprocess_snapshot_reproducibility.contract.md
@@ -1,0 +1,71 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_preprocess_snapshot_reproducibility.md" story-hash="5bc489a56ca311f6" issue-ref="https://github.com/promptdriven/pdd/issues/1698" -->
+
+# Contract: Preprocessed prompts can be replayed
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_preprocess_snapshot_reproducibility.md`), not this contract.
+
+## Covers
+
+- R1: Preprocess expands includes, shell/web directives, and template variables into the prompt sent to the model.
+- R2: Missing includes or unsafe dynamic directives fail with actionable diagnostics before generation.
+- R3: Snapshot mode records replayable evidence for dynamic context that affects contract-critical prompts.
+- R4: Context inspection reports hydrated token counts without triggering generation.
+- R5: Replay and audit metadata make it possible to inspect what the model saw later.
+
+## Context
+
+Preprocess and snapshot behavior is a unit-test-like foundation for all PDD
+generation: if prompt hydration is unstable, every higher-level story can rot.
+This story spans preprocess expansion, the preprocess CLI, snapshot capture, and
+context inspection.
+
+## Acceptance Criteria
+
+1. Given a prompt with static includes, when preprocess runs, then the included content appears in the hydrated prompt in the documented location.
+2. Given a prompt references a missing include, when preprocess runs, then it fails clearly before any model call.
+3. Given a prompt uses dynamic shell or web context under snapshot mode, when preprocess completes, then replayable snapshot evidence records the expanded input.
+4. Given `pdd context <prompt>` is used for inspection, when it reports token counts, then it does not start a generation workflow.
+5. Given reviewers inspect a generated artifact later, when snapshot evidence exists, then they can identify the prompt context that shaped the output.
+
+## Oracle
+
+These details matter for pass/fail:
+- include expansion is deterministic
+- missing context fails before generation
+- dynamic context can be snapshotted and replayed
+- context inspection remains read-only
+- hydrated prompt evidence is available for audit
+
+## Non-Oracle
+
+These details should not matter:
+- exact model provider configuration
+- exact token count implementation as long as counts are stable enough for budgeting
+- cosmetic formatting of context reports
+- unrelated prompt rewrite behavior
+
+## Negative Cases
+
+- Missing include files must not be silently omitted.
+- Dynamic contract-critical context must not be used without replayable evidence when snapshot mode is required.
+- Context inspection must not write generated code or cost rows.
+- Snapshot evidence must not point at an unrelated prompt.
+
+## Non-Goals
+
+- This story does not require live network access.
+- This story does not prescribe every supported directive.
+- This story does not verify model output quality.
+
+## Candidate Prompts
+
+- `prompts/preprocess_python.prompt` - owns prompt directive expansion.
+- `prompts/preprocess_main_python.prompt` - owns preprocess command behavior.
+- `prompts/context_snapshot_python.prompt` - owns replayable dynamic context snapshots.
+- `prompts/commands/context_python.prompt` - owns context inspection commands.
+
+## Notes
+
+This story makes prompt hydration itself part of the regression suite.

--- a/user_stories/story__pdd_context_compression_manifest.md
+++ b/user_stories/story__pdd_context_compression_manifest.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/content_selector_python.prompt, prompts/test_context_packer_python.prompt, prompts/pytest_slicer_python.prompt, prompts/llm_invoke_python.prompt -->
+<!-- pdd-story-dev-units: content_selector_python.prompt, test_context_packer_python.prompt, pytest_slicer_python.prompt, llm_invoke_python.prompt -->
+
+# User Story: Context compression leaves an audit trail
+
+## Story
+
+As a maintainer reducing model context cost, I want PDD to compress examples and tests with a clear manifest, so that smaller prompts still preserve the behavioral evidence selected for generation or repair.

--- a/user_stories/story__pdd_estimate_side_effect_free.md
+++ b/user_stories/story__pdd_estimate_side_effect_free.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/commands/generate_python.prompt, prompts/code_generator_main_python.prompt, prompts/track_cost_python.prompt, prompts/llm_invoke_python.prompt -->
+<!-- pdd-story-dev-units: generate_python.prompt, code_generator_main_python.prompt, track_cost_python.prompt, llm_invoke_python.prompt -->
+
+# User Story: Estimate mode previews cost without changing files
+
+## Story
+
+As a developer budgeting a generation run, I want estimate mode to report likely cost without writing outputs, evidence, or cost records, so that I can plan safely before spending tokens.

--- a/user_stories/story__pdd_preprocess_snapshot_reproducibility.md
+++ b/user_stories/story__pdd_preprocess_snapshot_reproducibility.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/preprocess_python.prompt, prompts/preprocess_main_python.prompt, prompts/context_snapshot_python.prompt, prompts/commands/context_python.prompt -->
+<!-- pdd-story-dev-units: preprocess_python.prompt, preprocess_main_python.prompt, context_snapshot_python.prompt, context_python.prompt -->
+
+# User Story: Preprocessed prompts can be replayed
+
+## Story
+
+As a reviewer auditing generated output, I want PDD to expand prompt context deterministically and snapshot dynamic context, so that a future run can explain exactly what the model saw.


### PR DESCRIPTION
## Summary

Adds the second unit-test-like story pack for context and model-control behavior:

- preprocess include expansion and snapshot reproducibility
- context compression with TestPackingManifest audit output
- side-effect-free estimate mode for supported generation paths

## Verification

```bash
python -m py_compile tests/test_story_backfill_unit_like_flows.py
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('unit_story_checks','tests/test_story_backfill_unit_like_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_unit_like_story_backfill_artifacts_are_complete(); print('unit-like story checks passed')"
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('cross_story_checks','tests/test_story_backfill_cross_unit_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_cross_unit_story_backfill_artifacts_are_complete(); print('cross-unit story checks passed')"
python -c "import importlib.util; spec=importlib.util.spec_from_file_location('story_checks','tests/test_story_backfill_top_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_top_flow_story_backfill_artifacts_are_complete(); print('story backfill checks passed')"
```

Part of #1698
Refs #1769