### PR TITLE
test(stories): add unit-like architecture sync stories

### DIFF
--- a/docs/story_regression_backfill.md
+++ b/docs/story_regression_backfill.md
@@ -42,6 +42,9 @@ that should feel as stable and focused as Python unit tests:
 - provider fallback and degraded workflow status
 - issue routing by source-of-truth classification
 - CI validation and post-push repair loops
+- architecture dependency ordering
+- conflict-safe sync and update behavior
+- story contract hash synchronization
 
 ## Verification
 

--- a/tests/test_story_backfill_unit_like_flows.py
+++ b/tests/test_story_backfill_unit_like_flows.py
@@ -43,6 +43,25 @@ REQUIRED_CONTRACT_SECTIONS = (
 )
 
 UNIT_LIKE_STORIES = {
+    "pdd_architecture_dependency_order": {
+        "metadata_prompts": [
+            "prompts/architecture_sync_python.prompt",
+            "prompts/sync_order_python.prompt",
+            "prompts/architecture_registry_python.prompt",
+            "prompts/metadata_sync_python.prompt",
+        ],
+        "dev_units": [
+            "architecture_sync_python.prompt",
+            "sync_order_python.prompt",
+            "architecture_registry_python.prompt",
+            "metadata_sync_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5"},
+        "must_contain": (
+            "architecture dependency order",
+            "generation order",
+        ),
+    },
     "pdd_agentic_provider_fallback_status": {
         "metadata_prompts": [
             "prompts/agentic_common_python.prompt",
@@ -100,6 +119,42 @@ UNIT_LIKE_STORIES = {
         "must_contain": (
             "source-of-truth routing",
             "wrong workflow",
+        ),
+    },
+    "pdd_story_contract_hash_sync": {
+        "metadata_prompts": [
+            "prompts/user_story_tests_python.prompt",
+            "prompts/generate_story_contract_LLM.prompt",
+            "prompts/coverage_contracts_python.prompt",
+        ],
+        "dev_units": [
+            "user_story_tests_python.prompt",
+            "generate_story_contract_LLM.prompt",
+            "coverage_contracts_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5"},
+        "must_contain": (
+            "story contract hash",
+            "stale contract",
+        ),
+    },
+    "pdd_sync_conflict_safe_update": {
+        "metadata_prompts": [
+            "prompts/sync_main_python.prompt",
+            "prompts/conflicts_in_prompts_python.prompt",
+            "prompts/conflicts_main_python.prompt",
+            "prompts/sync_orchestration_python.prompt",
+        ],
+        "dev_units": [
+            "sync_main_python.prompt",
+            "conflicts_in_prompts_python.prompt",
+            "conflicts_main_python.prompt",
+            "sync_orchestration_python.prompt",
+        ],
+        "covers": {"R1", "R2", "R3", "R4", "R5"},
+        "must_contain": (
+            "conflict-safe sync",
+            "reviewable conflict evidence",
         ),
     },
     "pdd_context_compression_manifest": {

--- a/user_stories/contracts/pdd_architecture_dependency_order.contract.md
+++ b/user_stories/contracts/pdd_architecture_dependency_order.contract.md
@@ -1,0 +1,72 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_architecture_dependency_order.md" story-hash="da3c66129b146eda" issue-ref="https://github.com/promptdriven/pdd/issues/1698" -->
+
+# Contract: Architecture order drives safe sync
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_architecture_dependency_order.md`), not this contract.
+
+## Covers
+
+- R1: Architecture sync reads dependency metadata from linked prompt and dev-unit records.
+- R2: Sync ordering produces a deterministic generation order that respects upstream dependencies.
+- R3: Missing dependency metadata and dependency cycles are reported as blockers.
+- R4: Metadata synchronization preserves the resolved order and linked unit attribution.
+- R5: Re-running the same architecture input produces the same ordered evidence.
+
+## Context
+
+Architecture-driven workflows span registry, ordering, sync, and metadata
+updates. A unit-test-like regression needs architecture dependency order to be
+explicit so a generated or synchronized unit is not refreshed before the
+dependency state it relies on is available.
+
+## Acceptance Criteria
+
+1. Given architecture metadata names dependencies, when sync planning runs, then the plan includes every referenced prompt and dev unit.
+2. Given dependencies form an acyclic graph, when ordering runs, then upstream units appear before dependent units.
+3. Given a dependency is missing or cyclic, when planning runs, then the workflow reports a blocker instead of guessing an order.
+4. Given metadata sync completes, when evidence is inspected, then the linked units and resolved order are visible.
+5. Given inputs are unchanged, when planning is repeated, then the generated order and evidence are stable.
+
+## Oracle
+
+These details matter for pass/fail:
+- architecture dependency order is derived from explicit metadata
+- generation order is deterministic and dependency-aware
+- missing or cyclic dependencies are blockers
+- metadata sync records the resolved unit attribution
+- unchanged inputs produce unchanged order evidence
+
+## Non-Oracle
+
+These details should not matter:
+- exact internal graph data structure
+- exact ordering of independent sibling units
+- cosmetic wording of blocker messages
+- exact location of cached architecture metadata
+
+## Negative Cases
+
+- A dependent unit must not be generated before its upstream source unit.
+- A dependency cycle must not silently fall back to file-system order.
+- Missing architecture metadata must not be treated as successful sync.
+- Metadata sync must not drop linked dev-unit attribution.
+
+## Non-Goals
+
+- This story does not prescribe a visual architecture diagram.
+- This story does not require live LLM generation during deterministic checks.
+- This story does not merge anything into `main`.
+
+## Candidate Prompts
+
+- `prompts/architecture_sync_python.prompt` - owns architecture sync behavior.
+- `prompts/sync_order_python.prompt` - owns dependency-aware ordering.
+- `prompts/architecture_registry_python.prompt` - owns registered architecture metadata.
+- `prompts/metadata_sync_python.prompt` - owns metadata synchronization.
+
+## Notes
+
+This story turns architecture ordering into a small regression oracle that can
+fail independently of the larger sync workflow.

--- a/user_stories/contracts/pdd_story_contract_hash_sync.contract.md
+++ b/user_stories/contracts/pdd_story_contract_hash_sync.contract.md
@@ -1,0 +1,70 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_story_contract_hash_sync.md" story-hash="d6aaf845ef5f242b" issue-ref="https://github.com/promptdriven/pdd/issues/1698" -->
+
+# Contract: Story edits invalidate stale contracts
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_story_contract_hash_sync.md`), not this contract.
+
+## Covers
+
+- R1: User-story tests compute a story contract hash from human story content while ignoring attribution metadata.
+- R2: Contract generation writes the current story hash and issue reference into the sidecar header.
+- R3: Coverage checks detect a stale contract when the story changes without sidecar synchronization.
+- R4: Regenerating or updating the sidecar clears the stale contract only when coverage still satisfies required rules.
+- R5: Verification attributes the synchronized story and contract to every linked dev unit.
+
+## Context
+
+The PDD user-story feature depends on a trustworthy link between human story
+text and generated contract sidecars. A stale contract should fail fast the same
+way a stale unit-test snapshot would fail after fixture input changes.
+
+## Acceptance Criteria
+
+1. Given a story has metadata and body text, when the hash is computed, then only the human story content drives the hash.
+2. Given a contract is generated, when its header is inspected, then it contains the current story hash and issue reference.
+3. Given a human story changes, when the sidecar still has the old hash, then verification reports a stale contract.
+4. Given the sidecar is regenerated, when coverage is still complete, then verification passes.
+5. Given a story names multiple dev units, when verification reports attribution, then every linked unit remains covered.
+
+## Oracle
+
+These details matter for pass/fail:
+- story contract hash is based on human story content
+- generated sidecars carry the current hash and issue reference
+- stale contract headers fail deterministic verification
+- coverage must still satisfy required rules after regeneration
+- linked dev-unit attribution is preserved
+
+## Non-Oracle
+
+These details should not matter:
+- exact hash algorithm beyond deterministic behavior and configured length
+- cosmetic contract wording
+- exact order of non-required notes
+- whether regeneration is LLM-backed or fixture-backed in local checks
+
+## Negative Cases
+
+- Editing metadata alone must not invalidate a contract that still matches the story body.
+- Editing story body text must not leave an old sidecar hash passing.
+- Regeneration must not clear a stale hash by dropping required coverage rules.
+- Multi-unit attribution must not collapse to a single owning prompt.
+
+## Non-Goals
+
+- This story does not require live LLM calls in the regression test.
+- This story does not prescribe a permanent contract file format beyond the existing header.
+- This story does not merge anything into `main`.
+
+## Candidate Prompts
+
+- `prompts/user_story_tests_python.prompt` - owns deterministic user-story verification.
+- `prompts/generate_story_contract_LLM.prompt` - owns generated contract content.
+- `prompts/coverage_contracts_python.prompt` - owns coverage reporting and stale contract evidence.
+
+## Notes
+
+This story makes story/contract synchronization itself part of the regression
+suite, comparable to snapshot tests with explicit fixture hashes.

--- a/user_stories/contracts/pdd_sync_conflict_safe_update.contract.md
+++ b/user_stories/contracts/pdd_sync_conflict_safe_update.contract.md
@@ -1,0 +1,71 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_sync_conflict_safe_update.md" story-hash="419d7df97e193e9c" issue-ref="https://github.com/promptdriven/pdd/issues/1698" -->
+
+# Contract: Sync preserves reviewable conflicts
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_sync_conflict_safe_update.md`), not this contract.
+
+## Covers
+
+- R1: Sync detects prompt/code conflicts before applying generated output.
+- R2: Conflict detection classifies prompt-side and code-side changes as reviewable conflict evidence.
+- R3: Conflict orchestration blocks unsafe overwrites until a resolution path is chosen.
+- R4: Resolved conflicts preserve the selected source of truth and discard only reviewed alternatives.
+- R5: Final sync evidence distinguishes clean sync, resolved conflict, and blocked conflict states.
+
+## Context
+
+Sync and update are only safe regression tools when they keep conflicting human
+and generated edits visible. The conflict-safe sync behavior should be small
+enough to test like a unit: detect, classify, preserve, and report.
+
+## Acceptance Criteria
+
+1. Given prompt and code changes disagree, when sync runs, then it detects the conflict before writing replacement output.
+2. Given a conflict is detected, when evidence is produced, then it identifies the affected files and conflicting sides.
+3. Given no resolution is supplied, when orchestration completes, then the workflow blocks the unsafe overwrite.
+4. Given a resolution is supplied, when sync applies it, then only the reviewed source of truth is kept.
+5. Given the workflow reports status, when evidence is inspected, then clean, resolved, and blocked conflict states are distinct.
+
+## Oracle
+
+These details matter for pass/fail:
+- conflict-safe sync detects prompt/code disagreement before writes
+- reviewable conflict evidence identifies affected files and sides
+- unsafe overwrites are blocked without resolution
+- resolved conflicts preserve the chosen source of truth
+- final evidence separates clean, resolved, and blocked outcomes
+
+## Non-Oracle
+
+These details should not matter:
+- exact conflict marker text
+- exact temporary file names
+- exact diff formatting
+- whether a resolver is interactive or scripted
+
+## Negative Cases
+
+- Sync must not silently overwrite human prompt edits with generated code.
+- Sync must not silently overwrite code edits with stale prompt content.
+- A blocked conflict must not be reported as a clean sync.
+- Conflict evidence must not disappear before review.
+
+## Non-Goals
+
+- This story does not define a full merge UI.
+- This story does not require every possible language-specific conflict parser.
+- This story does not merge anything into `main`.
+
+## Candidate Prompts
+
+- `prompts/sync_main_python.prompt` - owns the public sync execution path.
+- `prompts/conflicts_in_prompts_python.prompt` - owns prompt conflict detection.
+- `prompts/conflicts_main_python.prompt` - owns conflict reporting and status.
+- `prompts/sync_orchestration_python.prompt` - owns sync orchestration and resolution flow.
+
+## Notes
+
+This story protects sync and update from losing review context when generated
+changes meet human edits.

--- a/user_stories/story__pdd_architecture_dependency_order.md
+++ b/user_stories/story__pdd_architecture_dependency_order.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/architecture_sync_python.prompt, prompts/sync_order_python.prompt, prompts/architecture_registry_python.prompt, prompts/metadata_sync_python.prompt -->
+<!-- pdd-story-dev-units: architecture_sync_python.prompt, sync_order_python.prompt, architecture_registry_python.prompt, metadata_sync_python.prompt -->
+
+# User Story: Architecture order drives safe sync
+
+## Story
+
+As a PDD maintainer changing related prompts, I want architecture metadata to determine a stable dependency-aware generation order, so that sync and regeneration do not update dependent units before their sources are known.

--- a/user_stories/story__pdd_story_contract_hash_sync.md
+++ b/user_stories/story__pdd_story_contract_hash_sync.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/user_story_tests_python.prompt, prompts/generate_story_contract_LLM.prompt, prompts/coverage_contracts_python.prompt -->
+<!-- pdd-story-dev-units: user_story_tests_python.prompt, generate_story_contract_LLM.prompt, coverage_contracts_python.prompt -->
+
+# User Story: Story edits invalidate stale contracts
+
+## Story
+
+As a maintainer evolving user stories, I want edited human stories to invalidate stale generated contract sidecars until their hashes and coverage evidence are synchronized, so that story regressions behave like precise unit-test fixtures.

--- a/user_stories/story__pdd_sync_conflict_safe_update.md
+++ b/user_stories/story__pdd_sync_conflict_safe_update.md
@@ -1,0 +1,8 @@
+<!-- pdd-story-prompts: prompts/sync_main_python.prompt, prompts/conflicts_in_prompts_python.prompt, prompts/conflicts_main_python.prompt, prompts/sync_orchestration_python.prompt -->
+<!-- pdd-story-dev-units: sync_main_python.prompt, conflicts_in_prompts_python.prompt, conflicts_main_python.prompt, sync_orchestration_python.prompt -->
+
+# User Story: Sync preserves reviewable conflicts
+
+## Story
+
+As a developer running sync or update on changed prompt/code pairs, I want conflicting edits to produce reviewable conflict evidence instead of silent overwrites, so that regression repair never loses the human source of truth.


### PR DESCRIPTION
Adds unit-like PDD user-story regression coverage for architecture and sync infrastructure.\n\nCoverage:\n- architecture dependency ordering and deterministic generation order\n- conflict-safe sync/update behavior with reviewable conflict evidence\n- story contract hash synchronization and stale contract detection\n\nVerification:\n- python -m py_compile tests/test_story_backfill_unit_like_flows.py\n- python -c "import importlib.util; spec=importlib.util.spec_from_file_location('unit_story_checks','tests/test_story_backfill_unit_like_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_unit_like_story_backfill_artifacts_are_complete(); print('unit-like story checks passed')"\n- python -c "import importlib.util; spec=importlib.util.spec_from_file_location('cross_story_checks','tests/test_story_backfill_cross_unit_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_cross_unit_story_backfill_artifacts_are_complete(); print('cross-unit story checks passed')"\n- python -c "import importlib.util; spec=importlib.util.spec_from_file_location('story_checks','tests/test_story_backfill_top_flows.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.test_top_flow_story_backfill_artifacts_are_complete(); print('story backfill checks passed')"\n\nPart of #1698\nRefs #1769