### PR TITLE
fix(release): align Discord backfill webhook payload

### DIFF
--- a/scripts/backfill_release_video_discord.py
+++ b/scripts/backfill_release_video_discord.py
@@ -24,6 +24,13 @@ YOUTUBE_URL_IN_TEXT_RE = re.compile(r"https?://(?:www\.)?(?:youtube\.com|youtu\.
 YOUTUBE_VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{6,}$")
 GITHUB_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 DISCORD_HTTP_ERROR_RE = re.compile(r"^Discord webhook returned HTTP (\d{3})")
+DISCORD_WEBHOOK_URL_RE = re.compile(
+    r"https://(?:canary\.|ptb\.)?discord(?:app)?\.com/api/webhooks/[^\s\"'<>]+"
+)
+DISCORD_EMBED_COLOR = 3447003
+DISCORD_USER_AGENT = "curl/8.5.0"
+DISCORD_ERROR_BODY_MAX_BYTES = 4096
+DISCORD_ERROR_BODY_MAX_CHARS = 500
 MARKER_NAME = "pdd-release-video-discord-backfill"
 PENDING_MARKER_NAME = "pdd-release-video-discord-backfill-pending"
 POST_MARKER_MAX_ATTEMPTS = 3
@@ -317,11 +324,90 @@ def mark_release_body_posted(
     )
 
 
-def build_discord_payload(tag: str, youtube_url: str, repo: str) -> dict[str, str]:
+def build_discord_payload(tag: str, youtube_url: str, repo: str) -> dict[str, Any]:
     release_url = f"https://github.com/{repo}/releases/tag/{tag}"
     return {
-        "content": f"Release video recovered for {tag}: {youtube_url}\nRelease: {release_url}"
+        "embeds": [
+            {
+                "title": f"Release {tag}",
+                "url": release_url,
+                "description": (
+                    f"\U0001f3a5 **Release video:** {youtube_url}\n\n"
+                    f"Recovered release video for {tag}.\n"
+                    f"Release: {release_url}"
+                ),
+                "color": DISCORD_EMBED_COLOR,
+            }
+        ]
     }
+
+
+def redact_discord_webhook_references(body: str, webhook_url: str | None) -> str:
+    """Redact Discord webhook URLs, including common encoded forms."""
+    variants: set[str] = set()
+    if webhook_url:
+        quoted = urllib.parse.quote(webhook_url, safe="")
+        quoted_plus = urllib.parse.quote_plus(webhook_url, safe="")
+        variants.update(
+            {
+                webhook_url,
+                webhook_url.replace("/", "\\/"),
+                quoted,
+                quoted_plus,
+                lower_percent_escapes(quoted),
+                lower_percent_escapes(quoted_plus),
+            }
+        )
+    for variant in sorted(variants, key=len, reverse=True):
+        if variant:
+            body = body.replace(variant, "[redacted-discord-webhook]")
+    return DISCORD_WEBHOOK_URL_RE.sub("[redacted-discord-webhook]", body)
+
+
+def lower_percent_escapes(value: str) -> str:
+    """Normalize percent escape hex digits to lowercase without changing token text."""
+    return re.sub(r"%[0-9A-Fa-f]{2}", lambda match: match.group(0).lower(), value)
+
+
+def sanitized_response_body_excerpt(response: Any, webhook_url: str | None = None) -> str:
+    try:
+        raw_body = response.read(DISCORD_ERROR_BODY_MAX_BYTES + 1)
+    except (AttributeError, OSError, ValueError):
+        return ""
+
+    if not raw_body:
+        return ""
+    if isinstance(raw_body, str):
+        body = raw_body
+    else:
+        body = raw_body.decode("utf8", errors="replace")
+
+    body = redact_discord_webhook_references(body, webhook_url)
+    body = (
+        body.replace("\\r", " ")
+        .replace("\\n", " ")
+        .replace("\\t", " ")
+        .replace("\r", " ")
+        .replace("\n", " ")
+        .replace("\t", " ")
+    )
+    body = " ".join(body.split())
+    if len(body) > DISCORD_ERROR_BODY_MAX_CHARS:
+        return f"{body[:DISCORD_ERROR_BODY_MAX_CHARS]}..."
+    return body
+
+
+def discord_http_error_message(
+    status: int,
+    reason: str,
+    response: Any,
+    webhook_url: str | None = None,
+) -> str:
+    message = f"Discord webhook returned HTTP {status}: {reason}"
+    body_excerpt = sanitized_response_body_excerpt(response, webhook_url)
+    if body_excerpt:
+        message = f"{message} Response body excerpt: {body_excerpt}"
+    return message
 
 
 def send_discord_webhook(
@@ -334,7 +420,11 @@ def send_discord_webhook(
     request = urllib.request.Request(
         webhook_url,
         data=data,
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Accept": "*/*",
+            "Content-Type": "application/json",
+            "User-Agent": DISCORD_USER_AGENT,
+        },
         method="POST",
     )
     try:
@@ -347,7 +437,7 @@ def send_discord_webhook(
                 )
     except urllib.error.HTTPError as exc:
         raise DiscordWebhookError(
-            f"Discord webhook returned HTTP {exc.code}: {exc.reason}",
+            discord_http_error_message(exc.code, str(exc.reason), exc, webhook_url),
             post_definitely_failed=discord_http_status_definitely_failed(exc.code),
         ) from exc
     except urllib.error.URLError as exc:

--- a/tests/test_release_video_discord_backfill.py
+++ b/tests/test_release_video_discord_backfill.py
@@ -1,5 +1,7 @@
 import importlib.util
+import io
 from pathlib import Path
+import urllib.error
 
 import pytest
 
@@ -44,6 +46,149 @@ def load_backfill_module():
     return module
 
 
+def expected_discord_embed_payload(tag: str, youtube_url: str, repo: str) -> dict:
+    release_url = f"https://github.com/{repo}/releases/tag/{tag}"
+    return {
+        "embeds": [
+            {
+                "title": f"Release {tag}",
+                "url": release_url,
+                "description": (
+                    f"\U0001f3a5 **Release video:** {youtube_url}\n\n"
+                    f"Recovered release video for {tag}.\n"
+                    f"Release: {release_url}"
+                ),
+                "color": 3447003,
+            }
+        ]
+    }
+
+
+def test_build_discord_payload_uses_release_workflow_embed_style():
+    module = load_backfill_module()
+    youtube_url = "https://www.youtube.com/watch?v=RIkxCaylRAQ"
+
+    payload = module.build_discord_payload("v0.0.283", youtube_url, "promptdriven/pdd")
+
+    assert "content" not in payload
+    assert payload == expected_discord_embed_payload(
+        "v0.0.283",
+        youtube_url,
+        "promptdriven/pdd",
+    )
+
+
+def test_send_discord_webhook_posts_json_with_user_agent(monkeypatch):
+    module = load_backfill_module()
+    payload = expected_discord_embed_payload(
+        "v0.0.283",
+        "https://youtu.be/RIkxCaylRAQ",
+        "promptdriven/pdd",
+    )
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        status = 204
+
+        def getcode(self) -> int:
+            return self.status
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> bool:
+            return False
+
+    def fake_urlopen(request, *, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    module.send_discord_webhook("https://discord.example/webhook", payload, timeout=7)
+
+    request = captured["request"]
+    assert request.get_method() == "POST"
+    assert request.get_header("Content-type") == "application/json"
+    assert request.get_header("User-agent").startswith("curl/")
+    assert request.get_header("Accept") == "*/*"
+    assert module.json.loads(request.data.decode("utf8")) == payload
+    assert captured["timeout"] == 7
+
+
+def test_send_discord_webhook_includes_sanitized_http_error_response_body(monkeypatch):
+    module = load_backfill_module()
+    payload = expected_discord_embed_payload(
+        "v0.0.283",
+        "https://youtu.be/RIkxCaylRAQ",
+        "promptdriven/pdd",
+    )
+    response_body = (
+        b'{"message":"blocked webhook\\ntry again",'
+        b'"webhook":"https://discord.com/api/webhooks/123456789/secret-token"}'
+    )
+
+    def fake_urlopen(request, *, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            403,
+            "Forbidden",
+            hdrs={},
+            fp=io.BytesIO(response_body),
+        )
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(module.DiscordWebhookError) as exc_info:
+        module.send_discord_webhook("https://discord.example/webhook", payload)
+
+    message = str(exc_info.value)
+    assert "Discord webhook returned HTTP 403: Forbidden" in message
+    assert "Response body excerpt:" in message
+    assert "blocked webhook try again" in message
+    assert "secret-token" not in message
+    assert "https://discord.com/api/webhooks/123456789/secret-token" not in message
+
+
+def test_send_discord_webhook_redacts_encoded_webhook_urls_from_error_body(monkeypatch):
+    module = load_backfill_module()
+    webhook_url = "https://discord.com/api/webhooks/123456789/Secret-Token"
+    payload = expected_discord_embed_payload(
+        "v0.0.283",
+        "https://youtu.be/RIkxCaylRAQ",
+        "promptdriven/pdd",
+    )
+    response_body = (
+        b'{"literal":"https://discord.com/api/webhooks/123456789/Secret-Token",'
+        b'"json_escaped":"https:\\/\\/discord.com\\/api\\/webhooks\\/123456789\\/Secret-Token",'
+        b'"encoded":"https%3A%2F%2Fdiscord.com%2Fapi%2Fwebhooks%2F123456789%2FSecret-Token",'
+        b'"encoded_lower":"https%3a%2f%2fdiscord.com%2fapi%2fwebhooks%2f123456789%2fSecret-Token"}'
+    )
+
+    def fake_urlopen(request, *, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            403,
+            "Forbidden",
+            hdrs={},
+            fp=io.BytesIO(response_body),
+        )
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(module.DiscordWebhookError) as exc_info:
+        module.send_discord_webhook(webhook_url, payload)
+
+    message = str(exc_info.value)
+    assert "Response body excerpt:" in message
+    assert "Secret-Token" not in message
+    assert "123456789" not in message
+    assert "https:\\/\\/discord.com\\/api\\/webhooks" not in message
+    assert "https%3A%2F%2Fdiscord.com%2Fapi%2Fwebhooks" not in message
+    assert "https%3a%2f%2fdiscord.com%2fapi%2fwebhooks" not in message
+
+
 def test_backfill_posts_discord_followup_and_marks_release_body():
     module = load_backfill_module()
     youtube_url = "https://www.youtube.com/watch?v=RIkxCaylRAQ"
@@ -63,13 +208,7 @@ def test_backfill_posts_discord_followup_and_marks_release_body():
     assert posts == [
         (
             "https://discord.example/webhook",
-            {
-                "content": (
-                    "Release video recovered for v0.0.283: "
-                    "https://www.youtube.com/watch?v=RIkxCaylRAQ\n"
-                    "Release: https://github.com/promptdriven/pdd/releases/tag/v0.0.283"
-                )
-            },
+            expected_discord_embed_payload("v0.0.283", youtube_url, "promptdriven/pdd"),
         )
     ]
     assert github.body.startswith(f"Release video: {youtube_url}\n\n")
@@ -404,7 +543,11 @@ def test_backfill_does_not_skip_for_a_different_video_url():
 
     assert result.posted is True
     assert len(posts) == 1
-    assert f"Release video recovered for v0.0.283: {second_url}" in posts[0][1]["content"]
+    assert posts[0][1] == expected_discord_embed_payload(
+        "v0.0.283",
+        second_url,
+        "promptdriven/pdd",
+    )
     assert module.discord_backfill_marker("v0.0.283", second_url) in github.body
 
 


### PR DESCRIPTION
## Summary

- change release-video Discord backfill posts from plain `content` payloads to the same embed-style payload shape used by the normal release workflow
- add curl-like request headers to the Python webhook sender so the backfill path behaves closer to the working release path
- include bounded, sanitized Discord HTTP response body excerpts in webhook failure diagnostics

Fixes #1832.

## Repro / Evidence Before Fix

Normal release Discord posting succeeded using `secrets.DISCORD_WEBHOOK_URL`, shell `curl`, and an embed payload:

```text
Run 28694651823, v0.0.295:
Posted release notes for v0.0.295 to Discord.
```

Backfill posting failed with the same secret name but the Python backfill sender and a plain `content` payload:

```text
Run 28695650735, v0.0.293:
release-video-discord-backfill: Discord webhook returned HTTP 403: Forbidden
```

TDD red run after adding the regression tests and before implementation:

```bash
conda run -n pdd --no-capture-output env \
  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
  PYDANTIC_DISABLE_PLUGINS=1 \
  python -m pytest tests/test_release_video_discord_backfill.py -q
# 5 failed, 14 passed
```

## Test Plan

- [x] `conda run -n pdd --no-capture-output env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYDANTIC_DISABLE_PLUGINS=1 python -m pytest tests/test_release_video_discord_backfill.py -q` -> `20 passed, 1 warning`
- [x] `conda run -n pdd --no-capture-output python -m py_compile scripts/backfill_release_video_discord.py tests/test_release_video_discord_backfill.py`
- [x] `git diff --check`

## Risks / Out of Scope

- No live Discord post was made in the PR branch. Post-merge validation should rerun the existing `Backfill release video Discord post` workflow for `v0.0.293` and confirm the marker is written only after Discord accepts the post.
- This does not change the normal release workflow Discord step.