### PR TITLE
Research #1209 v2 (2/5): context-snapshot instrumentation — recording proxy + iteration-bloat analyzer

### DIFF
--- a/research/repo-bloat-benchmark/harness/__init__.py
+++ b/research/repo-bloat-benchmark/harness/__init__.py
@@ -1,0 +1,1 @@
+"""Experiment harness for the repo-bloat localization benchmark (issue #1209)."""

--- a/research/repo-bloat-benchmark/harness/context_snapshots/README.md
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/README.md
@@ -1,0 +1,69 @@
+# Context-snapshot instrumentation
+
+Implements design.md **§6.2 tap 1** — the v2 primary instrument. Captures the
+byte-exact composed context of every model request an agent CLI makes, then
+turns the per-request series into the pre-registered metric families:
+context-window **penetration** and the **iteration trajectory** (H2).
+
+## Pieces
+
+| Module | Role |
+|--------|------|
+| `proxy.py` | `RecordingProxy` — local HTTP relay; archives request/response bodies + provider `usage` per request; detects edit tool calls (first-edit boundary) |
+| `schema.py` | `SnapshotRecord` (one per request) + JSONL read/write |
+| `attribution.py` | `TreeIndex` — normalized-line index of the materialized variant; attributes surfaced content to core / distractor / ambiguous / unknown; `reconcile_with_usage` caps estimates at provider counts |
+| `iteration_analyzer.py` | `analyze_run` — per-iteration token/composition series, early/middle/late phases, `growth_shape` (gradual/step/plateau/sawtooth), first-edit boundary |
+| `session_parser.py` | tolerant parser for the CLI's own session/rollout JSONL + `reconcile` cross-check against the proxy record |
+
+## Usage sketch
+
+```python
+from harness.context_snapshots import (
+    RecordingProxy, TreeIndex, analyze_run, parse_session_log, reconcile,
+)
+
+proxy = RecordingProxy(
+    upstream_base_url="https://api.openai.com",
+    archive_dir="reports/run-001",
+    run_id="run-001",
+)
+base_url = proxy.start()
+
+# Route the stock CLI through the proxy (no fork):
+#   OPENAI_BASE_URL={base_url}/v1   (or the CLI's base-url config key)
+# ... run the agent to completion ...
+
+proxy.stop()
+
+index = TreeIndex(variant_root, distractor_paths=manifest_paths)
+attributions = [
+    index.classify_request_payload((proxy.archive_dir / r.payload_path).read_bytes())
+    for r in proxy.records
+]
+trajectory = analyze_run(proxy.records, attributions)
+trajectory.growth_shape                    # H2: gradual / step / plateau / sawtooth
+trajectory.share_delta_late_minus_early    # H2 threshold input (§7.5)
+```
+
+## Honesty notes (mirrored in design.md)
+
+- **Provider `usage` is the only authoritative token count.** Attribution
+  splits it; `reconcile_with_usage` guarantees attributed tokens never exceed
+  measured tokens. Attribution itself is a *lower bound* (paraphrased or
+  truncated content does not match the line index).
+- **SSE responses are buffered, not streamed through.** Capture fidelity and
+  response content are preserved; streaming latency lands in
+  `wall_clock_seconds` (secondary metric). Pass-through streaming is a TODO.
+- **The proxy only sees what is routed through it.** The run-environment
+  freeze (design §8.1.1) must lock network egress to the proxy for the record
+  to be complete by construction; `session_parser.reconcile` flags traffic
+  that bypassed it.
+
+## Tests
+
+```bash
+cd research/repo-bloat-benchmark
+python3 -m pytest harness/context_snapshots/tests/ -q
+```
+
+No external dependencies (stdlib + pytest only).

--- a/research/repo-bloat-benchmark/harness/context_snapshots/__init__.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/__init__.py
@@ -1,0 +1,28 @@
+"""Context-snapshot instrumentation (design.md §6.2, tap 1).
+
+The primary instrument of the v2 design: an API-boundary recording proxy that
+captures the byte-exact composed context of every model request, plus the
+analysis pieces that turn the per-request snapshot series into the metric
+families the design pre-registers (penetration, iteration trajectory / H2).
+"""
+
+from .attribution import Attribution, TreeIndex
+from .iteration_analyzer import IterationPoint, RunTrajectory, analyze_run
+from .proxy import RecordingProxy
+from .schema import SnapshotRecord, read_snapshots, write_snapshots
+from .session_parser import SessionSummary, parse_session_log, reconcile
+
+__all__ = [
+    "Attribution",
+    "TreeIndex",
+    "IterationPoint",
+    "RunTrajectory",
+    "analyze_run",
+    "RecordingProxy",
+    "SnapshotRecord",
+    "read_snapshots",
+    "write_snapshots",
+    "SessionSummary",
+    "parse_session_log",
+    "reconcile",
+]

--- a/research/repo-bloat-benchmark/harness/context_snapshots/attribution.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/attribution.py
@@ -1,0 +1,181 @@
+"""Content attribution: which parts of a context snapshot are distractor bulk?
+
+Implements the analysis half of design.md §6.2 tap 1: match the content that
+was surfaced into model requests against the materialized tree + manifest, and
+attribute spans to ``core`` / ``distractor`` / ``unknown``.
+
+Method: a normalized-line index. Every sufficiently long line of every
+materialized file is normalized (whitespace-collapsed) and indexed with its
+origin class. Request text is then scanned line-by-line against the index.
+
+Honesty notes (mirrored in the design):
+
+- Attribution is a **lower bound**: paraphrased or heavily truncated content
+  does not match. The provider ``usage`` numbers remain the authoritative
+  token totals; attribution only splits them.
+- Token counts here are **estimates** under a pluggable tokenizer (default:
+  chars/4). The reconciliation step caps attributed tokens at the provider
+  count so attribution can never exceed measurement.
+- Lines shorter than ``min_line_len`` (import boilerplate, ``return None``)
+  are ignored to avoid false-positive matches; a line appearing in both a
+  core and a distractor file counts as ``ambiguous`` and is excluded from the
+  distractor total (conservative direction).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def default_token_estimator(text: str) -> float:
+    """Crude but deterministic token estimate (~4 chars/token)."""
+    return len(text) / 4.0
+
+
+def normalize_line(line: str) -> str:
+    return _WHITESPACE.sub(" ", line.strip())
+
+
+@dataclass
+class Attribution:
+    """Per-text attribution result (token estimates, not provider counts)."""
+
+    core_tokens: float = 0.0
+    distractor_tokens: float = 0.0
+    ambiguous_tokens: float = 0.0
+    unknown_tokens: float = 0.0
+    core_lines: int = 0
+    distractor_lines: int = 0
+    ambiguous_lines: int = 0
+    unknown_lines: int = 0
+    distractor_files: set[str] = field(default_factory=set)
+    core_files: set[str] = field(default_factory=set)
+
+    @property
+    def total_tokens(self) -> float:
+        return (
+            self.core_tokens
+            + self.distractor_tokens
+            + self.ambiguous_tokens
+            + self.unknown_tokens
+        )
+
+    @property
+    def distractor_share(self) -> float:
+        total = self.total_tokens
+        return self.distractor_tokens / total if total > 0 else 0.0
+
+
+class TreeIndex:
+    """Normalized-line index over a materialized variant tree.
+
+    ``distractor_paths`` is the manifest's secret label key (paths relative to
+    the tree root); every other indexed file is core. The index is built once
+    per (scenario, size) and reused across trials.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        distractor_paths: Iterable[str],
+        min_line_len: int = 24,
+        token_estimator: Callable[[str], float] = default_token_estimator,
+        extensions: tuple[str, ...] = (".py", ".md", ".txt", ".toml", ".cfg", ".json"),
+    ) -> None:
+        self.root = Path(root)
+        self.min_line_len = min_line_len
+        self.token_estimator = token_estimator
+        self._distractors = {p.replace("\\", "/") for p in distractor_paths}
+        # normalized line -> (has_core, has_distractor, first core path, first distractor path)
+        self._index: dict[str, list] = {}
+        for file_path in sorted(self.root.rglob("*")):
+            if not file_path.is_file() or file_path.suffix not in extensions:
+                continue
+            rel = file_path.relative_to(self.root).as_posix()
+            is_distractor = rel in self._distractors
+            try:
+                text = file_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            for line in text.splitlines():
+                norm = normalize_line(line)
+                if len(norm) < self.min_line_len:
+                    continue
+                entry = self._index.setdefault(norm, [False, False, None, None])
+                if is_distractor:
+                    entry[1] = True
+                    if entry[3] is None:
+                        entry[3] = rel
+                else:
+                    entry[0] = True
+                    if entry[2] is None:
+                        entry[2] = rel
+
+    @property
+    def distractor_paths(self) -> set[str]:
+        return set(self._distractors)
+
+    def classify_text(self, text: str) -> Attribution:
+        """Attribute one blob of surfaced text (e.g. one request body)."""
+        result = Attribution()
+        for line in text.splitlines():
+            norm = normalize_line(line)
+            if len(norm) < self.min_line_len:
+                continue
+            tokens = self.token_estimator(norm)
+            entry = self._index.get(norm)
+            if entry is None:
+                result.unknown_tokens += tokens
+                result.unknown_lines += 1
+            elif entry[0] and entry[1]:
+                result.ambiguous_tokens += tokens
+                result.ambiguous_lines += 1
+            elif entry[1]:
+                result.distractor_tokens += tokens
+                result.distractor_lines += 1
+                result.distractor_files.add(entry[3])
+            else:
+                result.core_tokens += tokens
+                result.core_lines += 1
+                result.core_files.add(entry[2])
+        return result
+
+    def classify_request_payload(self, payload_bytes: bytes) -> Attribution:
+        """Attribute a raw archived request body (JSON or free text)."""
+        text = payload_bytes.decode("utf-8", errors="replace")
+        return self.classify_text(text)
+
+
+def reconcile_with_usage(
+    attribution: Attribution, provider_input_tokens: int | None
+) -> dict[str, float]:
+    """Scale attribution so it can never exceed the provider-reported input.
+
+    Returns a dict with ``distractor_context_tokens`` (reconciled),
+    ``distractor_context_share``, and the raw estimate for transparency.
+    If provider usage is unavailable, the raw estimates are used and flagged.
+    """
+    raw = attribution.distractor_tokens
+    total_est = attribution.total_tokens
+    if provider_input_tokens is None or total_est <= 0:
+        return {
+            "distractor_context_tokens": raw,
+            "distractor_context_share": attribution.distractor_share,
+            "raw_estimate_tokens": raw,
+            "reconciled_against_usage": False,
+        }
+    scale = min(1.0, provider_input_tokens / total_est)
+    reconciled = raw * scale
+    return {
+        "distractor_context_tokens": min(reconciled, float(provider_input_tokens)),
+        "distractor_context_share": min(1.0, reconciled / provider_input_tokens)
+        if provider_input_tokens
+        else 0.0,
+        "raw_estimate_tokens": raw,
+        "reconciled_against_usage": True,
+    }

--- a/research/repo-bloat-benchmark/harness/context_snapshots/iteration_analyzer.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/iteration_analyzer.py
@@ -1,0 +1,206 @@
+"""Per-iteration analysis of the snapshot series (design.md §6.1, H2).
+
+Turns the ordered ``SnapshotRecord`` sequence (plus optional per-request
+attribution) into the pre-registered *iteration trajectory* family:
+
+- per-request ``input_tokens`` and ``context_growth`` series,
+- per-request ``distractor_context_share`` series,
+- early / middle / late phase medians (thirds by request ordinal),
+- ``growth_shape`` classification: ``gradual`` / ``step`` / ``plateau`` /
+  ``sawtooth`` (thresholds fixed here, mirrored in design §6.1; precedence
+  when curves qualify for more than one class: sawtooth → step → plateau →
+  gradual),
+- ``largest_single_jump_share``,
+- first-edit boundary (`iterations_before_first_edit`).
+
+The shape thresholds are part of the pre-registration: changing them after
+runs is a new experiment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from statistics import median
+from typing import Sequence
+
+from .attribution import Attribution
+from .schema import SnapshotRecord
+
+# Pre-registered classification thresholds (design §6.1).
+STEP_JUMP_SHARE = 0.30  # one request contributing > 30% of final context ⇒ step
+PLATEAU_TAIL_SHARE = 0.05  # < 5% of final context added in the last third ⇒ plateau
+SAWTOOTH_DROP_TOLERANCE = 0.02  # relative shrink > 2% of final context ⇒ sawtooth
+
+
+@dataclass
+class IterationPoint:
+    ordinal: int
+    input_tokens: int | None
+    context_growth: int | None  # None for the first point / missing usage
+    distractor_share: float | None
+    distractor_tokens: float | None
+    edit_tool_call: bool
+
+
+@dataclass
+class PhaseStats:
+    name: str  # early / middle / late
+    ordinals: list[int]
+    median_input_tokens: float | None
+    median_growth: float | None
+    median_distractor_share: float | None
+
+
+@dataclass
+class RunTrajectory:
+    run_id: str
+    iterations_total: int
+    iterations_before_first_edit: int | None  # None ⇒ no edit ever happened
+    first_edit_ordinal: int | None
+    growth_shape: str
+    largest_single_jump_share: float | None
+    points: list[IterationPoint] = field(default_factory=list)
+    phases: list[PhaseStats] = field(default_factory=list)
+
+    @property
+    def distractor_share_early(self) -> float | None:
+        return self._phase_share("early")
+
+    @property
+    def distractor_share_late(self) -> float | None:
+        return self._phase_share("late")
+
+    def _phase_share(self, name: str) -> float | None:
+        for phase in self.phases:
+            if phase.name == name:
+                return phase.median_distractor_share
+        return None
+
+    @property
+    def share_delta_late_minus_early(self) -> float | None:
+        early, late = self.distractor_share_early, self.distractor_share_late
+        if early is None or late is None:
+            return None
+        return late - early
+
+
+def _thirds(n: int) -> list[tuple[str, range]]:
+    """Split ordinals 1..n into early/middle/late thirds (early gets remainder)."""
+    if n <= 0:
+        return []
+    third = max(1, n // 3)
+    early_end = n - 2 * third  # early takes the remainder for small n
+    return [
+        ("early", range(1, early_end + 1)),
+        ("middle", range(early_end + 1, early_end + third + 1)),
+        ("late", range(early_end + third + 1, n + 1)),
+    ]
+
+
+def _median_or_none(values: Sequence[float]) -> float | None:
+    values = [v for v in values if v is not None]
+    return median(values) if values else None
+
+
+def classify_growth_shape(
+    growths: Sequence[int], final_tokens: int | None
+) -> tuple[str, float | None]:
+    """Classify the cumulative-context curve; returns (shape, largest_jump_share)."""
+    growths = [g for g in growths if g is not None]
+    if not growths or not final_tokens or final_tokens <= 0:
+        return "unknown", None
+    largest_jump = max(growths)
+    largest_share = largest_jump / final_tokens
+    total_growth = sum(growths)
+    if any(g < -SAWTOOTH_DROP_TOLERANCE * final_tokens for g in growths):
+        return "sawtooth", largest_share
+    if largest_share > STEP_JUMP_SHARE:
+        return "step", largest_share
+    tail_count = max(1, len(growths) // 3)
+    tail_growth = sum(growths[-tail_count:])
+    if total_growth > 0 and tail_growth < PLATEAU_TAIL_SHARE * final_tokens:
+        return "plateau", largest_share
+    return "gradual", largest_share
+
+
+def analyze_run(
+    records: Sequence[SnapshotRecord],
+    attributions: Sequence[Attribution] | None = None,
+) -> RunTrajectory:
+    """Build the iteration-trajectory family for one run.
+
+    ``records`` must be the full ordered snapshot series of a single run;
+    ``attributions`` (optional) must be parallel to ``records``.
+    """
+    records = sorted(records, key=lambda r: r.ordinal)
+    if attributions is not None and len(attributions) != len(records):
+        raise ValueError("attributions must be parallel to records")
+
+    run_id = records[0].run_id if records else ""
+    points: list[IterationPoint] = []
+    previous_tokens: int | None = None
+    first_edit_ordinal: int | None = None
+
+    for i, record in enumerate(records):
+        growth: int | None = None
+        if record.input_tokens is not None and previous_tokens is not None:
+            growth = record.input_tokens - previous_tokens
+        if record.input_tokens is not None:
+            previous_tokens = record.input_tokens
+        share = tokens = None
+        if attributions is not None:
+            attribution = attributions[i]
+            share = attribution.distractor_share
+            tokens = attribution.distractor_tokens
+        if record.edit_tool_call and first_edit_ordinal is None:
+            first_edit_ordinal = record.ordinal
+        points.append(
+            IterationPoint(
+                ordinal=record.ordinal,
+                input_tokens=record.input_tokens,
+                context_growth=growth,
+                distractor_share=share,
+                distractor_tokens=tokens,
+                edit_tool_call=record.edit_tool_call,
+            )
+        )
+
+    final_tokens = next(
+        (p.input_tokens for p in reversed(points) if p.input_tokens is not None), None
+    )
+    shape, largest_share = classify_growth_shape(
+        [p.context_growth for p in points], final_tokens
+    )
+
+    phases: list[PhaseStats] = []
+    by_ordinal = {p.ordinal: p for p in points}
+    for name, ordinal_range in _thirds(len(points)):
+        phase_points = [by_ordinal[o] for o in ordinal_range if o in by_ordinal]
+        phases.append(
+            PhaseStats(
+                name=name,
+                ordinals=[p.ordinal for p in phase_points],
+                median_input_tokens=_median_or_none(
+                    [p.input_tokens for p in phase_points]
+                ),
+                median_growth=_median_or_none(
+                    [p.context_growth for p in phase_points]
+                ),
+                median_distractor_share=_median_or_none(
+                    [p.distractor_share for p in phase_points]
+                ),
+            )
+        )
+
+    return RunTrajectory(
+        run_id=run_id,
+        iterations_total=len(points),
+        iterations_before_first_edit=(
+            first_edit_ordinal - 1 if first_edit_ordinal is not None else None
+        ),
+        first_edit_ordinal=first_edit_ordinal,
+        growth_shape=shape,
+        largest_single_jump_share=largest_share,
+        points=points,
+        phases=phases,
+    )

--- a/research/repo-bloat-benchmark/harness/context_snapshots/proxy.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/proxy.py
@@ -1,0 +1,342 @@
+"""API-boundary recording proxy (design.md §6.2, tap 1 — PRIMARY).
+
+A local HTTP relay the agent's model traffic is routed through via a base-URL
+override (e.g. ``OPENAI_BASE_URL=http://127.0.0.1:<port>/v1``). For every
+request it archives the byte-exact request body (the composed context window),
+the response body, and provider-reported ``usage``, then forwards the response
+to the client unchanged.
+
+Design properties:
+
+- **Agent-agnostic and fork-free.** Works with any CLI that honors a base-URL
+  override; the agent binary is never modified.
+- **Complete by construction** when the run environment locks network egress
+  to the proxy (design §8.1.1): every model request is captured or it never
+  happened.
+- **Byte-exact.** The archived request body is the exact bytes received; the
+  sha256 in the snapshot record lets a third party verify fidelity.
+
+Known limitation (documented in design §6.2): streamed (SSE) responses are
+buffered and relayed after completion rather than streamed through. This
+preserves capture fidelity and response content but serializes streaming
+latency into ``wall_clock_seconds`` (a secondary metric). True pass-through
+streaming is a follow-up.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+from .schema import SnapshotRecord
+
+# Hop-by-hop headers that must not be forwarded either direction.
+_HOP_BY_HOP = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+    "host",
+    "content-length",
+}
+
+# Tool names whose invocation counts as an *edit* for the first-edit boundary
+# (design §6.2). Checked case-insensitively; substring fallbacks catch
+# provider-specific variants like ``apply_patch_call``.
+DEFAULT_EDIT_TOOL_NAMES = frozenset(
+    {"apply_patch", "edit", "edit_file", "write_file", "create_file", "str_replace_editor"}
+)
+_EDIT_SUBSTRINGS = ("patch", "edit", "write_file")
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _extract_usage(obj: dict[str, Any]) -> tuple[int | None, int | None, int | None]:
+    """Pull (input, output, total) tokens from a usage dict of either API shape."""
+    usage = obj.get("usage") or {}
+    if not isinstance(usage, dict):
+        return None, None, None
+    input_tokens = usage.get("input_tokens", usage.get("prompt_tokens"))
+    output_tokens = usage.get("output_tokens", usage.get("completion_tokens"))
+    total = usage.get("total_tokens")
+    if total is None and input_tokens is not None and output_tokens is not None:
+        total = input_tokens + output_tokens
+    return input_tokens, output_tokens, total
+
+
+def _extract_tool_calls(obj: dict[str, Any]) -> list[str]:
+    """Collect tool-call names from a chat-completions or Responses-API body."""
+    names: list[str] = []
+    # Chat Completions: choices[].message.tool_calls[].function.name
+    for choice in obj.get("choices") or []:
+        message = (choice or {}).get("message") or {}
+        for call in message.get("tool_calls") or []:
+            name = ((call or {}).get("function") or {}).get("name")
+            if name:
+                names.append(str(name))
+    # Responses API: output[] items typed *_call
+    for item in obj.get("output") or []:
+        if not isinstance(item, dict):
+            continue
+        item_type = str(item.get("type", ""))
+        if item_type.endswith("_call"):
+            names.append(str(item.get("name") or item_type))
+    return names
+
+
+def _parse_sse_events(body: bytes) -> list[dict[str, Any]]:
+    """Best-effort parse of ``data:`` JSON payloads from an SSE body."""
+    events: list[dict[str, Any]] = []
+    for raw_line in body.decode("utf-8", errors="replace").splitlines():
+        line = raw_line.strip()
+        if not line.startswith("data:"):
+            continue
+        data = line[len("data:"):].strip()
+        if not data or data == "[DONE]":
+            continue
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            events.append(parsed)
+    return events
+
+
+def _analyze_response_body(body: bytes, content_type: str) -> dict[str, Any]:
+    """Extract usage/tool-call facts from a JSON or SSE response body."""
+    result: dict[str, Any] = {
+        "input_tokens": None,
+        "output_tokens": None,
+        "total_tokens": None,
+        "tool_call_names": [],
+        "streamed": False,
+    }
+    candidates: list[dict[str, Any]] = []
+    if "text/event-stream" in content_type:
+        result["streamed"] = True
+        for event in _parse_sse_events(body):
+            candidates.append(event)
+            # Responses API terminal event nests the response object.
+            nested = event.get("response")
+            if isinstance(nested, dict):
+                candidates.append(nested)
+    else:
+        try:
+            parsed = json.loads(body.decode("utf-8"))
+            if isinstance(parsed, dict):
+                candidates.append(parsed)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+    for obj in candidates:
+        input_tokens, output_tokens, total = _extract_usage(obj)
+        if input_tokens is not None or output_tokens is not None:
+            result["input_tokens"] = input_tokens
+            result["output_tokens"] = output_tokens
+            result["total_tokens"] = total
+        for name in _extract_tool_calls(obj):
+            if name not in result["tool_call_names"]:
+                result["tool_call_names"].append(name)
+    return result
+
+
+def is_edit_tool(name: str, edit_tool_names: frozenset[str] = DEFAULT_EDIT_TOOL_NAMES) -> bool:
+    lowered = name.lower()
+    if lowered in edit_tool_names:
+        return True
+    return any(sub in lowered for sub in _EDIT_SUBSTRINGS)
+
+
+class RecordingProxy:
+    """Recording relay between an agent CLI and its model provider.
+
+    Usage::
+
+        proxy = RecordingProxy(
+            upstream_base_url="https://api.openai.com",
+            archive_dir="reports/run-123",
+            run_id="run-123",
+        )
+        base_url = proxy.start()      # export OPENAI_BASE_URL=f"{base_url}/v1"
+        ...  # run the agent
+        proxy.stop()
+        proxy.records                 # list[SnapshotRecord], ordinal-ordered
+    """
+
+    def __init__(
+        self,
+        upstream_base_url: str,
+        archive_dir: str | Path,
+        run_id: str,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        edit_tool_names: frozenset[str] = DEFAULT_EDIT_TOOL_NAMES,
+        forward_timeout: float = 600.0,
+    ) -> None:
+        self.upstream_base_url = upstream_base_url.rstrip("/")
+        self.archive_dir = Path(archive_dir)
+        self.payload_dir = self.archive_dir / "payloads"
+        self.run_id = run_id
+        self.host = host
+        self.port = port
+        self.edit_tool_names = edit_tool_names
+        self.forward_timeout = forward_timeout
+        self.records: list[SnapshotRecord] = []
+        self._lock = threading.Lock()
+        self._ordinal = 0
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._snapshot_file: Path = self.archive_dir / "context_snapshots.jsonl"
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> str:
+        """Start serving; returns the proxy base URL (no trailing slash)."""
+        self.payload_dir.mkdir(parents=True, exist_ok=True)
+        proxy = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *args: Any) -> None:  # silence stderr
+                pass
+
+            def do_POST(self) -> None:  # noqa: N802 (stdlib naming)
+                proxy._handle(self, record=True)
+
+            def do_GET(self) -> None:  # noqa: N802
+                proxy._handle(self, record=False)
+
+        self._server = ThreadingHTTPServer((self.host, self.port), Handler)
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return f"http://{self.host}:{self.port}"
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    # -- request handling ----------------------------------------------------
+
+    def _next_ordinal(self) -> int:
+        with self._lock:
+            self._ordinal += 1
+            return self._ordinal
+
+    def _append_record(self, record: SnapshotRecord) -> None:
+        with self._lock:
+            self.records.append(record)
+            self.archive_dir.mkdir(parents=True, exist_ok=True)
+            with self._snapshot_file.open("a", encoding="utf-8") as fh:
+                fh.write(record.to_json() + "\n")
+
+    def _forward(
+        self, method: str, path: str, headers: dict[str, str], body: bytes | None
+    ) -> tuple[int, dict[str, str], bytes]:
+        url = self.upstream_base_url + path
+        out_headers = {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP}
+        request = urllib.request.Request(url, data=body, headers=out_headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self.forward_timeout) as resp:
+                resp_body = resp.read()
+                resp_headers = {k: v for k, v in resp.headers.items()}
+                return resp.status, resp_headers, resp_body
+        except urllib.error.HTTPError as exc:
+            return exc.code, dict(exc.headers or {}), exc.read()
+        except (urllib.error.URLError, OSError) as exc:
+            message = json.dumps({"error": {"message": f"proxy forward failed: {exc}"}})
+            return 502, {"Content-Type": "application/json"}, message.encode("utf-8")
+
+    def _handle(self, handler: BaseHTTPRequestHandler, record: bool) -> None:
+        received_at = time.time()
+        length = int(handler.headers.get("Content-Length") or 0)
+        body = handler.rfile.read(length) if length else b""
+        headers = {k: v for k, v in handler.headers.items()}
+
+        status, resp_headers, resp_body = self._forward(
+            handler.command, handler.path, headers, body or None
+        )
+
+        if record and body:
+            self._record_exchange(handler.path, received_at, body, status, resp_headers, resp_body)
+
+        handler.send_response(status)
+        content_type = resp_headers.get("Content-Type", "application/json")
+        handler.send_header("Content-Type", content_type)
+        handler.send_header("Content-Length", str(len(resp_body)))
+        handler.send_header("Connection", "close")
+        handler.end_headers()
+        handler.wfile.write(resp_body)
+
+    def _record_exchange(
+        self,
+        path: str,
+        received_at: float,
+        body: bytes,
+        status: int,
+        resp_headers: dict[str, str],
+        resp_body: bytes,
+    ) -> None:
+        ordinal = self._next_ordinal()
+        request_name = f"{ordinal:05d}.request.json"
+        response_name = f"{ordinal:05d}.response.body"
+        (self.payload_dir / request_name).write_bytes(body)
+        (self.payload_dir / response_name).write_bytes(resp_body)
+
+        model: str | None = None
+        message_count: int | None = None
+        try:
+            payload = json.loads(body.decode("utf-8"))
+            if isinstance(payload, dict):
+                model = payload.get("model")
+                messages = payload.get("messages", payload.get("input"))
+                if isinstance(messages, list):
+                    message_count = len(messages)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
+        analysis = _analyze_response_body(
+            resp_body, resp_headers.get("Content-Type", "")
+        )
+        tool_names = analysis["tool_call_names"]
+        self._append_record(
+            SnapshotRecord(
+                run_id=self.run_id,
+                ordinal=ordinal,
+                timestamp=received_at,
+                endpoint=path,
+                request_sha256=_sha256(body),
+                payload_path=f"payloads/{request_name}",
+                response_path=f"payloads/{response_name}",
+                status_code=status,
+                model=model,
+                input_tokens=analysis["input_tokens"],
+                output_tokens=analysis["output_tokens"],
+                total_tokens=analysis["total_tokens"],
+                message_count=message_count,
+                request_bytes=len(body),
+                response_bytes=len(resp_body),
+                tool_call_names=tool_names,
+                edit_tool_call=any(is_edit_tool(n, self.edit_tool_names) for n in tool_names),
+                streamed=analysis["streamed"],
+            )
+        )

--- a/research/repo-bloat-benchmark/harness/context_snapshots/schema.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/schema.py
@@ -1,0 +1,75 @@
+"""Snapshot record schema (design.md §6.2 tap 1, §6.3).
+
+One ``SnapshotRecord`` per model request captured by the recording proxy.
+Records are serialized as JSONL next to the archived request/response payloads
+so a third party can re-derive every downstream metric from raw artifacts.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator
+
+SCHEMA_VERSION = 1
+
+
+@dataclass
+class SnapshotRecord:
+    """Metadata for one captured model request (a *context snapshot*).
+
+    The byte-exact request/response bodies live at ``payload_path`` /
+    ``response_path``; this record carries what analysis needs without
+    re-parsing the payloads.
+    """
+
+    run_id: str
+    ordinal: int  # 1-based request index within the run
+    timestamp: float  # epoch seconds when the proxy received the request
+    endpoint: str  # request path, e.g. /v1/chat/completions or /v1/responses
+    request_sha256: str
+    payload_path: str  # archived request body (relative to the archive dir)
+    response_path: str | None = None
+    status_code: int | None = None
+    model: str | None = None
+    # Provider-reported usage (authoritative token source; design §6.1).
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    # Cheap structural facts extracted at capture time.
+    message_count: int | None = None
+    request_bytes: int = 0
+    response_bytes: int = 0
+    tool_call_names: list[str] = field(default_factory=list)
+    edit_tool_call: bool = False  # response contains an edit/patch tool call
+    streamed: bool = False
+    schema_version: int = SCHEMA_VERSION
+
+    def to_json(self) -> str:
+        return json.dumps(dataclasses.asdict(self), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, line: str) -> "SnapshotRecord":
+        data = json.loads(line)
+        known = {f.name for f in dataclasses.fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+def write_snapshots(records: Iterable[SnapshotRecord], path: str | Path) -> None:
+    """Write records as JSONL (one record per line, sorted keys)."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(record.to_json() + "\n")
+
+
+def read_snapshots(path: str | Path) -> Iterator[SnapshotRecord]:
+    """Read records back from JSONL, skipping blank lines."""
+    with Path(path).open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                yield SnapshotRecord.from_json(line)

--- a/research/repo-bloat-benchmark/harness/context_snapshots/session_parser.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/session_parser.py
@@ -1,0 +1,168 @@
+"""Tolerant parser for agent-CLI session/rollout logs (design.md §6.2 tap 1).
+
+The recording proxy is the primary source; the CLI's own session log (for
+Codex, JSONL rollout files under ``CODEX_HOME/sessions``) is a redundant
+cross-check. The parser is deliberately schema-tolerant: it extracts what it
+recognizes (token usage, tool calls, request-ish events) and records what it
+does not, so schema drift in a pinned CLI version surfaces as data instead of
+a crash.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass
+class SessionSummary:
+    path: str
+    line_count: int = 0
+    parsed_lines: int = 0
+    malformed_lines: int = 0
+    tool_call_names: list[str] = field(default_factory=list)
+    token_events: list[dict[str, int | None]] = field(default_factory=list)
+    event_types: dict[str, int] = field(default_factory=dict)
+    unknown_event_types: list[str] = field(default_factory=list)
+
+    @property
+    def cumulative_input_tokens(self) -> int | None:
+        values = [e["input_tokens"] for e in self.token_events if e["input_tokens"]]
+        return sum(values) if values else None
+
+    @property
+    def request_count_estimate(self) -> int:
+        return len(self.token_events)
+
+
+_USAGE_KEYS = ("usage", "token_usage", "total_token_usage", "last_token_usage")
+_INPUT_KEYS = ("input_tokens", "prompt_tokens", "input", "cached_input_tokens")
+_OUTPUT_KEYS = ("output_tokens", "completion_tokens", "output")
+
+
+def _find_usage(obj: Any, depth: int = 0) -> dict[str, int | None] | None:
+    """Recursively locate a usage-like dict and normalize it."""
+    if depth > 6 or not isinstance(obj, dict):
+        return None
+    for key in _USAGE_KEYS:
+        candidate = obj.get(key)
+        if isinstance(candidate, dict):
+            input_tokens = next(
+                (candidate[k] for k in _INPUT_KEYS if isinstance(candidate.get(k), int)),
+                None,
+            )
+            output_tokens = next(
+                (candidate[k] for k in _OUTPUT_KEYS if isinstance(candidate.get(k), int)),
+                None,
+            )
+            if input_tokens is not None or output_tokens is not None:
+                return {"input_tokens": input_tokens, "output_tokens": output_tokens}
+    for value in obj.values():
+        found = _find_usage(value, depth + 1)
+        if found is not None:
+            return found
+    return None
+
+
+def _find_tool_calls(obj: Any, depth: int = 0) -> Iterable[str]:
+    """Recursively collect tool/function-call names."""
+    if depth > 6:
+        return
+    if isinstance(obj, dict):
+        obj_type = str(obj.get("type", ""))
+        if obj_type.endswith("_call") or obj_type in ("tool_call", "function_call"):
+            name = obj.get("name") or (obj.get("function") or {}).get("name")
+            yield str(name) if name else obj_type
+        for value in obj.values():
+            yield from _find_tool_calls(value, depth + 1)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _find_tool_calls(item, depth + 1)
+
+
+_KNOWN_TYPE_HINTS = (
+    "message",
+    "response",
+    "request",
+    "tool",
+    "function",
+    "token",
+    "usage",
+    "turn",
+    "session",
+    "event",
+    "shell",
+    "patch",
+    "reasoning",
+)
+
+
+def parse_session_log(path: str | Path) -> SessionSummary:
+    """Parse one JSONL session/rollout file into a summary."""
+    path = Path(path)
+    summary = SessionSummary(path=str(path))
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            summary.line_count += 1
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                summary.malformed_lines += 1
+                continue
+            summary.parsed_lines += 1
+            if not isinstance(event, dict):
+                continue
+            event_type = str(
+                event.get("type") or (event.get("payload") or {}).get("type") or "untyped"
+            )
+            summary.event_types[event_type] = summary.event_types.get(event_type, 0) + 1
+            if not any(hint in event_type.lower() for hint in _KNOWN_TYPE_HINTS):
+                if event_type not in summary.unknown_event_types:
+                    summary.unknown_event_types.append(event_type)
+            usage = _find_usage(event)
+            if usage is not None:
+                summary.token_events.append(usage)
+            for name in _find_tool_calls(event):
+                summary.tool_call_names.append(name)
+    return summary
+
+
+def reconcile(
+    proxy_input_tokens_total: int | None,
+    proxy_request_count: int,
+    session: SessionSummary,
+    token_tolerance: float = 0.05,
+) -> list[str]:
+    """Compare proxy record against the CLI's own session log.
+
+    Returns a list of human-readable discrepancies (empty = consistent).
+    Disagreement flags the run per design §6.2 — it does not auto-void it.
+    """
+    problems: list[str] = []
+    if session.malformed_lines:
+        problems.append(
+            f"session log has {session.malformed_lines} malformed lines"
+        )
+    session_tokens = session.cumulative_input_tokens
+    if proxy_input_tokens_total is not None and session_tokens is not None:
+        if proxy_input_tokens_total > 0:
+            drift = abs(session_tokens - proxy_input_tokens_total) / proxy_input_tokens_total
+            if drift > token_tolerance:
+                problems.append(
+                    "input-token mismatch: proxy="
+                    f"{proxy_input_tokens_total} session={session_tokens} "
+                    f"(drift {drift:.1%} > {token_tolerance:.0%})"
+                )
+    if session.request_count_estimate and proxy_request_count:
+        if session.request_count_estimate > proxy_request_count:
+            problems.append(
+                "session log reports more usage events "
+                f"({session.request_count_estimate}) than proxied requests "
+                f"({proxy_request_count}) — traffic may have bypassed the proxy"
+            )
+    return problems

--- a/research/repo-bloat-benchmark/harness/context_snapshots/tests/conftest.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Make `harness.*` importable when pytest runs from any directory."""
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parents[3]
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))

--- a/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_attribution.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_attribution.py
@@ -1,0 +1,101 @@
+"""Tests for content attribution against a materialized tree."""
+
+import pytest
+
+from harness.context_snapshots.attribution import (
+    Attribution,
+    TreeIndex,
+    reconcile_with_usage,
+)
+
+CORE_CONTENT = '''\
+def slice_page(items, page, page_size):
+    """Return one page of items using half-open slicing semantics."""
+    start_index_for_requested_page = page * page_size
+    return items[start_index_for_requested_page:start_index_for_requested_page + page_size]
+'''
+
+DISTRACTOR_CONTENT = '''\
+def format_ledger_totals_for_export(ledger_rows, currency_code):
+    """Format ledger totals for the quarterly export pipeline."""
+    formatted_ledger_export_rows = [f"{row.total:.2f} {currency_code}" for row in ledger_rows]
+    return formatted_ledger_export_rows
+'''
+
+
+@pytest.fixture()
+def tree(tmp_path):
+    (tmp_path / "src" / "pkg").mkdir(parents=True)
+    (tmp_path / "src" / "pkg" / "pagination.py").write_text(CORE_CONTENT)
+    (tmp_path / "src" / "pkg" / "ledger_formatter.py").write_text(DISTRACTOR_CONTENT)
+    return tmp_path
+
+
+@pytest.fixture()
+def index(tree):
+    return TreeIndex(tree, distractor_paths=["src/pkg/ledger_formatter.py"])
+
+
+def test_distractor_lines_attributed(index):
+    request_text = (
+        "Here is a file I read:\n" + DISTRACTOR_CONTENT + "\nWhat should I do next?"
+    )
+    result = index.classify_text(request_text)
+    assert result.distractor_lines > 0
+    assert result.distractor_tokens > 0
+    assert result.core_lines == 0
+    assert "src/pkg/ledger_formatter.py" in result.distractor_files
+
+
+def test_core_lines_attributed(index):
+    result = index.classify_text(CORE_CONTENT)
+    assert result.core_lines > 0
+    assert result.distractor_lines == 0
+    assert "src/pkg/pagination.py" in result.core_files
+
+
+def test_unmatched_text_is_unknown(index):
+    result = index.classify_text(
+        "The assistant reasons at length about pagination strategies in prose."
+    )
+    assert result.distractor_lines == 0
+    assert result.core_lines == 0
+    assert result.unknown_tokens > 0
+
+
+def test_short_lines_ignored(index):
+    result = index.classify_text("return x\n\npass\n")
+    assert result.total_tokens == 0
+
+
+def test_ambiguous_lines_not_counted_as_distractor(tmp_path):
+    shared = "shared_helper_line_that_is_long_enough_to_index = compute_shared_value()\n"
+    (tmp_path / "core.py").write_text(shared)
+    (tmp_path / "extra.py").write_text(shared)
+    index = TreeIndex(tmp_path, distractor_paths=["extra.py"])
+    result = index.classify_text(shared)
+    assert result.distractor_tokens == 0
+    assert result.ambiguous_lines == 1
+
+
+def test_distractor_share(index):
+    text = DISTRACTOR_CONTENT + CORE_CONTENT
+    result = index.classify_text(text)
+    assert 0.0 < result.distractor_share < 1.0
+
+
+def test_reconcile_caps_at_provider_usage():
+    attribution = Attribution(distractor_tokens=900.0, core_tokens=300.0)
+    # Provider says the request was only 600 tokens; estimates must scale down.
+    reconciled = reconcile_with_usage(attribution, provider_input_tokens=600)
+    assert reconciled["reconciled_against_usage"]
+    assert reconciled["distractor_context_tokens"] <= 600
+    assert reconciled["distractor_context_share"] <= 1.0
+    assert reconciled["raw_estimate_tokens"] == 900.0
+
+
+def test_reconcile_without_usage_flags_itself():
+    attribution = Attribution(distractor_tokens=100.0)
+    reconciled = reconcile_with_usage(attribution, provider_input_tokens=None)
+    assert not reconciled["reconciled_against_usage"]
+    assert reconciled["distractor_context_tokens"] == 100.0

--- a/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_iteration_analyzer.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_iteration_analyzer.py
@@ -1,0 +1,112 @@
+"""Tests for the iteration-trajectory analysis (H2 machinery)."""
+
+from harness.context_snapshots.attribution import Attribution
+from harness.context_snapshots.iteration_analyzer import (
+    analyze_run,
+    classify_growth_shape,
+)
+from harness.context_snapshots.schema import SnapshotRecord
+
+
+def _record(ordinal, input_tokens, edit=False):
+    return SnapshotRecord(
+        run_id="run",
+        ordinal=ordinal,
+        timestamp=1000.0 + ordinal,
+        endpoint="/v1/chat/completions",
+        request_sha256="0" * 64,
+        payload_path=f"payloads/{ordinal:05d}.request.json",
+        input_tokens=input_tokens,
+        edit_tool_call=edit,
+    )
+
+
+def test_gradual_growth_classified():
+    # Linear accretion: every request adds ~1000 tokens.
+    records = [_record(i, 1000 * i) for i in range(1, 10)]
+    trajectory = analyze_run(records)
+    assert trajectory.growth_shape == "gradual"
+    assert trajectory.iterations_total == 9
+    assert trajectory.largest_single_jump_share < 0.30
+
+
+def test_step_growth_classified():
+    # One giant read dominates the final context.
+    tokens = [1000, 1100, 9000, 9100, 9200, 9300]
+    records = [_record(i + 1, t) for i, t in enumerate(tokens)]
+    trajectory = analyze_run(records)
+    assert trajectory.growth_shape == "step"
+    assert trajectory.largest_single_jump_share > 0.30
+
+
+def test_plateau_classified():
+    # Steady growth that stalls (truncation ceiling) with no dominating jump:
+    # step takes precedence over plateau, so no single growth may exceed 30%.
+    tokens = [3000, 5500, 8000, 10500, 11000, 11050, 11080, 11100, 11110]
+    records = [_record(i + 1, t) for i, t in enumerate(tokens)]
+    trajectory = analyze_run(records)
+    assert trajectory.growth_shape == "plateau"
+
+
+def test_sawtooth_classified():
+    # Context shrinks mid-run: compaction dropped content.
+    tokens = [3000, 6000, 9000, 4000, 7000, 10000]
+    records = [_record(i + 1, t) for i, t in enumerate(tokens)]
+    trajectory = analyze_run(records)
+    assert trajectory.growth_shape == "sawtooth"
+
+
+def test_first_edit_boundary():
+    records = [
+        _record(1, 1000),
+        _record(2, 2000),
+        _record(3, 3000, edit=True),
+        _record(4, 4000),
+    ]
+    trajectory = analyze_run(records)
+    assert trajectory.first_edit_ordinal == 3
+    assert trajectory.iterations_before_first_edit == 2
+
+
+def test_no_edit_ever():
+    records = [_record(1, 1000), _record(2, 2000)]
+    trajectory = analyze_run(records)
+    assert trajectory.first_edit_ordinal is None
+    assert trajectory.iterations_before_first_edit is None
+
+
+def test_phase_medians_and_share_delta():
+    records = []
+    attributions = []
+    for i in range(1, 10):
+        records.append(_record(i, 1000 * i))
+        # Distractor share climbs from 0.1 to 0.9 across the run.
+        share = i / 10.0
+        attributions.append(
+            Attribution(distractor_tokens=share * 100, core_tokens=(1 - share) * 100)
+        )
+    trajectory = analyze_run(records, attributions)
+    early = trajectory.distractor_share_early
+    late = trajectory.distractor_share_late
+    assert early is not None and late is not None
+    assert late > early
+    assert trajectory.share_delta_late_minus_early is not None
+    assert trajectory.share_delta_late_minus_early > 0.3
+    assert [p.name for p in trajectory.phases] == ["early", "middle", "late"]
+
+
+def test_missing_usage_tolerated():
+    records = [
+        _record(1, None),
+        _record(2, 2000),
+        _record(3, None),
+        _record(4, 4000),
+    ]
+    trajectory = analyze_run(records)
+    assert trajectory.iterations_total == 4  # no crash; growth where computable
+
+
+def test_classify_growth_shape_empty():
+    shape, share = classify_growth_shape([], None)
+    assert shape == "unknown"
+    assert share is None

--- a/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_proxy.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_proxy.py
@@ -1,0 +1,247 @@
+"""End-to-end tests for the recording proxy against a scripted upstream.
+
+These are the automated core of the §6.6 calibration gate's proxy-fidelity
+assertions: byte-exact archiving, usage capture, ordinal indexing, edit
+detection, and transparent forwarding.
+"""
+
+import hashlib
+import json
+import threading
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from harness.context_snapshots.proxy import RecordingProxy, is_edit_tool
+from harness.context_snapshots.schema import read_snapshots
+
+
+class ScriptedUpstream:
+    """Minimal fake model API returning queued responses."""
+
+    def __init__(self):
+        self.responses = []
+        self.received = []
+        self._server = None
+        self._thread = None
+        self.base_url = None
+
+    def queue(self, body: dict, content_type: str = "application/json"):
+        self.responses.append((json.dumps(body).encode(), content_type))
+
+    def queue_raw(self, body: bytes, content_type: str):
+        self.responses.append((body, content_type))
+
+    def start(self):
+        upstream = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *args):
+                pass
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length") or 0)
+                upstream.received.append(self.rfile.read(length))
+                body, content_type = upstream.responses.pop(0)
+                self.send_response(200)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.base_url = f"http://127.0.0.1:{self._server.server_address[1]}"
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self.base_url
+
+    def stop(self):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+
+CHAT_RESPONSE_READ = {
+    "id": "chatcmpl-1",
+    "model": "gpt-test",
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "read_file"}}],
+            }
+        }
+    ],
+    "usage": {"prompt_tokens": 1000, "completion_tokens": 50, "total_tokens": 1050},
+}
+
+CHAT_RESPONSE_EDIT = {
+    "id": "chatcmpl-2",
+    "model": "gpt-test",
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "apply_patch"}}],
+            }
+        }
+    ],
+    "usage": {"prompt_tokens": 2400, "completion_tokens": 80, "total_tokens": 2480},
+}
+
+
+@pytest.fixture()
+def upstream():
+    server = ScriptedUpstream()
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture()
+def proxy(upstream, tmp_path):
+    recording_proxy = RecordingProxy(
+        upstream_base_url=upstream.base_url,
+        archive_dir=tmp_path / "run",
+        run_id="test-run",
+    )
+    recording_proxy.start()
+    yield recording_proxy
+    recording_proxy.stop()
+
+
+def _post(base_url: str, path: str, payload: dict) -> dict:
+    body = json.dumps(payload).encode()
+    request = urllib.request.Request(
+        f"{base_url}{path}",
+        data=body,
+        headers={"Content-Type": "application/json", "Authorization": "Bearer test"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def test_forwards_and_records_in_order(upstream, proxy, tmp_path):
+    upstream.queue(CHAT_RESPONSE_READ)
+    upstream.queue(CHAT_RESPONSE_EDIT)
+    base = f"http://127.0.0.1:{proxy.port}"
+
+    first_payload = {"model": "gpt-test", "messages": [{"role": "user", "content": "find bug"}]}
+    second_payload = {
+        "model": "gpt-test",
+        "messages": [
+            {"role": "user", "content": "find bug"},
+            {"role": "tool", "content": "def slice_page(): ..."},
+        ],
+    }
+    first_response = _post(base, "/v1/chat/completions", first_payload)
+    second_response = _post(base, "/v1/chat/completions", second_payload)
+
+    # Forwarding is transparent: the client sees the upstream body verbatim.
+    assert first_response == CHAT_RESPONSE_READ
+    assert second_response == CHAT_RESPONSE_EDIT
+    # Upstream saw the exact client bytes.
+    assert json.loads(upstream.received[0]) == first_payload
+
+    assert [r.ordinal for r in proxy.records] == [1, 2]
+    first, second = proxy.records
+    assert first.input_tokens == 1000
+    assert second.input_tokens == 2400
+    assert first.message_count == 1
+    assert second.message_count == 2
+    assert first.tool_call_names == ["read_file"]
+    assert not first.edit_tool_call
+    assert second.edit_tool_call  # apply_patch ⇒ first-edit boundary marker
+
+
+def test_payloads_archived_byte_exact(upstream, proxy, tmp_path):
+    upstream.queue(CHAT_RESPONSE_READ)
+    base = f"http://127.0.0.1:{proxy.port}"
+    payload = {"model": "gpt-test", "messages": [{"role": "user", "content": "x" * 100}]}
+    _post(base, "/v1/chat/completions", payload)
+
+    record = proxy.records[0]
+    archived = (proxy.archive_dir / record.payload_path).read_bytes()
+    assert hashlib.sha256(archived).hexdigest() == record.request_sha256
+    assert json.loads(archived) == payload
+
+
+def test_snapshot_jsonl_round_trip(upstream, proxy):
+    upstream.queue(CHAT_RESPONSE_READ)
+    base = f"http://127.0.0.1:{proxy.port}"
+    _post(base, "/v1/chat/completions", {"model": "gpt-test", "messages": []})
+
+    reloaded = list(read_snapshots(proxy.archive_dir / "context_snapshots.jsonl"))
+    assert len(reloaded) == 1
+    assert reloaded[0].run_id == "test-run"
+    assert reloaded[0].input_tokens == 1000
+
+
+def test_responses_api_sse_usage_extracted(upstream, proxy):
+    completed = {
+        "type": "response.completed",
+        "response": {
+            "usage": {"input_tokens": 3210, "output_tokens": 99, "total_tokens": 3309},
+            "output": [{"type": "function_call", "name": "shell"}],
+        },
+    }
+    sse_body = (
+        b'data: {"type": "response.output_text.delta", "delta": "hi"}\n\n'
+        + b"data: " + json.dumps(completed).encode() + b"\n\n"
+        + b"data: [DONE]\n\n"
+    )
+    upstream.queue_raw(sse_body, "text/event-stream")
+    base = f"http://127.0.0.1:{proxy.port}"
+    body = json.dumps({"model": "gpt-test", "input": [{"role": "user", "content": "go"}]}).encode()
+    request = urllib.request.Request(
+        f"{base}/v1/responses", data=body,
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as resp:
+        relayed = resp.read()
+
+    assert relayed == sse_body  # SSE body relayed intact (buffered)
+    record = proxy.records[0]
+    assert record.streamed
+    assert record.input_tokens == 3210
+    assert record.tool_call_names == ["shell"]
+    assert record.message_count == 1
+
+
+def test_upstream_failure_becomes_502_and_is_recorded(tmp_path):
+    recording_proxy = RecordingProxy(
+        upstream_base_url="http://127.0.0.1:1",  # nothing listens here
+        archive_dir=tmp_path / "run",
+        run_id="down",
+        forward_timeout=2,
+    )
+    base = recording_proxy.start()
+    try:
+        body = json.dumps({"model": "m", "messages": []}).encode()
+        request = urllib.request.Request(
+            f"{base}/v1/chat/completions", data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        try:
+            urllib.request.urlopen(request, timeout=10)
+            status = 200
+        except urllib.error.HTTPError as exc:
+            status = exc.code
+        assert status == 502
+        assert recording_proxy.records[0].status_code == 502
+    finally:
+        recording_proxy.stop()
+
+
+def test_edit_tool_name_matching():
+    assert is_edit_tool("apply_patch")
+    assert is_edit_tool("apply_patch_call")
+    assert is_edit_tool("str_replace_editor")
+    assert is_edit_tool("Edit")
+    assert not is_edit_tool("read_file")
+    assert not is_edit_tool("shell")

--- a/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_session_parser.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_session_parser.py
@@ -1,0 +1,95 @@
+"""Tests for the tolerant session-log parser and proxy reconciliation."""
+
+import json
+
+from harness.context_snapshots.session_parser import parse_session_log, reconcile
+
+
+def _write_session(tmp_path, events):
+    path = tmp_path / "session.jsonl"
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+    return path
+
+
+def test_extracts_usage_and_tool_calls(tmp_path):
+    events = [
+        {"type": "session_meta", "payload": {"id": "abc"}},
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "usage": {"input_tokens": 1200, "output_tokens": 40},
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {"type": "function_call", "name": "shell"},
+        },
+        {
+            "type": "response_item",
+            "payload": {"type": "custom_tool_call", "name": "apply_patch"},
+        },
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "usage": {"input_tokens": 2500, "output_tokens": 60},
+            },
+        },
+    ]
+    summary = parse_session_log(_write_session(tmp_path, events))
+    assert summary.parsed_lines == 5
+    assert summary.malformed_lines == 0
+    assert summary.request_count_estimate == 2
+    assert summary.cumulative_input_tokens == 3700
+    assert "shell" in summary.tool_call_names
+    assert "apply_patch" in summary.tool_call_names
+
+
+def test_malformed_lines_counted_not_fatal(tmp_path):
+    path = tmp_path / "session.jsonl"
+    path.write_text('{"type": "ok"}\nnot json at all\n{"type": "also_ok"}\n')
+    summary = parse_session_log(path)
+    assert summary.line_count == 3
+    assert summary.parsed_lines == 2
+    assert summary.malformed_lines == 1
+
+
+def test_unknown_event_types_recorded(tmp_path):
+    events = [{"type": "wormhole_sync", "payload": {}}]
+    summary = parse_session_log(_write_session(tmp_path, events))
+    assert "wormhole_sync" in summary.unknown_event_types
+
+
+def test_reconcile_consistent(tmp_path):
+    events = [
+        {"usage": {"input_tokens": 1000, "output_tokens": 10}},
+        {"usage": {"input_tokens": 2000, "output_tokens": 10}},
+    ]
+    summary = parse_session_log(_write_session(tmp_path, events))
+    problems = reconcile(
+        proxy_input_tokens_total=3000, proxy_request_count=2, session=summary
+    )
+    assert problems == []
+
+
+def test_reconcile_flags_token_drift(tmp_path):
+    events = [{"usage": {"input_tokens": 5000, "output_tokens": 10}}]
+    summary = parse_session_log(_write_session(tmp_path, events))
+    problems = reconcile(
+        proxy_input_tokens_total=3000, proxy_request_count=1, session=summary
+    )
+    assert any("mismatch" in p for p in problems)
+
+
+def test_reconcile_flags_bypassed_traffic(tmp_path):
+    events = [
+        {"usage": {"input_tokens": 100, "output_tokens": 1}},
+        {"usage": {"input_tokens": 100, "output_tokens": 1}},
+        {"usage": {"input_tokens": 100, "output_tokens": 1}},
+    ]
+    summary = parse_session_log(_write_session(tmp_path, events))
+    problems = reconcile(
+        proxy_input_tokens_total=300, proxy_request_count=2, session=summary
+    )
+    assert any("bypass" in p for p in problems)


### PR DESCRIPTION
**Sub-PR 2 of 5** for epic #1851 (base = `epic/1209-repo-bloat-v2`; merge order 1 → 2 → 3 → 4 → 5). File-disjoint from PR 1/3/5; PR 4 stacks on this.

## What changed

New package `research/repo-bloat-benchmark/harness/context_snapshots/` — the v2 design's **primary instrument** (design §6.2 tap 1), stdlib-only:

- **`proxy.py` — `RecordingProxy`**: a local HTTP relay the stock (unforked) agent CLI is pointed at via base-URL override. Per request it archives the **byte-exact request payload** (the composed context window), the response, provider `usage`, tool-call names, and an edit-tool flag (the first-edit boundary marker). Handles both Chat Completions and Responses-API shapes, including SSE streams (buffered relay with usage extraction from the terminal event — limitation documented). Upstream failures surface as recorded 502s.
- **`attribution.py` — `TreeIndex`**: normalized-line index over the materialized variant; attributes surfaced request content to core / distractor / ambiguous / unknown with per-file provenance. `reconcile_with_usage` guarantees attributed tokens **never exceed** provider-measured tokens; ambiguous lines count *against* the distractor total (conservative).
- **`iteration_analyzer.py` — `analyze_run`**: turns the ordered snapshot series into the pre-registered **iteration-trajectory family (H2)**: per-request token/growth/share series, early/middle/late phase medians, `growth_shape` classification (gradual / step / plateau / sawtooth, precedence sawtooth→step→plateau→gradual, thresholds pre-registered in code + design), `largest_single_jump_share`, first-edit boundary.
- **`session_parser.py`**: tolerant parser for the CLI's own session/rollout JSONL + `reconcile()` cross-check that flags token drift and traffic that bypassed the proxy.
- **`schema.py`**: `SnapshotRecord` + JSONL round-trip.

## Why it matters to the research

This is the feedback item *"study context snapshots — don't rely only on file-level investigation"* made concrete: evidence about the context window now comes from the window itself (byte-exact request payloads), and the *"does token bloat happen gradually across iterations?"* question (H2) is answerable from the per-request series — growth-shape classes distinguish gradual accretion from one-big-read step profiles, which points mitigations at context-management vs. retrieval policy respectively. Because the instrument sits at the API boundary, **no Codex fork is needed** and the same tap works for any CLI honoring a base-URL override (cheap cross-agent extension).

## How to run

```bash
cd research/repo-bloat-benchmark
python3 -m pytest harness/context_snapshots/tests/ -q   # 29 passed
```

Tests cover: transparent forwarding + byte-exact archiving (sha-verified), ordinal ordering, usage extraction (JSON + SSE), edit detection, JSONL round-trip, upstream-failure recording, attribution classes + usage reconciliation, all four growth shapes, first-edit boundary, phase medians, tolerant session parsing + bypass detection.

## Still incomplete

- True pass-through SSE streaming (currently buffered; capture fidelity unaffected, wall-clock inflated — documented, secondary metric).
- Attribution is a documented lower bound (line-index matching); a pinned real tokenizer can replace the chars/4 estimator via the `token_estimator` hook.
- Confirming the pinned Codex build honors base-URL override remains the §10 pre-run blocker (fallback chain documented in design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)