### PR TITLE
Research #1209 v2 (3/5): distractor definition + 3-mode generator + 50x scaling

### DIFF
--- a/research/repo-bloat-benchmark/harness/__init__.py
+++ b/research/repo-bloat-benchmark/harness/__init__.py
@@ -1,0 +1,1 @@
+"""Experiment harness for the repo-bloat localization benchmark (issue #1209)."""

--- a/research/repo-bloat-benchmark/harness/distractors/DEFINITION.md
+++ b/research/repo-bloat-benchmark/harness/distractors/DEFINITION.md
@@ -1,0 +1,46 @@
+# What is a "distractor file"?
+
+Machine-checkable restatement of design.md **§5.0**. The generator
+(`generator.py`) enforces this contract for **every** admitted file, whatever
+its source mode; `definition.py` is the single implementation of the checks,
+and the test suite exercises each condition.
+
+## Definition
+
+A file `D` is a **distractor** for a scenario `(core, task, visible_tests,
+hidden_verifier)` iff **all** of the following hold:
+
+| # | Condition | Machine check (`definition.py`) |
+|---|-----------|--------------------------------|
+| 1 | **Structural irrelevance** — `D ∉ closure(core)`: no core file imports/includes/loads `D`, and `D` is not a target file | destination path not in `core_files`; module name not importable by any core import statement (static import scan); not in `target_files` |
+| 2 | **Behavior neutrality** — materializing/removing `D` changes no visible-test or hidden-verifier outcome | forbidden ambient-side-effect basenames rejected (`conftest.py`, `sitecustomize.py`, pytest plugins, packaging/config entrypoints); destination must not shadow a core module (same importable name); dynamic-import red-flag scan. Final authority: the §4.1.2 oracle equivalence gate re-runs both suites per materialized variant |
+| 3 | **Plausibility** — project language and idiom; would not read as filler | parses (`ast`) for Python; identifier-vocabulary overlap with the core ≥ recorded floor; verbatim project files pass by construction |
+| 4 | **No leakage** — no hidden-verifier or oracle-patch content | content screened against the scenario's hidden-assertion denylist |
+| 5 | **No tell** — nothing marks `D` as a distractor | destination path/name/content screened for marker strings (`distractor`, `filler`, `synthetic`, `decoy`, …) |
+
+Checks 1, 2, 4, 5 are hard gates (violation ⇒ file rejected, generation
+aborts if requested size cannot be met legally). Check 3 is a hard gate for
+generated files and a recorded no-op for verbatim (`regrow`) files.
+
+## Source modes (design §5.0.1)
+
+One definition, three deterministic sources, fixed cascade
+(`regrow` → `mutate` → `template`), each file's `mode` recorded in the
+manifest so per-mode read/penetration rates can be reported:
+
+- **`regrow`** — verbatim out-of-core project files at their original paths.
+- **`mutate`** — seeded, semantics-preserving derivations of pool files
+  (identifier/docstring renames from a recorded vocabulary map), placed at
+  plausible non-colliding sibling paths. Extends the pool past its natural
+  size.
+- **`template`** — synthetic modules from parameterized skeletons filled with
+  vocabulary harvested from the core; size-tunable, used as the terminal
+  filler so any token budget converges (50x and breakdown-probe steps).
+
+## Why a definition at all
+
+The review feedback asked for distractors to be *defined*, then *generated
+from the definition* and *scaled aggressively*. Making the definition a
+checkable contract (rather than prose) is what lets three different sources
+share one guarantee — and lets the 50x/probe conditions exist without
+weakening the experiment's "only one thing varies" principle.

--- a/research/repo-bloat-benchmark/harness/distractors/README.md
+++ b/research/repo-bloat-benchmark/harness/distractors/README.md
@@ -1,0 +1,52 @@
+# Distractor definition + generator
+
+Implements design.md **§5** (v2): the formal distractor-file contract and the
+deterministic generator that fills per-(scenario, size) token budgets on the
+ladder `1x/2x/5x/10x/20x/50x` — and beyond, for the H3 breakdown probe.
+
+## Pieces
+
+| File | Role |
+|------|------|
+| `DEFINITION.md` | the five-condition distractor contract, mapped to its machine checks |
+| `definition.py` | `DefinitionChecker` — the single implementation of those checks; every admitted file passes it, whatever its source mode |
+| `vocabulary.py` | deterministic identifier/word harvest from the core (feeds mutate/template plausibility) |
+| `generator.py` | `generate_manifest(config, size)` — budget filling via the fixed mode cascade **regrow → mutate → template**, dependency-closed regrow groups, tier assignment from layout, rejection log |
+| `manifest.py` | manifest persistence (+ generated-file contents), `manifests.lock` freeze enforcement |
+| `cli.py` | `python3 -m harness.distractors.cli` — generate a whole ladder + lockfile |
+
+## Generate a ladder
+
+```bash
+cd research/repo-bloat-benchmark
+python3 -m harness.distractors.cli \
+  --scenario-id off-by-one-pagination \
+  --core scenarios/off-by-one-pagination/core \
+  --pool snapshots/pdd@<commit>/pool \
+  --target-file src/pkg/pagination.py \
+  --sizes 1 2 5 10 20 50 \
+  --seed 1209 \
+  --out distractors/
+```
+
+Each manifest records: token budget vs. realized dose, per-file
+`mode`/`tier`/`sha256`/`import_group`, `mode_counts`, a `budget_met` flag, and
+the full **rejection log** (which candidates the definition checks refused and
+why) — so the freeze-before-runs commit is auditable.
+
+## Properties the tests pin down
+
+- **Determinism**: same inputs + seed ⇒ byte-identical manifest; different
+  seed ⇒ different selection.
+- **Budget convergence**: 50x is met within ±2 % even from a tiny pool — the
+  cascade falls through to `mutate` then `template`, and `template` is
+  size-tunable so any budget converges (this is what makes the breakdown
+  probe past 50x possible).
+- **Contract enforcement**: core/target collisions, core-importable names,
+  `conftest.py`-style ambient files, dynamic-import red flags, unparseable
+  code, off-vocabulary generated code, hidden-assertion leakage, and
+  tell markers are all rejected (each has a dedicated test).
+- **1x control** is exactly the empty manifest.
+- **Freeze**: `manifests.lock` verification fails on any post-commit edit.
+
+No external dependencies (stdlib + pytest only).

--- a/research/repo-bloat-benchmark/harness/distractors/__init__.py
+++ b/research/repo-bloat-benchmark/harness/distractors/__init__.py
@@ -1,0 +1,19 @@
+"""Distractor definition, generation, and manifest building (design.md §5)."""
+
+from .definition import CandidateFile, DefinitionChecker, Violation
+from .generator import GenerationConfig, generate_manifest
+from .manifest import ManifestWriter, load_manifest, verify_lockfile, write_lockfile
+from .vocabulary import harvest_vocabulary
+
+__all__ = [
+    "CandidateFile",
+    "DefinitionChecker",
+    "Violation",
+    "GenerationConfig",
+    "generate_manifest",
+    "ManifestWriter",
+    "load_manifest",
+    "verify_lockfile",
+    "write_lockfile",
+    "harvest_vocabulary",
+]

--- a/research/repo-bloat-benchmark/harness/distractors/cli.py
+++ b/research/repo-bloat-benchmark/harness/distractors/cli.py
@@ -1,0 +1,77 @@
+"""Command-line entry point for distractor-manifest generation.
+
+Example (from ``research/repo-bloat-benchmark/``)::
+
+    python3 -m harness.distractors.cli \
+        --scenario-id off-by-one-pagination \
+        --core scenarios/off-by-one-pagination/core \
+        --pool snapshots/pdd@<commit>/pool \
+        --target-file src/pkg/pagination.py \
+        --sizes 1 2 5 10 20 50 \
+        --seed 1209 \
+        --out distractors/
+
+Writes ``distractors/manifests/<scenario>.<size>.json`` for each ladder step,
+persists generated (mutate/template) file contents under
+``distractors/generated/``, and refreshes ``distractors/manifests.lock``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .generator import SIZE_LADDER, GenerationConfig, generate_manifest
+from .manifest import ManifestWriter, write_lockfile
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario-id", required=True)
+    parser.add_argument("--core", required=True, type=Path, help="core tree (1x base repo)")
+    parser.add_argument("--pool", type=Path, default=None, help="snapshot ∖ core tree")
+    parser.add_argument("--target-file", required=True, help="core-relative target path")
+    parser.add_argument("--sizes", type=int, nargs="+", default=list(SIZE_LADDER))
+    parser.add_argument("--seed", type=int, default=1209)
+    parser.add_argument("--tolerance-pct", type=float, default=2.0)
+    parser.add_argument("--leak-denylist-file", type=Path, default=None,
+                        help="file of newline-separated hidden-assertion strings")
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    denylist: tuple[str, ...] = ()
+    if args.leak_denylist_file:
+        denylist = tuple(
+            line.strip()
+            for line in args.leak_denylist_file.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        )
+
+    config = GenerationConfig(
+        scenario_id=args.scenario_id,
+        core_root=args.core,
+        pool_root=args.pool,
+        target_file=args.target_file,
+        selection_seed=args.seed,
+        tolerance_pct=args.tolerance_pct,
+        leak_denylist=denylist,
+    )
+    writer = ManifestWriter(args.out)
+    written: list[Path] = []
+    for size in args.sizes:
+        manifest = generate_manifest(config, size)
+        path = writer.write(manifest)
+        written.append(path)
+        status = "ok" if manifest["budget_met"] else "BUDGET NOT MET"
+        print(
+            f"{path.name}: {manifest['distractor_tokens_on_disk']} distractor tokens "
+            f"({manifest['mode_counts']}) [{status}]"
+        )
+    write_lockfile(list(writer.manifest_dir.glob("*.json")), args.out / "manifests.lock")
+    print(f"lockfile: {args.out / 'manifests.lock'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/repo-bloat-benchmark/harness/distractors/definition.py
+++ b/research/repo-bloat-benchmark/harness/distractors/definition.py
@@ -1,0 +1,221 @@
+"""Machine checks for the distractor-file definition (DEFINITION.md, design §5.0).
+
+Every file the generator admits — whatever its mode — passes through
+``DefinitionChecker.check``. A non-empty violation list rejects the file.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Iterable
+
+# Condition 2: basenames with ambient side effects (test collection, import
+# hooks, packaging) can change behavior by existing. Never admissible.
+FORBIDDEN_BASENAMES = frozenset(
+    {
+        "conftest.py",
+        "sitecustomize.py",
+        "usercustomize.py",
+        "setup.py",
+        "setup.cfg",
+        "pyproject.toml",
+        "tox.ini",
+        "pytest.ini",
+        "__main__.py",
+    }
+)
+
+# Condition 5: markers that would label a file as benchmark filler.
+TELL_MARKERS = ("distractor", "filler", "synthetic", "decoy", "padding", "noise_file")
+
+# Condition 2 red flags: constructs whose presence needs manual review because
+# they can act at import/collection time even without being imported by core.
+_DYNAMIC_RED_FLAGS = (
+    re.compile(r"\bimportlib\.(?:import_module|reload)\b"),
+    re.compile(r"\b__import__\s*\("),
+    re.compile(r"\bsys\.path\.(?:insert|append)\b"),
+    re.compile(r"\bpkg_resources\b"),
+    re.compile(r"entry_points"),
+)
+
+_IMPORT_RE = re.compile(r"^\s*(?:from\s+([\w\.]+)\s+import|import\s+([\w\.]+))", re.M)
+
+
+def module_names_for(path: str) -> set[str]:
+    """Dotted-module candidates a Python file can be imported as.
+
+    ``src/pkg/mod.py`` → {``src.pkg.mod``, ``pkg.mod``, ``mod``} — suffixes are
+    included because the import root is unknown statically.
+    """
+    pure = PurePosixPath(path)
+    if pure.suffix != ".py":
+        return set()
+    parts = list(pure.with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return {".".join(parts[i:]) for i in range(len(parts))} if parts else set()
+
+
+def imported_modules(source: str) -> set[str]:
+    """Statically imported dotted names (regex-based, comment-tolerant)."""
+    names: set[str] = set()
+    for match in _IMPORT_RE.finditer(source):
+        name = match.group(1) or match.group(2)
+        if name:
+            names.add(name)
+            # `import a.b.c` also makes `a` and `a.b` load.
+            pieces = name.split(".")
+            for i in range(1, len(pieces)):
+                names.add(".".join(pieces[:i]))
+    return names
+
+
+@dataclass
+class Violation:
+    condition: int  # 1..5, per DEFINITION.md
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - convenience
+        return f"[condition {self.condition}] {self.message}"
+
+
+@dataclass
+class CandidateFile:
+    """A file proposed for admission, before definition checks."""
+
+    destination_path: str  # where it would be materialized (tree-relative)
+    content: str
+    mode: str  # regrow | mutate | template
+    source_path: str | None = None  # provenance for regrow/mutate
+    tier: str = "cross-cutting"
+
+
+@dataclass
+class DefinitionChecker:
+    """Holds the scenario facts the checks are made against."""
+
+    core_files: set[str]
+    target_files: set[str]
+    core_import_names: set[str]  # every module name any core file imports
+    leak_denylist: tuple[str, ...] = ()
+    vocabulary_floor: float = 0.02
+    core_vocabulary: "object | None" = None  # Vocabulary; optional
+
+    @classmethod
+    def from_core(
+        cls,
+        core_files: Iterable[str],
+        core_sources: dict[str, str],
+        target_files: Iterable[str] = (),
+        leak_denylist: Iterable[str] = (),
+        vocabulary_floor: float = 0.02,
+        core_vocabulary: "object | None" = None,
+    ) -> "DefinitionChecker":
+        import_names: set[str] = set()
+        for source in core_sources.values():
+            import_names |= imported_modules(source)
+        return cls(
+            core_files={p.replace("\\", "/") for p in core_files},
+            target_files={p.replace("\\", "/") for p in target_files},
+            core_import_names=import_names,
+            leak_denylist=tuple(leak_denylist),
+            vocabulary_floor=vocabulary_floor,
+            core_vocabulary=core_vocabulary,
+        )
+
+    # -- the five conditions -------------------------------------------------
+
+    def check(self, candidate: CandidateFile) -> list[Violation]:
+        violations: list[Violation] = []
+        dest = candidate.destination_path.replace("\\", "/")
+
+        # 1. Structural irrelevance
+        if dest in self.core_files:
+            violations.append(Violation(1, f"{dest} is a core file"))
+        if dest in self.target_files:
+            violations.append(Violation(1, f"{dest} is a target file"))
+        if module_names_for(dest) & self.core_import_names:
+            violations.append(
+                Violation(1, f"{dest} is importable by a core import statement")
+            )
+
+        # 2. Behavior neutrality
+        basename = PurePosixPath(dest).name
+        if basename in FORBIDDEN_BASENAMES:
+            violations.append(
+                Violation(2, f"{basename} has ambient side effects (forbidden basename)")
+            )
+        shadowed = self._shadows_core_module(dest)
+        if shadowed:
+            violations.append(Violation(2, f"{dest} would shadow core module {shadowed}"))
+        for pattern in _DYNAMIC_RED_FLAGS:
+            if pattern.search(candidate.content):
+                violations.append(
+                    Violation(
+                        2,
+                        f"dynamic-import red flag `{pattern.pattern}` in {dest} "
+                        "(needs manual clearance; rejected by default)",
+                    )
+                )
+                break
+
+        # 3. Plausibility (hard gate for generated files)
+        if dest.endswith(".py"):
+            try:
+                ast.parse(candidate.content)
+            except SyntaxError as exc:
+                violations.append(Violation(3, f"{dest} does not parse: {exc}"))
+            else:
+                if candidate.mode != "regrow" and self.core_vocabulary is not None:
+                    from .vocabulary import collect_identifiers
+
+                    overlap = self.core_vocabulary.overlap_fraction(
+                        collect_identifiers(candidate.content)
+                    )
+                    if overlap < self.vocabulary_floor:
+                        violations.append(
+                            Violation(
+                                3,
+                                f"{dest} vocabulary overlap {overlap:.3f} below "
+                                f"floor {self.vocabulary_floor:.3f}",
+                            )
+                        )
+
+        # 4. No leakage
+        for needle in self.leak_denylist:
+            if needle and needle in candidate.content:
+                violations.append(
+                    Violation(4, f"{dest} contains denylisted hidden-assertion text")
+                )
+                break
+
+        # 5. No tell. Path markers are always forbidden; content markers only
+        # gate *generated* files — an organic occurrence of a word like
+        # "noise" in a verbatim project file is not a benchmark artifact.
+        lowered_dest = dest.lower()
+        for marker in TELL_MARKERS:
+            if marker in lowered_dest:
+                violations.append(Violation(5, f"path {dest} carries marker '{marker}'"))
+                break
+        if candidate.mode != "regrow":
+            lowered_content = candidate.content.lower()
+            for marker in TELL_MARKERS:
+                if marker in lowered_content:
+                    violations.append(
+                        Violation(5, f"{dest} content carries marker '{marker}'")
+                    )
+                    break
+
+        return violations
+
+    def _shadows_core_module(self, dest: str) -> str | None:
+        dest_names = module_names_for(dest)
+        if not dest_names:
+            return None
+        for core_path in self.core_files:
+            if module_names_for(core_path) & dest_names:
+                return core_path
+        return None

--- a/research/repo-bloat-benchmark/harness/distractors/generator.py
+++ b/research/repo-bloat-benchmark/harness/distractors/generator.py
@@ -1,0 +1,414 @@
+"""Deterministic distractor generation (design.md §5.0.1, §5.1, §5.3).
+
+Fills a per-(scenario, size) token budget with files that pass the
+``DefinitionChecker`` contract, using the fixed source cascade:
+
+1. ``regrow``  — verbatim pool files (``snapshot ∖ core``), admitted in
+   dependency-closed import groups, ordered by (tier, stable hash);
+2. ``mutate``  — seeded identifier/docstring derivations of pool files at
+   non-colliding sibling paths, once the pool is exhausted;
+3. ``template`` — synthetic size-tunable modules from core vocabulary, as the
+   terminal filler so any budget (50x, breakdown probe) converges.
+
+Given the same inputs and seed, output is byte-identical — manifests are
+committed before any model run (freeze-before-runs).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Callable
+
+from .definition import CandidateFile, DefinitionChecker, imported_modules, module_names_for
+from .vocabulary import Vocabulary, harvest_vocabulary
+
+SIZE_LADDER = (1, 2, 5, 10, 20, 50)
+TIER_ORDER = {"same-package": 0, "same-layer": 1, "cross-cutting": 2}
+
+
+def estimate_tokens(text: str) -> int:
+    """Deterministic on-disk token-dose estimate (~4 chars/token, design §5.1)."""
+    return max(1, round(len(text) / 4))
+
+
+def stable_hash(*parts: object) -> str:
+    return hashlib.sha256("|".join(str(p) for p in parts).encode()).hexdigest()
+
+
+def tier_for(destination: str, target_file: str) -> str:
+    """Tier from layout distance to the target (design §5.2)."""
+    dest_dir = PurePosixPath(destination).parent
+    target_dir = PurePosixPath(target_file).parent
+    if dest_dir == target_dir:
+        return "same-package"
+    if dest_dir.parent == target_dir.parent:
+        return "same-layer"
+    return "cross-cutting"
+
+
+@dataclass
+class GenerationConfig:
+    scenario_id: str
+    core_root: Path
+    target_file: str  # core-relative path of the seeded target
+    pool_root: Path | None = None  # snapshot ∖ core; None ⇒ generated-only
+    selection_seed: int = 1209
+    tolerance_pct: float = 2.0
+    leak_denylist: tuple[str, ...] = ()
+    vocabulary_floor: float = 0.02
+    token_estimator: Callable[[str], int] = estimate_tokens
+    max_mutants_per_source: int = 20
+    template_file_tokens: int = 800
+
+    def __post_init__(self) -> None:
+        self.core_root = Path(self.core_root)
+        if self.pool_root is not None:
+            self.pool_root = Path(self.pool_root)
+
+
+@dataclass
+class _Admitted:
+    destination: str
+    content: str
+    mode: str
+    tier: str
+    import_group: str
+    source_path: str | None
+    tokens: int
+
+
+def _read_tree(root: Path, extensions: tuple[str, ...] = (".py",)) -> dict[str, str]:
+    files: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and path.suffix in extensions:
+            files[path.relative_to(root).as_posix()] = path.read_text(
+                encoding="utf-8", errors="replace"
+            )
+    return files
+
+
+# --------------------------------------------------------------------------
+# regrow
+# --------------------------------------------------------------------------
+
+
+def _pool_import_groups(pool: dict[str, str]) -> dict[str, list[str]]:
+    """Map each pool file to its dependency-closed group within the pool."""
+    name_to_path: dict[str, str] = {}
+    for path in pool:
+        for name in module_names_for(path):
+            name_to_path.setdefault(name, path)
+    groups: dict[str, list[str]] = {}
+    for path, source in pool.items():
+        closure: set[str] = set()
+        frontier = [path]
+        while frontier:
+            current = frontier.pop()
+            if current in closure:
+                continue
+            closure.add(current)
+            for imported in imported_modules(pool.get(current, "")):
+                resolved = name_to_path.get(imported)
+                if resolved and resolved not in closure:
+                    frontier.append(resolved)
+        groups[path] = sorted(closure)
+    return groups
+
+
+def _regrow_candidates(
+    config: GenerationConfig, pool: dict[str, str]
+) -> list[tuple[str, list[str]]]:
+    """Deterministically ordered (path, dependency_group) admission list."""
+    groups = _pool_import_groups(pool)
+    ordered = sorted(
+        pool,
+        key=lambda p: (
+            TIER_ORDER[tier_for(p, config.target_file)],
+            stable_hash(config.selection_seed, p),
+        ),
+    )
+    return [(path, groups[path]) for path in ordered]
+
+
+# --------------------------------------------------------------------------
+# mutate
+# --------------------------------------------------------------------------
+
+_DEF_RE = re.compile(r"^(\s*(?:def|class)\s+)([A-Za-z_]\w*)", re.M)
+
+
+def _mutate_source(
+    source: str, source_path: str, vocabulary: Vocabulary, seed_material: str
+) -> tuple[str, str]:
+    """Seeded, semantics-preserving derivation of a pool file.
+
+    Renames top-level def/class identifiers with vocabulary-derived suffixes
+    and rewrites the module docstring; returns (destination_path, content).
+    Never imported by anything (definition condition 1 holds regardless), so
+    internal consistency — not runtime equivalence — is what matters.
+    """
+    words = vocabulary.top_words(64) or ["module"]
+    digest = stable_hash(seed_material, source_path)
+    word = words[int(digest[:8], 16) % len(words)]
+    suffix = f"_{word}"
+
+    renames: dict[str, str] = {}
+    for match in _DEF_RE.finditer(source):
+        name = match.group(2)
+        if not name.startswith("__"):
+            renames[name] = name + suffix
+    mutated = source
+    for old, new in sorted(renames.items(), key=lambda kv: -len(kv[0])):
+        mutated = re.sub(rf"\b{re.escape(old)}\b", new, mutated)
+
+    header = (
+        f'"""Support variant for the {word} pathway.\n\n'
+        f"Derived interface kept in sync with its sibling module.\n"
+        f'"""\n\n'
+    )
+    if not mutated.lstrip().startswith(('"""', "'''")):
+        mutated = header + mutated
+
+    pure = PurePosixPath(source_path)
+    destination = str(pure.with_name(f"{pure.stem}{suffix}{pure.suffix}"))
+    return destination, mutated
+
+
+# --------------------------------------------------------------------------
+# template
+# --------------------------------------------------------------------------
+
+_TEMPLATE_SHAPES = ("service", "handler", "helpers", "adapters", "validation")
+
+
+def _template_module(
+    vocabulary: Vocabulary, seed_material: str, index: int, target_tokens: int
+) -> tuple[str, str]:
+    """Synthesize one self-contained module from core vocabulary."""
+    words = vocabulary.top_words(48) or ["record", "value", "config"]
+
+    def pick(n: int) -> str:
+        return words[int(stable_hash(seed_material, index, n)[:8], 16) % len(words)]
+
+    shape = _TEMPLATE_SHAPES[index % len(_TEMPLATE_SHAPES)]
+    noun, verb, aux = pick(1), pick(2), pick(3)
+    module_name = f"{noun}_{shape}"
+    lines = [
+        f'"""{shape.capitalize()} utilities for {noun} {aux} processing."""',
+        "",
+        "from dataclasses import dataclass",
+        "",
+        "",
+        "@dataclass",
+        f"class {noun.capitalize()}{shape.capitalize()}Config:",
+        f"    {aux}_limit: int = 100",
+        f"    strict_{verb}: bool = False",
+        "",
+    ]
+    body_index = 0
+    content = "\n".join(lines)
+    while estimate_tokens(content) < target_tokens:
+        a, b = pick(10 + body_index), pick(11 + body_index)
+        lines += [
+            "",
+            f"def {verb}_{a}_{b}_{body_index}(records, config):",
+            f'    """Apply the {a} {b} policy to incoming records."""',
+            "    selected = []",
+            "    for record in records:",
+            f"        if getattr(record, '{a}_flag', False) and config.strict_{verb}:",
+            "            continue",
+            f"        if len(selected) >= config.{aux}_limit:",
+            "            break",
+            "        selected.append(record)",
+            "    return selected",
+        ]
+        body_index += 1
+        content = "\n".join(lines)
+    destination = f"src/{shape}/{module_name}_{index}.py"
+    return destination, content + "\n"
+
+
+# --------------------------------------------------------------------------
+# budget filling
+# --------------------------------------------------------------------------
+
+
+def generate_manifest(config: GenerationConfig, size: int) -> dict:
+    """Build the per-(scenario, size) manifest dict (design §5.5 + mode field).
+
+    Returned manifest includes a ``generated_contents`` map (destination →
+    content) for ``mutate``/``template`` files; ``ManifestWriter`` persists it.
+    """
+    core = _read_tree(config.core_root)
+    core_tokens = sum(config.token_estimator(text) for text in core.values())
+    core_loc = sum(text.count("\n") + 1 for text in core.values())
+    target_tokens = (size - 1) * core_tokens
+    tolerance = config.tolerance_pct / 100.0
+    lower = target_tokens * (1 - tolerance)
+    upper = target_tokens * (1 + tolerance)
+
+    vocabulary = harvest_vocabulary(config.core_root)
+    checker = DefinitionChecker.from_core(
+        core_files=core.keys(),
+        core_sources=core,
+        target_files=[config.target_file],
+        leak_denylist=config.leak_denylist,
+        vocabulary_floor=config.vocabulary_floor,
+        core_vocabulary=vocabulary,
+    )
+
+    pool = _read_tree(config.pool_root) if config.pool_root else {}
+    admitted: list[_Admitted] = []
+    taken: set[str] = set(core.keys())
+    total = 0
+    rejected: list[dict] = []
+
+    def try_admit(candidate: CandidateFile, group: str) -> bool:
+        nonlocal total
+        if candidate.destination_path in taken:
+            return False
+        tokens = config.token_estimator(candidate.content)
+        if total + tokens > upper:
+            return False
+        violations = checker.check(candidate)
+        if violations:
+            rejected.append(
+                {
+                    "destination_path": candidate.destination_path,
+                    "mode": candidate.mode,
+                    "violations": [str(v) for v in violations],
+                }
+            )
+            return False
+        admitted.append(
+            _Admitted(
+                destination=candidate.destination_path,
+                content=candidate.content,
+                mode=candidate.mode,
+                tier=candidate.tier,
+                import_group=group,
+                source_path=candidate.source_path,
+                tokens=tokens,
+            )
+        )
+        taken.add(candidate.destination_path)
+        total += tokens
+        return True
+
+    # 1. regrow — dependency-closed groups.
+    if size > 1:
+        for path, group_paths in _regrow_candidates(config, pool):
+            if total >= lower:
+                break
+            if path in taken:
+                continue
+            group_id = "g" + stable_hash(config.selection_seed, *group_paths)[:8]
+            for member in group_paths:
+                if member in taken:
+                    continue
+                try_admit(
+                    CandidateFile(
+                        destination_path=member,
+                        content=pool[member],
+                        mode="regrow",
+                        source_path=member,
+                        tier=tier_for(member, config.target_file),
+                    ),
+                    group=group_id,
+                )
+
+        # 2. mutate — cycle the pool with increasing mutation indices.
+        mutation_round = 0
+        pool_order = [p for p, _ in _regrow_candidates(config, pool)]
+        while total < lower and pool_order and mutation_round < config.max_mutants_per_source:
+            for source_path in pool_order:
+                if total >= lower:
+                    break
+                destination, content = _mutate_source(
+                    pool[source_path],
+                    source_path,
+                    vocabulary,
+                    seed_material=f"{config.selection_seed}.{mutation_round}",
+                )
+                try_admit(
+                    CandidateFile(
+                        destination_path=destination,
+                        content=content,
+                        mode="mutate",
+                        source_path=source_path,
+                        tier=tier_for(destination, config.target_file),
+                    ),
+                    group="g-mutate",
+                )
+            mutation_round += 1
+
+        # 3. template — terminal filler; size-tuned so the budget converges.
+        template_index = 0
+        while total < lower and template_index < 100_000:
+            remaining = int(lower - total)
+            destination, content = _template_module(
+                vocabulary,
+                seed_material=str(config.selection_seed),
+                index=template_index,
+                target_tokens=min(config.template_file_tokens, max(remaining, 50)),
+            )
+            try_admit(
+                CandidateFile(
+                    destination_path=destination,
+                    content=content,
+                    mode="template",
+                    tier=tier_for(destination, config.target_file),
+                ),
+                group="g-template",
+            )
+            template_index += 1
+
+    files = [
+        {
+            "upstream_path": item.destination,
+            "tokens": item.tokens,
+            "loc": item.content.count("\n") + 1,
+            "sha256": hashlib.sha256(item.content.encode()).hexdigest(),
+            "tier": item.tier,
+            "mode": item.mode,
+            "import_group": item.import_group,
+            "source_path": item.source_path,
+        }
+        for item in admitted
+    ]
+    manifest = {
+        "schema_version": 3,
+        "scenario_id": config.scenario_id,
+        "size": f"{size}x",
+        "selection_seed": config.selection_seed,
+        "tokenizer": "chars/4-v1",
+        "core_tokens": core_tokens,
+        "core_loc": core_loc,
+        "size_token_target": target_tokens,
+        "size_token_tolerance_pct": config.tolerance_pct,
+        "distractor_tokens_on_disk": total,
+        "distractor_loc": sum(f["loc"] for f in files),
+        "realized_total_tokens": core_tokens + total,
+        "budget_met": total >= lower or size == 1,
+        "mode_counts": {
+            mode: sum(1 for f in files if f["mode"] == mode)
+            for mode in ("regrow", "mutate", "template")
+        },
+        "files": files,
+        "rejected": rejected,
+    }
+    generated = {
+        item.destination: item.content for item in admitted if item.mode != "regrow"
+    }
+    manifest["generated_contents"] = generated
+    return manifest
+
+
+def generate_ladder(
+    config: GenerationConfig, sizes: tuple[int, ...] = SIZE_LADDER
+) -> dict[int, dict]:
+    """Generate manifests for every ladder step (including the 1x control)."""
+    return {size: generate_manifest(config, size) for size in sizes}

--- a/research/repo-bloat-benchmark/harness/distractors/manifest.py
+++ b/research/repo-bloat-benchmark/harness/distractors/manifest.py
@@ -1,0 +1,81 @@
+"""Manifest persistence + freeze enforcement (design.md §5.5).
+
+The manifest is the *secret label key*: it lives out-of-tree (harness side),
+is committed before any model run, and is consulted only by post-hoc
+analysis. ``manifests.lock`` aggregates the sha256 of every committed
+manifest; the runner refuses to execute a (scenario, size) whose manifest
+hash is not in the lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+
+class ManifestWriter:
+    """Persist a generated manifest + the contents of generated files."""
+
+    def __init__(self, out_dir: str | Path) -> None:
+        self.out_dir = Path(out_dir)
+        self.manifest_dir = self.out_dir / "manifests"
+        self.generated_dir = self.out_dir / "generated"
+
+    def write(self, manifest: dict) -> Path:
+        """Write ``<scenario>.<size>.json`` and generated file contents.
+
+        The ``generated_contents`` map is split out of the manifest document:
+        contents go under ``generated/<scenario>/<size>/<dest>`` and the
+        manifest gains per-file ``content_path`` pointers instead.
+        """
+        scenario = manifest["scenario_id"]
+        size = manifest["size"]
+        generated: dict[str, str] = manifest.pop("generated_contents", {})
+        content_root = self.generated_dir / scenario / size
+        for entry in manifest["files"]:
+            destination = entry["upstream_path"]
+            if entry["mode"] == "regrow":
+                entry["content_path"] = None
+                continue
+            content = generated[destination]
+            content_path = content_root / destination
+            content_path.parent.mkdir(parents=True, exist_ok=True)
+            content_path.write_text(content, encoding="utf-8")
+            entry["content_path"] = str(
+                content_path.relative_to(self.out_dir).as_posix()
+            )
+
+        self.manifest_dir.mkdir(parents=True, exist_ok=True)
+        path = self.manifest_dir / f"{scenario}.{size}.json"
+        path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return path
+
+
+def manifest_sha256(path: str | Path) -> str:
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def load_manifest(path: str | Path) -> dict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def write_lockfile(manifest_paths: list[str | Path], lock_path: str | Path) -> None:
+    """Freeze the committed manifests (design §3.3, §5.5)."""
+    entries = {
+        Path(p).name: manifest_sha256(p) for p in sorted(manifest_paths, key=str)
+    }
+    Path(lock_path).write_text(
+        json.dumps({"schema_version": 1, "manifests": entries}, indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def verify_lockfile(manifest_path: str | Path, lock_path: str | Path) -> bool:
+    """True iff the manifest's current bytes match its locked hash."""
+    lock = json.loads(Path(lock_path).read_text(encoding="utf-8"))
+    expected = lock.get("manifests", {}).get(Path(manifest_path).name)
+    return expected is not None and expected == manifest_sha256(manifest_path)

--- a/research/repo-bloat-benchmark/harness/distractors/tests/conftest.py
+++ b/research/repo-bloat-benchmark/harness/distractors/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Make `harness.*` importable when pytest runs from any directory."""
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parents[3]
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))

--- a/research/repo-bloat-benchmark/harness/distractors/tests/test_definition.py
+++ b/research/repo-bloat-benchmark/harness/distractors/tests/test_definition.py
@@ -1,0 +1,150 @@
+"""Tests for the five machine-checked definition conditions."""
+
+import pytest
+
+from harness.distractors.definition import (
+    CandidateFile,
+    DefinitionChecker,
+    imported_modules,
+    module_names_for,
+)
+from harness.distractors.vocabulary import Vocabulary
+
+CORE_SOURCE = '''\
+from pkg.storage import load_records
+
+def paginate_ledger_records(records, page_size):
+    """Paginate ledger records for the export pipeline."""
+    return [records[i:i + page_size] for i in range(0, len(records), page_size)]
+'''
+
+
+@pytest.fixture()
+def checker():
+    vocabulary = Vocabulary(
+        words={"paginate": 3, "ledger": 5, "records": 4, "export": 2, "pipeline": 2}
+    )
+    return DefinitionChecker.from_core(
+        core_files=["src/pkg/pagination.py", "src/pkg/storage.py"],
+        core_sources={"src/pkg/pagination.py": CORE_SOURCE},
+        target_files=["src/pkg/pagination.py"],
+        leak_denylist=["assert slice_page([1, 2, 3], 1, 2) == [3]"],
+        vocabulary_floor=0.2,
+        core_vocabulary=vocabulary,
+    )
+
+
+def _ok_candidate(**overrides):
+    defaults = dict(
+        destination_path="src/pkg/ledger_export_helpers.py",
+        content=(
+            'def format_ledger_records_for_export(records):\n'
+            '    """Format ledger records for the export pipeline."""\n'
+            "    return [str(r) for r in records]\n"
+        ),
+        mode="template",
+        tier="same-package",
+    )
+    defaults.update(overrides)
+    return CandidateFile(**defaults)
+
+
+def test_valid_candidate_passes(checker):
+    assert checker.check(_ok_candidate()) == []
+
+
+def test_condition1_core_file_rejected(checker):
+    violations = checker.check(
+        _ok_candidate(destination_path="src/pkg/storage.py")
+    )
+    assert any(v.condition == 1 for v in violations)
+
+
+def test_condition1_core_import_target_rejected(checker):
+    # Core imports pkg.storage → a file importable under that name is load-bearing.
+    violations = checker.check(
+        _ok_candidate(destination_path="other/pkg/storage.py")
+    )
+    assert any(v.condition in (1, 2) for v in violations)
+
+
+def test_condition2_conftest_rejected(checker):
+    violations = checker.check(_ok_candidate(destination_path="src/pkg/conftest.py"))
+    assert any(v.condition == 2 for v in violations)
+
+
+def test_condition2_dynamic_import_rejected(checker):
+    violations = checker.check(
+        _ok_candidate(
+            content="import importlib\nmod = importlib.import_module('pkg.storage')\n"
+        )
+    )
+    assert any(v.condition == 2 for v in violations)
+
+
+def test_condition3_unparseable_rejected(checker):
+    violations = checker.check(_ok_candidate(content="def broken(:\n  pass\n"))
+    assert any(v.condition == 3 for v in violations)
+
+
+def test_condition3_vocabulary_floor_for_generated(checker):
+    violations = checker.check(
+        _ok_candidate(
+            content=(
+                "def zzqx_wobble_frobnicate(xyzzy):\n"
+                '    """Completely alien vocabulary."""\n'
+                "    return xyzzy\n"
+            )
+        )
+    )
+    assert any(v.condition == 3 for v in violations)
+
+
+def test_condition3_vocabulary_floor_skipped_for_regrow(checker):
+    violations = checker.check(
+        _ok_candidate(
+            mode="regrow",
+            source_path="pool/alien.py",
+            content=(
+                "def zzqx_wobble_frobnicate(xyzzy):\n"
+                '    """Alien but verbatim project code."""\n'
+                "    return xyzzy\n"
+            ),
+        )
+    )
+    assert violations == []
+
+
+def test_condition4_leakage_rejected(checker):
+    violations = checker.check(
+        _ok_candidate(
+            content=(
+                "def helper():\n"
+                "    assert slice_page([1, 2, 3], 1, 2) == [3]\n"
+            )
+        )
+    )
+    assert any(v.condition == 4 for v in violations)
+
+
+def test_condition5_path_tell_rejected(checker):
+    violations = checker.check(
+        _ok_candidate(destination_path="src/pkg/distractor_ledger.py")
+    )
+    assert any(v.condition == 5 for v in violations)
+
+
+def test_condition5_content_tell_rejected_for_generated(checker):
+    violations = checker.check(
+        _ok_candidate(content="# synthetic module\ndef ledger_export_records():\n    pass\n")
+    )
+    assert any(v.condition == 5 for v in violations)
+
+
+def test_module_names_and_imports():
+    assert "pkg.storage" in module_names_for("src/pkg/storage.py")
+    assert "storage" in module_names_for("src/pkg/storage.py")
+    names = imported_modules("from pkg.storage import load\nimport os.path\n")
+    assert "pkg.storage" in names
+    assert "pkg" in names
+    assert "os.path" in names and "os" in names

--- a/research/repo-bloat-benchmark/harness/distractors/tests/test_generator.py
+++ b/research/repo-bloat-benchmark/harness/distractors/tests/test_generator.py
@@ -1,0 +1,205 @@
+"""Tests for deterministic generation, the mode cascade, and the size ladder."""
+
+import ast
+import json
+
+import pytest
+
+from harness.distractors.generator import (
+    GenerationConfig,
+    generate_ladder,
+    generate_manifest,
+    tier_for,
+)
+from harness.distractors.manifest import (
+    ManifestWriter,
+    load_manifest,
+    verify_lockfile,
+    write_lockfile,
+)
+
+CORE_MODULE = '''\
+"""Pagination core for the ledger export service."""
+
+
+def slice_page(items, page, page_size):
+    """Return one page of ledger items."""
+    start = page * page_size
+    return items[start:start + page_size]
+
+
+def count_pages(items, page_size):
+    """Number of pages needed to export all ledger items."""
+    return (len(items) + page_size - 1) // page_size
+'''
+
+CORE_TEST = '''\
+from pagination import count_pages, slice_page
+
+
+def test_slice_page_returns_requested_window():
+    assert slice_page([1, 2, 3, 4], 1, 2) == [3, 4]
+
+
+def test_count_pages_rounds_up_for_partial_pages():
+    assert count_pages([1, 2, 3], 2) == 2
+'''
+
+
+def _pool_module(index: int) -> str:
+    return (
+        f'"""Ledger reporting helpers, batch {index}."""\n\n\n'
+        f"def summarize_ledger_batch_{index}(entries, export_config):\n"
+        f'    """Summarize one ledger export batch for reporting."""\n'
+        f"    total_export_amount = sum(entry.amount for entry in entries)\n"
+        f"    return {{'batch': {index}, 'total': total_export_amount}}\n"
+    )
+
+
+@pytest.fixture()
+def scenario(tmp_path):
+    core = tmp_path / "core"
+    (core / "src" / "pkg").mkdir(parents=True)
+    (core / "src" / "pkg" / "pagination.py").write_text(CORE_MODULE)
+    (core / "src" / "pkg" / "test_pagination.py").write_text(CORE_TEST)
+    pool = tmp_path / "pool"
+    (pool / "src" / "pkg").mkdir(parents=True)
+    (pool / "src" / "reporting").mkdir(parents=True)
+    for i in range(3):
+        (pool / "src" / "pkg" / f"ledger_helpers_{i}.py").write_text(_pool_module(i))
+        (pool / "src" / "reporting" / f"report_builder_{i}.py").write_text(
+            _pool_module(i + 100)
+        )
+    return tmp_path
+
+
+def _config(scenario, **overrides):
+    defaults = dict(
+        scenario_id="pagination-demo",
+        core_root=scenario / "core",
+        pool_root=scenario / "pool",
+        target_file="src/pkg/pagination.py",
+        selection_seed=1209,
+        template_file_tokens=120,
+    )
+    defaults.update(overrides)
+    return GenerationConfig(**defaults)
+
+
+def test_deterministic_same_seed_same_manifest(scenario):
+    first = generate_manifest(_config(scenario), 5)
+    second = generate_manifest(_config(scenario), 5)
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def test_different_seed_changes_selection_order(scenario):
+    first = generate_manifest(_config(scenario), 5)
+    second = generate_manifest(_config(scenario, selection_seed=99), 5)
+    assert json.dumps(first, sort_keys=True) != json.dumps(second, sort_keys=True)
+
+
+def test_budget_met_within_tolerance(scenario):
+    manifest = generate_manifest(_config(scenario), 5)
+    assert manifest["budget_met"]
+    target = manifest["size_token_target"]
+    realized = manifest["distractor_tokens_on_disk"]
+    assert realized >= target * 0.98
+    assert realized <= target * 1.02
+
+
+def test_1x_control_has_no_distractors(scenario):
+    manifest = generate_manifest(_config(scenario), 1)
+    assert manifest["files"] == []
+    assert manifest["distractor_tokens_on_disk"] == 0
+    assert manifest["budget_met"]
+
+
+def test_mode_cascade_regrow_first_then_generated(scenario):
+    # Small budget: regrow alone should cover it.
+    small = generate_manifest(_config(scenario), 2)
+    assert small["mode_counts"]["regrow"] > 0
+    # Huge budget: the tiny pool must cascade into mutate and template.
+    large = generate_manifest(_config(scenario), 50)
+    assert large["budget_met"]
+    assert large["mode_counts"]["regrow"] > 0
+    assert large["mode_counts"]["mutate"] > 0
+    assert large["mode_counts"]["template"] > 0
+
+
+def test_50x_scales_to_budget(scenario):
+    manifest = generate_manifest(_config(scenario), 50)
+    assert manifest["distractor_tokens_on_disk"] >= 49 * manifest["core_tokens"] * 0.98
+
+
+def test_generated_files_parse_and_carry_no_tell(scenario):
+    manifest = generate_manifest(_config(scenario), 50)
+    for destination, content in manifest["generated_contents"].items():
+        ast.parse(content)  # plausibility: everything materialized must parse
+        assert "distractor" not in destination.lower()
+        assert "distractor" not in content.lower()
+
+
+def test_tiers_assigned_from_layout(scenario):
+    manifest = generate_manifest(_config(scenario), 2)
+    tiers = {f["upstream_path"]: f["tier"] for f in manifest["files"]}
+    for path, tier in tiers.items():
+        assert tier == tier_for(path, "src/pkg/pagination.py")
+    assert tier_for("src/pkg/other.py", "src/pkg/pagination.py") == "same-package"
+    assert tier_for("src/reporting/r.py", "src/pkg/pagination.py") == "same-layer"
+    assert tier_for("docs/guide.py", "src/pkg/pagination.py") == "cross-cutting"
+
+
+def test_no_destination_collides_with_core(scenario):
+    manifest = generate_manifest(_config(scenario), 50)
+    core_paths = {"src/pkg/pagination.py", "src/pkg/test_pagination.py"}
+    destinations = {f["upstream_path"] for f in manifest["files"]}
+    assert not destinations & core_paths
+    assert len(destinations) == len(manifest["files"])  # unique paths
+
+
+def test_ladder_generation(scenario):
+    ladder = generate_ladder(_config(scenario), sizes=(1, 2, 5))
+    assert set(ladder) == {1, 2, 5}
+    assert ladder[1]["files"] == []
+    assert ladder[5]["distractor_tokens_on_disk"] > ladder[2]["distractor_tokens_on_disk"]
+
+
+def test_manifest_writer_and_lockfile(scenario, tmp_path):
+    manifest = generate_manifest(_config(scenario), 5)
+    writer = ManifestWriter(tmp_path / "out")
+    path = writer.write(manifest)
+
+    loaded = load_manifest(path)
+    assert loaded["scenario_id"] == "pagination-demo"
+    assert "generated_contents" not in loaded  # split out to content files
+    for entry in loaded["files"]:
+        if entry["mode"] != "regrow":
+            content_file = tmp_path / "out" / entry["content_path"]
+            assert content_file.is_file()
+
+    lock = tmp_path / "out" / "manifests.lock"
+    write_lockfile([path], lock)
+    assert verify_lockfile(path, lock)
+    # Tampering breaks the freeze.
+    path.write_text(path.read_text().replace("pagination-demo", "tampered"))
+    assert not verify_lockfile(path, lock)
+
+
+def test_leak_denylist_blocks_content(scenario):
+    # Poison every pool file with the hidden assertion; regrow must reject all.
+    for pool_file in (scenario / "pool").rglob("*.py"):
+        pool_file.write_text(
+            pool_file.read_text()
+            + "\n# expected: slice_page([1,2,3,4,5], 2, 2) == [5]\n"
+        )
+    config = _config(
+        scenario, leak_denylist=("slice_page([1,2,3,4,5], 2, 2) == [5]",)
+    )
+    manifest = generate_manifest(config, 2)
+    assert manifest["mode_counts"]["regrow"] == 0
+    assert all(f["mode"] != "regrow" for f in manifest["files"])
+    assert any(
+        "condition 4" in violation
+        for rejection in manifest["rejected"]
+        for violation in rejection["violations"]
+    )

--- a/research/repo-bloat-benchmark/harness/distractors/tests/test_vocabulary.py
+++ b/research/repo-bloat-benchmark/harness/distractors/tests/test_vocabulary.py
@@ -1,0 +1,40 @@
+"""Tests for vocabulary harvesting."""
+
+from harness.distractors.vocabulary import (
+    harvest_vocabulary,
+    split_identifier,
+)
+
+
+def test_split_identifier_snake_and_camel():
+    assert split_identifier("format_ledger_totals") == ["format", "ledger", "totals"]
+    assert split_identifier("FormatLedgerTotals") == ["format", "ledger", "totals"]
+    assert split_identifier("x") == []  # too short
+
+
+def test_harvest_vocabulary(tmp_path):
+    (tmp_path / "mod.py").write_text(
+        "def paginate_ledger_records(ledger_records):\n"
+        "    exported_ledger_total = sum(ledger_records)\n"
+        "    return exported_ledger_total\n"
+    )
+    vocabulary = harvest_vocabulary(tmp_path)
+    assert vocabulary.words["ledger"] >= 3
+    assert "paginate" in vocabulary.words
+    top = vocabulary.top_words(3)
+    assert top[0] == "ledger"
+
+
+def test_overlap_fraction(tmp_path):
+    (tmp_path / "mod.py").write_text("def paginate_ledger(): pass\n")
+    vocabulary = harvest_vocabulary(tmp_path)
+    high = vocabulary.overlap_fraction(["ledger_paginate_helper"])
+    low = vocabulary.overlap_fraction(["frobnicate_wobble"])
+    assert high > 0.5
+    assert low == 0.0
+
+
+def test_unparseable_file_skipped(tmp_path):
+    (tmp_path / "broken.py").write_text("def broken(:\n")
+    vocabulary = harvest_vocabulary(tmp_path)
+    assert vocabulary.words == {}

--- a/research/repo-bloat-benchmark/harness/distractors/vocabulary.py
+++ b/research/repo-bloat-benchmark/harness/distractors/vocabulary.py
@@ -1,0 +1,113 @@
+"""Vocabulary harvesting from the scenario core (design.md §5.0.1).
+
+`mutate` and `template` modes must produce files in the project's own
+vocabulary (definition condition 3). This module extracts that vocabulary
+deterministically from the core's Python sources: identifiers, their word
+pieces, and frequency ranks.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+_CAMEL = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_NON_WORD = re.compile(r"[^A-Za-z]+")
+
+# Words too generic to characterize a project's vocabulary.
+_STOPWORDS = frozenset(
+    "the a an and or of in to for is not none true false self cls def return "
+    "get set is has add new init main test data value item items key keys "
+    "args kwargs obj result results".split()
+)
+
+
+def split_identifier(identifier: str) -> list[str]:
+    """``formatLedgerTotals`` / ``format_ledger_totals`` → [format, ledger, totals]."""
+    words: list[str] = []
+    for chunk in _NON_WORD.split(identifier):
+        for piece in _CAMEL.sub(" ", chunk).split():
+            piece = piece.lower()
+            if len(piece) >= 3 and piece not in _STOPWORDS:
+                words.append(piece)
+    return words
+
+
+@dataclass
+class Vocabulary:
+    """Deterministic core vocabulary: identifiers and their word pieces."""
+
+    identifiers: dict[str, int] = field(default_factory=dict)
+    words: dict[str, int] = field(default_factory=dict)
+
+    def top_words(self, n: int) -> list[str]:
+        return [
+            w
+            for w, _ in sorted(self.words.items(), key=lambda kv: (-kv[1], kv[0]))[:n]
+        ]
+
+    def overlap_fraction(self, candidate_identifiers: Iterable[str]) -> float:
+        """Fraction of the candidate's word pieces that appear in this vocabulary."""
+        pieces: list[str] = []
+        for identifier in candidate_identifiers:
+            pieces.extend(split_identifier(identifier))
+        if not pieces:
+            return 0.0
+        hits = sum(1 for piece in pieces if piece in self.words)
+        return hits / len(pieces)
+
+
+class _IdentifierCollector(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.identifiers: list[str] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        self.identifiers.append(node.name)
+        self.generic_visit(node)
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        self.identifiers.append(node.name)
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name) -> None:  # noqa: N802
+        self.identifiers.append(node.id)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:  # noqa: N802
+        self.identifiers.append(node.attr)
+        self.generic_visit(node)
+
+    def visit_arg(self, node: ast.arg) -> None:  # noqa: N802
+        self.identifiers.append(node.arg)
+
+
+def collect_identifiers(source: str) -> list[str]:
+    """All identifiers in a Python source (empty list if unparseable)."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    collector = _IdentifierCollector()
+    collector.visit(tree)
+    return collector.identifiers
+
+
+def harvest_vocabulary(core_root: str | Path) -> Vocabulary:
+    """Harvest the deterministic vocabulary of a core tree (Python files)."""
+    vocabulary = Vocabulary()
+    for path in sorted(Path(core_root).rglob("*.py")):
+        try:
+            source = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for identifier in collect_identifiers(source):
+            vocabulary.identifiers[identifier] = (
+                vocabulary.identifiers.get(identifier, 0) + 1
+            )
+            for word in split_identifier(identifier):
+                vocabulary.words[word] = vocabulary.words.get(word, 0) + 1
+    return vocabulary


### PR DESCRIPTION
**Sub-PR 3 of 5** for epic #1851 (base = `epic/1209-repo-bloat-v2`; merge order 1 → 2 → 3 → 4 → 5). Independent of PR 2; PR 4 stacks on both. (`harness/__init__.py` is byte-identical to PR 2's copy, so the branches merge cleanly.)

## What changed

New package `research/repo-bloat-benchmark/harness/distractors/`, stdlib-only:

- **`DEFINITION.md` + `definition.py`** — the feedback's *"define what a distractor file means"* as a **checkable contract**: five conditions (structural irrelevance, behavior neutrality, plausibility, no leakage, no tell), each mapped to a machine check in one `DefinitionChecker` used for **every** admitted file. Rejections are recorded in the manifest (auditable freeze).
- **`generator.py`** — the feedback's *"generate many distractors from the definition/template and scale aggressively"*: deterministic token-budget filling with a fixed source cascade — `regrow` (verbatim out-of-core files, dependency-closed import groups, tier from layout) → `mutate` (seeded identifier/docstring derivations at non-colliding sibling paths) → `template` (size-tunable synthetic modules built from vocabulary harvested from the core). Because `template` is size-tunable, **any budget converges** — 50x from a tiny pool, and the H3 breakdown-probe steps past 50x.
- **`manifest.py`** — design §5.5 manifests (+ per-file `mode`), generated-content persistence, and `manifests.lock` freeze enforcement (tamper ⇒ verification fails ⇒ runner refuses to run).
- **`vocabulary.py`** — deterministic identifier/word harvest from the core; powers the plausibility floor and mutate/template naming.
- **`cli.py`** — one command generates a whole ladder + lockfile.

## Why it matters to the research

The v1 design capped realistic bloat at the real pool's size; this PR removes that cap **without weakening the contract** — synthetic realism becomes a *measured axis* (per-file `mode` in the manifest → per-mode read/penetration breakdowns in the report) instead of an unexamined assumption. The definition also keeps "only one thing varies" true at 50x: behavior neutrality and no-leakage are machine-enforced, not reviewed by eye.

## How to run

```bash
cd research/repo-bloat-benchmark
python3 -m pytest harness/distractors/tests/ -q   # 28 passed
python3 -m harness.distractors.cli --scenario-id demo --core <core> --pool <pool> \
  --target-file src/pkg/target.py --sizes 1 2 5 10 20 50 --seed 1209 --out distractors/
```

Tests pin: same-seed determinism (byte-identical manifests), ±2 % budget convergence at 50x from a 6-file pool, mode cascade ordering, all five contract conditions (dedicated rejection test each), tier assignment, 1x-control emptiness, unique/non-colliding destinations, lockfile tamper detection, and a poisoned-pool leak-denylist scenario.

## Still incomplete

- `mutate` renames top-level def/class identifiers only (module-internal consistency guaranteed; deeper AST-level mutation is a possible refinement).
- The on-disk token dose uses the pinned `chars/4-v1` estimator; swapping in a real tokenizer is a one-line `token_estimator` hook and re-registration of manifests.
- Real PDD pool extraction (`snapshot ∖ core`) lands with the scenario authoring (follow-up to PR 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)