### PR TITLE
Research #1209 v2 (1/5): design revision — SWE-bench exclusion, context snapshots, H2/H3, PDD target, distractor definition

### DIFF
--- a/research/repo-bloat-benchmark/README.md
+++ b/research/repo-bloat-benchmark/README.md
@@ -11,11 +11,24 @@ patching**.
 This is the home branch for the experiment. Polished write-ups may later be
 promoted to `docs/whitepaper_with_benchmarks/`; active infra lives here.
 
+**v2 (2026-07-06):** the design was revised — before any model run — to
+incorporate review feedback: SWE-bench explicitly excluded from the core
+experiment; **context snapshots** (API-boundary recording proxy) promoted to
+primary instrumentation; a pre-registered **within-run token-bloat** hypothesis
+(H2) and **breakdown-location** hypothesis (H3); **PDD as the primary target
+repo**; a formal distractor definition with `regrow`/`mutate`/`template`
+generator modes; and a denser size ladder (`1x/2x/5x/10x/20x/50x` plus a
+breakdown probe). See `epic-1209-v2.md` for the decision table.
+
 ## Start here
 
-- **[design.md](design.md)** — the design document: benchmark architecture,
-  scenario format, distractor sourcing strategy (subset-and-regrow), instrumentation
+- **[design.md](design.md)** — the design document: hypotheses, benchmark
+  architecture, scenario format, distractor definition + sourcing, instrumentation
   plan, and reporting format. Read this first.
+- **[epic-1209-v2.md](epic-1209-v2.md)** — the v2 epic plan: what the review
+  feedback asked for, the decisions made, and the sub-PR map.
+- **[paper/paper.md](paper/paper.md)** — the research-paper draft (added in this
+  epic; kept in sync with `design.md`).
 - **[presentation.md](presentation.md)** — a GitHub-rendered, Marp-exportable slide
   deck of the design talk (the question → subset-and-regrow → the pipeline → the
   three instrumentation taps → pre-registered verdict). A 15-slide tour of `design.md`.
@@ -34,54 +47,68 @@ promoted to `docs/whitepaper_with_benchmarks/`; active infra lives here.
   agentic CLI harness, model, thinking, and repeat-run configs once cross-CLI
   usage/cost instrumentation is available.
 
-## Planned layout
+## Layout
 
 ```
 research/repo-bloat-benchmark/
-  design.md          ← design document (current deliverable)
-  README.md          ← this file
-  snapshots/         ← pinned, vendored upstream OSS repos (harness-only) (planned)
-  scenarios/         ← dependency-sliced cores + seed.patch + task briefs + hidden verifiers (planned)
-  distractors/       ← per-size token-budgeted manifests + manifests.lock (planned)
-  harness/           ← subsetter, runner, variant builder, instrumentation tap, verifier driver (planned)
-  reports/           ← raw traces, run records, generated tables/plots (planned)
+  design.md            ← design document (v2)
+  README.md            ← this file
+  epic-1209-v2.md      ← v2 epic plan (feedback → decisions → sub-PR map)
+  paper/               ← research-paper draft (this epic)
+  harness/             ← experiment code (this epic)
+    context_snapshots/   API-boundary recording proxy + per-iteration analyzer
+    distractors/         distractor definition, generator (regrow/mutate/template), manifests
+    runner/              variant builder, run orchestration, metrics, report generator
+  snapshots/           ← pinned, vendored upstream repos (harness-only) (planned)
+  scenarios/           ← dependency-sliced cores + seed.patch + task briefs + hidden verifiers
+  distractors/         ← per-size token-budgeted manifests + manifests.lock (generated)
+  reports/             ← raw traces, run records, generated tables/plots (generated)
 ```
 
 ## Pilot scope
 
-- 3 frozen bug-fix scenarios — each a **bug seeded into a dependency-sliced real-OSS core**.
-- Deterministic distractor manifests at **1x / 5x / 20x / 50x** by **token budget**,
-  produced by regrowing the repo's own out-of-core files, committed before runs.
+- 3 frozen bug-fix scenarios — each a **bug seeded into a dependency-sliced
+  real-OSS core**; primary upstream repo: **PDD itself** (design §4.1.0).
+- Deterministic distractor manifests on the ladder **1x / 2x / 5x / 10x / 20x / 50x**
+  by **token budget** (regrow → mutate → template mode cascade), committed before
+  runs; pre-registered **breakdown probe** beyond 50x if the knee is not located (H3).
 - One arm first: `agentic_code_patch`. (`pdd_prompt_space` comparison deferred.)
 - Primary outcomes: hidden-pass-rate and token usage, plus localization cost
-  (files read / tool calls before first edit) and **distractor context-window
-  penetration** (how much bloat actually reaches the model window).
+  (files read / tool calls before first edit), **distractor context-window
+  penetration** (how much bloat actually reaches the model window), and the
+  **iteration trajectory** of context composition within each run (H2).
+- **SWE-bench is excluded** from the core experiment (design §1.2) — related-work
+  citation only.
 
 ## Locked decisions (frozen before runs — see design §10)
 
 | Decision | Choice |
 |----------|--------|
-| Pilot agent + model | **Codex CLI (GPT)** |
-| Base repo + distractor source | **Real OSS snapshot, dependency-sliced to a minimal core + one seeded bug; distractors = the repo's own out-of-core files regrown to a token budget** *(revised 2026-06-04 from hand-authored repos, before any run)* |
-| Filesystem tap | **Linux container + OverlayFS (edits) + FUSE passthrough, byte-extent reads** |
-| Replicates per `(scenario, size)` | **5** (`trial_index`; seed-pinned only if Codex exposes a supported seed → 60 runs) |
+| Pilot agent + model | **Stock Codex CLI (GPT), unforked** — instrumented at the API boundary |
+| Primary instrumentation | **Context-snapshot recording proxy** (byte-exact request payloads + provider `usage`); FUSE/OverlayFS filesystem tap demoted to an optional cross-check tier *(v2, pre-run)* |
+| Base repo + distractor source | **Real OSS snapshot — primary: PDD @ pinned commit — sliced to a minimal core + one seeded bug; distractors = out-of-core files regrown to a token budget, extended by `mutate`/`template` modes** |
+| Size ladder | **1x/2x/5x/10x/20x/50x** + doubling breakdown probe past 50x *(v2)* |
+| Replicates per `(scenario, size)` | **5** (`trial_index`; seed-pinned only if Codex exposes a supported seed → 90 runs) |
 | Per-run timeout | **30 min** |
+| SWE-bench | **Excluded from the core experiment** *(v2)* |
 
 Still to confirm (does not block scenario authoring): exact Codex model id +
-reasoning effort, whether Codex exposes a supported seed, whether its
-transcript exposes per-request `usage` **and tool-result content** (for token-level
-context-penetration attribution), and the pinned Codex read/search execution path
-(shell-spawned, direct local reads, or any server-side/MCP retrieval). Tool-result
-content, or a harness wrapper that captures surfaced read/search content, is a
-blocker for token-level context-penetration metrics; without it, token-dose
-thresholds must be demoted before runs.
+reasoning effort; whether Codex exposes a supported seed; and that the pinned
+build honors a base-URL override so the recording proxy captures all requests —
+fallback: its session transcript (needs per-request `usage` + tool-result
+content), last resort: a disclosed transport-only fork. Without any of the
+three, token-level penetration and iteration-trajectory metrics must be demoted
+before runs.
 
 ## Ground rules (see design §2)
 
 - Determinism + content hashing before any model run.
-- Distractors are the upstream repo's own files outside the target's dependency
-  closure; each seed needs a novelty audit because an oracle patch can otherwise
-  be an upstream-code restoration.
+- Distractors satisfy the formal definition in design §5.0 (structurally
+  irrelevant, behavior-neutral, plausible, leak-free, tell-free); the default
+  source is the upstream repo's own out-of-core files, extended by `mutate`/
+  `template` modes only when a ladder step exceeds the real pool. Each seed
+  needs a novelty audit because an oracle patch can otherwise be an
+  upstream-code restoration.
 - Hidden verifiers are physically isolated and never enter the agent's context.
 - Only distractor volume varies across sizes; everything else is held constant.
 - Every materialized size variant must pass the oracle equivalence gate: registered
@@ -92,11 +119,15 @@ thresholds must be demoted before runs.
 
 - [x] Design document drafted.
 - [x] §10 pilot decisions locked.
-- [ ] Upstream OSS repos chosen + vendored as pinned snapshots (license/provenance recorded).
-- [ ] Scenarios defined (sliced cores + seeded bugs + hidden verifiers + seed-novelty audits).
+- [x] v2 revision incorporating review feedback (SWE-bench exclusion, context
+      snapshots primary, H2/H3, PDD target, distractor definition + modes, ladder).
+- [ ] Harness + instrumentation implemented (`harness/` — this epic: proxy +
+      analyzer, distractor generator, runner + report).
+- [ ] Paper draft (`paper/paper.md` — this epic).
+- [ ] PDD pinned snapshot vendored; scenarios defined (sliced cores + seeded bugs
+      + hidden verifiers + seed-novelty audits).
 - [ ] Token-budgeted distractor manifests committed.
 - [ ] Oracle equivalence gate passed for every `(scenario, size)` variant.
-- [ ] Harness + instrumentation implemented.
 - [ ] Pilot runs + report.
 
 Tracking issue: [#1209](https://github.com/promptdriven/pdd/issues/1209)

--- a/research/repo-bloat-benchmark/design.md
+++ b/research/repo-bloat-benchmark/design.md
@@ -1,11 +1,20 @@
 # Design: Agentic Localization Degradation Under Repository Bloat
 
 **Issue:** [#1209](https://github.com/promptdriven/pdd/issues/1209) — Research: measure agentic localization degradation under repository bloat
-**Status:** Draft (pilot design) — **§10 decisions LOCKED** (Codex CLI · real-OSS subset-and-regrow w/ seeded bug · Linux container + OverlayFS + FUSE byte-extent reads · N=5 · 30-min timeout)
-**Branch:** `research/issue-1209-oss-subset-regrow`
-**Last updated:** 2026-06-04
+**Status:** Draft **v2** (pilot design) — §10 decisions re-locked after review feedback (Codex CLI **unforked**, instrumented at the API boundary · **PDD as primary target repo** · subset-and-regrow + definition-driven generator modes for 50x+ · context snapshots as the primary instrument · N=5 · 30-min timeout)
+**Branch:** `epic/1209-repo-bloat-v2`
+**Last updated:** 2026-07-06
 
-> **Revision note (2026-06-04).** §10 decision #3 was revised *before any model run* from "hand-authored minimal repos" to **real open-source snapshots, dependency-sliced to a minimal core with one seeded bug, regrown with the repo's own out-of-core files** (see [§5](#5-distractor-sourcing-strategy-subset-and-regrow), [§10](#10-locked-decisions)). Rationale: hand-authoring believable repos *and* a 50x distractor pool is costly and carries an "honesty cost" — synthetic siblings an agent may pattern-match as filler. Using a real repo's own files as distractors removes that cost and is intrinsically realistic. Because no runs have occurred, this is a legitimate pre-registration revision, not post-hoc tuning. Two metric families were added in the same revision: **distractor context-window penetration** ([§6.1](#61-what-we-capture)) and a **token-dose vs. fixability** axis ([§7.2](#72-trend--slope-fits)).
+> **Revision note (2026-06-04).** §10 decision #3 was revised *before any model run* from "hand-authored minimal repos" to **real open-source snapshots, dependency-sliced to a minimal core with one seeded bug, regrown with the repo's own out-of-core files** (see [§5](#5-distractor-definition-and-sourcing-strategy), [§10](#10-locked-decisions)). Rationale: hand-authoring believable repos *and* a 50x distractor pool is costly and carries an "honesty cost" — synthetic siblings an agent may pattern-match as filler. Using a real repo's own files as distractors removes that cost and is intrinsically realistic. Because no runs have occurred, this is a legitimate pre-registration revision, not post-hoc tuning. Two metric families were added in the same revision: **distractor context-window penetration** ([§6.1](#61-what-we-capture)) and a **token-dose vs. fixability** axis ([§7.2](#72-trend--slope-fits)).
+
+> **Revision note (2026-07-06, v2).** A second pre-run revision incorporating review feedback. Because no model runs have occurred, these remain legitimate pre-registration revisions, not post-hoc tuning. The changes:
+>
+> 1. **SWE-bench is explicitly excluded from the core experiment** ([§1.2](#12-why-swe-bench-is-excluded-from-the-core-experiment)). It was never a scenario source in v1; v2 states the exclusion and its rationale so the paper cannot drift back toward it.
+> 2. **Context snapshots become the primary instrument** ([§6.2](#62-how-we-capture-it-defense-in-depth)): an API-boundary **recording proxy** captures the byte-exact composed context of every model request. The FUSE/OverlayFS filesystem tap is demoted from *required* to an *optional cross-check tier* — the design no longer relies on file-level read tracing as its main evidence, and the pilot becomes runnable without a Linux container.
+> 3. **Within-run token-bloat trajectory is a new pre-registered hypothesis (H2)** ([§1.1](#11-hypotheses)): does irrelevant-context share accumulate gradually across agent iterations (tool-result accretion), or arrive as a step? Measured from the per-request snapshot series, with early/middle/late phase comparison ([§6.1](#61-what-we-capture)).
+> 4. **PDD is the primary target repository** ([§4.1.0](#410-primary-upstream-repo-pdd-itself)); **Codex CLI is not forked** — it is instrumented *around*, at the API boundary, preserving external validity ([§8.1](#81-agentic_code_patch-pilot-required)).
+> 5. **"Distractor file" gets a formal, checkable definition** ([§5.0](#50-what-is-a-distractor-file-formal-definition)), and the generator gains `mutate` and `template` modes derived from that definition so the dose can scale past the pool's natural size — enabling an aggressive ladder (`1x/2x/5x/10x/20x/50x`) plus a **breakdown probe** beyond 50x ([§5.1](#51-sizing-model-token-budgeted)).
+> 6. **Task performance vs. distractor scale** is reported per ladder step so the degradation curve's knee is located, not just its endpoints ([§7](#7-reporting-format)).
 
 ---
 
@@ -19,22 +28,41 @@ Operationalized:
 
 The benchmark holds the *task* constant and varies *only* the volume of irrelevant co-resident files, then measures whether the agent reads more, searches more, spends more tokens, edits the wrong files, or fails hidden tests as the repo grows. Critically, it also measures **how much of that irrelevant bulk actually crosses into the model's context window** (vs. is merely visited on disk and dropped), so the "effective context window" claim is tested against the *in-context distractor dose* in tokens — not just against on-disk repo size.
 
-**Where the repos come from.** Rather than hand-author repos and a synthetic distractor pool, each scenario is built from a **real open-source repository**, pinned to a commit, then *dependency-sliced* to a minimal runnable **core** into which we **seed one controlled bug**. The repo's own files that lie *outside* that core are the distractor pool; bloat is produced by deterministically **regrowing** those real files back to a token budget ([§5](#5-distractor-sourcing-strategy-subset-and-regrow)). This makes distractors intrinsically realistic (they are the project's actual code) while keeping the manipulation fully controlled. Because public upstream code may be memorized, the design does **not** assert by default that the oracle fix is absent from training data; each seed must pass a seed-novelty audit or be reported under an explicit upstream-recall caveat.
+**Where the repos come from.** Rather than hand-author repos and a synthetic distractor pool, each scenario is built from a **real open-source repository** — primarily **PDD itself** ([§4.1.0](#410-primary-upstream-repo-pdd-itself)) — pinned to a commit, then *dependency-sliced* to a minimal runnable **core** into which we **seed one controlled bug**. The repo's own files that lie *outside* that core are the distractor pool; bloat is produced by deterministically **regrowing** those real files back to a token budget, extended past the pool's natural size by definition-derived `mutate`/`template` generation when a ladder step demands it ([§5](#5-distractor-definition-and-sourcing-strategy)). This makes distractors intrinsically realistic (they are the project's actual code) while keeping the manipulation fully controlled. Because public upstream code may be memorized, the design does **not** assert by default that the oracle fix is absent from training data; each seed must pass a seed-novelty audit or be reported under an explicit upstream-recall caveat.
+
+### 1.1 Hypotheses
+
+Three pre-registered hypotheses, each falsifiable from the pilot's own data:
+
+- **H1 (cross-size degradation).** As the provisioned distractor dose grows along the size ladder, the agentic arm's localization cost rises (input tokens, tool calls, files consulted before the first edit) and/or `hidden_pass_rate` falls, beyond the practical thresholds in [§7.5](#75-conclusion-required-pre-committed-interpretation). The sharper form regresses success against the **realized in-context distractor dose**, not on-disk size.
+- **H2 (within-run gradual bloat).** *Within a single run*, the irrelevant share of the context window is not delivered in one step: it **accumulates across agent iterations** as tool results (file reads, search output) accrete into the conversation. Concretely: `distractor_context_share` measured per request rises from the run's **early** phase to its **late** phase, and cumulative input tokens grow super-linearly in iteration index at large `S` while staying near-linear at `1x`. The alternative (a step profile — one large read dominates, after which composition is flat) is distinguishable in the same per-request series ([§6.1](#61-what-we-capture), "iteration trajectory" family). H2 matters because it decides *where* a mitigation belongs: gradual accretion points at context-management policy (compaction, result truncation, selective retention); a step profile points at retrieval policy (what to read at all).
+- **H3 (breakdown location).** There exists a ladder step `S*` at which task performance stops degrading gracefully and **breaks down** — `hidden_pass_rate` at `S*` falls below half its `1x` value, or `context_overflow`/`timeout` failures become the modal failure class. The pilot's job is to locate `S*` (or establish it lies beyond 50x), which is why the ladder is dense (`1x/2x/5x/10x/20x/50x`) rather than endpoint-only, and why a breakdown probe past 50x is specified ([§5.1](#51-sizing-model-token-budgeted)).
+
+### 1.2 Why SWE-bench is excluded from the core experiment
+
+SWE-bench (and its Lite/Verified variants) is the field's default substrate for agentic code-patching evaluation, so its exclusion needs to be explicit and argued, not implicit:
+
+1. **The independent variable is not controllable there.** SWE-bench instances come with their repos as-is; repo size varies *across* instances together with task difficulty, project vocabulary, test style, and era. Our design needs the same task at multiple repo sizes — a within-task manipulation SWE-bench cannot provide without rebuilding the instance, at which point none of its ecosystem value (leaderboards, comparability) survives anyway.
+2. **Contamination is pervasive and unmeasurable at the instance level.** SWE-bench repos, issues, and gold patches are heavily represented in training corpora; models demonstrably solve some instances from memory. For a *causal* claim about localization cost this is fatal: a memorized fix short-circuits exactly the search behavior we are measuring. Our seeded-bug + novelty-audit procedure exists precisely to control this.
+3. **Its success criterion is coarser than ours.** SWE-bench scores patch acceptance against fixed tests; it has no notion of localization cost, context composition, or read behavior. Everything this experiment adds (context snapshots, penetration metrics, iteration trajectories) would have to be bolted on anyway — the instances contribute nothing but the task, which is the cheapest part to replace.
+4. **Task heterogeneity buries the signal.** With ~2k heterogeneous tasks, size effects are swamped by between-task variance; with a small curated subset, SWE-bench's statistical appeal disappears and only its contamination remains.
+
+What survives: the **hidden-test idea** (success judged by tests the agent never sees) is adopted from SWE-bench's design ([§4.4](#44-visible-vs-hidden-split)), and SWE-bench remains a citation anchor in related work (see `research-context/literature-review.md`). It contributes **no scenarios, no repos, no tasks, and no evaluation harness** to the core experiment.
 
 This document is the design deliverable for the pilot. It specifies, in order:
 
 1. [Benchmark architecture](#3-benchmark-architecture)
 2. [Scenario format](#4-scenario-format)
-3. [Distractor sourcing strategy](#5-distractor-sourcing-strategy-subset-and-regrow)
+3. [Distractor sourcing strategy](#5-distractor-definition-and-sourcing-strategy)
 4. [Instrumentation plan](#6-instrumentation-plan)
 5. [Reporting format](#7-reporting-format)
 
 ### Pilot scope
 
-- **3 frozen bug-fix scenarios**, each a **seeded bug in a dependency-sliced real-OSS core** (the minimum for the issue's acceptance criteria).
-- **Deterministic distractor manifests** at **1x / 5x / 20x / 50x** repo sizes — produced by regrowing the repo's own out-of-core files to a token budget — committed *before* any model run.
+- **3 frozen bug-fix scenarios**, each a **seeded bug in a dependency-sliced real-OSS core** (primary repo: PDD, [§4.1.0](#410-primary-upstream-repo-pdd-itself)) — the minimum for the issue's acceptance criteria.
+- **Deterministic distractor manifests** on the ladder **1x / 2x / 5x / 10x / 20x / 50x** — produced by regrowing the repo's own out-of-core files to a token budget (extended by `mutate`/`template` modes where the pool runs out) — committed *before* any model run; plus a post-pilot **breakdown probe** beyond 50x if 50x has not yet located `S*` ([§1.1](#11-hypotheses) H3).
 - **One arm only** for the first pass: `agentic_code_patch`. The optional `pdd_prompt_space` comparison arm is specified but deferred (see [§8](#8-arms)).
-- **Primary outcomes:** hidden-pass-rate and token usage, plus localization-cost metrics (files read / tool calls before first edit) and **distractor context-window penetration** (how many distractor tokens actually entered the model context, vs. were visited on disk and dropped).
+- **Primary outcomes:** hidden-pass-rate and token usage, plus localization-cost metrics (files read / tool calls before first edit), **distractor context-window penetration** (how many distractor tokens actually entered the model context, vs. were visited on disk and dropped), and the **iteration trajectory** of context composition within each run (H2).
 
 ### Falsification stance (pre-registered)
 
@@ -54,7 +82,7 @@ These constraints come directly from issue #1209's "Hold constant", "Distractor 
 
 - **Determinism before runs.** Every scenario, distractor manifest, and verifier is content-addressed (sha256) and committed before a single model invocation. A run references manifests by hash; a changed manifest is a new experiment, never a silent edit.
 - **Hidden-test isolation.** Hidden verifiers live outside the repo tree handed to the agent and are never placed in model context, never copied as distractors, and never used as grounding. Visible tests and hidden verifiers are physically separate trees.
-- **Only one thing varies.** Across sizes `S ∈ {1x, 5x, 20x, 50x}` for a given scenario, the **core** (the dependency-sliced slice the seeded bug lives in), task brief, target files, allowed edit scope, model, timeout, visible tests, and hidden verifier are byte-identical. The *only* difference is the set of regrown out-of-core distractor files.
+- **Only one thing varies.** Across sizes `S ∈ {1x, 2x, 5x, 10x, 20x, 50x}` for a given scenario, the **core** (the dependency-sliced slice the seeded bug lives in), task brief, target files, allowed edit scope, model, timeout, visible tests, and hidden verifier are byte-identical. The *only* difference is the set of regrown out-of-core distractor files.
 - **Realistic distractors, by construction.** Distractors are the **repo's own files that lie outside the target's dependency closure** — real, same-project code with the project's actual vocabulary, imports, and layout. A file is a distractor *iff* it is outside that closure, decided **statically before any run** (never by what the agent did). No random filler, no synthetic noise, no templated siblings, no files that change target behavior by merely existing, no import collisions, no leaked answers. (This replaces the prior hand-authored/templated pool and its "honesty cost" — see [§5.3](#53-sourcing-and-placing-distractor-files).)
 - **Contamination is measured, not wished away.** The base repo may appear in model training data, and for a public OSS snapshot the oracle patch might be equivalent to restoring upstream code the model has seen. Before runs, each seed must pass a **seed-novelty audit** showing the oracle patch is not a byte-for-byte restoration of the upstream file and is not a trivial semantic restoration of the pre-seed behavior. Seeds that cannot clear that audit remain eligible only as a pre-registered caveat/stratum for upstream-code recall, not as evidence that the fix was novel. Residual layout-familiarity and upstream-recall risks are recorded in the methodology note ([§7.4](#74-methodology-note), [§11](#11-non-goals-carried-from-the-issue)).
 - **No benchmark tell.** Nothing the agent can observe inside the sandbox may reveal which files are distractors vs. target. The manifest is never mounted into the sandbox; distractors carry **no marker** — no `_distractors/` directory, no naming prefix, no tier label, no comment. They are interleaved into realistic locations and named like real code. A file may be distinguishable as irrelevant **only by genuine reasoning** (reachability, imports, test references) — never by a benchmark artifact. Distractor-vs-target classification for metrics is done **post-hoc** by the harness against the out-of-tree manifest, not by anything in the repo. *(See [§3.3](#33-determinism-and-isolation-guarantees), [§5.3](#53-sourcing-and-placing-distractor-files), [§6.2](#62-how-we-capture-it-defense-in-depth).)*
@@ -78,7 +106,7 @@ These constraints come directly from issue #1209's "Hold constant", "Distractor 
               ▼                      ▼                        ▼
    ┌────────────────┐     ┌────────────────────┐    ┌──────────────────┐
    │ distractor pool │ ──▶ │ manifest builder   │ ─▶ │ size manifests   │
-   │ (snapshot ∖ core)│    │ (regrow to token   │    │ 1x/5x/20x/50x    │
+   │ (snapshot ∖ core)│    │ (regrow to token   │    │ ladder 1x…50x    │
    │  real OSS files │     │  budget, seeded)   │    │ (token-budgeted) │
    └────────────────┘     └────────────────────┘    └────────┬─────────┘
                                                               │
@@ -114,7 +142,7 @@ These constraints come directly from issue #1209's "Hold constant", "Distractor 
 ### 3.2 Stages
 
 1. **Scenario fixtures (from a real OSS snapshot).** A pinned upstream repository snapshot, *dependency-sliced* to a minimal runnable **core** (the smallest slice in which the visible tests run), into which one controlled bug is **seeded**. The core is the 1x base repo; it carries the target task brief, target implementation file(s), visible tests, and an out-of-tree hidden verifier authored for the seeded bug. ([§4](#4-scenario-format))
-2. **Distractor pool + manifest builder.** The pool is exactly the snapshot's files **outside the core** (real, same-project code). A deterministic, seeded algorithm selects pool files — in dependency-closed groups so each imports cleanly — into a per-(scenario, size) manifest sized to a **token budget**, committed before runs. ([§5](#5-distractor-sourcing-strategy-subset-and-regrow))
+2. **Distractor pool + manifest builder.** The pool is exactly the snapshot's files **outside the core** (real, same-project code). A deterministic, seeded algorithm selects pool files — in dependency-closed groups so each imports cleanly — into a per-(scenario, size) manifest sized to a **token budget**, committed before runs. ([§5](#5-distractor-definition-and-sourcing-strategy))
 3. **Variant builder.** Given `(core, manifest)`, materializes a working repo by copying the selected real out-of-core files to their **original upstream paths**. Pure function of inputs → byte-identical output; verified by re-hashing the resulting tree.
 4. **Run harness.** For each `(scenario, size, trial)`:
    - creates an isolated sandbox (fresh temp dir + `git init`, committing the materialized core+distractors as the pre-run baseline),
@@ -153,7 +181,14 @@ research/repo-bloat-benchmark/
     manifests/
       <scenario_id>.<size>.json  per-size distractor manifest = the secret label key (see §5)
     manifests.lock               sha256 lockfile of all committed manifests
-  harness/                       subsetter, runner, variant builder, instrumentation tap, verifier driver
+  harness/                       experiment code (implemented in this epic)
+    context_snapshots/           API-boundary recording proxy, snapshot schema, session-log
+                                 parser, per-iteration analyzer (§6.2 tap 1)
+    distractors/                 DEFINITION.md + generator (regrow/mutate/template) +
+                                 token-budgeted manifest builder (§5)
+    runner/                      variant builder, run orchestration, metrics, report generator
+  paper/
+    paper.md                     research-paper draft (kept in sync with this design)
   reports/
     <run_id>/                    raw traces, run records (JSONL), generated tables/plots
 ```
@@ -167,6 +202,22 @@ The `snapshots/`, `distractors/`, and `scenarios/<id>/{scenario.json,core_files.
 ## 4. Scenario format
 
 A **scenario** is a frozen, hidden-testable maintenance task built from a real OSS repo. The pilot uses 3 bug-fix scenarios. Each scenario directory contains a dependency-sliced **core** (the 1x base repo, with one seeded bug), a task brief, a machine-readable descriptor, and an isolated hidden verifier.
+
+### 4.1.0 Primary upstream repo: PDD itself
+
+The review feedback proposed two candidate substrates: fork Codex (the agent) or use PDD (the repo). These answer different needs — forking Codex is an *instrumentation* question (rejected in [§8.1](#81-agentic_code_patch-pilot-required): we instrument at the API boundary instead), while PDD-as-target is a *scenario-substrate* question, adopted here.
+
+**Decision.** The pilot's scenarios are dependency-sliced cores of the **PDD repository itself** (`github.com/promptdriven/pdd`, pinned commit recorded per scenario). At least 2 of the 3 pilot scenarios come from distinct PDD subsystems (e.g. CLI command dispatch vs. LLM invocation vs. template preprocessing); the third may come from a second, unaffiliated OSS repo as an external-validity check if time allows.
+
+Why PDD satisfies the §4.1 criteria better than an arbitrary OSS repo:
+
+- **We control the ground truth.** The core/distractor boundary, the seeded bug, and the hidden verifier are auditable by the people who wrote the code. The main threat to the [§4.1.2](#412-variantoracle-equivalence-gate-pre-run) oracle gate — a "distractor" that is secretly load-bearing (dynamic import, plugin discovery, config side effect) — is far easier to catch in a codebase we maintain.
+- **Right size.** `pdd/` is a mid-size production package (hundreds of modules across CLI, server, LLM-invocation, and template subsystems) — large enough that `regrow` reaches high ladder steps before generator modes must take over, small enough that dependency-sliced cores stay runnable inside the timeout.
+- **License/provenance is trivial** — vendoring a pinned snapshot of our own repo raises no redistribution questions.
+- **Offline-runnable tests** for the sliceable subsystems (pure-Python units under pytest), satisfying the determinism requirement.
+- **Dogfooding payoff.** If bloat sensitivity is real, observing it on PDD's own codebase makes the product follow-ups (context audits, context manifests, prompt-owned module boundaries) directly actionable rather than analogical.
+
+The known cost is **contamination**: PDD is public on GitHub and plausibly present in training data — but that is true of any real OSS repo, and the [§4.1.1](#411-subsetting--seeding-procedure-deterministic-pre-run) seed-novelty audit plus seeded (never historical) bugs are the existing controls. One PDD-specific caveat goes in the methodology note: the agent under test may have seen PDD's layout, and a familiarity effect would *reduce* measured localization cost at all sizes — biasing **against** H1, i.e. in the conservative direction.
 
 ### 4.1 Upstream-repo selection criteria
 
@@ -187,7 +238,7 @@ For each chosen repo, the harness derives the scenario as a pure, recorded trans
 2. **Seed one controlled bug** at that site (`seed.patch`) — a single, unambiguous behavior defect.
 3. **Compute the minimal core** — the dependency closure required for the relevant visible tests to run: start from `{target, its tests}`, add imports/fixtures until the visible suite executes, stop. `core_files.txt` records membership. This core is the 1x base repo.
 4. **Author the hidden verifier** for the seeded bug, exercising behavior the visible tests do not fully pin down; it lives out-of-tree (`hidden/`).
-5. **Define the distractor pool** as `snapshot ∖ core`. Every file outside the core is, by construction, a real same-project distractor ([§5](#5-distractor-sourcing-strategy-subset-and-regrow)).
+5. **Define the distractor pool** as `snapshot ∖ core`. Every file outside the core is, by construction, a real same-project distractor ([§5](#5-distractor-definition-and-sourcing-strategy)).
 6. **Run the seed-novelty audit** before accepting the scenario:
    - byte-compare the oracle-fixed target file(s) against the pinned upstream file(s); a byte-for-byte restoration fails the novelty claim;
    - review the oracle patch for semantic restoration of upstream behavior (for example, simply undoing the seeded hunk with no new logic); if it restores upstream semantics, record the scenario as an upstream-recall stratum or replace the seed;
@@ -199,7 +250,7 @@ A scenario must verify **deterministically** (no flakiness, wall-clock, or netwo
 
 Subsetting from visible tests and then regrowing files at original paths can accidentally change behavior across sizes via hidden-verifier dependencies, dynamic imports, package discovery, plugins/config, optional dependencies, or import shadowing. Therefore every materialized variant must pass an **oracle equivalence gate** before any model run.
 
-For each `(scenario, size)` variant (`1x`, `5x`, `20x`, `50x`) under one fixed dependency environment, the harness records:
+For each `(scenario, size)` variant (every ladder step `1x`…`50x`) under one fixed dependency environment, the harness records:
 
 - baseline visible-test result and baseline hidden-verifier result on the seeded bug;
 - oracle-fixed visible-test result and oracle-fixed hidden-verifier result;
@@ -280,9 +331,33 @@ An issue-style request: symptom, reproduction, and acceptance phrased as behavio
 
 ---
 
-## 5. Distractor sourcing strategy (subset-and-regrow)
+## 5. Distractor definition and sourcing strategy
 
-Distractors are the upstream repo's **own files that lie outside the core's dependency closure** — real, plausible-but-irrelevant code that agentic search may legitimately, but unprofitably, inspect. We do not generate them; we **regrow** the real repo around the minimal core. The selection is deterministic, tiered, and recorded in a manifest committed before runs.
+The default distractor source is unchanged from v1: the upstream repo's **own files that lie outside the core's dependency closure** — real, plausible-but-irrelevant code that agentic search may legitimately, but unprofitably, inspect, **regrown** around the minimal core. v2 adds what the feedback asked for: a **formal, checkable definition** of *distractor file*, and **generator modes derived from that definition** so the dose can scale past the pool's natural size (50x and beyond). Selection remains deterministic, tiered, and recorded in a manifest committed before runs.
+
+### 5.0 What is a "distractor file"? (formal definition)
+
+A file `D` is a **distractor** for a scenario `(core, task, visible_tests, hidden_verifier)` iff **all** of the following hold:
+
+1. **Structural irrelevance.** `D ∉ closure(core)`: no core file imports, includes, or loads `D` (statically decidable **before** any run), and `D` is not among `target_files`.
+2. **Behavior neutrality.** Materializing or removing `D` changes no visible-test outcome and no hidden-verifier outcome — enforced by the [§4.1.2](#412-variantoracle-equivalence-gate-pre-run) oracle equivalence gate, plus static exclusion of files with ambient side effects (`conftest.py`, pytest plugins, `sitecustomize`, import-path shadowing).
+3. **Plausibility.** `D` is written in the project's language and idiom, imports cleanly within its own admission group, and would not read as filler to a reviewer who knows the project. Operationalized: same language as the core; parses; identifier-vocabulary overlap with the core at or above a recorded floor. Verbatim project files satisfy this by construction.
+4. **No leakage.** `D` contains no hidden-verifier content, no oracle-patch content, and no string on the hidden-assertion denylist.
+5. **No tell.** `D` carries no marker of distractor status — in path, name, comment, or content (§2 "No benchmark tell").
+
+Conditions 1, 2, 4, 5 are machine-checked by the generator for **every** admitted file; condition 3 is machine-checked where possible (language, parse, vocabulary floor). The definition is deliberately source-agnostic: any file that meets it is admissible, which is what lets the three generator modes below share one contract — and one test suite.
+
+### 5.0.1 Generator modes (one definition, three sources)
+
+Real pools are finite: `snapshot ∖ core` can run out below the 50x budget, and the H3 breakdown probe needs more still. v2 defines three deterministic modes, all validated against §5.0, ordered by realism:
+
+| Mode | Source | Realism | Role |
+|------|--------|---------|------|
+| `regrow` | verbatim out-of-core project files at their original upstream paths | organic (highest) | default; fills every budget it can |
+| `mutate` | derived variants of pool files: seeded identifier/docstring renames from a recorded vocabulary map, semantics-preserving reordering — placed at plausible sibling paths that do not collide with any real path | high | extends the pool once `regrow` is exhausted |
+| `template` | synthetic modules from parameterized skeletons (service/handler/util shapes) filled with vocabulary harvested from the core (identifier n-grams, domain nouns), seeded RNG | bounded | last resort for extreme ladder steps / the breakdown probe |
+
+Mode policy is fixed and recorded, never chosen per run: `regrow` until exhausted, then `mutate`, then `template`. The manifest records each file's `mode` alongside its `tier`, and the report breaks read and penetration metrics down **by mode** — if agents ignore `template` files but read `regrow` files, that heterogeneity is measured rather than hidden. This handles the v1 "honesty cost" objection to synthetic files honestly: realism becomes a *measured axis* (per-mode read/penetration rates) instead of a reason to cap the experiment at the pool's natural size.
 
 ### 5.1 Sizing model (token-budgeted)
 
@@ -291,13 +366,19 @@ Distractors are the upstream repo's **own files that lie outside the core's depe
 | Size | Target added distractor tokens | Total repo tokens (≈) |
 |------|--------------------------------|-----------------------|
 | 1x   | 0 (control)                    | `core_tokens`         |
+| 2x   | `1 × core_tokens`              | `2 × core_tokens`     |
 | 5x   | `4 × core_tokens`              | `5 × core_tokens`     |
+| 10x  | `9 × core_tokens`              | `10 × core_tokens`    |
 | 20x  | `19 × core_tokens`             | `20 × core_tokens`    |
 | 50x  | `49 × core_tokens`             | `50 × core_tokens`    |
 
+The v2 ladder is denser than the issue's suggested `1x/5x/20x/50x` because H3 asks *where* performance breaks down, and a knee between 5x and 50x is invisible with endpoint-heavy spacing. The four original steps are a subset of the ladder, so the issue's acceptance criteria remain satisfied verbatim.
+
 **Two distinct "token" notions — do not conflate.** The budget above is **on-disk token size** of distractor files under a fixed, recorded tokenizer — the dose we *provision*. It is *not* the same as the **in-context distractor tokens** that actually reach the model window, which are measured per-run from the transcript ([§6.1](#61-what-we-capture)) and are the real test of the effective-context claim ([§7.2](#72-trend--slope-fits)). The pilot reports outcomes against **both**: provisioned dose (`S`) and realized in-context dose.
 
-`1x` is the no-distractor control (core only). Sizes are token-budget targets; the builder fills the budget greedily from the ordered candidate list ([§5.3](#53-sourcing-and-placing-distractor-files)) until within a tolerance (e.g. ±2% of target), recording realized tokens and LOC. If a size is infeasible (pool too small for 50x, or a budget unreachable without breaking dependency-closed grouping), that is documented per the acceptance criteria rather than silently skipped — and is itself a reason to prefer larger upstream repos ([§4.1](#41-upstream-repo-selection-criteria)).
+`1x` is the no-distractor control (core only). Sizes are token-budget targets; the builder fills the budget greedily from the ordered candidate list ([§5.3](#53-sourcing-and-placing-distractor-files)) until within a tolerance (e.g. ±2% of target), recording realized tokens and LOC. If a size is infeasible under `regrow` alone, the builder falls through to `mutate` then `template` per the §5.0.1 mode policy; a size is documented as infeasible only if the full mode cascade cannot fill it (per the acceptance criteria, never silently skipped).
+
+**Breakdown probe (H3).** If 50x has not located `S*` — `hidden_pass_rate` at 50x still above half its 1x value, and `context_overflow`/`timeout` not the modal failure class — the ladder is extended post-pilot by doubling (100x, 200x, …) with the same manifest machinery, `mutate`/`template` supplying the dose beyond the real pool. Probe steps are pre-registered the same way (manifests committed before runs); they are an *extension* of the experiment, not a redesign.
 
 ### 5.2 Distractor tiers
 
@@ -328,7 +409,8 @@ If the pilot shows agents skip distractors regardless of size (flat `irrelevant_
 - no distractor changes target behavior by existing (no `conftest`/plugin/`sitecustomize` side effects, no shadowing of a core import path) — upstream test-config files outside the core are excluded from the pool,
 - no hidden-verifier file or its content is ever included,
 - no distractor contains the seeded contract's answer (checked against a denylist of hidden-assertion tokens — cheap insurance alongside the seed-novelty audit),
-- admitted distractors import cleanly (dependency-closed grouping) so none is trivially ignorable as broken.
+- admitted distractors import cleanly (dependency-closed grouping) so none is trivially ignorable as broken,
+- every admitted file — any mode — passes the §5.0 definition checks; `mutate`/`template` files additionally pass the plausibility floor (parse + vocabulary overlap) and are recorded with their `mode` and generation seed.
 
 ### 5.4 Determinism
 
@@ -376,7 +458,7 @@ A `manifests.lock` aggregates the sha256 of every committed manifest; the harnes
 
 ## 6. Instrumentation plan
 
-Instrumentation answers: *how hard did the agent have to work to localize, and did it succeed under the hidden contract?* The pilot prioritizes **file reads**, **tool calls**, **token usage**, and **hidden pass/fail**.
+Instrumentation answers: *how hard did the agent have to work to localize, what actually occupied its context window while it worked, and did it succeed under the hidden contract?* The pilot prioritizes **context snapshots** (the composed model requests themselves), **token usage**, **tool calls**, and **hidden pass/fail**. File-level read tracing is a supporting, optional tier in v2: evidence about the context window comes from the window itself, not only from disk activity.
 
 ### 6.1 What we capture
 
@@ -416,6 +498,19 @@ This family answers the question the FS tap *cannot*: of all the distractor mate
 
 > **Three layers, deliberately kept separate.** On-disk *dose* (`distractor_tokens_on_disk`, §5) ⊇ *visited* (FS tap, `irrelevant_file_read_ratio`) ⊇ *in-context* (transcript attribution, this family). Each inclusion can leak — an agent can provision-but-not-read, read-but-not-surface, or surface-into-context. The pilot reports all three so a flat outcome can be attributed to the right layer.
 
+**Iteration trajectory (H2 — the within-run token-bloat profile):**
+
+Computed from the per-request snapshot series (tap 1 in §6.2), indexed by request ordinal `i = 1..n`:
+
+- `input_tokens[i]` and `context_growth[i] = input_tokens[i] − input_tokens[i−1]` — the per-iteration context series
+- `distractor_context_share[i]` — per-request irrelevant occupancy (the §6.1 penetration attribution applied per request)
+- `phase_stats` — the series split into **early / middle / late** thirds by request ordinal, with per-phase medians of both series; H2 compares late vs. early
+- `growth_shape` — classification of the cumulative-context curve per run: `gradual` (no single request contributes > 30 % of final context; positive early→late trend), `step` (one request's growth dominates), `plateau` (context stops growing — compaction/truncation visible), `sawtooth` (drops from compaction mid-run)
+- `largest_single_jump_share` = `max_i(context_growth[i]) / input_tokens[n]`
+- `iterations_total`, `iterations_before_first_edit`
+
+This family exists because a per-run total cannot distinguish *how* the window filled: sixty small accretions and one giant read produce the same `input_tokens_per_run` but demand different mitigations (context-management policy vs. retrieval policy). H2 is decided from this series, per [§7.5](#75-conclusion-required-pre-committed-interpretation).
+
 **Outcome:**
 
 - `hidden_pass` (bool) — sole success criterion
@@ -424,19 +519,23 @@ This family answers the question the FS tap *cannot*: of all the distractor mate
 
 ### 6.2 How we capture it (defense in depth)
 
-The agent arm may report some of this; we do **not** trust self-report alone. Three independent taps, reconciled in analysis:
+The agent arm may report some of this; we do **not** trust self-report alone. Three independent taps, reconciled in analysis. **v2 change:** the context-snapshot tap is primary and required; the filesystem tap is an optional cross-check tier — the pilot is valid without it, and therefore runnable outside a Linux container.
 
-1. **Filesystem tap (ground truth for reads + edits) — LOCKED: Linux container + OverlayFS + FUSE passthrough.** The agent runs inside a **Linux container** (Docker/Podman/Colima) so the kernel features below work regardless of the macOS dev host. Two stacked layers:
+1. **Context-snapshot tap (PRIMARY — ground truth for what the model saw): API-boundary recording proxy.** All of the agent's model traffic is routed through a local recording relay (base-URL override, e.g. `OPENAI_BASE_URL=http://127.0.0.1:<port>/v1`), which archives, per request: the **byte-exact request payload** — the full composed context: system/instructions, task, conversation history, tool results — the response, provider `usage` (input/output tokens), timestamps, and a request ordinal. This is a *context snapshot*: not an inference about what the model saw from disk activity, but the composed window itself.
+   - **All `input_tokens_*` metrics, `max_request_input_tokens`, the penetration family, and the iteration-trajectory family come from this tap.** Attribution matches each request's surfaced content against the materialized tree + manifest (normalized-span matching), tags spans `core` / `distractor` / `hidden`(never), tokenizes distractor spans with the pinned tokenizer, and reconciles repeat-counted attribution against provider `usage` so attributed input can never exceed measured input for a request. De-duplicated span coverage per distractor file yields `distractor_unique_tokens_entered_context` and `distractor_pool_coverage`.
+   - The stock CLI's own **session/rollout logs** (from the per-run `CODEX_HOME`) are parsed as a redundant cross-check: tool-call sequence and any self-reported token counts must be consistent with the proxy record; disagreement flags the run.
+   - Works with the **unforked** agent binary; the same instrument serves any CLI that honors a base-URL override, which is what makes the cross-agent extension cheap.
+   - *Pre-run blocker:* the pinned Codex build must honor the base-URL override for all provider traffic. Documented fallback: Codex's session transcript, iff it exposes per-request `usage` **and** tool-result content; failing both, a transport-only fork is the disclosed last resort ([§10](#10-locked-decisions), still-to-confirm #3).
+
+2. **Filesystem tap (OPTIONAL cross-check tier — ground truth for on-disk reads + edits): Linux container + OverlayFS + FUSE passthrough.** The agent runs inside a **Linux container** (Docker/Podman/Colima) so the kernel features below work regardless of the macOS dev host. Two stacked layers:
    - **OverlayFS for write isolation / edit ground truth.** `lowerdir` = the frozen materialized repo (core + distractors, read-only), `upperdir` = empty scratch, `merged` = what the agent sees and edits. Every file the agent writes lands in `upperdir`, so post-run the `upperdir` **is** the edit set (no diff heuristics) and the core stays provably pristine. This feeds `wrong_file_edit_rate` and `forbidden_file_edits`.
    - **FUSE passthrough for read ground truth.** A passthrough FUSE daemon mounts the repo and logs every `open`/`read` with `{path, offset, length, pid, ts}`, forwarding to the backing files. **Byte-extent granularity is locked** (over coarser fanotify open-events) so we capture read *volume* and exact path extents, not just which files were opened. This underpins `files_read_*`, `bytes_read_*`, `irrelevant_file_read_ratio`, and `forbidden_file_reads`, regardless of what the agent claims. **Filesystem bytes are deliberately not turned into a token metric** — see the read-volume-≠-tokens note in [§6.1](#61-what-we-capture); model token counts come exclusively from the transcript tap below.
 
    The container needs `/dev/fuse` + `CAP_SYS_ADMIN`. FUSE adds per-read latency, which inflates `wall_clock_seconds` (a secondary metric) but **not** the read/token *counts* that are the primary signal — flagged in the methodology note ([§7.4](#74-methodology-note)). This kernel/FS-boundary tap is chosen over an in-process shim precisely because Codex may shell out to tools (`ripgrep`, `grep`, subprocesses) whose reads a wrapper shim would miss.
-2. **Tool-call / transcript tap.** The agent runner emits a structured event log of tool invocations (search, read, edit, shell) and per-request token accounting from the provider response `usage` (input tokens, output tokens, with request timestamps). **All `input_tokens_*` metrics come exclusively from this provider accounting**, split at the first-edit boundary by request timestamp — never derived from filesystem bytes. The tool-call counts yield `search_or_tool_calls_before_first_edit`. (If Codex's emitted transcript does not expose per-request `usage`, that is a blocker resolved in [§8.1](#81-agentic_code_patch-pilot-required) before runs — token metrics must have a real source.) The merged `pdd context` audit core (PR #1387, closing #789; the `pdd.server.token_counter` utilities) is reused only for the deferred prompt-space arm.
-
-   **Content attribution for context-window penetration.** This tap also records, for every tool result that returns file content (read/search/grep output) and is carried into a subsequent request, the **content actually surfaced**. In analysis the harness attributes each surfaced span to a `core` / `distractor` / `hidden`(should-never-happen) path by matching it against the materialized tree + manifest, tokenizes the distractor spans with the pinned tokenizer, and reconciles repeat-counted attribution against provider `usage` so attributed input cannot exceed measured input tokens for a request. It separately computes de-duplicated span coverage per distractor file for `distractor_unique_tokens_entered_context` and `distractor_pool_coverage`. This yields the [§6.1](#61-what-we-capture) penetration family (`distractor_context_tokens_total`, `distractor_context_share`, `distractor_unique_tokens_entered_context`, `distractor_pool_coverage`, `distractor_files_entered_context`). The "visited-but-not-contextualized" set is the FS-tap distractor-read set minus the set of distractor paths whose content appears in any request. **Pre-run blocker:** Codex's transcript must expose tool-result content, or the harness must wrap read/search tools to capture surfaced content. If neither is available, token-level context-penetration and token-dose thresholds are removed/demoted before runs; they are not reported from approximate attribution.
+   When this tier is enabled, the "visited-but-not-contextualized" set is the FS-tap distractor-read set minus the set of distractor paths whose content appears in any request (tap 1). When it is disabled, `files_read_*`, `bytes_read_*`, `irrelevant_file_read_ratio`, `forbidden_file_reads`, and `distractor_files_visited_not_contextualized` are reported as **unavailable** — never imputed from the snapshot tap. Tool-call counts (`search_or_tool_calls_before_first_edit`) come from the snapshot tap's tool-call records and remain available either way. The merged `pdd context` audit core (PR #1387, closing #789; the `pdd.server.token_counter` utilities) is reused only for the deferred prompt-space arm.
 3. **Git diff tap (ground truth for edits).** Post-run `git diff` against the pre-run baseline classifies every changed path as target / in-scope / wrong-file / forbidden, giving `wrong_file_edit_rate` and `forbidden_file_edits` independent of the transcript.
 
-The **first-edit boundary** is determined by the first write event that lands in the OverlayFS `upperdir` (tap 1), and is used to split tap-2 events into before/after. The git-diff tap (3) is retained as a redundant cross-check on the OverlayFS `upperdir`, not the primary edit source.
+The **first-edit boundary** is determined from the snapshot series (tap 1): the first request in which the agent issues an edit/patch tool call (equivalently, the first request whose successor carries an edit-tool result). When the optional FS tier is enabled, the first OverlayFS `upperdir` write must agree with that request's timestamp — disagreement is a calibration failure, not a judgment call. The git-diff tap (3) is the primary edit ground truth when the FS tier is absent, and a redundant cross-check on `upperdir` when it is present.
 
 **Post-hoc classification (where the secret label key is applied).** The agent's sandbox carries no distractor/target labels ([§2](#2-design-principles), [§3.3](#33-determinism-and-isolation-guarantees)). Classification happens **after** the run, in the analysis step, never during it:
 
@@ -490,7 +589,16 @@ One JSONL line per run, plus pointers to raw trace artifacts:
   "distractor_unique_tokens_entered_context": 0,
   "distractor_pool_coverage": 0.0,
   "distractor_files_entered_context": 0,
-  "distractor_files_visited_not_contextualized": 0,
+  "distractor_files_visited_not_contextualized": null,
+
+  "iterations_total": 0,
+  "iterations_before_first_edit": 0,
+  "growth_shape": "gradual",
+  "largest_single_jump_share": 0.0,
+  "distractor_context_share_early": 0.0,
+  "distractor_context_share_late": 0.0,
+
+  "fs_tap_enabled": false,
 
   "visible_pass": false,
   "hidden_pass": false,
@@ -502,6 +610,9 @@ One JSONL line per run, plus pointers to raw trace artifacts:
   "number_of_distractor_files": 117,
 
   "raw_trace_paths": {
+    "context_snapshots": "reports/<run_id>/context_snapshots.jsonl",
+    "context_payloads": "reports/<run_id>/payloads/",
+    "session_log": "reports/<run_id>/codex_session.jsonl",
     "fs_reads": "reports/<run_id>/fs_reads.log",
     "tool_calls": "reports/<run_id>/tool_calls.jsonl",
     "git_diff": "reports/<run_id>/post_run.diff"
@@ -523,7 +634,7 @@ Every non-pass run is labeled with exactly one primary `failure_class` (issue re
 
 ### 6.5 Replication (trials)
 
-Each `(scenario, size)` is run over **`N = 5` replicates** (`trial_index` 0–4) — 3 scenarios × 4 sizes × 5 = **60 runs** for the pilot arm. All replicates of a cell share the identical materialized repo; only the agent's run-to-run nondeterminism varies.
+Each `(scenario, size)` is run over **`N = 5` replicates** (`trial_index` 0–4) — 3 scenarios × 6 ladder sizes × 5 = **90 runs** for the pilot arm. All replicates of a cell share the identical materialized repo; only the agent's run-to-run nondeterminism varies.
 
 **Seed vs. replicate (review #2).** Calling these "seeds" would imply a pinned, reproducible RNG. Codex CLI does **not** currently expose a documented, supported seed that makes a run bit-reproducible, so we do **not** claim reproducibility of individual trials. They are **replicates** that sample Codex's natural run-to-run variance (sampling temperature, tool-ordering, etc.), recorded as `trial_index`. The run schema keeps an optional `codex_seed` field: *if* a supported seed mechanism is confirmed ([§8.1](#81-agentic_code_patch-pilot-required)), we pin it, populate `codex_seed`, and only then describe trials as reproducible seeds. Until then, variance language throughout is about **dispersion across replicates**, not seed-controlled reproducibility.
 
@@ -541,6 +652,8 @@ The locked FUSE/OverlayFS/transcript stack can fail silently — a missed read e
    - the transcript/event tap recorded the synthetic tool calls,
    - the **first-edit boundary** lands at the known edit, correctly splitting before/after.
 
+In v2 the calibration fixture also validates the **context-snapshot tap**: a scripted client replays a known request sequence through the recording proxy, and the harness asserts payload fidelity (byte-exact round-trip), `usage` capture, ordinal indexing, and that the first-edit boundary is detected at the scripted edit call. The FS-tap assertions above apply only when that optional tier is enabled.
+
 The run record carries `calibration_passed: true`; **a failed or skipped calibration aborts the cell** (no model tokens are spent against an uninstrumented sandbox). This converts "we believe the traces are valid" into a checked precondition, and is added to the freeze checklist ([§9](#9-pilot-execution-checklist-maps-to-acceptance-criteria)).
 
 ---
@@ -551,8 +664,8 @@ The report turns run records into per-size tables, trend fits, and an explicit v
 
 ### 7.1 Per-size summary table (per scenario and pooled)
 
-| Metric (point estimate ± interval over 5 replicates) | 1x | 5x | 20x | 50x |
-|-----------------------------------|----|----|-----|-----|
+| Metric (point estimate ± interval over 5 replicates) | 1x | 2x | 5x | 10x | 20x | 50x |
+|-----------------------------------|----|----|----|-----|-----|-----|
 | `hidden_pass_rate`                |    |    |     |     |
 | `files_read_before_first_edit`    |    |    |     |     |
 | `search_or_tool_calls_before_first_edit` | | |  |     |
@@ -565,6 +678,9 @@ The report turns run records into per-size tables, trend fits, and an explicit v
 | `wrong_file_edit_rate`            |    |    |     |     |
 | `wall_clock_seconds`              |    |    |     |     |
 | `max_request_input_tokens`        |    |    |     |     |
+| `iterations_total`                |    |    |     |     |
+| `distractor_context_share` late − early (H2) |    |    |     |     |
+| `growth_shape` modal class (H2)   |    |    |     |     |
 
 `input_tokens_per_hidden_success` = total input tokens spent in a cell ÷ number of hidden passes in that cell (undefined/flagged when a cell has zero hidden passes — itself a notable result).
 
@@ -579,6 +695,15 @@ input_tokens          ≈ α + β · additional_repo_loc
 files_read            ≈ α + β · additional_repo_loc
 irrelevant_read_ratio  by S         (table + line)
 hidden_pass_rate       by S         (table + line)
+```
+
+**Iteration-trajectory fits (H2).** Pooled per cell from the per-request series:
+
+```
+distractor_context_share[i] ≈ α + β · i     (per run; report the median per-run β per cell —
+                                             β > 0 at high S ⇒ accumulation is gradual)
+growth_shape distribution by S               (gradual / step / plateau / sawtooth share per cell)
+cumulative input_tokens vs. i, per S         (near-linear at 1x vs. super-linear at high S)
 ```
 
 **Token-dose fits (the sharpened effective-context test).** Beyond the on-disk-size axis above, regress outcomes against the **realized in-context distractor dose** — the tokens that actually occupied the window — since that is the mechanism the claim names:
@@ -600,6 +725,9 @@ The directional read is: a positive `β` for cost metrics whose magnitude crosse
 - `irrelevant_file_read_ratio` vs `S`, stacked by distractor tier.
 - `distractor_pool_coverage` and `distractor_context_share` vs `S`, stacked by distractor tier (how much provisioned bulk actually reaches the window, and from which tiers).
 - Failure-class breakdown per `S` (stacked bar).
+- `distractor_context_share[i]` vs. iteration ordinal `i`, one line per size (the H2 headline).
+- Cumulative `input_tokens` vs. iteration ordinal, per size (gradual vs. step visible directly).
+- `hidden_pass_rate` vs. ladder step with the located knee `S*` marked (H3), including breakdown-probe steps if run.
 
 ### 7.4 Methodology note
 
@@ -629,6 +757,8 @@ A short prose section recording, per the acceptance criteria:
 | Targeting degradation | `irrelevant_file_read_ratio` rises by ≥ **0.20** absolute |
 | Context-window penetration | `distractor_context_share` rises by ≥ **0.20** absolute *and* `distractor_pool_coverage` is non-trivial (≥ **0.10**) at 50x — i.e. the bulk genuinely reaches the window rather than being shielded by search |
 | Hidden-success drop | `hidden_pass_rate` falls by ≥ **20 percentage points** across `S`, **or** a negative `hidden_pass_rate`-vs-`distractor_context_tokens_total` slope whose 1x→50x fitted drop is ≥ 20 pp |
+| Within-run accumulation (H2) | median late-phase per-request `distractor_context_share` exceeds the early phase by ≥ **0.15** absolute at ≥ 20x, **and** `growth_shape = gradual` is the modal class at ≥ 20x. Step/plateau modal ⇒ H2 rejected in favor of the step profile (a finding, not a null) |
+| Breakdown located (H3) | some ladder step `S*` has `hidden_pass_rate(S*) ≤ 0.5 × hidden_pass_rate(1x)`, or `context_overflow` + `timeout` jointly modal at `S*`; if no step qualifies through 50x, report "S* > 50x" and trigger the §5.1 breakdown probe |
 | "Flat" (weakening evidence) | all of the above stay within half their threshold across every step |
 
 The report must then state, in plain language, whether the result:
@@ -649,7 +779,9 @@ The report closes by filing follow-up issues for any product gaps surfaced (e.g.
 
 ### 8.1 `agentic_code_patch` (pilot, required)
 
-**LOCKED: Codex CLI (GPT), run inside the Linux container ([§6.2](#62-how-we-capture-it-defense-in-depth)).** Codex receives `task.md` and the materialized repo via the OverlayFS `merged` mount, may search/read before editing, and edits implementation code. All [§6](#6-instrumentation-plan) instrumentation applies.
+**LOCKED: stock Codex CLI (GPT), unforked, with all model traffic routed through the recording proxy ([§6.2](#62-how-we-capture-it-defense-in-depth)).** Codex receives `task.md` and the materialized repo (via the OverlayFS `merged` mount when the optional FS tier is enabled; a plain isolated working copy otherwise), may search/read before editing, and edits implementation code. All [§6](#6-instrumentation-plan) instrumentation applies.
+
+**Why not fork Codex?** The review feedback offered a fork as one instrumentation route. Rejected, for three reasons. (1) *External validity:* a fork is a different agent — any patch near context assembly or tool plumbing risks perturbing the behavior under measurement, and the claim of record must be about the stock CLI users actually run. (2) *Maintenance:* a fork must chase upstream releases for the confirmatory study and diverges silently. (3) *Sufficiency:* everything an in-process hook would reveal about the context window is already serialized, in full, at the API boundary, where the recording proxy captures it. The proxy is also agent-agnostic — the pre-registered cross-agent extension (e.g. Claude Code) reuses the same instrument unchanged. A transport-only fork (base-URL plumbing, never context assembly) remains the disclosed last resort if the pinned build cannot route through the proxy ([§10](#10-locked-decisions), still-to-confirm #3).
 
 Codex is treated as the pilot's local agentic-search arm, but its exact read/search execution path remains a pre-run calibration item rather than a locked design fact. Current OpenAI docs establish that Codex can read/edit local files, run model-generated shell commands under sandboxing, use web search modes, connect MCP tools, and expose `apply_patch` hook matching; they do not establish a supported "no precomputed index" guarantee or the exact `grep`/`ripgrep`/`find`/`cat` command path. The companion background section ([`agentic_cli_search.md`](./agentic_cli_search.md), issue [#1430](https://github.com/promptdriven/pdd/issues/1430)) documents this distinction, places Codex provisionally in a cross-agent taxonomy, and explains why this single-agent lock is one point in a retrieval-mechanism space worth a pre-registered cross-agent extension (e.g., Claude Code as a second agentic-search agent; Aider/Cursor as index/embedding comparators).
 
@@ -668,10 +800,11 @@ Filesystem isolation alone is not enough: the *agent* environment is a second so
 | **MCP servers / plugins / hooks** | None enabled unless part of the arm definition; the set is enumerated and frozen. |
 | **Shell environment** | Sanitized allowlist of env vars; secrets limited to the model API key; no inherited dev shell. |
 | **Caches** | Prompt/response/tool caches cleared or disabled so a warm cache cannot shortcut localization. |
+| **Model traffic routing** | All provider traffic egresses **only** via the recording proxy (base-URL override); the proxy is the sole permitted network path to the model API, making the snapshot record complete by construction. |
 
 Anything genuinely variable that cannot be eliminated (e.g. provider-side nondeterminism) is documented in the methodology note ([§7.4](#74-methodology-note)) rather than left implicit.
 
-**Still to confirm before runs** (does not block scenario authoring): the exact pinned Codex CLI version + model id + reasoning effort; whether Codex exposes a supported seed ([§6.5](#65-replication-trials)); and whether its transcript exposes per-request `usage` for the token metrics ([§6.2](#62-how-we-capture-it-defense-in-depth)).
+**Still to confirm before runs** (does not block scenario authoring): the exact pinned Codex CLI version + model id + reasoning effort; whether Codex exposes a supported seed ([§6.5](#65-replication-trials)); and that the pinned build honors a base-URL override so the recording proxy captures **all** requests ([§6.2](#62-how-we-capture-it-defense-in-depth)) — with the CLI's own session transcript as the documented fallback source.
 
 ### 8.2 `pdd_prompt_space` (deferred comparison)
 
@@ -683,14 +816,18 @@ A PDD-style prompt/test/spec context rendered from a fixed manifest. The key pro
 
 - [ ] 3 upstream OSS repos chosen (permissive license, offline-runnable), vendored as pinned snapshots with provenance + LICENSE recorded.
 - [ ] 3 frozen bug-fix scenarios defined (`scenario.json` + `task.md` + dependency-sliced `core/` + `core_files.txt` + `seed.patch` + hidden verifier + `seed_novelty.md`); oracle fix classified as novel or upstream-recall caveat before runs.
-- [ ] Per-scenario size variants at 1x/5x/20x/50x by **token budget**, or a documented infeasibility reason.
+- [ ] Per-scenario size variants at 1x/2x/5x/10x/20x/50x by **token budget**, or a documented infeasibility reason.
 - [ ] Oracle equivalence gate passes for every materialized `(scenario, size)`: registered baseline outcomes match and the oracle fix passes visible + hidden verification under one fixed dependency environment.
 - [ ] Deterministic distractor manifests committed (+ `manifests.lock`) before any model run; distractors = real out-of-core files at upstream paths, admitted in dependency-closed groups, no on-disk marker.
 - [ ] Hidden verifiers physically separate from visible tests; harness asserts they never enter the agent sandbox.
 - [ ] Distractor manifest + full snapshot never mounted into the sandbox; distractor/core classification applied post-hoc against `core_files.txt`.
 - [ ] Context-window penetration captured (`distractor_context_tokens_total`, `distractor_context_share`, `distractor_unique_tokens_entered_context`, `distractor_pool_coverage`, visited-but-not-contextualized) and reconciled against provider `usage`.
+- [ ] Context snapshots captured for **every** model request via the recording proxy; per-request payloads archived; provider `usage` recorded per request.
+- [ ] Iteration-trajectory family computed (per-request share series, early/middle/late phase stats, growth-shape classification) — H2.
+- [ ] FS tap explicitly recorded as enabled/disabled per run (`fs_tap_enabled`); when disabled, read-volume metrics reported as unavailable, never imputed.
+- [ ] SWE-bench absent from scenarios, repos, tasks, and harness (related-work citation only) — §1.2.
 - [ ] Codex run-environment frozen + fingerprinted (CLI version, model+effort, clean `CODEX_HOME`, no user config, ephemeral session, web/MCP/hook/network/cache settings explicit) — [§8.1.1](#811-run-environment-freeze-review-3).
-- [ ] Instrumentation calibration gate passes in-container before model runs — [§6.6](#66-instrumentation-calibration-gate-review-4).
+- [ ] Instrumentation calibration gate passes before model runs — proxy-fidelity assertions always; FS assertions when that tier is enabled — [§6.6](#66-instrumentation-calibration-gate-review-4).
 - [ ] Read-volume (`bytes_read_*`, FS tap) and token (`input_tokens_*`, provider `usage`) metrics kept separate; tokens never derived from bytes.
 - [ ] Pre-registered practical thresholds fixed before runs; pilot framed as descriptive/directional.
 - [ ] Agentic arm records file reads, tool calls, edits, token usage, wall time, hidden pass/fail.
@@ -704,17 +841,19 @@ Frozen before any model run (pre-registration). A change to any of these is a ne
 
 | # | Decision | Locked choice | Where it lands |
 |---|----------|---------------|----------------|
-| 1 | Pilot arm agent/CLI + model | **Codex CLI (GPT)**, frozen environment held constant across all sizes/trials | [§8.1](#81-agentic_code_patch-pilot-required), [§8.1.1](#811-run-environment-freeze-review-3) |
-| 2 | Filesystem tap | **Linux container + OverlayFS (edits) + FUSE passthrough, byte-extent reads** | [§6.2](#62-how-we-capture-it-defense-in-depth) |
-| 3 | Base repo + distractor source | **Real OSS snapshot, dependency-sliced to a minimal core with one seeded bug; distractors = the repo's own out-of-core files, regrown to a token budget** *(revised 2026-06-04 from "hand-authored minimal repos" — before any run; see header revision note)* | [§4](#4-scenario-format), [§5](#5-distractor-sourcing-strategy-subset-and-regrow) |
-| 4 | Replicates per `(scenario, size)` | **`N = 5`** (trials; seed-pinned only if Codex supports it) → 60 runs for the pilot arm | [§6.5](#65-replication-trials) |
+| 1 | Pilot arm agent/CLI + model | **Stock Codex CLI (GPT), unforked**, frozen environment held constant across all sizes/trials; all model traffic via the recording proxy *(v2: "no fork" made explicit)* | [§8.1](#81-agentic_code_patch-pilot-required), [§8.1.1](#811-run-environment-freeze-review-3) |
+| 2 | Primary instrumentation | **API-boundary context-snapshot recording proxy** (byte-exact request payloads + provider `usage`); the v1 FUSE/OverlayFS filesystem tap **demoted to an optional cross-check tier** *(v2 revision 2026-07-06, pre-run)* | [§6.2](#62-how-we-capture-it-defense-in-depth) |
+| 3 | Base repo + distractor source | **Real OSS snapshot — primary: PDD @ pinned commit — dependency-sliced to a minimal core with one seeded bug; distractors = out-of-core files regrown to a token budget, extended by definition-derived `mutate`/`template` modes** *(2026-06-04: subset-and-regrow; v2: PDD primary + generator modes)* | [§4.1.0](#410-primary-upstream-repo-pdd-itself), [§5](#5-distractor-definition-and-sourcing-strategy) |
+| 4 | Replicates per `(scenario, size)` | **`N = 5`** (trials; seed-pinned only if Codex supports it) → 90 runs for the pilot arm | [§6.5](#65-replication-trials) |
 | 5 | Per-run timeout | **1800 s (30 min)** — generous enough that 50x is not penalized on wall-clock alone | run config / [§6.3](#63-run-record-schema) |
+| 6 | Size ladder | **1x / 2x / 5x / 10x / 20x / 50x** by token budget, plus a pre-registered doubling **breakdown probe** beyond 50x if H3's `S*` is not located *(v2)* | [§5.1](#51-sizing-model-token-budgeted) |
+| 7 | SWE-bench | **Excluded from the core experiment** — no scenarios, repos, tasks, or harness; related-work citation only *(v2)* | [§1.2](#12-why-swe-bench-is-excluded-from-the-core-experiment) |
 
 ### Still to confirm (Codex specifics — do not block scenario authoring)
 
 1. **Exact Codex model id + reasoning-effort** setting to pin in the run config (must be stated in the report).
 2. **Codex read/search execution path** — confirm whether the pinned Codex build shells out (e.g. `ripgrep`), performs direct local file reads, or uses any server-side/MCP retrieval path. Shell-spawned and direct local reads are kernel-visible to the FUSE tap; server-side or index-backed retrieval would require an additional tool-boundary tap. This affects both how we reconcile the transcript tap against the FS tap and whether the Codex arm can be described as purely local agentic search. (Why this matters across agents is analyzed in [`agentic_cli_search.md` §6](./agentic_cli_search.md#6-implications-for-the-benchmarks-instrumentation-and-validity).)
-3. **Tool-result content in the transcript** — confirm Codex's transcript exposes the *content* surfaced by read/search tools (not just token counts), or add a harness wrapper that captures it. Without one of those sources, token-level context-penetration metrics and token-dose thresholds are blocked and must be demoted/removed before runs.
+3. **Base-URL override / proxy routing** — confirm the pinned Codex build routes **all** provider traffic through a configurable base URL so the recording proxy captures every request. Documented fallback: Codex's session transcript, iff it exposes per-request `usage` **and** tool-result content. Failing both, a transport-only fork (base-URL plumbing, never context assembly or tool logic) is the disclosed last resort. Without any of the three, token-level context-penetration metrics, the iteration-trajectory family, and token-dose thresholds are blocked and must be demoted/removed before runs.
 
 ### Consequence of choice #3 (real-OSS subset-and-regrow) — contamination guardrail
 


### PR DESCRIPTION
**Sub-PR 1 of 5** for epic #1851 (base = `epic/1209-repo-bloat-v2`; merge order 1 → 2 → 3 → 4 → 5).

## What changed

`design.md` gets a **v2 pre-run revision** (documented in the header revision note — no model runs have occurred, so this is legitimate pre-registration revision, not post-hoc tuning):

- **§1.1 Hypotheses** — the research question is decomposed into three falsifiable, pre-registered hypotheses: **H1** (cross-size degradation of localization cost / hidden success), **H2** (*within-run* gradual accumulation of irrelevant context across agent iterations — new), **H3** (a locatable breakdown knee `S*` on the size ladder — new).
- **§1.2 SWE-bench exclusion** — explicit, argued exclusion from the core experiment: uncontrollable IV (repo size varies with task), pervasive instance-level contamination that short-circuits exactly the search behavior under measurement, coarser success criterion, task heterogeneity. Only the hidden-test idea and related-work citations survive.
- **§4.1.0 PDD as primary target repo** — scenarios are dependency-sliced cores of PDD itself (pinned commit): auditable ground truth, right size, trivial licensing, offline tests, dogfooding payoff; the layout-familiarity caveat is recorded and biases *against* H1 (conservative).
- **§5.0 formal distractor definition** — five machine-checkable conditions (structural irrelevance, behavior neutrality, plausibility, no leakage, no tell); **§5.0.1** three generator modes (`regrow`/`mutate`/`template`) sharing that one contract, with a fixed mode cascade so the dose can scale past the real pool; denser ladder **1x/2x/5x/10x/20x/50x** + pre-registered doubling **breakdown probe** past 50x.
- **§6 instrumentation re-tiered** — the **API-boundary context-snapshot recording proxy** (byte-exact request payloads + provider `usage`) becomes the primary, required tap; the v1 FUSE/OverlayFS filesystem tap is demoted to an optional cross-check tier (pilot no longer requires a Linux container). New **iteration-trajectory metric family** (per-request token/composition series, early/middle/late phases, growth-shape classification) decides H2.
- **§7** per-iteration fits/plots and two new pre-registered thresholds (H2 accumulation, H3 breakdown); summary table extended to the full ladder.
- **§8.1 why-not-fork** — the Codex-fork option is explicitly rejected (external validity, maintenance, sufficiency of the API boundary), with a transport-only fork as disclosed last resort.
- **§9/§10** checklist + locked-decision table re-registered (7 decisions, incl. ladder and SWE-bench exclusion).

`README.md` is refreshed to match (v2 summary, new layout, updated locked-decisions table, status).

## Why it matters

This is the pre-registration document — every later PR (instrumentation, generator, runner, paper) implements what this file locks. Getting the feedback incorporated *here first* keeps the experiment falsifiable and prevents the paper from drifting back to SWE-bench or file-level-only evidence.

## How to review

Read `design.md` §1.1–§1.2, §4.1.0, §5.0–§5.0.1, §6.2, §7.5, §8.1, §10 — the v2 deltas are concentrated there and flagged with *(v2)* markers. `git diff` against the epic branch shows the full delta.

## Still incomplete

- The three concrete PDD scenarios (target sites, seeds, hidden verifiers) are specified procedurally but not yet authored — deliberately after the harness lands (PRs 2–4).
- Codex base-URL-override confirmation remains a pre-run blocker (§10 still-to-confirm #3); the design names the fallback chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)