### PR TITLE
Research #1209 v2 (4/5): experiment runner, metrics collection, report generator + example scenario

### DIFF
--- a/research/repo-bloat-benchmark/harness/__init__.py
+++ b/research/repo-bloat-benchmark/harness/__init__.py
@@ -1,0 +1,1 @@
+"""Experiment harness for the repo-bloat localization benchmark (issue #1209)."""

--- a/research/repo-bloat-benchmark/harness/context_snapshots/README.md
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/README.md
@@ -1,0 +1,69 @@
+# Context-snapshot instrumentation
+
+Implements design.md **§6.2 tap 1** — the v2 primary instrument. Captures the
+byte-exact composed context of every model request an agent CLI makes, then
+turns the per-request series into the pre-registered metric families:
+context-window **penetration** and the **iteration trajectory** (H2).
+
+## Pieces
+
+| Module | Role |
+|--------|------|
+| `proxy.py` | `RecordingProxy` — local HTTP relay; archives request/response bodies + provider `usage` per request; detects edit tool calls (first-edit boundary) |
+| `schema.py` | `SnapshotRecord` (one per request) + JSONL read/write |
+| `attribution.py` | `TreeIndex` — normalized-line index of the materialized variant; attributes surfaced content to core / distractor / ambiguous / unknown; `reconcile_with_usage` caps estimates at provider counts |
+| `iteration_analyzer.py` | `analyze_run` — per-iteration token/composition series, early/middle/late phases, `growth_shape` (gradual/step/plateau/sawtooth), first-edit boundary |
+| `session_parser.py` | tolerant parser for the CLI's own session/rollout JSONL + `reconcile` cross-check against the proxy record |
+
+## Usage sketch
+
+```python
+from harness.context_snapshots import (
+    RecordingProxy, TreeIndex, analyze_run, parse_session_log, reconcile,
+)
+
+proxy = RecordingProxy(
+    upstream_base_url="https://api.openai.com",
+    archive_dir="reports/run-001",
+    run_id="run-001",
+)
+base_url = proxy.start()
+
+# Route the stock CLI through the proxy (no fork):
+#   OPENAI_BASE_URL={base_url}/v1   (or the CLI's base-url config key)
+# ... run the agent to completion ...
+
+proxy.stop()
+
+index = TreeIndex(variant_root, distractor_paths=manifest_paths)
+attributions = [
+    index.classify_request_payload((proxy.archive_dir / r.payload_path).read_bytes())
+    for r in proxy.records
+]
+trajectory = analyze_run(proxy.records, attributions)
+trajectory.growth_shape                    # H2: gradual / step / plateau / sawtooth
+trajectory.share_delta_late_minus_early    # H2 threshold input (§7.5)
+```
+
+## Honesty notes (mirrored in design.md)
+
+- **Provider `usage` is the only authoritative token count.** Attribution
+  splits it; `reconcile_with_usage` guarantees attributed tokens never exceed
+  measured tokens. Attribution itself is a *lower bound* (paraphrased or
+  truncated content does not match the line index).
+- **SSE responses are buffered, not streamed through.** Capture fidelity and
+  response content are preserved; streaming latency lands in
+  `wall_clock_seconds` (secondary metric). Pass-through streaming is a TODO.
+- **The proxy only sees what is routed through it.** The run-environment
+  freeze (design §8.1.1) must lock network egress to the proxy for the record
+  to be complete by construction; `session_parser.reconcile` flags traffic
+  that bypassed it.
+
+## Tests
+
+```bash
+cd research/repo-bloat-benchmark
+python3 -m pytest harness/context_snapshots/tests/ -q
+```
+
+No external dependencies (stdlib + pytest only).

--- a/research/repo-bloat-benchmark/harness/context_snapshots/__init__.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/__init__.py
@@ -1,0 +1,28 @@
+"""Context-snapshot instrumentation (design.md §6.2, tap 1).
+
+The primary instrument of the v2 design: an API-boundary recording proxy that
+captures the byte-exact composed context of every model request, plus the
+analysis pieces that turn the per-request snapshot series into the metric
+families the design pre-registers (penetration, iteration trajectory / H2).
+"""
+
+from .attribution import Attribution, TreeIndex
+from .iteration_analyzer import IterationPoint, RunTrajectory, analyze_run
+from .proxy import RecordingProxy
+from .schema import SnapshotRecord, read_snapshots, write_snapshots
+from .session_parser import SessionSummary, parse_session_log, reconcile
+
+__all__ = [
+    "Attribution",
+    "TreeIndex",
+    "IterationPoint",
+    "RunTrajectory",
+    "analyze_run",
+    "RecordingProxy",
+    "SnapshotRecord",
+    "read_snapshots",
+    "write_snapshots",
+    "SessionSummary",
+    "parse_session_log",
+    "reconcile",
+]

--- a/research/repo-bloat-benchmark/harness/context_snapshots/attribution.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/attribution.py
@@ -1,0 +1,181 @@
+"""Content attribution: which parts of a context snapshot are distractor bulk?
+
+Implements the analysis half of design.md §6.2 tap 1: match the content that
+was surfaced into model requests against the materialized tree + manifest, and
+attribute spans to ``core`` / ``distractor`` / ``unknown``.
+
+Method: a normalized-line index. Every sufficiently long line of every
+materialized file is normalized (whitespace-collapsed) and indexed with its
+origin class. Request text is then scanned line-by-line against the index.
+
+Honesty notes (mirrored in the design):
+
+- Attribution is a **lower bound**: paraphrased or heavily truncated content
+  does not match. The provider ``usage`` numbers remain the authoritative
+  token totals; attribution only splits them.
+- Token counts here are **estimates** under a pluggable tokenizer (default:
+  chars/4). The reconciliation step caps attributed tokens at the provider
+  count so attribution can never exceed measurement.
+- Lines shorter than ``min_line_len`` (import boilerplate, ``return None``)
+  are ignored to avoid false-positive matches; a line appearing in both a
+  core and a distractor file counts as ``ambiguous`` and is excluded from the
+  distractor total (conservative direction).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def default_token_estimator(text: str) -> float:
+    """Crude but deterministic token estimate (~4 chars/token)."""
+    return len(text) / 4.0
+
+
+def normalize_line(line: str) -> str:
+    return _WHITESPACE.sub(" ", line.strip())
+
+
+@dataclass
+class Attribution:
+    """Per-text attribution result (token estimates, not provider counts)."""
+
+    core_tokens: float = 0.0
+    distractor_tokens: float = 0.0
+    ambiguous_tokens: float = 0.0
+    unknown_tokens: float = 0.0
+    core_lines: int = 0
+    distractor_lines: int = 0
+    ambiguous_lines: int = 0
+    unknown_lines: int = 0
+    distractor_files: set[str] = field(default_factory=set)
+    core_files: set[str] = field(default_factory=set)
+
+    @property
+    def total_tokens(self) -> float:
+        return (
+            self.core_tokens
+            + self.distractor_tokens
+            + self.ambiguous_tokens
+            + self.unknown_tokens
+        )
+
+    @property
+    def distractor_share(self) -> float:
+        total = self.total_tokens
+        return self.distractor_tokens / total if total > 0 else 0.0
+
+
+class TreeIndex:
+    """Normalized-line index over a materialized variant tree.
+
+    ``distractor_paths`` is the manifest's secret label key (paths relative to
+    the tree root); every other indexed file is core. The index is built once
+    per (scenario, size) and reused across trials.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        distractor_paths: Iterable[str],
+        min_line_len: int = 24,
+        token_estimator: Callable[[str], float] = default_token_estimator,
+        extensions: tuple[str, ...] = (".py", ".md", ".txt", ".toml", ".cfg", ".json"),
+    ) -> None:
+        self.root = Path(root)
+        self.min_line_len = min_line_len
+        self.token_estimator = token_estimator
+        self._distractors = {p.replace("\\", "/") for p in distractor_paths}
+        # normalized line -> (has_core, has_distractor, first core path, first distractor path)
+        self._index: dict[str, list] = {}
+        for file_path in sorted(self.root.rglob("*")):
+            if not file_path.is_file() or file_path.suffix not in extensions:
+                continue
+            rel = file_path.relative_to(self.root).as_posix()
+            is_distractor = rel in self._distractors
+            try:
+                text = file_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            for line in text.splitlines():
+                norm = normalize_line(line)
+                if len(norm) < self.min_line_len:
+                    continue
+                entry = self._index.setdefault(norm, [False, False, None, None])
+                if is_distractor:
+                    entry[1] = True
+                    if entry[3] is None:
+                        entry[3] = rel
+                else:
+                    entry[0] = True
+                    if entry[2] is None:
+                        entry[2] = rel
+
+    @property
+    def distractor_paths(self) -> set[str]:
+        return set(self._distractors)
+
+    def classify_text(self, text: str) -> Attribution:
+        """Attribute one blob of surfaced text (e.g. one request body)."""
+        result = Attribution()
+        for line in text.splitlines():
+            norm = normalize_line(line)
+            if len(norm) < self.min_line_len:
+                continue
+            tokens = self.token_estimator(norm)
+            entry = self._index.get(norm)
+            if entry is None:
+                result.unknown_tokens += tokens
+                result.unknown_lines += 1
+            elif entry[0] and entry[1]:
+                result.ambiguous_tokens += tokens
+                result.ambiguous_lines += 1
+            elif entry[1]:
+                result.distractor_tokens += tokens
+                result.distractor_lines += 1
+                result.distractor_files.add(entry[3])
+            else:
+                result.core_tokens += tokens
+                result.core_lines += 1
+                result.core_files.add(entry[2])
+        return result
+
+    def classify_request_payload(self, payload_bytes: bytes) -> Attribution:
+        """Attribute a raw archived request body (JSON or free text)."""
+        text = payload_bytes.decode("utf-8", errors="replace")
+        return self.classify_text(text)
+
+
+def reconcile_with_usage(
+    attribution: Attribution, provider_input_tokens: int | None
+) -> dict[str, float]:
+    """Scale attribution so it can never exceed the provider-reported input.
+
+    Returns a dict with ``distractor_context_tokens`` (reconciled),
+    ``distractor_context_share``, and the raw estimate for transparency.
+    If provider usage is unavailable, the raw estimates are used and flagged.
+    """
+    raw = attribution.distractor_tokens
+    total_est = attribution.total_tokens
+    if provider_input_tokens is None or total_est <= 0:
+        return {
+            "distractor_context_tokens": raw,
+            "distractor_context_share": attribution.distractor_share,
+            "raw_estimate_tokens": raw,
+            "reconciled_against_usage": False,
+        }
+    scale = min(1.0, provider_input_tokens / total_est)
+    reconciled = raw * scale
+    return {
+        "distractor_context_tokens": min(reconciled, float(provider_input_tokens)),
+        "distractor_context_share": min(1.0, reconciled / provider_input_tokens)
+        if provider_input_tokens
+        else 0.0,
+        "raw_estimate_tokens": raw,
+        "reconciled_against_usage": True,
+    }

--- a/research/repo-bloat-benchmark/harness/context_snapshots/attribution.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/attribution.py
@@ -24,6 +24,7 @@ Honesty notes (mirrored in the design):
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -69,6 +70,35 @@ class Attribution:
     def distractor_share(self) -> float:
         total = self.total_tokens
         return self.distractor_tokens / total if total > 0 else 0.0
+
+
+def extract_payload_text(payload_bytes: bytes) -> str:
+    """Collect every string value from a JSON request body.
+
+    Message/tool content lives in JSON string values where newlines are
+    escaped; joining the collected strings restores real newlines so the
+    line index can match surfaced file content. Non-JSON bodies are returned
+    decoded as-is.
+    """
+    raw = payload_bytes.decode("utf-8", errors="replace")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+    parts: list[str] = []
+
+    def walk(node: object) -> None:
+        if isinstance(node, str):
+            parts.append(node)
+        elif isinstance(node, dict):
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(data)
+    return "\n".join(parts)
 
 
 class TreeIndex:
@@ -146,9 +176,31 @@ class TreeIndex:
         return result
 
     def classify_request_payload(self, payload_bytes: bytes) -> Attribution:
-        """Attribute a raw archived request body (JSON or free text)."""
-        text = payload_bytes.decode("utf-8", errors="replace")
-        return self.classify_text(text)
+        """Attribute an archived request body (JSON payloads are unwrapped).
+
+        A raw JSON request escapes newlines inside message strings, which
+        would defeat line matching — so string values are extracted first
+        (``extract_payload_text``) and classified with real newlines.
+        """
+        return self.classify_text(extract_payload_text(payload_bytes))
+
+    def matched_distractor_lines(self, text: str) -> set[str]:
+        """Normalized distractor-only lines present in ``text``.
+
+        Used for de-duplicated pool coverage
+        (``distractor_unique_tokens_entered_context``, design §6.1): the union
+        of these keys across a run's requests, token-estimated once, cannot
+        grow with repeated resurfacing of the same content.
+        """
+        keys: set[str] = set()
+        for line in text.splitlines():
+            norm = normalize_line(line)
+            if len(norm) < self.min_line_len:
+                continue
+            entry = self._index.get(norm)
+            if entry is not None and entry[1] and not entry[0]:
+                keys.add(norm)
+        return keys
 
 
 def reconcile_with_usage(

--- a/research/repo-bloat-benchmark/harness/context_snapshots/iteration_analyzer.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/iteration_analyzer.py
@@ -1,0 +1,206 @@
+"""Per-iteration analysis of the snapshot series (design.md §6.1, H2).
+
+Turns the ordered ``SnapshotRecord`` sequence (plus optional per-request
+attribution) into the pre-registered *iteration trajectory* family:
+
+- per-request ``input_tokens`` and ``context_growth`` series,
+- per-request ``distractor_context_share`` series,
+- early / middle / late phase medians (thirds by request ordinal),
+- ``growth_shape`` classification: ``gradual`` / ``step`` / ``plateau`` /
+  ``sawtooth`` (thresholds fixed here, mirrored in design §6.1; precedence
+  when curves qualify for more than one class: sawtooth → step → plateau →
+  gradual),
+- ``largest_single_jump_share``,
+- first-edit boundary (`iterations_before_first_edit`).
+
+The shape thresholds are part of the pre-registration: changing them after
+runs is a new experiment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from statistics import median
+from typing import Sequence
+
+from .attribution import Attribution
+from .schema import SnapshotRecord
+
+# Pre-registered classification thresholds (design §6.1).
+STEP_JUMP_SHARE = 0.30  # one request contributing > 30% of final context ⇒ step
+PLATEAU_TAIL_SHARE = 0.05  # < 5% of final context added in the last third ⇒ plateau
+SAWTOOTH_DROP_TOLERANCE = 0.02  # relative shrink > 2% of final context ⇒ sawtooth
+
+
+@dataclass
+class IterationPoint:
+    ordinal: int
+    input_tokens: int | None
+    context_growth: int | None  # None for the first point / missing usage
+    distractor_share: float | None
+    distractor_tokens: float | None
+    edit_tool_call: bool
+
+
+@dataclass
+class PhaseStats:
+    name: str  # early / middle / late
+    ordinals: list[int]
+    median_input_tokens: float | None
+    median_growth: float | None
+    median_distractor_share: float | None
+
+
+@dataclass
+class RunTrajectory:
+    run_id: str
+    iterations_total: int
+    iterations_before_first_edit: int | None  # None ⇒ no edit ever happened
+    first_edit_ordinal: int | None
+    growth_shape: str
+    largest_single_jump_share: float | None
+    points: list[IterationPoint] = field(default_factory=list)
+    phases: list[PhaseStats] = field(default_factory=list)
+
+    @property
+    def distractor_share_early(self) -> float | None:
+        return self._phase_share("early")
+
+    @property
+    def distractor_share_late(self) -> float | None:
+        return self._phase_share("late")
+
+    def _phase_share(self, name: str) -> float | None:
+        for phase in self.phases:
+            if phase.name == name:
+                return phase.median_distractor_share
+        return None
+
+    @property
+    def share_delta_late_minus_early(self) -> float | None:
+        early, late = self.distractor_share_early, self.distractor_share_late
+        if early is None or late is None:
+            return None
+        return late - early
+
+
+def _thirds(n: int) -> list[tuple[str, range]]:
+    """Split ordinals 1..n into early/middle/late thirds (early gets remainder)."""
+    if n <= 0:
+        return []
+    third = max(1, n // 3)
+    early_end = n - 2 * third  # early takes the remainder for small n
+    return [
+        ("early", range(1, early_end + 1)),
+        ("middle", range(early_end + 1, early_end + third + 1)),
+        ("late", range(early_end + third + 1, n + 1)),
+    ]
+
+
+def _median_or_none(values: Sequence[float]) -> float | None:
+    values = [v for v in values if v is not None]
+    return median(values) if values else None
+
+
+def classify_growth_shape(
+    growths: Sequence[int], final_tokens: int | None
+) -> tuple[str, float | None]:
+    """Classify the cumulative-context curve; returns (shape, largest_jump_share)."""
+    growths = [g for g in growths if g is not None]
+    if not growths or not final_tokens or final_tokens <= 0:
+        return "unknown", None
+    largest_jump = max(growths)
+    largest_share = largest_jump / final_tokens
+    total_growth = sum(growths)
+    if any(g < -SAWTOOTH_DROP_TOLERANCE * final_tokens for g in growths):
+        return "sawtooth", largest_share
+    if largest_share > STEP_JUMP_SHARE:
+        return "step", largest_share
+    tail_count = max(1, len(growths) // 3)
+    tail_growth = sum(growths[-tail_count:])
+    if total_growth > 0 and tail_growth < PLATEAU_TAIL_SHARE * final_tokens:
+        return "plateau", largest_share
+    return "gradual", largest_share
+
+
+def analyze_run(
+    records: Sequence[SnapshotRecord],
+    attributions: Sequence[Attribution] | None = None,
+) -> RunTrajectory:
+    """Build the iteration-trajectory family for one run.
+
+    ``records`` must be the full ordered snapshot series of a single run;
+    ``attributions`` (optional) must be parallel to ``records``.
+    """
+    records = sorted(records, key=lambda r: r.ordinal)
+    if attributions is not None and len(attributions) != len(records):
+        raise ValueError("attributions must be parallel to records")
+
+    run_id = records[0].run_id if records else ""
+    points: list[IterationPoint] = []
+    previous_tokens: int | None = None
+    first_edit_ordinal: int | None = None
+
+    for i, record in enumerate(records):
+        growth: int | None = None
+        if record.input_tokens is not None and previous_tokens is not None:
+            growth = record.input_tokens - previous_tokens
+        if record.input_tokens is not None:
+            previous_tokens = record.input_tokens
+        share = tokens = None
+        if attributions is not None:
+            attribution = attributions[i]
+            share = attribution.distractor_share
+            tokens = attribution.distractor_tokens
+        if record.edit_tool_call and first_edit_ordinal is None:
+            first_edit_ordinal = record.ordinal
+        points.append(
+            IterationPoint(
+                ordinal=record.ordinal,
+                input_tokens=record.input_tokens,
+                context_growth=growth,
+                distractor_share=share,
+                distractor_tokens=tokens,
+                edit_tool_call=record.edit_tool_call,
+            )
+        )
+
+    final_tokens = next(
+        (p.input_tokens for p in reversed(points) if p.input_tokens is not None), None
+    )
+    shape, largest_share = classify_growth_shape(
+        [p.context_growth for p in points], final_tokens
+    )
+
+    phases: list[PhaseStats] = []
+    by_ordinal = {p.ordinal: p for p in points}
+    for name, ordinal_range in _thirds(len(points)):
+        phase_points = [by_ordinal[o] for o in ordinal_range if o in by_ordinal]
+        phases.append(
+            PhaseStats(
+                name=name,
+                ordinals=[p.ordinal for p in phase_points],
+                median_input_tokens=_median_or_none(
+                    [p.input_tokens for p in phase_points]
+                ),
+                median_growth=_median_or_none(
+                    [p.context_growth for p in phase_points]
+                ),
+                median_distractor_share=_median_or_none(
+                    [p.distractor_share for p in phase_points]
+                ),
+            )
+        )
+
+    return RunTrajectory(
+        run_id=run_id,
+        iterations_total=len(points),
+        iterations_before_first_edit=(
+            first_edit_ordinal - 1 if first_edit_ordinal is not None else None
+        ),
+        first_edit_ordinal=first_edit_ordinal,
+        growth_shape=shape,
+        largest_single_jump_share=largest_share,
+        points=points,
+        phases=phases,
+    )

--- a/research/repo-bloat-benchmark/harness/context_snapshots/proxy.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/proxy.py
@@ -1,0 +1,342 @@
+"""API-boundary recording proxy (design.md §6.2, tap 1 — PRIMARY).
+
+A local HTTP relay the agent's model traffic is routed through via a base-URL
+override (e.g. ``OPENAI_BASE_URL=http://127.0.0.1:<port>/v1``). For every
+request it archives the byte-exact request body (the composed context window),
+the response body, and provider-reported ``usage``, then forwards the response
+to the client unchanged.
+
+Design properties:
+
+- **Agent-agnostic and fork-free.** Works with any CLI that honors a base-URL
+  override; the agent binary is never modified.
+- **Complete by construction** when the run environment locks network egress
+  to the proxy (design §8.1.1): every model request is captured or it never
+  happened.
+- **Byte-exact.** The archived request body is the exact bytes received; the
+  sha256 in the snapshot record lets a third party verify fidelity.
+
+Known limitation (documented in design §6.2): streamed (SSE) responses are
+buffered and relayed after completion rather than streamed through. This
+preserves capture fidelity and response content but serializes streaming
+latency into ``wall_clock_seconds`` (a secondary metric). True pass-through
+streaming is a follow-up.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+from .schema import SnapshotRecord
+
+# Hop-by-hop headers that must not be forwarded either direction.
+_HOP_BY_HOP = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+    "host",
+    "content-length",
+}
+
+# Tool names whose invocation counts as an *edit* for the first-edit boundary
+# (design §6.2). Checked case-insensitively; substring fallbacks catch
+# provider-specific variants like ``apply_patch_call``.
+DEFAULT_EDIT_TOOL_NAMES = frozenset(
+    {"apply_patch", "edit", "edit_file", "write_file", "create_file", "str_replace_editor"}
+)
+_EDIT_SUBSTRINGS = ("patch", "edit", "write_file")
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _extract_usage(obj: dict[str, Any]) -> tuple[int | None, int | None, int | None]:
+    """Pull (input, output, total) tokens from a usage dict of either API shape."""
+    usage = obj.get("usage") or {}
+    if not isinstance(usage, dict):
+        return None, None, None
+    input_tokens = usage.get("input_tokens", usage.get("prompt_tokens"))
+    output_tokens = usage.get("output_tokens", usage.get("completion_tokens"))
+    total = usage.get("total_tokens")
+    if total is None and input_tokens is not None and output_tokens is not None:
+        total = input_tokens + output_tokens
+    return input_tokens, output_tokens, total
+
+
+def _extract_tool_calls(obj: dict[str, Any]) -> list[str]:
+    """Collect tool-call names from a chat-completions or Responses-API body."""
+    names: list[str] = []
+    # Chat Completions: choices[].message.tool_calls[].function.name
+    for choice in obj.get("choices") or []:
+        message = (choice or {}).get("message") or {}
+        for call in message.get("tool_calls") or []:
+            name = ((call or {}).get("function") or {}).get("name")
+            if name:
+                names.append(str(name))
+    # Responses API: output[] items typed *_call
+    for item in obj.get("output") or []:
+        if not isinstance(item, dict):
+            continue
+        item_type = str(item.get("type", ""))
+        if item_type.endswith("_call"):
+            names.append(str(item.get("name") or item_type))
+    return names
+
+
+def _parse_sse_events(body: bytes) -> list[dict[str, Any]]:
+    """Best-effort parse of ``data:`` JSON payloads from an SSE body."""
+    events: list[dict[str, Any]] = []
+    for raw_line in body.decode("utf-8", errors="replace").splitlines():
+        line = raw_line.strip()
+        if not line.startswith("data:"):
+            continue
+        data = line[len("data:"):].strip()
+        if not data or data == "[DONE]":
+            continue
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            events.append(parsed)
+    return events
+
+
+def _analyze_response_body(body: bytes, content_type: str) -> dict[str, Any]:
+    """Extract usage/tool-call facts from a JSON or SSE response body."""
+    result: dict[str, Any] = {
+        "input_tokens": None,
+        "output_tokens": None,
+        "total_tokens": None,
+        "tool_call_names": [],
+        "streamed": False,
+    }
+    candidates: list[dict[str, Any]] = []
+    if "text/event-stream" in content_type:
+        result["streamed"] = True
+        for event in _parse_sse_events(body):
+            candidates.append(event)
+            # Responses API terminal event nests the response object.
+            nested = event.get("response")
+            if isinstance(nested, dict):
+                candidates.append(nested)
+    else:
+        try:
+            parsed = json.loads(body.decode("utf-8"))
+            if isinstance(parsed, dict):
+                candidates.append(parsed)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+    for obj in candidates:
+        input_tokens, output_tokens, total = _extract_usage(obj)
+        if input_tokens is not None or output_tokens is not None:
+            result["input_tokens"] = input_tokens
+            result["output_tokens"] = output_tokens
+            result["total_tokens"] = total
+        for name in _extract_tool_calls(obj):
+            if name not in result["tool_call_names"]:
+                result["tool_call_names"].append(name)
+    return result
+
+
+def is_edit_tool(name: str, edit_tool_names: frozenset[str] = DEFAULT_EDIT_TOOL_NAMES) -> bool:
+    lowered = name.lower()
+    if lowered in edit_tool_names:
+        return True
+    return any(sub in lowered for sub in _EDIT_SUBSTRINGS)
+
+
+class RecordingProxy:
+    """Recording relay between an agent CLI and its model provider.
+
+    Usage::
+
+        proxy = RecordingProxy(
+            upstream_base_url="https://api.openai.com",
+            archive_dir="reports/run-123",
+            run_id="run-123",
+        )
+        base_url = proxy.start()      # export OPENAI_BASE_URL=f"{base_url}/v1"
+        ...  # run the agent
+        proxy.stop()
+        proxy.records                 # list[SnapshotRecord], ordinal-ordered
+    """
+
+    def __init__(
+        self,
+        upstream_base_url: str,
+        archive_dir: str | Path,
+        run_id: str,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        edit_tool_names: frozenset[str] = DEFAULT_EDIT_TOOL_NAMES,
+        forward_timeout: float = 600.0,
+    ) -> None:
+        self.upstream_base_url = upstream_base_url.rstrip("/")
+        self.archive_dir = Path(archive_dir)
+        self.payload_dir = self.archive_dir / "payloads"
+        self.run_id = run_id
+        self.host = host
+        self.port = port
+        self.edit_tool_names = edit_tool_names
+        self.forward_timeout = forward_timeout
+        self.records: list[SnapshotRecord] = []
+        self._lock = threading.Lock()
+        self._ordinal = 0
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._snapshot_file: Path = self.archive_dir / "context_snapshots.jsonl"
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> str:
+        """Start serving; returns the proxy base URL (no trailing slash)."""
+        self.payload_dir.mkdir(parents=True, exist_ok=True)
+        proxy = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *args: Any) -> None:  # silence stderr
+                pass
+
+            def do_POST(self) -> None:  # noqa: N802 (stdlib naming)
+                proxy._handle(self, record=True)
+
+            def do_GET(self) -> None:  # noqa: N802
+                proxy._handle(self, record=False)
+
+        self._server = ThreadingHTTPServer((self.host, self.port), Handler)
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return f"http://{self.host}:{self.port}"
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    # -- request handling ----------------------------------------------------
+
+    def _next_ordinal(self) -> int:
+        with self._lock:
+            self._ordinal += 1
+            return self._ordinal
+
+    def _append_record(self, record: SnapshotRecord) -> None:
+        with self._lock:
+            self.records.append(record)
+            self.archive_dir.mkdir(parents=True, exist_ok=True)
+            with self._snapshot_file.open("a", encoding="utf-8") as fh:
+                fh.write(record.to_json() + "\n")
+
+    def _forward(
+        self, method: str, path: str, headers: dict[str, str], body: bytes | None
+    ) -> tuple[int, dict[str, str], bytes]:
+        url = self.upstream_base_url + path
+        out_headers = {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP}
+        request = urllib.request.Request(url, data=body, headers=out_headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self.forward_timeout) as resp:
+                resp_body = resp.read()
+                resp_headers = {k: v for k, v in resp.headers.items()}
+                return resp.status, resp_headers, resp_body
+        except urllib.error.HTTPError as exc:
+            return exc.code, dict(exc.headers or {}), exc.read()
+        except (urllib.error.URLError, OSError) as exc:
+            message = json.dumps({"error": {"message": f"proxy forward failed: {exc}"}})
+            return 502, {"Content-Type": "application/json"}, message.encode("utf-8")
+
+    def _handle(self, handler: BaseHTTPRequestHandler, record: bool) -> None:
+        received_at = time.time()
+        length = int(handler.headers.get("Content-Length") or 0)
+        body = handler.rfile.read(length) if length else b""
+        headers = {k: v for k, v in handler.headers.items()}
+
+        status, resp_headers, resp_body = self._forward(
+            handler.command, handler.path, headers, body or None
+        )
+
+        if record and body:
+            self._record_exchange(handler.path, received_at, body, status, resp_headers, resp_body)
+
+        handler.send_response(status)
+        content_type = resp_headers.get("Content-Type", "application/json")
+        handler.send_header("Content-Type", content_type)
+        handler.send_header("Content-Length", str(len(resp_body)))
+        handler.send_header("Connection", "close")
+        handler.end_headers()
+        handler.wfile.write(resp_body)
+
+    def _record_exchange(
+        self,
+        path: str,
+        received_at: float,
+        body: bytes,
+        status: int,
+        resp_headers: dict[str, str],
+        resp_body: bytes,
+    ) -> None:
+        ordinal = self._next_ordinal()
+        request_name = f"{ordinal:05d}.request.json"
+        response_name = f"{ordinal:05d}.response.body"
+        (self.payload_dir / request_name).write_bytes(body)
+        (self.payload_dir / response_name).write_bytes(resp_body)
+
+        model: str | None = None
+        message_count: int | None = None
+        try:
+            payload = json.loads(body.decode("utf-8"))
+            if isinstance(payload, dict):
+                model = payload.get("model")
+                messages = payload.get("messages", payload.get("input"))
+                if isinstance(messages, list):
+                    message_count = len(messages)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
+        analysis = _analyze_response_body(
+            resp_body, resp_headers.get("Content-Type", "")
+        )
+        tool_names = analysis["tool_call_names"]
+        self._append_record(
+            SnapshotRecord(
+                run_id=self.run_id,
+                ordinal=ordinal,
+                timestamp=received_at,
+                endpoint=path,
+                request_sha256=_sha256(body),
+                payload_path=f"payloads/{request_name}",
+                response_path=f"payloads/{response_name}",
+                status_code=status,
+                model=model,
+                input_tokens=analysis["input_tokens"],
+                output_tokens=analysis["output_tokens"],
+                total_tokens=analysis["total_tokens"],
+                message_count=message_count,
+                request_bytes=len(body),
+                response_bytes=len(resp_body),
+                tool_call_names=tool_names,
+                edit_tool_call=any(is_edit_tool(n, self.edit_tool_names) for n in tool_names),
+                streamed=analysis["streamed"],
+            )
+        )

--- a/research/repo-bloat-benchmark/harness/context_snapshots/schema.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/schema.py
@@ -1,0 +1,75 @@
+"""Snapshot record schema (design.md §6.2 tap 1, §6.3).
+
+One ``SnapshotRecord`` per model request captured by the recording proxy.
+Records are serialized as JSONL next to the archived request/response payloads
+so a third party can re-derive every downstream metric from raw artifacts.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator
+
+SCHEMA_VERSION = 1
+
+
+@dataclass
+class SnapshotRecord:
+    """Metadata for one captured model request (a *context snapshot*).
+
+    The byte-exact request/response bodies live at ``payload_path`` /
+    ``response_path``; this record carries what analysis needs without
+    re-parsing the payloads.
+    """
+
+    run_id: str
+    ordinal: int  # 1-based request index within the run
+    timestamp: float  # epoch seconds when the proxy received the request
+    endpoint: str  # request path, e.g. /v1/chat/completions or /v1/responses
+    request_sha256: str
+    payload_path: str  # archived request body (relative to the archive dir)
+    response_path: str | None = None
+    status_code: int | None = None
+    model: str | None = None
+    # Provider-reported usage (authoritative token source; design §6.1).
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    # Cheap structural facts extracted at capture time.
+    message_count: int | None = None
+    request_bytes: int = 0
+    response_bytes: int = 0
+    tool_call_names: list[str] = field(default_factory=list)
+    edit_tool_call: bool = False  # response contains an edit/patch tool call
+    streamed: bool = False
+    schema_version: int = SCHEMA_VERSION
+
+    def to_json(self) -> str:
+        return json.dumps(dataclasses.asdict(self), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, line: str) -> "SnapshotRecord":
+        data = json.loads(line)
+        known = {f.name for f in dataclasses.fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+def write_snapshots(records: Iterable[SnapshotRecord], path: str | Path) -> None:
+    """Write records as JSONL (one record per line, sorted keys)."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(record.to_json() + "\n")
+
+
+def read_snapshots(path: str | Path) -> Iterator[SnapshotRecord]:
+    """Read records back from JSONL, skipping blank lines."""
+    with Path(path).open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                yield SnapshotRecord.from_json(line)

--- a/research/repo-bloat-benchmark/harness/context_snapshots/session_parser.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/session_parser.py
@@ -1,0 +1,168 @@
+"""Tolerant parser for agent-CLI session/rollout logs (design.md §6.2 tap 1).
+
+The recording proxy is the primary source; the CLI's own session log (for
+Codex, JSONL rollout files under ``CODEX_HOME/sessions``) is a redundant
+cross-check. The parser is deliberately schema-tolerant: it extracts what it
+recognizes (token usage, tool calls, request-ish events) and records what it
+does not, so schema drift in a pinned CLI version surfaces as data instead of
+a crash.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass
+class SessionSummary:
+    path: str
+    line_count: int = 0
+    parsed_lines: int = 0
+    malformed_lines: int = 0
+    tool_call_names: list[str] = field(default_factory=list)
+    token_events: list[dict[str, int | None]] = field(default_factory=list)
+    event_types: dict[str, int] = field(default_factory=dict)
+    unknown_event_types: list[str] = field(default_factory=list)
+
+    @property
+    def cumulative_input_tokens(self) -> int | None:
+        values = [e["input_tokens"] for e in self.token_events if e["input_tokens"]]
+        return sum(values) if values else None
+
+    @property
+    def request_count_estimate(self) -> int:
+        return len(self.token_events)
+
+
+_USAGE_KEYS = ("usage", "token_usage", "total_token_usage", "last_token_usage")
+_INPUT_KEYS = ("input_tokens", "prompt_tokens", "input", "cached_input_tokens")
+_OUTPUT_KEYS = ("output_tokens", "completion_tokens", "output")
+
+
+def _find_usage(obj: Any, depth: int = 0) -> dict[str, int | None] | None:
+    """Recursively locate a usage-like dict and normalize it."""
+    if depth > 6 or not isinstance(obj, dict):
+        return None
+    for key in _USAGE_KEYS:
+        candidate = obj.get(key)
+        if isinstance(candidate, dict):
+            input_tokens = next(
+                (candidate[k] for k in _INPUT_KEYS if isinstance(candidate.get(k), int)),
+                None,
+            )
+            output_tokens = next(
+                (candidate[k] for k in _OUTPUT_KEYS if isinstance(candidate.get(k), int)),
+                None,
+            )
+            if input_tokens is not None or output_tokens is not None:
+                return {"input_tokens": input_tokens, "output_tokens": output_tokens}
+    for value in obj.values():
+        found = _find_usage(value, depth + 1)
+        if found is not None:
+            return found
+    return None
+
+
+def _find_tool_calls(obj: Any, depth: int = 0) -> Iterable[str]:
+    """Recursively collect tool/function-call names."""
+    if depth > 6:
+        return
+    if isinstance(obj, dict):
+        obj_type = str(obj.get("type", ""))
+        if obj_type.endswith("_call") or obj_type in ("tool_call", "function_call"):
+            name = obj.get("name") or (obj.get("function") or {}).get("name")
+            yield str(name) if name else obj_type
+        for value in obj.values():
+            yield from _find_tool_calls(value, depth + 1)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _find_tool_calls(item, depth + 1)
+
+
+_KNOWN_TYPE_HINTS = (
+    "message",
+    "response",
+    "request",
+    "tool",
+    "function",
+    "token",
+    "usage",
+    "turn",
+    "session",
+    "event",
+    "shell",
+    "patch",
+    "reasoning",
+)
+
+
+def parse_session_log(path: str | Path) -> SessionSummary:
+    """Parse one JSONL session/rollout file into a summary."""
+    path = Path(path)
+    summary = SessionSummary(path=str(path))
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            summary.line_count += 1
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                summary.malformed_lines += 1
+                continue
+            summary.parsed_lines += 1
+            if not isinstance(event, dict):
+                continue
+            event_type = str(
+                event.get("type") or (event.get("payload") or {}).get("type") or "untyped"
+            )
+            summary.event_types[event_type] = summary.event_types.get(event_type, 0) + 1
+            if not any(hint in event_type.lower() for hint in _KNOWN_TYPE_HINTS):
+                if event_type not in summary.unknown_event_types:
+                    summary.unknown_event_types.append(event_type)
+            usage = _find_usage(event)
+            if usage is not None:
+                summary.token_events.append(usage)
+            for name in _find_tool_calls(event):
+                summary.tool_call_names.append(name)
+    return summary
+
+
+def reconcile(
+    proxy_input_tokens_total: int | None,
+    proxy_request_count: int,
+    session: SessionSummary,
+    token_tolerance: float = 0.05,
+) -> list[str]:
+    """Compare proxy record against the CLI's own session log.
+
+    Returns a list of human-readable discrepancies (empty = consistent).
+    Disagreement flags the run per design §6.2 — it does not auto-void it.
+    """
+    problems: list[str] = []
+    if session.malformed_lines:
+        problems.append(
+            f"session log has {session.malformed_lines} malformed lines"
+        )
+    session_tokens = session.cumulative_input_tokens
+    if proxy_input_tokens_total is not None and session_tokens is not None:
+        if proxy_input_tokens_total > 0:
+            drift = abs(session_tokens - proxy_input_tokens_total) / proxy_input_tokens_total
+            if drift > token_tolerance:
+                problems.append(
+                    "input-token mismatch: proxy="
+                    f"{proxy_input_tokens_total} session={session_tokens} "
+                    f"(drift {drift:.1%} > {token_tolerance:.0%})"
+                )
+    if session.request_count_estimate and proxy_request_count:
+        if session.request_count_estimate > proxy_request_count:
+            problems.append(
+                "session log reports more usage events "
+                f"({session.request_count_estimate}) than proxied requests "
+                f"({proxy_request_count}) — traffic may have bypassed the proxy"
+            )
+    return problems

--- a/research/repo-bloat-benchmark/harness/context_snapshots/tests/conftest.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Make `harness.*` importable when pytest runs from any directory."""
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parents[3]
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))

--- a/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_attribution.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_attribution.py
@@ -1,0 +1,101 @@
+"""Tests for content attribution against a materialized tree."""
+
+import pytest
+
+from harness.context_snapshots.attribution import (
+    Attribution,
+    TreeIndex,
+    reconcile_with_usage,
+)
+
+CORE_CONTENT = '''\
+def slice_page(items, page, page_size):
+    """Return one page of items using half-open slicing semantics."""
+    start_index_for_requested_page = page * page_size
+    return items[start_index_for_requested_page:start_index_for_requested_page + page_size]
+'''
+
+DISTRACTOR_CONTENT = '''\
+def format_ledger_totals_for_export(ledger_rows, currency_code):
+    """Format ledger totals for the quarterly export pipeline."""
+    formatted_ledger_export_rows = [f"{row.total:.2f} {currency_code}" for row in ledger_rows]
+    return formatted_ledger_export_rows
+'''
+
+
+@pytest.fixture()
+def tree(tmp_path):
+    (tmp_path / "src" / "pkg").mkdir(parents=True)
+    (tmp_path / "src" / "pkg" / "pagination.py").write_text(CORE_CONTENT)
+    (tmp_path / "src" / "pkg" / "ledger_formatter.py").write_text(DISTRACTOR_CONTENT)
+    return tmp_path
+
+
+@pytest.fixture()
+def index(tree):
+    return TreeIndex(tree, distractor_paths=["src/pkg/ledger_formatter.py"])
+
+
+def test_distractor_lines_attributed(index):
+    request_text = (
+        "Here is a file I read:\n" + DISTRACTOR_CONTENT + "\nWhat should I do next?"
+    )
+    result = index.classify_text(request_text)
+    assert result.distractor_lines > 0
+    assert result.distractor_tokens > 0
+    assert result.core_lines == 0
+    assert "src/pkg/ledger_formatter.py" in result.distractor_files
+
+
+def test_core_lines_attributed(index):
+    result = index.classify_text(CORE_CONTENT)
+    assert result.core_lines > 0
+    assert result.distractor_lines == 0
+    assert "src/pkg/pagination.py" in result.core_files
+
+
+def test_unmatched_text_is_unknown(index):
+    result = index.classify_text(
+        "The assistant reasons at length about pagination strategies in prose."
+    )
+    assert result.distractor_lines == 0
+    assert result.core_lines == 0
+    assert result.unknown_tokens > 0
+
+
+def test_short_lines_ignored(index):
+    result = index.classify_text("return x\n\npass\n")
+    assert result.total_tokens == 0
+
+
+def test_ambiguous_lines_not_counted_as_distractor(tmp_path):
+    shared = "shared_helper_line_that_is_long_enough_to_index = compute_shared_value()\n"
+    (tmp_path / "core.py").write_text(shared)
+    (tmp_path / "extra.py").write_text(shared)
+    index = TreeIndex(tmp_path, distractor_paths=["extra.py"])
+    result = index.classify_text(shared)
+    assert result.distractor_tokens == 0
+    assert result.ambiguous_lines == 1
+
+
+def test_distractor_share(index):
+    text = DISTRACTOR_CONTENT + CORE_CONTENT
+    result = index.classify_text(text)
+    assert 0.0 < result.distractor_share < 1.0
+
+
+def test_reconcile_caps_at_provider_usage():
+    attribution = Attribution(distractor_tokens=900.0, core_tokens=300.0)
+    # Provider says the request was only 600 tokens; estimates must scale down.
+    reconciled = reconcile_with_usage(attribution, provider_input_tokens=600)
+    assert reconciled["reconciled_against_usage"]
+    assert reconciled["distractor_context_tokens"] <= 600
+    assert reconciled["distractor_context_share"] <= 1.0
+    assert reconciled["raw_estimate_tokens"] == 900.0
+
+
+def test_reconcile_without_usage_flags_itself():
+    attribution = Attribution(distractor_tokens=100.0)
+    reconciled = reconcile_with_usage(attribution, provider_input_tokens=None)
+    assert not reconciled["reconciled_against_usage"]
+    assert reconciled["distractor_context_tokens"] == 100.0

--- a/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_iteration_analyzer.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_iteration_analyzer.py
@@ -1,0 +1,112 @@
+"""Tests for the iteration-trajectory analysis (H2 machinery)."""
+
+from harness.context_snapshots.attribution import Attribution
+from harness.context_snapshots.iteration_analyzer import (
+    analyze_run,
+    classify_growth_shape,
+)
+from harness.context_snapshots.schema import SnapshotRecord
+
+
+def _record(ordinal, input_tokens, edit=False):
+    return SnapshotRecord(
+        run_id="run",
+        ordinal=ordinal,
+        timestamp=1000.0 + ordinal,
+        endpoint="/v1/chat/completions",
+        request_sha256="0" * 64,
+        payload_path=f"payloads/{ordinal:05d}.request.json",
+        input_tokens=input_tokens,
+        edit_tool_call=edit,
+    )
+
+
+def test_gradual_growth_classified():
+    # Linear accretion: every request adds ~1000 tokens.
+    records = [_record(i, 1000 * i) for i in range(1, 10)]
+    trajectory = analyze_run(records)
+    assert trajectory.growth_shape == "gradual"
+    assert trajectory.iterations_total == 9
+    assert trajectory.largest_single_jump_share < 0.30
+
+
+def test_step_growth_classified():
+    # One giant read dominates the final context.
+    tokens = [1000, 1100, 9000, 9100, 9200, 9300]
+    records = [_record(i + 1, t) for i, t in enumerate(tokens)]
+    trajectory = analyze_run(records)
+    assert trajectory.growth_shape == "step"
+    assert trajectory.largest_single_jump_share > 0.30
+
+
+def test_plateau_classified():
+    # Steady growth that stalls (truncation ceiling) with no dominating jump:
+    # step takes precedence over plateau, so no single growth may exceed 30%.
+    tokens = [3000, 5500, 8000, 10500, 11000, 11050, 11080, 11100, 11110]
+    records = [_record(i + 1, t) for i, t in enumerate(tokens)]
+    trajectory = analyze_run(records)
+    assert trajectory.growth_shape == "plateau"
+
+
+def test_sawtooth_classified():
+    # Context shrinks mid-run: compaction dropped content.
+    tokens = [3000, 6000, 9000, 4000, 7000, 10000]
+    records = [_record(i + 1, t) for i, t in enumerate(tokens)]
+    trajectory = analyze_run(records)
+    assert trajectory.growth_shape == "sawtooth"
+
+
+def test_first_edit_boundary():
+    records = [
+        _record(1, 1000),
+        _record(2, 2000),
+        _record(3, 3000, edit=True),
+        _record(4, 4000),
+    ]
+    trajectory = analyze_run(records)
+    assert trajectory.first_edit_ordinal == 3
+    assert trajectory.iterations_before_first_edit == 2
+
+
+def test_no_edit_ever():
+    records = [_record(1, 1000), _record(2, 2000)]
+    trajectory = analyze_run(records)
+    assert trajectory.first_edit_ordinal is None
+    assert trajectory.iterations_before_first_edit is None
+
+
+def test_phase_medians_and_share_delta():
+    records = []
+    attributions = []
+    for i in range(1, 10):
+        records.append(_record(i, 1000 * i))
+        # Distractor share climbs from 0.1 to 0.9 across the run.
+        share = i / 10.0
+        attributions.append(
+            Attribution(distractor_tokens=share * 100, core_tokens=(1 - share) * 100)
+        )
+    trajectory = analyze_run(records, attributions)
+    early = trajectory.distractor_share_early
+    late = trajectory.distractor_share_late
+    assert early is not None and late is not None
+    assert late > early
+    assert trajectory.share_delta_late_minus_early is not None
+    assert trajectory.share_delta_late_minus_early > 0.3
+    assert [p.name for p in trajectory.phases] == ["early", "middle", "late"]
+
+
+def test_missing_usage_tolerated():
+    records = [
+        _record(1, None),
+        _record(2, 2000),
+        _record(3, None),
+        _record(4, 4000),
+    ]
+    trajectory = analyze_run(records)
+    assert trajectory.iterations_total == 4  # no crash; growth where computable
+
+
+def test_classify_growth_shape_empty():
+    shape, share = classify_growth_shape([], None)
+    assert shape == "unknown"
+    assert share is None

--- a/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_proxy.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_proxy.py
@@ -1,0 +1,247 @@
+"""End-to-end tests for the recording proxy against a scripted upstream.
+
+These are the automated core of the §6.6 calibration gate's proxy-fidelity
+assertions: byte-exact archiving, usage capture, ordinal indexing, edit
+detection, and transparent forwarding.
+"""
+
+import hashlib
+import json
+import threading
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from harness.context_snapshots.proxy import RecordingProxy, is_edit_tool
+from harness.context_snapshots.schema import read_snapshots
+
+
+class ScriptedUpstream:
+    """Minimal fake model API returning queued responses."""
+
+    def __init__(self):
+        self.responses = []
+        self.received = []
+        self._server = None
+        self._thread = None
+        self.base_url = None
+
+    def queue(self, body: dict, content_type: str = "application/json"):
+        self.responses.append((json.dumps(body).encode(), content_type))
+
+    def queue_raw(self, body: bytes, content_type: str):
+        self.responses.append((body, content_type))
+
+    def start(self):
+        upstream = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *args):
+                pass
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length") or 0)
+                upstream.received.append(self.rfile.read(length))
+                body, content_type = upstream.responses.pop(0)
+                self.send_response(200)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.base_url = f"http://127.0.0.1:{self._server.server_address[1]}"
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self.base_url
+
+    def stop(self):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+
+CHAT_RESPONSE_READ = {
+    "id": "chatcmpl-1",
+    "model": "gpt-test",
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "read_file"}}],
+            }
+        }
+    ],
+    "usage": {"prompt_tokens": 1000, "completion_tokens": 50, "total_tokens": 1050},
+}
+
+CHAT_RESPONSE_EDIT = {
+    "id": "chatcmpl-2",
+    "model": "gpt-test",
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "apply_patch"}}],
+            }
+        }
+    ],
+    "usage": {"prompt_tokens": 2400, "completion_tokens": 80, "total_tokens": 2480},
+}
+
+
+@pytest.fixture()
+def upstream():
+    server = ScriptedUpstream()
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture()
+def proxy(upstream, tmp_path):
+    recording_proxy = RecordingProxy(
+        upstream_base_url=upstream.base_url,
+        archive_dir=tmp_path / "run",
+        run_id="test-run",
+    )
+    recording_proxy.start()
+    yield recording_proxy
+    recording_proxy.stop()
+
+
+def _post(base_url: str, path: str, payload: dict) -> dict:
+    body = json.dumps(payload).encode()
+    request = urllib.request.Request(
+        f"{base_url}{path}",
+        data=body,
+        headers={"Content-Type": "application/json", "Authorization": "Bearer test"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def test_forwards_and_records_in_order(upstream, proxy, tmp_path):
+    upstream.queue(CHAT_RESPONSE_READ)
+    upstream.queue(CHAT_RESPONSE_EDIT)
+    base = f"http://127.0.0.1:{proxy.port}"
+
+    first_payload = {"model": "gpt-test", "messages": [{"role": "user", "content": "find bug"}]}
+    second_payload = {
+        "model": "gpt-test",
+        "messages": [
+            {"role": "user", "content": "find bug"},
+            {"role": "tool", "content": "def slice_page(): ..."},
+        ],
+    }
+    first_response = _post(base, "/v1/chat/completions", first_payload)
+    second_response = _post(base, "/v1/chat/completions", second_payload)
+
+    # Forwarding is transparent: the client sees the upstream body verbatim.
+    assert first_response == CHAT_RESPONSE_READ
+    assert second_response == CHAT_RESPONSE_EDIT
+    # Upstream saw the exact client bytes.
+    assert json.loads(upstream.received[0]) == first_payload
+
+    assert [r.ordinal for r in proxy.records] == [1, 2]
+    first, second = proxy.records
+    assert first.input_tokens == 1000
+    assert second.input_tokens == 2400
+    assert first.message_count == 1
+    assert second.message_count == 2
+    assert first.tool_call_names == ["read_file"]
+    assert not first.edit_tool_call
+    assert second.edit_tool_call  # apply_patch ⇒ first-edit boundary marker
+
+
+def test_payloads_archived_byte_exact(upstream, proxy, tmp_path):
+    upstream.queue(CHAT_RESPONSE_READ)
+    base = f"http://127.0.0.1:{proxy.port}"
+    payload = {"model": "gpt-test", "messages": [{"role": "user", "content": "x" * 100}]}
+    _post(base, "/v1/chat/completions", payload)
+
+    record = proxy.records[0]
+    archived = (proxy.archive_dir / record.payload_path).read_bytes()
+    assert hashlib.sha256(archived).hexdigest() == record.request_sha256
+    assert json.loads(archived) == payload
+
+
+def test_snapshot_jsonl_round_trip(upstream, proxy):
+    upstream.queue(CHAT_RESPONSE_READ)
+    base = f"http://127.0.0.1:{proxy.port}"
+    _post(base, "/v1/chat/completions", {"model": "gpt-test", "messages": []})
+
+    reloaded = list(read_snapshots(proxy.archive_dir / "context_snapshots.jsonl"))
+    assert len(reloaded) == 1
+    assert reloaded[0].run_id == "test-run"
+    assert reloaded[0].input_tokens == 1000
+
+
+def test_responses_api_sse_usage_extracted(upstream, proxy):
+    completed = {
+        "type": "response.completed",
+        "response": {
+            "usage": {"input_tokens": 3210, "output_tokens": 99, "total_tokens": 3309},
+            "output": [{"type": "function_call", "name": "shell"}],
+        },
+    }
+    sse_body = (
+        b'data: {"type": "response.output_text.delta", "delta": "hi"}\n\n'
+        + b"data: " + json.dumps(completed).encode() + b"\n\n"
+        + b"data: [DONE]\n\n"
+    )
+    upstream.queue_raw(sse_body, "text/event-stream")
+    base = f"http://127.0.0.1:{proxy.port}"
+    body = json.dumps({"model": "gpt-test", "input": [{"role": "user", "content": "go"}]}).encode()
+    request = urllib.request.Request(
+        f"{base}/v1/responses", data=body,
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as resp:
+        relayed = resp.read()
+
+    assert relayed == sse_body  # SSE body relayed intact (buffered)
+    record = proxy.records[0]
+    assert record.streamed
+    assert record.input_tokens == 3210
+    assert record.tool_call_names == ["shell"]
+    assert record.message_count == 1
+
+
+def test_upstream_failure_becomes_502_and_is_recorded(tmp_path):
+    recording_proxy = RecordingProxy(
+        upstream_base_url="http://127.0.0.1:1",  # nothing listens here
+        archive_dir=tmp_path / "run",
+        run_id="down",
+        forward_timeout=2,
+    )
+    base = recording_proxy.start()
+    try:
+        body = json.dumps({"model": "m", "messages": []}).encode()
+        request = urllib.request.Request(
+            f"{base}/v1/chat/completions", data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        try:
+            urllib.request.urlopen(request, timeout=10)
+            status = 200
+        except urllib.error.HTTPError as exc:
+            status = exc.code
+        assert status == 502
+        assert recording_proxy.records[0].status_code == 502
+    finally:
+        recording_proxy.stop()
+
+
+def test_edit_tool_name_matching():
+    assert is_edit_tool("apply_patch")
+    assert is_edit_tool("apply_patch_call")
+    assert is_edit_tool("str_replace_editor")
+    assert is_edit_tool("Edit")
+    assert not is_edit_tool("read_file")
+    assert not is_edit_tool("shell")

--- a/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_session_parser.py
+++ b/research/repo-bloat-benchmark/harness/context_snapshots/tests/test_session_parser.py
@@ -1,0 +1,95 @@
+"""Tests for the tolerant session-log parser and proxy reconciliation."""
+
+import json
+
+from harness.context_snapshots.session_parser import parse_session_log, reconcile
+
+
+def _write_session(tmp_path, events):
+    path = tmp_path / "session.jsonl"
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+    return path
+
+
+def test_extracts_usage_and_tool_calls(tmp_path):
+    events = [
+        {"type": "session_meta", "payload": {"id": "abc"}},
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "usage": {"input_tokens": 1200, "output_tokens": 40},
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {"type": "function_call", "name": "shell"},
+        },
+        {
+            "type": "response_item",
+            "payload": {"type": "custom_tool_call", "name": "apply_patch"},
+        },
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "usage": {"input_tokens": 2500, "output_tokens": 60},
+            },
+        },
+    ]
+    summary = parse_session_log(_write_session(tmp_path, events))
+    assert summary.parsed_lines == 5
+    assert summary.malformed_lines == 0
+    assert summary.request_count_estimate == 2
+    assert summary.cumulative_input_tokens == 3700
+    assert "shell" in summary.tool_call_names
+    assert "apply_patch" in summary.tool_call_names
+
+
+def test_malformed_lines_counted_not_fatal(tmp_path):
+    path = tmp_path / "session.jsonl"
+    path.write_text('{"type": "ok"}\nnot json at all\n{"type": "also_ok"}\n')
+    summary = parse_session_log(path)
+    assert summary.line_count == 3
+    assert summary.parsed_lines == 2
+    assert summary.malformed_lines == 1
+
+
+def test_unknown_event_types_recorded(tmp_path):
+    events = [{"type": "wormhole_sync", "payload": {}}]
+    summary = parse_session_log(_write_session(tmp_path, events))
+    assert "wormhole_sync" in summary.unknown_event_types
+
+
+def test_reconcile_consistent(tmp_path):
+    events = [
+        {"usage": {"input_tokens": 1000, "output_tokens": 10}},
+        {"usage": {"input_tokens": 2000, "output_tokens": 10}},
+    ]
+    summary = parse_session_log(_write_session(tmp_path, events))
+    problems = reconcile(
+        proxy_input_tokens_total=3000, proxy_request_count=2, session=summary
+    )
+    assert problems == []
+
+
+def test_reconcile_flags_token_drift(tmp_path):
+    events = [{"usage": {"input_tokens": 5000, "output_tokens": 10}}]
+    summary = parse_session_log(_write_session(tmp_path, events))
+    problems = reconcile(
+        proxy_input_tokens_total=3000, proxy_request_count=1, session=summary
+    )
+    assert any("mismatch" in p for p in problems)
+
+
+def test_reconcile_flags_bypassed_traffic(tmp_path):
+    events = [
+        {"usage": {"input_tokens": 100, "output_tokens": 1}},
+        {"usage": {"input_tokens": 100, "output_tokens": 1}},
+        {"usage": {"input_tokens": 100, "output_tokens": 1}},
+    ]
+    summary = parse_session_log(_write_session(tmp_path, events))
+    problems = reconcile(
+        proxy_input_tokens_total=300, proxy_request_count=2, session=summary
+    )
+    assert any("bypass" in p for p in problems)

--- a/research/repo-bloat-benchmark/harness/distractors/DEFINITION.md
+++ b/research/repo-bloat-benchmark/harness/distractors/DEFINITION.md
@@ -1,0 +1,46 @@
+# What is a "distractor file"?
+
+Machine-checkable restatement of design.md **§5.0**. The generator
+(`generator.py`) enforces this contract for **every** admitted file, whatever
+its source mode; `definition.py` is the single implementation of the checks,
+and the test suite exercises each condition.
+
+## Definition
+
+A file `D` is a **distractor** for a scenario `(core, task, visible_tests,
+hidden_verifier)` iff **all** of the following hold:
+
+| # | Condition | Machine check (`definition.py`) |
+|---|-----------|--------------------------------|
+| 1 | **Structural irrelevance** — `D ∉ closure(core)`: no core file imports/includes/loads `D`, and `D` is not a target file | destination path not in `core_files`; module name not importable by any core import statement (static import scan); not in `target_files` |
+| 2 | **Behavior neutrality** — materializing/removing `D` changes no visible-test or hidden-verifier outcome | forbidden ambient-side-effect basenames rejected (`conftest.py`, `sitecustomize.py`, pytest plugins, packaging/config entrypoints); destination must not shadow a core module (same importable name); dynamic-import red-flag scan. Final authority: the §4.1.2 oracle equivalence gate re-runs both suites per materialized variant |
+| 3 | **Plausibility** — project language and idiom; would not read as filler | parses (`ast`) for Python; identifier-vocabulary overlap with the core ≥ recorded floor; verbatim project files pass by construction |
+| 4 | **No leakage** — no hidden-verifier or oracle-patch content | content screened against the scenario's hidden-assertion denylist |
+| 5 | **No tell** — nothing marks `D` as a distractor | destination path/name/content screened for marker strings (`distractor`, `filler`, `synthetic`, `decoy`, …) |
+
+Checks 1, 2, 4, 5 are hard gates (violation ⇒ file rejected, generation
+aborts if requested size cannot be met legally). Check 3 is a hard gate for
+generated files and a recorded no-op for verbatim (`regrow`) files.
+
+## Source modes (design §5.0.1)
+
+One definition, three deterministic sources, fixed cascade
+(`regrow` → `mutate` → `template`), each file's `mode` recorded in the
+manifest so per-mode read/penetration rates can be reported:
+
+- **`regrow`** — verbatim out-of-core project files at their original paths.
+- **`mutate`** — seeded, semantics-preserving derivations of pool files
+  (identifier/docstring renames from a recorded vocabulary map), placed at
+  plausible non-colliding sibling paths. Extends the pool past its natural
+  size.
+- **`template`** — synthetic modules from parameterized skeletons filled with
+  vocabulary harvested from the core; size-tunable, used as the terminal
+  filler so any token budget converges (50x and breakdown-probe steps).
+
+## Why a definition at all
+
+The review feedback asked for distractors to be *defined*, then *generated
+from the definition* and *scaled aggressively*. Making the definition a
+checkable contract (rather than prose) is what lets three different sources
+share one guarantee — and lets the 50x/probe conditions exist without
+weakening the experiment's "only one thing varies" principle.

--- a/research/repo-bloat-benchmark/harness/distractors/README.md
+++ b/research/repo-bloat-benchmark/harness/distractors/README.md
@@ -1,0 +1,52 @@
+# Distractor definition + generator
+
+Implements design.md **§5** (v2): the formal distractor-file contract and the
+deterministic generator that fills per-(scenario, size) token budgets on the
+ladder `1x/2x/5x/10x/20x/50x` — and beyond, for the H3 breakdown probe.
+
+## Pieces
+
+| File | Role |
+|------|------|
+| `DEFINITION.md` | the five-condition distractor contract, mapped to its machine checks |
+| `definition.py` | `DefinitionChecker` — the single implementation of those checks; every admitted file passes it, whatever its source mode |
+| `vocabulary.py` | deterministic identifier/word harvest from the core (feeds mutate/template plausibility) |
+| `generator.py` | `generate_manifest(config, size)` — budget filling via the fixed mode cascade **regrow → mutate → template**, dependency-closed regrow groups, tier assignment from layout, rejection log |
+| `manifest.py` | manifest persistence (+ generated-file contents), `manifests.lock` freeze enforcement |
+| `cli.py` | `python3 -m harness.distractors.cli` — generate a whole ladder + lockfile |
+
+## Generate a ladder
+
+```bash
+cd research/repo-bloat-benchmark
+python3 -m harness.distractors.cli \
+  --scenario-id off-by-one-pagination \
+  --core scenarios/off-by-one-pagination/core \
+  --pool snapshots/pdd@<commit>/pool \
+  --target-file src/pkg/pagination.py \
+  --sizes 1 2 5 10 20 50 \
+  --seed 1209 \
+  --out distractors/
+```
+
+Each manifest records: token budget vs. realized dose, per-file
+`mode`/`tier`/`sha256`/`import_group`, `mode_counts`, a `budget_met` flag, and
+the full **rejection log** (which candidates the definition checks refused and
+why) — so the freeze-before-runs commit is auditable.
+
+## Properties the tests pin down
+
+- **Determinism**: same inputs + seed ⇒ byte-identical manifest; different
+  seed ⇒ different selection.
+- **Budget convergence**: 50x is met within ±2 % even from a tiny pool — the
+  cascade falls through to `mutate` then `template`, and `template` is
+  size-tunable so any budget converges (this is what makes the breakdown
+  probe past 50x possible).
+- **Contract enforcement**: core/target collisions, core-importable names,
+  `conftest.py`-style ambient files, dynamic-import red flags, unparseable
+  code, off-vocabulary generated code, hidden-assertion leakage, and
+  tell markers are all rejected (each has a dedicated test).
+- **1x control** is exactly the empty manifest.
+- **Freeze**: `manifests.lock` verification fails on any post-commit edit.
+
+No external dependencies (stdlib + pytest only).

--- a/research/repo-bloat-benchmark/harness/distractors/__init__.py
+++ b/research/repo-bloat-benchmark/harness/distractors/__init__.py
@@ -1,0 +1,19 @@
+"""Distractor definition, generation, and manifest building (design.md §5)."""
+
+from .definition import CandidateFile, DefinitionChecker, Violation
+from .generator import GenerationConfig, generate_manifest
+from .manifest import ManifestWriter, load_manifest, verify_lockfile, write_lockfile
+from .vocabulary import harvest_vocabulary
+
+__all__ = [
+    "CandidateFile",
+    "DefinitionChecker",
+    "Violation",
+    "GenerationConfig",
+    "generate_manifest",
+    "ManifestWriter",
+    "load_manifest",
+    "verify_lockfile",
+    "write_lockfile",
+    "harvest_vocabulary",
+]

--- a/research/repo-bloat-benchmark/harness/distractors/cli.py
+++ b/research/repo-bloat-benchmark/harness/distractors/cli.py
@@ -1,0 +1,77 @@
+"""Command-line entry point for distractor-manifest generation.
+
+Example (from ``research/repo-bloat-benchmark/``)::
+
+    python3 -m harness.distractors.cli \
+        --scenario-id off-by-one-pagination \
+        --core scenarios/off-by-one-pagination/core \
+        --pool snapshots/pdd@<commit>/pool \
+        --target-file src/pkg/pagination.py \
+        --sizes 1 2 5 10 20 50 \
+        --seed 1209 \
+        --out distractors/
+
+Writes ``distractors/manifests/<scenario>.<size>.json`` for each ladder step,
+persists generated (mutate/template) file contents under
+``distractors/generated/``, and refreshes ``distractors/manifests.lock``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .generator import SIZE_LADDER, GenerationConfig, generate_manifest
+from .manifest import ManifestWriter, write_lockfile
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario-id", required=True)
+    parser.add_argument("--core", required=True, type=Path, help="core tree (1x base repo)")
+    parser.add_argument("--pool", type=Path, default=None, help="snapshot ∖ core tree")
+    parser.add_argument("--target-file", required=True, help="core-relative target path")
+    parser.add_argument("--sizes", type=int, nargs="+", default=list(SIZE_LADDER))
+    parser.add_argument("--seed", type=int, default=1209)
+    parser.add_argument("--tolerance-pct", type=float, default=2.0)
+    parser.add_argument("--leak-denylist-file", type=Path, default=None,
+                        help="file of newline-separated hidden-assertion strings")
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    denylist: tuple[str, ...] = ()
+    if args.leak_denylist_file:
+        denylist = tuple(
+            line.strip()
+            for line in args.leak_denylist_file.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        )
+
+    config = GenerationConfig(
+        scenario_id=args.scenario_id,
+        core_root=args.core,
+        pool_root=args.pool,
+        target_file=args.target_file,
+        selection_seed=args.seed,
+        tolerance_pct=args.tolerance_pct,
+        leak_denylist=denylist,
+    )
+    writer = ManifestWriter(args.out)
+    written: list[Path] = []
+    for size in args.sizes:
+        manifest = generate_manifest(config, size)
+        path = writer.write(manifest)
+        written.append(path)
+        status = "ok" if manifest["budget_met"] else "BUDGET NOT MET"
+        print(
+            f"{path.name}: {manifest['distractor_tokens_on_disk']} distractor tokens "
+            f"({manifest['mode_counts']}) [{status}]"
+        )
+    write_lockfile(list(writer.manifest_dir.glob("*.json")), args.out / "manifests.lock")
+    print(f"lockfile: {args.out / 'manifests.lock'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/repo-bloat-benchmark/harness/distractors/definition.py
+++ b/research/repo-bloat-benchmark/harness/distractors/definition.py
@@ -1,0 +1,221 @@
+"""Machine checks for the distractor-file definition (DEFINITION.md, design §5.0).
+
+Every file the generator admits — whatever its mode — passes through
+``DefinitionChecker.check``. A non-empty violation list rejects the file.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Iterable
+
+# Condition 2: basenames with ambient side effects (test collection, import
+# hooks, packaging) can change behavior by existing. Never admissible.
+FORBIDDEN_BASENAMES = frozenset(
+    {
+        "conftest.py",
+        "sitecustomize.py",
+        "usercustomize.py",
+        "setup.py",
+        "setup.cfg",
+        "pyproject.toml",
+        "tox.ini",
+        "pytest.ini",
+        "__main__.py",
+    }
+)
+
+# Condition 5: markers that would label a file as benchmark filler.
+TELL_MARKERS = ("distractor", "filler", "synthetic", "decoy", "padding", "noise_file")
+
+# Condition 2 red flags: constructs whose presence needs manual review because
+# they can act at import/collection time even without being imported by core.
+_DYNAMIC_RED_FLAGS = (
+    re.compile(r"\bimportlib\.(?:import_module|reload)\b"),
+    re.compile(r"\b__import__\s*\("),
+    re.compile(r"\bsys\.path\.(?:insert|append)\b"),
+    re.compile(r"\bpkg_resources\b"),
+    re.compile(r"entry_points"),
+)
+
+_IMPORT_RE = re.compile(r"^\s*(?:from\s+([\w\.]+)\s+import|import\s+([\w\.]+))", re.M)
+
+
+def module_names_for(path: str) -> set[str]:
+    """Dotted-module candidates a Python file can be imported as.
+
+    ``src/pkg/mod.py`` → {``src.pkg.mod``, ``pkg.mod``, ``mod``} — suffixes are
+    included because the import root is unknown statically.
+    """
+    pure = PurePosixPath(path)
+    if pure.suffix != ".py":
+        return set()
+    parts = list(pure.with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return {".".join(parts[i:]) for i in range(len(parts))} if parts else set()
+
+
+def imported_modules(source: str) -> set[str]:
+    """Statically imported dotted names (regex-based, comment-tolerant)."""
+    names: set[str] = set()
+    for match in _IMPORT_RE.finditer(source):
+        name = match.group(1) or match.group(2)
+        if name:
+            names.add(name)
+            # `import a.b.c` also makes `a` and `a.b` load.
+            pieces = name.split(".")
+            for i in range(1, len(pieces)):
+                names.add(".".join(pieces[:i]))
+    return names
+
+
+@dataclass
+class Violation:
+    condition: int  # 1..5, per DEFINITION.md
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - convenience
+        return f"[condition {self.condition}] {self.message}"
+
+
+@dataclass
+class CandidateFile:
+    """A file proposed for admission, before definition checks."""
+
+    destination_path: str  # where it would be materialized (tree-relative)
+    content: str
+    mode: str  # regrow | mutate | template
+    source_path: str | None = None  # provenance for regrow/mutate
+    tier: str = "cross-cutting"
+
+
+@dataclass
+class DefinitionChecker:
+    """Holds the scenario facts the checks are made against."""
+
+    core_files: set[str]
+    target_files: set[str]
+    core_import_names: set[str]  # every module name any core file imports
+    leak_denylist: tuple[str, ...] = ()
+    vocabulary_floor: float = 0.02
+    core_vocabulary: "object | None" = None  # Vocabulary; optional
+
+    @classmethod
+    def from_core(
+        cls,
+        core_files: Iterable[str],
+        core_sources: dict[str, str],
+        target_files: Iterable[str] = (),
+        leak_denylist: Iterable[str] = (),
+        vocabulary_floor: float = 0.02,
+        core_vocabulary: "object | None" = None,
+    ) -> "DefinitionChecker":
+        import_names: set[str] = set()
+        for source in core_sources.values():
+            import_names |= imported_modules(source)
+        return cls(
+            core_files={p.replace("\\", "/") for p in core_files},
+            target_files={p.replace("\\", "/") for p in target_files},
+            core_import_names=import_names,
+            leak_denylist=tuple(leak_denylist),
+            vocabulary_floor=vocabulary_floor,
+            core_vocabulary=core_vocabulary,
+        )
+
+    # -- the five conditions -------------------------------------------------
+
+    def check(self, candidate: CandidateFile) -> list[Violation]:
+        violations: list[Violation] = []
+        dest = candidate.destination_path.replace("\\", "/")
+
+        # 1. Structural irrelevance
+        if dest in self.core_files:
+            violations.append(Violation(1, f"{dest} is a core file"))
+        if dest in self.target_files:
+            violations.append(Violation(1, f"{dest} is a target file"))
+        if module_names_for(dest) & self.core_import_names:
+            violations.append(
+                Violation(1, f"{dest} is importable by a core import statement")
+            )
+
+        # 2. Behavior neutrality
+        basename = PurePosixPath(dest).name
+        if basename in FORBIDDEN_BASENAMES:
+            violations.append(
+                Violation(2, f"{basename} has ambient side effects (forbidden basename)")
+            )
+        shadowed = self._shadows_core_module(dest)
+        if shadowed:
+            violations.append(Violation(2, f"{dest} would shadow core module {shadowed}"))
+        for pattern in _DYNAMIC_RED_FLAGS:
+            if pattern.search(candidate.content):
+                violations.append(
+                    Violation(
+                        2,
+                        f"dynamic-import red flag `{pattern.pattern}` in {dest} "
+                        "(needs manual clearance; rejected by default)",
+                    )
+                )
+                break
+
+        # 3. Plausibility (hard gate for generated files)
+        if dest.endswith(".py"):
+            try:
+                ast.parse(candidate.content)
+            except SyntaxError as exc:
+                violations.append(Violation(3, f"{dest} does not parse: {exc}"))
+            else:
+                if candidate.mode != "regrow" and self.core_vocabulary is not None:
+                    from .vocabulary import collect_identifiers
+
+                    overlap = self.core_vocabulary.overlap_fraction(
+                        collect_identifiers(candidate.content)
+                    )
+                    if overlap < self.vocabulary_floor:
+                        violations.append(
+                            Violation(
+                                3,
+                                f"{dest} vocabulary overlap {overlap:.3f} below "
+                                f"floor {self.vocabulary_floor:.3f}",
+                            )
+                        )
+
+        # 4. No leakage
+        for needle in self.leak_denylist:
+            if needle and needle in candidate.content:
+                violations.append(
+                    Violation(4, f"{dest} contains denylisted hidden-assertion text")
+                )
+                break
+
+        # 5. No tell. Path markers are always forbidden; content markers only
+        # gate *generated* files — an organic occurrence of a word like
+        # "noise" in a verbatim project file is not a benchmark artifact.
+        lowered_dest = dest.lower()
+        for marker in TELL_MARKERS:
+            if marker in lowered_dest:
+                violations.append(Violation(5, f"path {dest} carries marker '{marker}'"))
+                break
+        if candidate.mode != "regrow":
+            lowered_content = candidate.content.lower()
+            for marker in TELL_MARKERS:
+                if marker in lowered_content:
+                    violations.append(
+                        Violation(5, f"{dest} content carries marker '{marker}'")
+                    )
+                    break
+
+        return violations
+
+    def _shadows_core_module(self, dest: str) -> str | None:
+        dest_names = module_names_for(dest)
+        if not dest_names:
+            return None
+        for core_path in self.core_files:
+            if module_names_for(core_path) & dest_names:
+                return core_path
+        return None

--- a/research/repo-bloat-benchmark/harness/distractors/generator.py
+++ b/research/repo-bloat-benchmark/harness/distractors/generator.py
@@ -1,0 +1,414 @@
+"""Deterministic distractor generation (design.md §5.0.1, §5.1, §5.3).
+
+Fills a per-(scenario, size) token budget with files that pass the
+``DefinitionChecker`` contract, using the fixed source cascade:
+
+1. ``regrow``  — verbatim pool files (``snapshot ∖ core``), admitted in
+   dependency-closed import groups, ordered by (tier, stable hash);
+2. ``mutate``  — seeded identifier/docstring derivations of pool files at
+   non-colliding sibling paths, once the pool is exhausted;
+3. ``template`` — synthetic size-tunable modules from core vocabulary, as the
+   terminal filler so any budget (50x, breakdown probe) converges.
+
+Given the same inputs and seed, output is byte-identical — manifests are
+committed before any model run (freeze-before-runs).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Callable
+
+from .definition import CandidateFile, DefinitionChecker, imported_modules, module_names_for
+from .vocabulary import Vocabulary, harvest_vocabulary
+
+SIZE_LADDER = (1, 2, 5, 10, 20, 50)
+TIER_ORDER = {"same-package": 0, "same-layer": 1, "cross-cutting": 2}
+
+
+def estimate_tokens(text: str) -> int:
+    """Deterministic on-disk token-dose estimate (~4 chars/token, design §5.1)."""
+    return max(1, round(len(text) / 4))
+
+
+def stable_hash(*parts: object) -> str:
+    return hashlib.sha256("|".join(str(p) for p in parts).encode()).hexdigest()
+
+
+def tier_for(destination: str, target_file: str) -> str:
+    """Tier from layout distance to the target (design §5.2)."""
+    dest_dir = PurePosixPath(destination).parent
+    target_dir = PurePosixPath(target_file).parent
+    if dest_dir == target_dir:
+        return "same-package"
+    if dest_dir.parent == target_dir.parent:
+        return "same-layer"
+    return "cross-cutting"
+
+
+@dataclass
+class GenerationConfig:
+    scenario_id: str
+    core_root: Path
+    target_file: str  # core-relative path of the seeded target
+    pool_root: Path | None = None  # snapshot ∖ core; None ⇒ generated-only
+    selection_seed: int = 1209
+    tolerance_pct: float = 2.0
+    leak_denylist: tuple[str, ...] = ()
+    vocabulary_floor: float = 0.02
+    token_estimator: Callable[[str], int] = estimate_tokens
+    max_mutants_per_source: int = 20
+    template_file_tokens: int = 800
+
+    def __post_init__(self) -> None:
+        self.core_root = Path(self.core_root)
+        if self.pool_root is not None:
+            self.pool_root = Path(self.pool_root)
+
+
+@dataclass
+class _Admitted:
+    destination: str
+    content: str
+    mode: str
+    tier: str
+    import_group: str
+    source_path: str | None
+    tokens: int
+
+
+def _read_tree(root: Path, extensions: tuple[str, ...] = (".py",)) -> dict[str, str]:
+    files: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and path.suffix in extensions:
+            files[path.relative_to(root).as_posix()] = path.read_text(
+                encoding="utf-8", errors="replace"
+            )
+    return files
+
+
+# --------------------------------------------------------------------------
+# regrow
+# --------------------------------------------------------------------------
+
+
+def _pool_import_groups(pool: dict[str, str]) -> dict[str, list[str]]:
+    """Map each pool file to its dependency-closed group within the pool."""
+    name_to_path: dict[str, str] = {}
+    for path in pool:
+        for name in module_names_for(path):
+            name_to_path.setdefault(name, path)
+    groups: dict[str, list[str]] = {}
+    for path, source in pool.items():
+        closure: set[str] = set()
+        frontier = [path]
+        while frontier:
+            current = frontier.pop()
+            if current in closure:
+                continue
+            closure.add(current)
+            for imported in imported_modules(pool.get(current, "")):
+                resolved = name_to_path.get(imported)
+                if resolved and resolved not in closure:
+                    frontier.append(resolved)
+        groups[path] = sorted(closure)
+    return groups
+
+
+def _regrow_candidates(
+    config: GenerationConfig, pool: dict[str, str]
+) -> list[tuple[str, list[str]]]:
+    """Deterministically ordered (path, dependency_group) admission list."""
+    groups = _pool_import_groups(pool)
+    ordered = sorted(
+        pool,
+        key=lambda p: (
+            TIER_ORDER[tier_for(p, config.target_file)],
+            stable_hash(config.selection_seed, p),
+        ),
+    )
+    return [(path, groups[path]) for path in ordered]
+
+
+# --------------------------------------------------------------------------
+# mutate
+# --------------------------------------------------------------------------
+
+_DEF_RE = re.compile(r"^(\s*(?:def|class)\s+)([A-Za-z_]\w*)", re.M)
+
+
+def _mutate_source(
+    source: str, source_path: str, vocabulary: Vocabulary, seed_material: str
+) -> tuple[str, str]:
+    """Seeded, semantics-preserving derivation of a pool file.
+
+    Renames top-level def/class identifiers with vocabulary-derived suffixes
+    and rewrites the module docstring; returns (destination_path, content).
+    Never imported by anything (definition condition 1 holds regardless), so
+    internal consistency — not runtime equivalence — is what matters.
+    """
+    words = vocabulary.top_words(64) or ["module"]
+    digest = stable_hash(seed_material, source_path)
+    word = words[int(digest[:8], 16) % len(words)]
+    suffix = f"_{word}"
+
+    renames: dict[str, str] = {}
+    for match in _DEF_RE.finditer(source):
+        name = match.group(2)
+        if not name.startswith("__"):
+            renames[name] = name + suffix
+    mutated = source
+    for old, new in sorted(renames.items(), key=lambda kv: -len(kv[0])):
+        mutated = re.sub(rf"\b{re.escape(old)}\b", new, mutated)
+
+    header = (
+        f'"""Support variant for the {word} pathway.\n\n'
+        f"Derived interface kept in sync with its sibling module.\n"
+        f'"""\n\n'
+    )
+    if not mutated.lstrip().startswith(('"""', "'''")):
+        mutated = header + mutated
+
+    pure = PurePosixPath(source_path)
+    destination = str(pure.with_name(f"{pure.stem}{suffix}{pure.suffix}"))
+    return destination, mutated
+
+
+# --------------------------------------------------------------------------
+# template
+# --------------------------------------------------------------------------
+
+_TEMPLATE_SHAPES = ("service", "handler", "helpers", "adapters", "validation")
+
+
+def _template_module(
+    vocabulary: Vocabulary, seed_material: str, index: int, target_tokens: int
+) -> tuple[str, str]:
+    """Synthesize one self-contained module from core vocabulary."""
+    words = vocabulary.top_words(48) or ["record", "value", "config"]
+
+    def pick(n: int) -> str:
+        return words[int(stable_hash(seed_material, index, n)[:8], 16) % len(words)]
+
+    shape = _TEMPLATE_SHAPES[index % len(_TEMPLATE_SHAPES)]
+    noun, verb, aux = pick(1), pick(2), pick(3)
+    module_name = f"{noun}_{shape}"
+    lines = [
+        f'"""{shape.capitalize()} utilities for {noun} {aux} processing."""',
+        "",
+        "from dataclasses import dataclass",
+        "",
+        "",
+        "@dataclass",
+        f"class {noun.capitalize()}{shape.capitalize()}Config:",
+        f"    {aux}_limit: int = 100",
+        f"    strict_{verb}: bool = False",
+        "",
+    ]
+    body_index = 0
+    content = "\n".join(lines)
+    while estimate_tokens(content) < target_tokens:
+        a, b = pick(10 + body_index), pick(11 + body_index)
+        lines += [
+            "",
+            f"def {verb}_{a}_{b}_{body_index}(records, config):",
+            f'    """Apply the {a} {b} policy to incoming records."""',
+            "    selected = []",
+            "    for record in records:",
+            f"        if getattr(record, '{a}_flag', False) and config.strict_{verb}:",
+            "            continue",
+            f"        if len(selected) >= config.{aux}_limit:",
+            "            break",
+            "        selected.append(record)",
+            "    return selected",
+        ]
+        body_index += 1
+        content = "\n".join(lines)
+    destination = f"src/{shape}/{module_name}_{index}.py"
+    return destination, content + "\n"
+
+
+# --------------------------------------------------------------------------
+# budget filling
+# --------------------------------------------------------------------------
+
+
+def generate_manifest(config: GenerationConfig, size: int) -> dict:
+    """Build the per-(scenario, size) manifest dict (design §5.5 + mode field).
+
+    Returned manifest includes a ``generated_contents`` map (destination →
+    content) for ``mutate``/``template`` files; ``ManifestWriter`` persists it.
+    """
+    core = _read_tree(config.core_root)
+    core_tokens = sum(config.token_estimator(text) for text in core.values())
+    core_loc = sum(text.count("\n") + 1 for text in core.values())
+    target_tokens = (size - 1) * core_tokens
+    tolerance = config.tolerance_pct / 100.0
+    lower = target_tokens * (1 - tolerance)
+    upper = target_tokens * (1 + tolerance)
+
+    vocabulary = harvest_vocabulary(config.core_root)
+    checker = DefinitionChecker.from_core(
+        core_files=core.keys(),
+        core_sources=core,
+        target_files=[config.target_file],
+        leak_denylist=config.leak_denylist,
+        vocabulary_floor=config.vocabulary_floor,
+        core_vocabulary=vocabulary,
+    )
+
+    pool = _read_tree(config.pool_root) if config.pool_root else {}
+    admitted: list[_Admitted] = []
+    taken: set[str] = set(core.keys())
+    total = 0
+    rejected: list[dict] = []
+
+    def try_admit(candidate: CandidateFile, group: str) -> bool:
+        nonlocal total
+        if candidate.destination_path in taken:
+            return False
+        tokens = config.token_estimator(candidate.content)
+        if total + tokens > upper:
+            return False
+        violations = checker.check(candidate)
+        if violations:
+            rejected.append(
+                {
+                    "destination_path": candidate.destination_path,
+                    "mode": candidate.mode,
+                    "violations": [str(v) for v in violations],
+                }
+            )
+            return False
+        admitted.append(
+            _Admitted(
+                destination=candidate.destination_path,
+                content=candidate.content,
+                mode=candidate.mode,
+                tier=candidate.tier,
+                import_group=group,
+                source_path=candidate.source_path,
+                tokens=tokens,
+            )
+        )
+        taken.add(candidate.destination_path)
+        total += tokens
+        return True
+
+    # 1. regrow — dependency-closed groups.
+    if size > 1:
+        for path, group_paths in _regrow_candidates(config, pool):
+            if total >= lower:
+                break
+            if path in taken:
+                continue
+            group_id = "g" + stable_hash(config.selection_seed, *group_paths)[:8]
+            for member in group_paths:
+                if member in taken:
+                    continue
+                try_admit(
+                    CandidateFile(
+                        destination_path=member,
+                        content=pool[member],
+                        mode="regrow",
+                        source_path=member,
+                        tier=tier_for(member, config.target_file),
+                    ),
+                    group=group_id,
+                )
+
+        # 2. mutate — cycle the pool with increasing mutation indices.
+        mutation_round = 0
+        pool_order = [p for p, _ in _regrow_candidates(config, pool)]
+        while total < lower and pool_order and mutation_round < config.max_mutants_per_source:
+            for source_path in pool_order:
+                if total >= lower:
+                    break
+                destination, content = _mutate_source(
+                    pool[source_path],
+                    source_path,
+                    vocabulary,
+                    seed_material=f"{config.selection_seed}.{mutation_round}",
+                )
+                try_admit(
+                    CandidateFile(
+                        destination_path=destination,
+                        content=content,
+                        mode="mutate",
+                        source_path=source_path,
+                        tier=tier_for(destination, config.target_file),
+                    ),
+                    group="g-mutate",
+                )
+            mutation_round += 1
+
+        # 3. template — terminal filler; size-tuned so the budget converges.
+        template_index = 0
+        while total < lower and template_index < 100_000:
+            remaining = int(lower - total)
+            destination, content = _template_module(
+                vocabulary,
+                seed_material=str(config.selection_seed),
+                index=template_index,
+                target_tokens=min(config.template_file_tokens, max(remaining, 50)),
+            )
+            try_admit(
+                CandidateFile(
+                    destination_path=destination,
+                    content=content,
+                    mode="template",
+                    tier=tier_for(destination, config.target_file),
+                ),
+                group="g-template",
+            )
+            template_index += 1
+
+    files = [
+        {
+            "upstream_path": item.destination,
+            "tokens": item.tokens,
+            "loc": item.content.count("\n") + 1,
+            "sha256": hashlib.sha256(item.content.encode()).hexdigest(),
+            "tier": item.tier,
+            "mode": item.mode,
+            "import_group": item.import_group,
+            "source_path": item.source_path,
+        }
+        for item in admitted
+    ]
+    manifest = {
+        "schema_version": 3,
+        "scenario_id": config.scenario_id,
+        "size": f"{size}x",
+        "selection_seed": config.selection_seed,
+        "tokenizer": "chars/4-v1",
+        "core_tokens": core_tokens,
+        "core_loc": core_loc,
+        "size_token_target": target_tokens,
+        "size_token_tolerance_pct": config.tolerance_pct,
+        "distractor_tokens_on_disk": total,
+        "distractor_loc": sum(f["loc"] for f in files),
+        "realized_total_tokens": core_tokens + total,
+        "budget_met": total >= lower or size == 1,
+        "mode_counts": {
+            mode: sum(1 for f in files if f["mode"] == mode)
+            for mode in ("regrow", "mutate", "template")
+        },
+        "files": files,
+        "rejected": rejected,
+    }
+    generated = {
+        item.destination: item.content for item in admitted if item.mode != "regrow"
+    }
+    manifest["generated_contents"] = generated
+    return manifest
+
+
+def generate_ladder(
+    config: GenerationConfig, sizes: tuple[int, ...] = SIZE_LADDER
+) -> dict[int, dict]:
+    """Generate manifests for every ladder step (including the 1x control)."""
+    return {size: generate_manifest(config, size) for size in sizes}

--- a/research/repo-bloat-benchmark/harness/distractors/manifest.py
+++ b/research/repo-bloat-benchmark/harness/distractors/manifest.py
@@ -1,0 +1,81 @@
+"""Manifest persistence + freeze enforcement (design.md §5.5).
+
+The manifest is the *secret label key*: it lives out-of-tree (harness side),
+is committed before any model run, and is consulted only by post-hoc
+analysis. ``manifests.lock`` aggregates the sha256 of every committed
+manifest; the runner refuses to execute a (scenario, size) whose manifest
+hash is not in the lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+
+class ManifestWriter:
+    """Persist a generated manifest + the contents of generated files."""
+
+    def __init__(self, out_dir: str | Path) -> None:
+        self.out_dir = Path(out_dir)
+        self.manifest_dir = self.out_dir / "manifests"
+        self.generated_dir = self.out_dir / "generated"
+
+    def write(self, manifest: dict) -> Path:
+        """Write ``<scenario>.<size>.json`` and generated file contents.
+
+        The ``generated_contents`` map is split out of the manifest document:
+        contents go under ``generated/<scenario>/<size>/<dest>`` and the
+        manifest gains per-file ``content_path`` pointers instead.
+        """
+        scenario = manifest["scenario_id"]
+        size = manifest["size"]
+        generated: dict[str, str] = manifest.pop("generated_contents", {})
+        content_root = self.generated_dir / scenario / size
+        for entry in manifest["files"]:
+            destination = entry["upstream_path"]
+            if entry["mode"] == "regrow":
+                entry["content_path"] = None
+                continue
+            content = generated[destination]
+            content_path = content_root / destination
+            content_path.parent.mkdir(parents=True, exist_ok=True)
+            content_path.write_text(content, encoding="utf-8")
+            entry["content_path"] = str(
+                content_path.relative_to(self.out_dir).as_posix()
+            )
+
+        self.manifest_dir.mkdir(parents=True, exist_ok=True)
+        path = self.manifest_dir / f"{scenario}.{size}.json"
+        path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return path
+
+
+def manifest_sha256(path: str | Path) -> str:
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def load_manifest(path: str | Path) -> dict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def write_lockfile(manifest_paths: list[str | Path], lock_path: str | Path) -> None:
+    """Freeze the committed manifests (design §3.3, §5.5)."""
+    entries = {
+        Path(p).name: manifest_sha256(p) for p in sorted(manifest_paths, key=str)
+    }
+    Path(lock_path).write_text(
+        json.dumps({"schema_version": 1, "manifests": entries}, indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def verify_lockfile(manifest_path: str | Path, lock_path: str | Path) -> bool:
+    """True iff the manifest's current bytes match its locked hash."""
+    lock = json.loads(Path(lock_path).read_text(encoding="utf-8"))
+    expected = lock.get("manifests", {}).get(Path(manifest_path).name)
+    return expected is not None and expected == manifest_sha256(manifest_path)

--- a/research/repo-bloat-benchmark/harness/distractors/tests/conftest.py
+++ b/research/repo-bloat-benchmark/harness/distractors/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Make `harness.*` importable when pytest runs from any directory."""
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parents[3]
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))

--- a/research/repo-bloat-benchmark/harness/distractors/tests/test_definition.py
+++ b/research/repo-bloat-benchmark/harness/distractors/tests/test_definition.py
@@ -1,0 +1,150 @@
+"""Tests for the five machine-checked definition conditions."""
+
+import pytest
+
+from harness.distractors.definition import (
+    CandidateFile,
+    DefinitionChecker,
+    imported_modules,
+    module_names_for,
+)
+from harness.distractors.vocabulary import Vocabulary
+
+CORE_SOURCE = '''\
+from pkg.storage import load_records
+
+def paginate_ledger_records(records, page_size):
+    """Paginate ledger records for the export pipeline."""
+    return [records[i:i + page_size] for i in range(0, len(records), page_size)]
+'''
+
+
+@pytest.fixture()
+def checker():
+    vocabulary = Vocabulary(
+        words={"paginate": 3, "ledger": 5, "records": 4, "export": 2, "pipeline": 2}
+    )
+    return DefinitionChecker.from_core(
+        core_files=["src/pkg/pagination.py", "src/pkg/storage.py"],
+        core_sources={"src/pkg/pagination.py": CORE_SOURCE},
+        target_files=["src/pkg/pagination.py"],
+        leak_denylist=["assert slice_page([1, 2, 3], 1, 2) == [3]"],
+        vocabulary_floor=0.2,
+        core_vocabulary=vocabulary,
+    )
+
+
+def _ok_candidate(**overrides):
+    defaults = dict(
+        destination_path="src/pkg/ledger_export_helpers.py",
+        content=(
+            'def format_ledger_records_for_export(records):\n'
+            '    """Format ledger records for the export pipeline."""\n'
+            "    return [str(r) for r in records]\n"
+        ),
+        mode="template",
+        tier="same-package",
+    )
+    defaults.update(overrides)
+    return CandidateFile(**defaults)
+
+
+def test_valid_candidate_passes(checker):
+    assert checker.check(_ok_candidate()) == []
+
+
+def test_condition1_core_file_rejected(checker):
+    violations = checker.check(
+        _ok_candidate(destination_path="src/pkg/storage.py")
+    )
+    assert any(v.condition == 1 for v in violations)
+
+
+def test_condition1_core_import_target_rejected(checker):
+    # Core imports pkg.storage → a file importable under that name is load-bearing.
+    violations = checker.check(
+        _ok_candidate(destination_path="other/pkg/storage.py")
+    )
+    assert any(v.condition in (1, 2) for v in violations)
+
+
+def test_condition2_conftest_rejected(checker):
+    violations = checker.check(_ok_candidate(destination_path="src/pkg/conftest.py"))
+    assert any(v.condition == 2 for v in violations)
+
+
+def test_condition2_dynamic_import_rejected(checker):
+    violations = checker.check(
+        _ok_candidate(
+            content="import importlib\nmod = importlib.import_module('pkg.storage')\n"
+        )
+    )
+    assert any(v.condition == 2 for v in violations)
+
+
+def test_condition3_unparseable_rejected(checker):
+    violations = checker.check(_ok_candidate(content="def broken(:\n  pass\n"))
+    assert any(v.condition == 3 for v in violations)
+
+
+def test_condition3_vocabulary_floor_for_generated(checker):
+    violations = checker.check(
+        _ok_candidate(
+            content=(
+                "def zzqx_wobble_frobnicate(xyzzy):\n"
+                '    """Completely alien vocabulary."""\n'
+                "    return xyzzy\n"
+            )
+        )
+    )
+    assert any(v.condition == 3 for v in violations)
+
+
+def test_condition3_vocabulary_floor_skipped_for_regrow(checker):
+    violations = checker.check(
+        _ok_candidate(
+            mode="regrow",
+            source_path="pool/alien.py",
+            content=(
+                "def zzqx_wobble_frobnicate(xyzzy):\n"
+                '    """Alien but verbatim project code."""\n'
+                "    return xyzzy\n"
+            ),
+        )
+    )
+    assert violations == []
+
+
+def test_condition4_leakage_rejected(checker):
+    violations = checker.check(
+        _ok_candidate(
+            content=(
+                "def helper():\n"
+                "    assert slice_page([1, 2, 3], 1, 2) == [3]\n"
+            )
+        )
+    )
+    assert any(v.condition == 4 for v in violations)
+
+
+def test_condition5_path_tell_rejected(checker):
+    violations = checker.check(
+        _ok_candidate(destination_path="src/pkg/distractor_ledger.py")
+    )
+    assert any(v.condition == 5 for v in violations)
+
+
+def test_condition5_content_tell_rejected_for_generated(checker):
+    violations = checker.check(
+        _ok_candidate(content="# synthetic module\ndef ledger_export_records():\n    pass\n")
+    )
+    assert any(v.condition == 5 for v in violations)
+
+
+def test_module_names_and_imports():
+    assert "pkg.storage" in module_names_for("src/pkg/storage.py")
+    assert "storage" in module_names_for("src/pkg/storage.py")
+    names = imported_modules("from pkg.storage import load\nimport os.path\n")
+    assert "pkg.storage" in names
+    assert "pkg" in names
+    assert "os.path" in names and "os" in names

--- a/research/repo-bloat-benchmark/harness/distractors/tests/test_generator.py
+++ b/research/repo-bloat-benchmark/harness/distractors/tests/test_generator.py
@@ -1,0 +1,205 @@
+"""Tests for deterministic generation, the mode cascade, and the size ladder."""
+
+import ast
+import json
+
+import pytest
+
+from harness.distractors.generator import (
+    GenerationConfig,
+    generate_ladder,
+    generate_manifest,
+    tier_for,
+)
+from harness.distractors.manifest import (
+    ManifestWriter,
+    load_manifest,
+    verify_lockfile,
+    write_lockfile,
+)
+
+CORE_MODULE = '''\
+"""Pagination core for the ledger export service."""
+
+
+def slice_page(items, page, page_size):
+    """Return one page of ledger items."""
+    start = page * page_size
+    return items[start:start + page_size]
+
+
+def count_pages(items, page_size):
+    """Number of pages needed to export all ledger items."""
+    return (len(items) + page_size - 1) // page_size
+'''
+
+CORE_TEST = '''\
+from pagination import count_pages, slice_page
+
+
+def test_slice_page_returns_requested_window():
+    assert slice_page([1, 2, 3, 4], 1, 2) == [3, 4]
+
+
+def test_count_pages_rounds_up_for_partial_pages():
+    assert count_pages([1, 2, 3], 2) == 2
+'''
+
+
+def _pool_module(index: int) -> str:
+    return (
+        f'"""Ledger reporting helpers, batch {index}."""\n\n\n'
+        f"def summarize_ledger_batch_{index}(entries, export_config):\n"
+        f'    """Summarize one ledger export batch for reporting."""\n'
+        f"    total_export_amount = sum(entry.amount for entry in entries)\n"
+        f"    return {{'batch': {index}, 'total': total_export_amount}}\n"
+    )
+
+
+@pytest.fixture()
+def scenario(tmp_path):
+    core = tmp_path / "core"
+    (core / "src" / "pkg").mkdir(parents=True)
+    (core / "src" / "pkg" / "pagination.py").write_text(CORE_MODULE)
+    (core / "src" / "pkg" / "test_pagination.py").write_text(CORE_TEST)
+    pool = tmp_path / "pool"
+    (pool / "src" / "pkg").mkdir(parents=True)
+    (pool / "src" / "reporting").mkdir(parents=True)
+    for i in range(3):
+        (pool / "src" / "pkg" / f"ledger_helpers_{i}.py").write_text(_pool_module(i))
+        (pool / "src" / "reporting" / f"report_builder_{i}.py").write_text(
+            _pool_module(i + 100)
+        )
+    return tmp_path
+
+
+def _config(scenario, **overrides):
+    defaults = dict(
+        scenario_id="pagination-demo",
+        core_root=scenario / "core",
+        pool_root=scenario / "pool",
+        target_file="src/pkg/pagination.py",
+        selection_seed=1209,
+        template_file_tokens=120,
+    )
+    defaults.update(overrides)
+    return GenerationConfig(**defaults)
+
+
+def test_deterministic_same_seed_same_manifest(scenario):
+    first = generate_manifest(_config(scenario), 5)
+    second = generate_manifest(_config(scenario), 5)
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def test_different_seed_changes_selection_order(scenario):
+    first = generate_manifest(_config(scenario), 5)
+    second = generate_manifest(_config(scenario, selection_seed=99), 5)
+    assert json.dumps(first, sort_keys=True) != json.dumps(second, sort_keys=True)
+
+
+def test_budget_met_within_tolerance(scenario):
+    manifest = generate_manifest(_config(scenario), 5)
+    assert manifest["budget_met"]
+    target = manifest["size_token_target"]
+    realized = manifest["distractor_tokens_on_disk"]
+    assert realized >= target * 0.98
+    assert realized <= target * 1.02
+
+
+def test_1x_control_has_no_distractors(scenario):
+    manifest = generate_manifest(_config(scenario), 1)
+    assert manifest["files"] == []
+    assert manifest["distractor_tokens_on_disk"] == 0
+    assert manifest["budget_met"]
+
+
+def test_mode_cascade_regrow_first_then_generated(scenario):
+    # Small budget: regrow alone should cover it.
+    small = generate_manifest(_config(scenario), 2)
+    assert small["mode_counts"]["regrow"] > 0
+    # Huge budget: the tiny pool must cascade into mutate and template.
+    large = generate_manifest(_config(scenario), 50)
+    assert large["budget_met"]
+    assert large["mode_counts"]["regrow"] > 0
+    assert large["mode_counts"]["mutate"] > 0
+    assert large["mode_counts"]["template"] > 0
+
+
+def test_50x_scales_to_budget(scenario):
+    manifest = generate_manifest(_config(scenario), 50)
+    assert manifest["distractor_tokens_on_disk"] >= 49 * manifest["core_tokens"] * 0.98
+
+
+def test_generated_files_parse_and_carry_no_tell(scenario):
+    manifest = generate_manifest(_config(scenario), 50)
+    for destination, content in manifest["generated_contents"].items():
+        ast.parse(content)  # plausibility: everything materialized must parse
+        assert "distractor" not in destination.lower()
+        assert "distractor" not in content.lower()
+
+
+def test_tiers_assigned_from_layout(scenario):
+    manifest = generate_manifest(_config(scenario), 2)
+    tiers = {f["upstream_path"]: f["tier"] for f in manifest["files"]}
+    for path, tier in tiers.items():
+        assert tier == tier_for(path, "src/pkg/pagination.py")
+    assert tier_for("src/pkg/other.py", "src/pkg/pagination.py") == "same-package"
+    assert tier_for("src/reporting/r.py", "src/pkg/pagination.py") == "same-layer"
+    assert tier_for("docs/guide.py", "src/pkg/pagination.py") == "cross-cutting"
+
+
+def test_no_destination_collides_with_core(scenario):
+    manifest = generate_manifest(_config(scenario), 50)
+    core_paths = {"src/pkg/pagination.py", "src/pkg/test_pagination.py"}
+    destinations = {f["upstream_path"] for f in manifest["files"]}
+    assert not destinations & core_paths
+    assert len(destinations) == len(manifest["files"])  # unique paths
+
+
+def test_ladder_generation(scenario):
+    ladder = generate_ladder(_config(scenario), sizes=(1, 2, 5))
+    assert set(ladder) == {1, 2, 5}
+    assert ladder[1]["files"] == []
+    assert ladder[5]["distractor_tokens_on_disk"] > ladder[2]["distractor_tokens_on_disk"]
+
+
+def test_manifest_writer_and_lockfile(scenario, tmp_path):
+    manifest = generate_manifest(_config(scenario), 5)
+    writer = ManifestWriter(tmp_path / "out")
+    path = writer.write(manifest)
+
+    loaded = load_manifest(path)
+    assert loaded["scenario_id"] == "pagination-demo"
+    assert "generated_contents" not in loaded  # split out to content files
+    for entry in loaded["files"]:
+        if entry["mode"] != "regrow":
+            content_file = tmp_path / "out" / entry["content_path"]
+            assert content_file.is_file()
+
+    lock = tmp_path / "out" / "manifests.lock"
+    write_lockfile([path], lock)
+    assert verify_lockfile(path, lock)
+    # Tampering breaks the freeze.
+    path.write_text(path.read_text().replace("pagination-demo", "tampered"))
+    assert not verify_lockfile(path, lock)
+
+
+def test_leak_denylist_blocks_content(scenario):
+    # Poison every pool file with the hidden assertion; regrow must reject all.
+    for pool_file in (scenario / "pool").rglob("*.py"):
+        pool_file.write_text(
+            pool_file.read_text()
+            + "\n# expected: slice_page([1,2,3,4,5], 2, 2) == [5]\n"
+        )
+    config = _config(
+        scenario, leak_denylist=("slice_page([1,2,3,4,5], 2, 2) == [5]",)
+    )
+    manifest = generate_manifest(config, 2)
+    assert manifest["mode_counts"]["regrow"] == 0
+    assert all(f["mode"] != "regrow" for f in manifest["files"])
+    assert any(
+        "condition 4" in violation
+        for rejection in manifest["rejected"]
+        for violation in rejection["violations"]
+    )

--- a/research/repo-bloat-benchmark/harness/distractors/tests/test_vocabulary.py
+++ b/research/repo-bloat-benchmark/harness/distractors/tests/test_vocabulary.py
@@ -1,0 +1,40 @@
+"""Tests for vocabulary harvesting."""
+
+from harness.distractors.vocabulary import (
+    harvest_vocabulary,
+    split_identifier,
+)
+
+
+def test_split_identifier_snake_and_camel():
+    assert split_identifier("format_ledger_totals") == ["format", "ledger", "totals"]
+    assert split_identifier("FormatLedgerTotals") == ["format", "ledger", "totals"]
+    assert split_identifier("x") == []  # too short
+
+
+def test_harvest_vocabulary(tmp_path):
+    (tmp_path / "mod.py").write_text(
+        "def paginate_ledger_records(ledger_records):\n"
+        "    exported_ledger_total = sum(ledger_records)\n"
+        "    return exported_ledger_total\n"
+    )
+    vocabulary = harvest_vocabulary(tmp_path)
+    assert vocabulary.words["ledger"] >= 3
+    assert "paginate" in vocabulary.words
+    top = vocabulary.top_words(3)
+    assert top[0] == "ledger"
+
+
+def test_overlap_fraction(tmp_path):
+    (tmp_path / "mod.py").write_text("def paginate_ledger(): pass\n")
+    vocabulary = harvest_vocabulary(tmp_path)
+    high = vocabulary.overlap_fraction(["ledger_paginate_helper"])
+    low = vocabulary.overlap_fraction(["frobnicate_wobble"])
+    assert high > 0.5
+    assert low == 0.0
+
+
+def test_unparseable_file_skipped(tmp_path):
+    (tmp_path / "broken.py").write_text("def broken(:\n")
+    vocabulary = harvest_vocabulary(tmp_path)
+    assert vocabulary.words == {}

--- a/research/repo-bloat-benchmark/harness/distractors/vocabulary.py
+++ b/research/repo-bloat-benchmark/harness/distractors/vocabulary.py
@@ -1,0 +1,113 @@
+"""Vocabulary harvesting from the scenario core (design.md §5.0.1).
+
+`mutate` and `template` modes must produce files in the project's own
+vocabulary (definition condition 3). This module extracts that vocabulary
+deterministically from the core's Python sources: identifiers, their word
+pieces, and frequency ranks.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+_CAMEL = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_NON_WORD = re.compile(r"[^A-Za-z]+")
+
+# Words too generic to characterize a project's vocabulary.
+_STOPWORDS = frozenset(
+    "the a an and or of in to for is not none true false self cls def return "
+    "get set is has add new init main test data value item items key keys "
+    "args kwargs obj result results".split()
+)
+
+
+def split_identifier(identifier: str) -> list[str]:
+    """``formatLedgerTotals`` / ``format_ledger_totals`` → [format, ledger, totals]."""
+    words: list[str] = []
+    for chunk in _NON_WORD.split(identifier):
+        for piece in _CAMEL.sub(" ", chunk).split():
+            piece = piece.lower()
+            if len(piece) >= 3 and piece not in _STOPWORDS:
+                words.append(piece)
+    return words
+
+
+@dataclass
+class Vocabulary:
+    """Deterministic core vocabulary: identifiers and their word pieces."""
+
+    identifiers: dict[str, int] = field(default_factory=dict)
+    words: dict[str, int] = field(default_factory=dict)
+
+    def top_words(self, n: int) -> list[str]:
+        return [
+            w
+            for w, _ in sorted(self.words.items(), key=lambda kv: (-kv[1], kv[0]))[:n]
+        ]
+
+    def overlap_fraction(self, candidate_identifiers: Iterable[str]) -> float:
+        """Fraction of the candidate's word pieces that appear in this vocabulary."""
+        pieces: list[str] = []
+        for identifier in candidate_identifiers:
+            pieces.extend(split_identifier(identifier))
+        if not pieces:
+            return 0.0
+        hits = sum(1 for piece in pieces if piece in self.words)
+        return hits / len(pieces)
+
+
+class _IdentifierCollector(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.identifiers: list[str] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        self.identifiers.append(node.name)
+        self.generic_visit(node)
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        self.identifiers.append(node.name)
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name) -> None:  # noqa: N802
+        self.identifiers.append(node.id)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:  # noqa: N802
+        self.identifiers.append(node.attr)
+        self.generic_visit(node)
+
+    def visit_arg(self, node: ast.arg) -> None:  # noqa: N802
+        self.identifiers.append(node.arg)
+
+
+def collect_identifiers(source: str) -> list[str]:
+    """All identifiers in a Python source (empty list if unparseable)."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    collector = _IdentifierCollector()
+    collector.visit(tree)
+    return collector.identifiers
+
+
+def harvest_vocabulary(core_root: str | Path) -> Vocabulary:
+    """Harvest the deterministic vocabulary of a core tree (Python files)."""
+    vocabulary = Vocabulary()
+    for path in sorted(Path(core_root).rglob("*.py")):
+        try:
+            source = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for identifier in collect_identifiers(source):
+            vocabulary.identifiers[identifier] = (
+                vocabulary.identifiers.get(identifier, 0) + 1
+            )
+            for word in split_identifier(identifier):
+                vocabulary.words[word] = vocabulary.words.get(word, 0) + 1
+    return vocabulary

--- a/research/repo-bloat-benchmark/harness/runner/README.md
+++ b/research/repo-bloat-benchmark/harness/runner/README.md
@@ -1,0 +1,61 @@
+# Experiment runner
+
+Design.md §3.2 stages 3–5: sha-verified variant materialization, run
+orchestration, metrics collection, and report generation. Runs are valid
+without the optional FS tap (`fs_tap_enabled: false` in every record);
+primary evidence comes from the context-snapshot tap.
+
+## Pieces
+
+| Module | Role |
+|--------|------|
+| `variant_builder.py` | materialize `(core, manifest)` → working repo; per-file sha256 verification; tree hash; hidden tree & manifest never copied in |
+| `runner.py` | `ExperimentRunner` — freeze check (`manifests.lock`) → materialize → git baseline → proxy (+ mock provider) → agent → visible/hidden verification → attribution → trajectory → run record |
+| `metrics.py` | design §6.3 run record: cost, penetration (usage-reconciled), H2 trajectory, edit classification (§6.2 precedence), §6.4 failure classes |
+| `report.py` | per-size tables, pure-python least-squares + Spearman fits, failure breakdown, computed §7.5 threshold checklist |
+| `mock_agent.py` | scripted agent + mock provider for **no-token** end-to-end pipeline validation (oracle / wrong_file / noop behaviors) |
+| `cli.py` | `python3 -m harness.runner.cli --config experiment.json` |
+
+## Quick demo (no network, no model tokens)
+
+```bash
+cd research/repo-bloat-benchmark
+python3 -m pytest harness/runner/tests/ -q        # includes the e2e pipeline test
+```
+
+Or drive it by hand against the committed example scenario:
+
+```bash
+python3 -m harness.distractors.cli \
+  --scenario-id example-pagination \
+  --core scenarios/example-pagination/core \
+  --pool scenarios/example-pagination/pool \
+  --target-file src/pager/pagination.py \
+  --sizes 1 2 5 --seed 1209 \
+  --out /tmp/rb-distractors
+
+cat > /tmp/rb-experiment.json <<'EOF'
+{
+  "scenario_dir": "scenarios/example-pagination",
+  "distractors_dir": "/tmp/rb-distractors",
+  "reports_dir": "/tmp/rb-reports",
+  "work_root": "/tmp/rb-work",
+  "arm": "mock",
+  "mock_behavior": "oracle",
+  "sizes": [1, 2, 5],
+  "trials": 2
+}
+EOF
+python3 -m harness.runner.cli --config /tmp/rb-experiment.json
+cat /tmp/rb-reports/report.md
+```
+
+## Running a real agent arm
+
+Set `"arm": "command"`, `"agent_command": ["codex", "exec", "--cd", "{workdir}", …]`
+and `"upstream_base_url": "https://api.openai.com"`. The runner injects
+`OPENAI_BASE_URL` pointing at the recording proxy; confirming the pinned
+Codex build honors that override is the §10 pre-run blocker. The
+run-environment freeze (§8.1.1 — pinned CLI, clean `CODEX_HOME`, ephemeral
+session, egress locked to the proxy) is **not yet implemented** here and must
+land before any real pilot run.

--- a/research/repo-bloat-benchmark/harness/runner/__init__.py
+++ b/research/repo-bloat-benchmark/harness/runner/__init__.py
@@ -1,0 +1,20 @@
+"""Experiment runner: variant materialization, orchestration, metrics, report.
+
+Design.md §3.2 stages 3-5. Runs are valid without the optional FS tap
+(``fs_tap_enabled: false``); primary evidence comes from the context-snapshot
+tap (harness.context_snapshots) per the v2 instrumentation tiering.
+"""
+
+from .metrics import build_run_record, classify_failure
+from .report import generate_report
+from .runner import ExperimentRunner, RunConfig
+from .variant_builder import materialize_variant
+
+__all__ = [
+    "build_run_record",
+    "classify_failure",
+    "generate_report",
+    "ExperimentRunner",
+    "RunConfig",
+    "materialize_variant",
+]

--- a/research/repo-bloat-benchmark/harness/runner/cli.py
+++ b/research/repo-bloat-benchmark/harness/runner/cli.py
@@ -1,0 +1,66 @@
+"""Run a whole experiment from a JSON config.
+
+Example (from ``research/repo-bloat-benchmark/``)::
+
+    python3 -m harness.runner.cli --config experiment.json
+
+with ``experiment.json``::
+
+    {
+      "scenario_dir": "scenarios/example-pagination",
+      "distractors_dir": "distractors/example-pagination",
+      "reports_dir": "reports/example-pagination",
+      "work_root": "/tmp/repo-bloat-work",
+      "arm": "mock",
+      "mock_behavior": "oracle",
+      "sizes": [1, 2, 5],
+      "trials": 3
+    }
+
+For a real agent arm set ``"arm": "command"`` plus ``"agent_command":
+["codex", "exec", "--cd", "{workdir}", "..."]`` and ``"upstream_base_url"``;
+the runner injects ``OPENAI_BASE_URL`` pointing at the recording proxy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .report import generate_report, load_run_records
+from .runner import ExperimentRunner, RunConfig
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    config_data = json.loads(args.config.read_text(encoding="utf-8"))
+    sizes = config_data.pop("sizes", [1])
+    trials = config_data.pop("trials", 1)
+    run_config = RunConfig(**config_data)
+    runner = ExperimentRunner(run_config)
+
+    for size in sizes:
+        for result in runner.run_cell(size, trials):
+            record = result.record
+            print(
+                f"{record['run_id']}: hidden={'PASS' if record['hidden_pass'] else 'fail'} "
+                f"tokens={record['input_tokens_per_run']} "
+                f"shape={record['growth_shape']} "
+                f"failure={record['failure_class']}"
+            )
+
+    records_path = run_config.reports_dir / "run_records.jsonl"
+    report = generate_report(load_run_records(records_path))
+    report_path = run_config.reports_dir / "report.md"
+    report_path.write_text(report, encoding="utf-8")
+    print(f"report: {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/repo-bloat-benchmark/harness/runner/metrics.py
+++ b/research/repo-bloat-benchmark/harness/runner/metrics.py
@@ -1,0 +1,282 @@
+"""Turn raw run artifacts into the design §6.3 run record.
+
+Sources (all v2 tier-1 — no FS tap required):
+
+- the proxy's snapshot series (tokens, tool calls, first-edit boundary),
+- per-request attribution against the materialized tree + manifest
+  (penetration family), reconciled against provider usage,
+- the iteration analyzer (H2 trajectory family),
+- ``git diff`` name lists against the pre-run baseline (edit classification),
+- visible-test / hidden-verifier outcomes.
+"""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Sequence
+
+from harness.context_snapshots.attribution import (
+    Attribution,
+    TreeIndex,
+    default_token_estimator,
+    reconcile_with_usage,
+)
+from harness.context_snapshots.iteration_analyzer import RunTrajectory
+from harness.context_snapshots.schema import SnapshotRecord
+
+FAILURE_CLASSES = (
+    "wrong_file_edit",
+    "localization_miss",
+    "context_overflow",
+    "timeout",
+    "hidden_contract_miss",
+    "forbidden_access",
+    "other",
+)
+
+
+def classify_edits(
+    changed_paths: Sequence[str],
+    target_files: set[str],
+    allowed_edit_globs: Sequence[str],
+    distractor_paths: set[str],
+    core_files: set[str],
+    forbidden_paths: Sequence[str] = ("hidden/**",),
+) -> dict[str, list[str]]:
+    """Design §6.2 post-hoc precedence: forbidden ⇒ distractor(wrong) ⇒
+    target ⇒ allowed-glob-within-core ⇒ wrong."""
+    result: dict[str, list[str]] = {
+        "forbidden": [],
+        "wrong_file": [],
+        "target": [],
+        "in_scope": [],
+    }
+    for path in changed_paths:
+        path = path.replace("\\", "/")
+        if any(fnmatch(path, glob) for glob in forbidden_paths):
+            result["forbidden"].append(path)
+        elif path in distractor_paths:
+            result["wrong_file"].append(path)
+        elif path in target_files:
+            result["target"].append(path)
+        elif path in core_files and any(
+            fnmatch(path, glob) for glob in allowed_edit_globs
+        ):
+            result["in_scope"].append(path)
+        else:
+            result["wrong_file"].append(path)
+    return result
+
+
+def classify_failure(
+    hidden_pass: bool,
+    visible_pass: bool,
+    timed_out: bool,
+    edit_classes: dict[str, list[str]],
+    target_read_into_context: bool,
+    context_overflow: bool,
+) -> str | None:
+    """One primary failure class per non-pass run (design §6.4)."""
+    if hidden_pass:
+        return None
+    if edit_classes["forbidden"]:
+        return "forbidden_access"
+    if timed_out:
+        return "timeout"
+    if context_overflow:
+        return "context_overflow"
+    if edit_classes["wrong_file"] and not edit_classes["target"]:
+        return "wrong_file_edit"
+    if not target_read_into_context and not edit_classes["target"]:
+        return "localization_miss"
+    if visible_pass:
+        return "hidden_contract_miss"
+    return "other"
+
+
+def build_run_record(
+    *,
+    run_id: str,
+    scenario_id: str,
+    size: str,
+    size_multiplier: int,
+    trial_index: int,
+    arm: str,
+    manifest: dict,
+    manifest_sha256: str,
+    records: Sequence[SnapshotRecord],
+    attributions: Sequence[Attribution],
+    trajectory: RunTrajectory,
+    tree_index: TreeIndex,
+    request_texts: Sequence[str],
+    changed_paths: Sequence[str],
+    target_files: Sequence[str],
+    allowed_edit_globs: Sequence[str],
+    core_files: Sequence[str],
+    visible_pass: bool,
+    hidden_pass: bool,
+    timed_out: bool,
+    wall_clock_seconds: float,
+    timeout_seconds: float,
+    context_overflow: bool = False,
+) -> dict:
+    """Assemble one design-§6.3 run record (JSONL-ready dict)."""
+    records = sorted(records, key=lambda r: r.ordinal)
+    if not (len(records) == len(attributions) == len(request_texts)):
+        raise ValueError("records, attributions, request_texts must be parallel")
+
+    first_edit = trajectory.first_edit_ordinal
+    before_edit = [
+        r for r in records if first_edit is None or r.ordinal < first_edit
+    ]
+
+    input_tokens = [r.input_tokens for r in records if r.input_tokens is not None]
+    input_tokens_per_run = sum(input_tokens)
+    input_tokens_before_first_edit = sum(
+        r.input_tokens for r in before_edit if r.input_tokens is not None
+    )
+    tool_calls_total = sum(len(r.tool_call_names) for r in records)
+    tool_calls_before_first_edit = sum(len(r.tool_call_names) for r in before_edit)
+
+    # Penetration family (repeat-counted, usage-reconciled per request).
+    distractor_context_tokens_total = 0.0
+    distractor_context_tokens_before_first_edit = 0.0
+    distractor_files_entered: set[str] = set()
+    unique_lines: set[str] = set()
+    any_unreconciled = False
+    for record, attribution, text in zip(records, attributions, request_texts):
+        reconciled = reconcile_with_usage(attribution, record.input_tokens)
+        tokens = reconciled["distractor_context_tokens"]
+        distractor_context_tokens_total += tokens
+        if first_edit is None or record.ordinal < first_edit:
+            distractor_context_tokens_before_first_edit += tokens
+        distractor_files_entered |= attribution.distractor_files
+        unique_lines |= tree_index.matched_distractor_lines(text)
+        if not reconciled["reconciled_against_usage"]:
+            any_unreconciled = True
+    distractor_unique_tokens = sum(
+        default_token_estimator(line) for line in unique_lines
+    )
+    distractor_tokens_on_disk = manifest.get("distractor_tokens_on_disk", 0)
+    pool_coverage = (
+        min(1.0, distractor_unique_tokens / distractor_tokens_on_disk)
+        if distractor_tokens_on_disk
+        else 0.0
+    )
+    distractor_context_share = (
+        distractor_context_tokens_total / input_tokens_per_run
+        if input_tokens_per_run
+        else 0.0
+    )
+
+    # Targeting quality (edits) — snapshot-tap era: reads are context-based.
+    distractor_paths = {f["upstream_path"] for f in manifest.get("files", [])}
+    edit_classes = classify_edits(
+        changed_paths,
+        target_files={t.replace("\\", "/") for t in target_files},
+        allowed_edit_globs=allowed_edit_globs,
+        distractor_paths=distractor_paths,
+        core_files={c.replace("\\", "/") for c in core_files},
+    )
+    edits_total = sum(len(v) for v in edit_classes.values())
+    wrong_file_edit_rate = (
+        len(edit_classes["wrong_file"]) / edits_total if edits_total else 0.0
+    )
+
+    target_read_into_context = any(
+        attribution.core_files & set(target_files) for attribution in attributions
+    )
+
+    failure_class = classify_failure(
+        hidden_pass=hidden_pass,
+        visible_pass=visible_pass,
+        timed_out=timed_out,
+        edit_classes=edit_classes,
+        target_read_into_context=target_read_into_context,
+        context_overflow=context_overflow,
+    )
+
+    return {
+        "schema_version": 3,
+        "run_id": run_id,
+        "scenario_id": scenario_id,
+        "size": size,
+        "size_multiplier": size_multiplier,
+        "arm": arm,
+        "trial_index": trial_index,
+        "timeout_seconds": timeout_seconds,
+        "manifest_sha256": manifest_sha256,
+        "fs_tap_enabled": False,
+        # Cost.
+        "iterations_total": trajectory.iterations_total,
+        "iterations_before_first_edit": trajectory.iterations_before_first_edit,
+        "search_or_tool_calls_before_first_edit": tool_calls_before_first_edit,
+        "tool_calls_total": tool_calls_total,
+        "input_tokens_before_first_edit": input_tokens_before_first_edit,
+        "input_tokens_per_run": input_tokens_per_run,
+        "max_request_input_tokens": max(input_tokens, default=0),
+        "wall_clock_seconds": wall_clock_seconds,
+        # Penetration.
+        "distractor_tokens_on_disk": distractor_tokens_on_disk,
+        "distractor_context_tokens_total": round(distractor_context_tokens_total, 1),
+        "distractor_context_tokens_total_before_first_edit": round(
+            distractor_context_tokens_before_first_edit, 1
+        ),
+        "distractor_context_share": round(distractor_context_share, 4),
+        "distractor_unique_tokens_entered_context": round(distractor_unique_tokens, 1),
+        "distractor_pool_coverage": round(pool_coverage, 4),
+        "distractor_files_entered_context": len(distractor_files_entered),
+        "attribution_unreconciled": any_unreconciled,
+        # Trajectory (H2).
+        "growth_shape": trajectory.growth_shape,
+        "largest_single_jump_share": trajectory.largest_single_jump_share,
+        "distractor_context_share_early": trajectory.distractor_share_early,
+        "distractor_context_share_late": trajectory.distractor_share_late,
+        "distractor_context_share_delta": trajectory.share_delta_late_minus_early,
+        # Edits.
+        "edit_classes": edit_classes,
+        "wrong_file_edit_rate": round(wrong_file_edit_rate, 4),
+        "forbidden_file_edits": len(edit_classes["forbidden"]),
+        # Outcome.
+        "visible_pass": visible_pass,
+        "hidden_pass": hidden_pass,
+        "failure_class": failure_class,
+    }
+
+
+# Runtime droppings that are not agent edits (created by running the tests).
+_EDIT_NOISE = ("__pycache__/", ".pytest_cache/", ".pyc")
+
+
+def read_changed_paths(workdir: str | Path) -> list[str]:
+    """Changed paths vs. the pre-run baseline commit (git diff tap).
+
+    Interpreter/test-runner cache artifacts are filtered: they are produced
+    by the harness's own verification runs, not by the agent.
+    """
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "HEAD"],
+        cwd=str(workdir),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    untracked = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=str(workdir),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    paths = [p for p in result.stdout.splitlines() if p.strip()]
+    paths += [p for p in untracked.stdout.splitlines() if p.strip()]
+    return sorted(
+        {
+            p
+            for p in paths
+            if not any(noise in p for noise in _EDIT_NOISE)
+        }
+    )

--- a/research/repo-bloat-benchmark/harness/runner/mock_agent.py
+++ b/research/repo-bloat-benchmark/harness/runner/mock_agent.py
@@ -1,0 +1,170 @@
+"""Scripted mock agent + mock model server for no-token pipeline validation.
+
+The design's calibration principle (§6.6): validate every instrumentation and
+scoring path end-to-end **without spending model tokens**. The mock agent
+drives realistic traffic through the real ``RecordingProxy`` — reading real
+files from the materialized variant and surfacing their contents into request
+payloads — and then edits the repo according to a scripted *behavior*:
+
+- ``oracle``     — applies the scenario's oracle edit (hidden verifier passes)
+- ``wrong_file`` — edits a distractor file instead (wrong-file edit)
+- ``noop``       — reads but never edits (hidden verifier keeps failing)
+
+The mock model server plays the provider: scripted tool-call responses with
+size-derived ``usage`` so the iteration analyzer sees a realistic growth curve.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+class MockModelServer:
+    """Fake provider: read-tool responses until the agent asks to edit."""
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 0) -> None:
+        self.host = host
+        self.port = port
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self.request_count = 0
+
+    def start(self) -> str:
+        server_ref = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *args):  # noqa: D102
+                pass
+
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(length)
+                server_ref.request_count += 1
+                try:
+                    payload = json.loads(body)
+                except json.JSONDecodeError:
+                    payload = {}
+                # The mock agent states its intent in the last message.
+                messages = payload.get("messages") or []
+                last = str(messages[-1].get("content", "")) if messages else ""
+                if "INTENT: edit" in last:
+                    tool = {"function": {"name": "apply_patch"}}
+                elif "INTENT: done" in last:
+                    tool = None
+                else:
+                    tool = {"function": {"name": "read_file"}}
+                message: dict = {"role": "assistant", "content": "ok"}
+                if tool:
+                    message["tool_calls"] = [tool]
+                response = {
+                    "id": f"mock-{server_ref.request_count}",
+                    "model": payload.get("model", "mock-model"),
+                    "choices": [{"message": message}],
+                    "usage": {
+                        # Size-derived so context growth mirrors payload growth.
+                        "prompt_tokens": max(1, len(body) // 4),
+                        "completion_tokens": 20,
+                        "total_tokens": max(1, len(body) // 4) + 20,
+                    },
+                }
+                out = json.dumps(response).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(out)))
+                self.end_headers()
+                self.wfile.write(out)
+
+        self._server = ThreadingHTTPServer((self.host, self.port), Handler)
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return f"http://{self.host}:{self.port}"
+
+    def stop(self) -> None:
+        if self._server:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+
+class MockAgent:
+    """Scripted client that behaves like a (very predictable) coding agent."""
+
+    def __init__(
+        self,
+        proxy_base_url: str,
+        workdir: str | Path,
+        behavior: str = "oracle",
+        files_to_read: list[str] | None = None,
+        oracle_edit: dict | None = None,
+        wrong_file: str | None = None,
+        model: str = "mock-model",
+    ) -> None:
+        self.proxy_base_url = proxy_base_url.rstrip("/")
+        self.workdir = Path(workdir)
+        self.behavior = behavior
+        self.files_to_read = files_to_read or []
+        self.oracle_edit = oracle_edit or {}
+        self.wrong_file = wrong_file
+        self.model = model
+        self._messages: list[dict] = [
+            {"role": "system", "content": "You are a code-patching agent."},
+        ]
+
+    def _post(self, content: str) -> dict:
+        self._messages.append({"role": "user", "content": content})
+        body = json.dumps({"model": self.model, "messages": self._messages}).encode()
+        request = urllib.request.Request(
+            f"{self.proxy_base_url}/v1/chat/completions",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=30) as resp:
+            return json.loads(resp.read())
+
+    def run(self, task_brief: str = "fix the bug") -> None:
+        self._post(f"TASK: {task_brief}")
+        # Localization phase: surface real file contents into the context.
+        for rel in self.files_to_read:
+            path = self.workdir / rel
+            content = path.read_text(encoding="utf-8", errors="replace")
+            self._messages.append(
+                {"role": "tool", "content": f"read_file({rel}):\n{content}"}
+            )
+            self._post(f"I read {rel}; continuing localization.")
+        # Edit phase.
+        if self.behavior == "oracle":
+            self._post("INTENT: edit — applying the fix to the target file.")
+            self._apply_oracle_edit()
+        elif self.behavior == "wrong_file":
+            self._post("INTENT: edit — applying a fix.")
+            self._apply_wrong_file_edit()
+        # noop: never edits.
+        self._post("INTENT: done")
+
+    def _apply_oracle_edit(self) -> None:
+        target = self.workdir / self.oracle_edit["file"]
+        source = target.read_text(encoding="utf-8")
+        old, new = self.oracle_edit["old"], self.oracle_edit["new"]
+        if old not in source:
+            raise AssertionError(f"oracle edit anchor not found in {target}")
+        target.write_text(source.replace(old, new), encoding="utf-8")
+
+    def _apply_wrong_file_edit(self) -> None:
+        if not self.wrong_file:
+            raise AssertionError("wrong_file behavior needs a wrong_file path")
+        path = self.workdir / self.wrong_file
+        path.write_text(
+            path.read_text(encoding="utf-8") + "\n# hotfix: adjusted rounding\n",
+            encoding="utf-8",
+        )

--- a/research/repo-bloat-benchmark/harness/runner/report.py
+++ b/research/repo-bloat-benchmark/harness/runner/report.py
@@ -1,0 +1,302 @@
+"""Report generation (design.md §7): per-size tables, descriptive fits,
+growth-shape distribution, and the pre-registered-threshold checklist.
+
+Pure-python statistics (least squares, Spearman rank correlation, medians) so
+the harness stays dependency-free; the numbers are descriptive effect sizes,
+never significance claims (§7.2).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from statistics import median
+from typing import Sequence
+
+# Pre-registered practical thresholds (design §7.5).
+THRESHOLD_COST_RISE = 2.0  # ≥2x input_tokens_per_run 1x→max
+THRESHOLD_SHARE_RISE = 0.20  # distractor_context_share absolute rise
+THRESHOLD_HIDDEN_DROP = 0.20  # hidden_pass_rate absolute drop
+THRESHOLD_H2_DELTA = 0.15  # late−early per-request share at ≥20x
+H3_BREAKDOWN_FACTOR = 0.5  # hidden_pass(S*) ≤ 0.5 × hidden_pass(1x)
+
+
+def least_squares(xs: Sequence[float], ys: Sequence[float]) -> tuple[float, float, float]:
+    """Return (alpha, beta, r_squared) for y ≈ alpha + beta·x."""
+    n = len(xs)
+    if n < 2:
+        return (ys[0] if ys else 0.0, 0.0, 0.0)
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    ss_xx = sum((x - mean_x) ** 2 for x in xs)
+    ss_xy = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    ss_yy = sum((y - mean_y) ** 2 for y in ys)
+    beta = ss_xy / ss_xx if ss_xx else 0.0
+    alpha = mean_y - beta * mean_x
+    r_squared = (ss_xy**2 / (ss_xx * ss_yy)) if ss_xx and ss_yy else 0.0
+    return alpha, beta, r_squared
+
+
+def _ranks(values: Sequence[float]) -> list[float]:
+    order = sorted(range(len(values)), key=lambda i: values[i])
+    ranks = [0.0] * len(values)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        rank = (i + j) / 2 + 1
+        for k in range(i, j + 1):
+            ranks[order[k]] = rank
+        i = j + 1
+    return ranks
+
+
+def spearman_rho(xs: Sequence[float], ys: Sequence[float]) -> float:
+    """Rank correlation — captures monotone (possibly threshold-like) trends."""
+    if len(xs) < 2:
+        return 0.0
+    rank_x, rank_y = _ranks(xs), _ranks(ys)
+    _, beta, r_squared = least_squares(rank_x, rank_y)
+    return (r_squared**0.5) * (1 if beta >= 0 else -1)
+
+
+# --------------------------------------------------------------------------
+
+
+def _by_size(records: list[dict]) -> dict[int, list[dict]]:
+    cells: dict[int, list[dict]] = {}
+    for record in records:
+        cells.setdefault(record["size_multiplier"], []).append(record)
+    return dict(sorted(cells.items()))
+
+
+def _fmt(value: float | None, digits: int = 1) -> str:
+    if value is None:
+        return "—"
+    return f"{value:.{digits}f}"
+
+
+def _median_of(cell: list[dict], key: str) -> float | None:
+    values = [r[key] for r in cell if r.get(key) is not None]
+    return median(values) if values else None
+
+
+def _rate_of(cell: list[dict], key: str) -> str:
+    hits = sum(1 for r in cell if r.get(key))
+    return f"{hits}/{len(cell)}"
+
+
+def _modal_shape(cell: list[dict]) -> str:
+    counts: dict[str, int] = {}
+    for record in cell:
+        shape = record.get("growth_shape", "unknown")
+        counts[shape] = counts.get(shape, 0) + 1
+    return max(counts.items(), key=lambda kv: (kv[1], kv[0]))[0] if counts else "—"
+
+
+def generate_report(records: list[dict], scenario_id: str | None = None) -> str:
+    """Render the markdown report for one scenario's run records."""
+    if scenario_id:
+        records = [r for r in records if r["scenario_id"] == scenario_id]
+    if not records:
+        return "# Repo-bloat report\n\n(no run records)\n"
+    cells = _by_size(records)
+    sizes = list(cells)
+    lines: list[str] = []
+    scenario = scenario_id or records[0]["scenario_id"]
+    lines.append(f"# Repo-bloat report — `{scenario}`")
+    lines.append("")
+    lines.append(
+        f"Runs: {len(records)} across sizes {', '.join(f'{s}x' for s in sizes)}. "
+        "All numbers are **descriptive** (median per cell; rates as k/n); "
+        "N per cell is small by design — no significance claims (design §7.2)."
+    )
+    lines.append("")
+
+    # §7.1 per-size table.
+    header = "| Metric | " + " | ".join(f"{s}x" for s in sizes) + " |"
+    lines.append(header)
+    lines.append("|" + "---|" * (len(sizes) + 1))
+    rows: list[tuple[str, list[str]]] = [
+        ("`hidden_pass_rate`", [_rate_of(cells[s], "hidden_pass") for s in sizes]),
+        ("`visible_pass_rate`", [_rate_of(cells[s], "visible_pass") for s in sizes]),
+        (
+            "`input_tokens_per_run` (med)",
+            [_fmt(_median_of(cells[s], "input_tokens_per_run"), 0) for s in sizes],
+        ),
+        (
+            "`input_tokens_before_first_edit` (med)",
+            [
+                _fmt(_median_of(cells[s], "input_tokens_before_first_edit"), 0)
+                for s in sizes
+            ],
+        ),
+        (
+            "`max_request_input_tokens` (med)",
+            [_fmt(_median_of(cells[s], "max_request_input_tokens"), 0) for s in sizes],
+        ),
+        (
+            "`search_or_tool_calls_before_first_edit` (med)",
+            [
+                _fmt(_median_of(cells[s], "search_or_tool_calls_before_first_edit"), 1)
+                for s in sizes
+            ],
+        ),
+        (
+            "`iterations_total` (med)",
+            [_fmt(_median_of(cells[s], "iterations_total"), 1) for s in sizes],
+        ),
+        (
+            "`distractor_context_share` (med)",
+            [_fmt(_median_of(cells[s], "distractor_context_share"), 3) for s in sizes],
+        ),
+        (
+            "`distractor_pool_coverage` (med)",
+            [_fmt(_median_of(cells[s], "distractor_pool_coverage"), 3) for s in sizes],
+        ),
+        (
+            "`distractor_context_share` Δ late−early (med, H2)",
+            [
+                _fmt(_median_of(cells[s], "distractor_context_share_delta"), 3)
+                for s in sizes
+            ],
+        ),
+        ("`growth_shape` (modal, H2)", [_modal_shape(cells[s]) for s in sizes]),
+        (
+            "`wrong_file_edit_rate` (med)",
+            [_fmt(_median_of(cells[s], "wrong_file_edit_rate"), 3) for s in sizes],
+        ),
+        (
+            "`wall_clock_seconds` (med)",
+            [_fmt(_median_of(cells[s], "wall_clock_seconds"), 1) for s in sizes],
+        ),
+    ]
+    for label, values in rows:
+        lines.append(f"| {label} | " + " | ".join(values) + " |")
+    lines.append("")
+
+    # §7.2 fits (dose = on-disk distractor tokens; per-run points).
+    xs = [float(r["distractor_tokens_on_disk"]) for r in records]
+    lines.append("## Trend fits (descriptive)")
+    lines.append("")
+    for key in ("input_tokens_per_run", "distractor_context_share"):
+        ys = [float(r[key]) for r in records if r.get(key) is not None]
+        xs_k = [
+            float(r["distractor_tokens_on_disk"])
+            for r in records
+            if r.get(key) is not None
+        ]
+        alpha, beta, r_squared = least_squares(xs_k, ys)
+        rho = spearman_rho(xs_k, ys)
+        lines.append(
+            f"- `{key}` ≈ {alpha:.1f} + {beta:.6f} · distractor_tokens_on_disk "
+            f"(R²={r_squared:.3f}, Spearman ρ={rho:.3f})"
+        )
+    hidden_ys = [1.0 if r["hidden_pass"] else 0.0 for r in records]
+    rho_hidden = spearman_rho(xs, hidden_ys)
+    lines.append(f"- `hidden_pass` vs. dose: Spearman ρ={rho_hidden:.3f}")
+    lines.append("")
+
+    # Failure classes.
+    lines.append("## Failure classes per size")
+    lines.append("")
+    for size in sizes:
+        counts: dict[str, int] = {}
+        for record in cells[size]:
+            if record["failure_class"]:
+                counts[record["failure_class"]] = counts.get(record["failure_class"], 0) + 1
+        rendered = ", ".join(f"{k}: {v}" for k, v in sorted(counts.items())) or "none"
+        lines.append(f"- **{size}x** — {rendered}")
+    lines.append("")
+
+    # §7.5 pre-registered threshold checklist.
+    lines.append("## Pre-registered thresholds (design §7.5)")
+    lines.append("")
+    verdicts = evaluate_thresholds(records)
+    for name, (status, detail) in verdicts.items():
+        lines.append(f"- **{name}**: {status} — {detail}")
+    lines.append("")
+    lines.append(
+        "> Interpretation rules are fixed in design §7.5; this checklist is "
+        "computed, but the supports/weakens/inconclusive verdict must be "
+        "written by the analyst against those rules, with dispersion in view."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def evaluate_thresholds(records: list[dict]) -> dict[str, tuple[str, str]]:
+    """Compute each §7.5 threshold where the data allows it."""
+    cells = _by_size(records)
+    sizes = list(cells)
+    out: dict[str, tuple[str, str]] = {}
+    if not sizes:
+        return out
+    smallest, largest = sizes[0], sizes[-1]
+
+    def rate(size: int) -> float:
+        cell = cells[size]
+        return sum(1 for r in cell if r["hidden_pass"]) / len(cell)
+
+    # H1 cost rise.
+    low = _median_of(cells[smallest], "input_tokens_per_run")
+    high = _median_of(cells[largest], "input_tokens_per_run")
+    if low and high:
+        ratio = high / low
+        crossed = ratio >= THRESHOLD_COST_RISE
+        out["localization-cost rise (≥2x tokens)"] = (
+            "CROSSED" if crossed else "not crossed",
+            f"{smallest}x med {low:.0f} → {largest}x med {high:.0f} ({ratio:.2f}x)",
+        )
+    # Penetration rise.
+    low_share = _median_of(cells[smallest], "distractor_context_share") or 0.0
+    high_share = _median_of(cells[largest], "distractor_context_share") or 0.0
+    out["context-penetration rise (≥0.20 share)"] = (
+        "CROSSED" if high_share - low_share >= THRESHOLD_SHARE_RISE else "not crossed",
+        f"share {low_share:.3f} → {high_share:.3f}",
+    )
+    # Hidden-success drop.
+    drop = rate(smallest) - rate(largest)
+    out["hidden-success drop (≥20 pp)"] = (
+        "CROSSED" if drop >= THRESHOLD_HIDDEN_DROP else "not crossed",
+        f"hidden_pass_rate {rate(smallest):.2f} → {rate(largest):.2f}",
+    )
+    # H2 within-run accumulation at ≥20x.
+    big_sizes = [s for s in sizes if s >= 20]
+    if big_sizes:
+        deltas = [
+            r.get("distractor_context_share_delta")
+            for s in big_sizes
+            for r in cells[s]
+            if r.get("distractor_context_share_delta") is not None
+        ]
+        modal = _modal_shape([r for s in big_sizes for r in cells[s]])
+        if deltas:
+            med_delta = median(deltas)
+            crossed = med_delta >= THRESHOLD_H2_DELTA and modal == "gradual"
+            out["H2 within-run accumulation"] = (
+                "CROSSED" if crossed else "not crossed",
+                f"median Δ(late−early)={med_delta:.3f} at ≥20x, modal shape={modal}",
+            )
+    # H3 breakdown location.
+    base_rate = rate(smallest)
+    knee = next(
+        (s for s in sizes if rate(s) <= H3_BREAKDOWN_FACTOR * base_rate), None
+    )
+    out["H3 breakdown location"] = (
+        f"S* = {knee}x" if knee is not None else f"S* > {largest}x",
+        f"first size with hidden_pass_rate ≤ {H3_BREAKDOWN_FACTOR} × rate(1x)"
+        if knee is not None
+        else "no ladder step qualifies; §5.1 breakdown probe applies",
+    )
+    return out
+
+
+def load_run_records(path: str | Path) -> list[dict]:
+    records = []
+    with Path(path).open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    return records

--- a/research/repo-bloat-benchmark/harness/runner/runner.py
+++ b/research/repo-bloat-benchmark/harness/runner/runner.py
@@ -1,0 +1,266 @@
+"""Run orchestration (design.md §3.2 stage 4).
+
+For each (scenario, size, trial):
+
+1. verify the manifest against ``manifests.lock`` (freeze enforcement),
+2. materialize a fresh variant (sha-verified) and ``git init`` a baseline,
+3. start the recording proxy (and, for the ``mock`` arm, the mock provider),
+4. run the agent (mock behavior or an external command with the proxy's
+   base URL injected into its environment),
+5. run visible tests and the hidden verifier (hidden tree never enters the
+   variant),
+6. attribute snapshots, analyze the iteration trajectory, and write one run
+   record (JSONL line) plus raw artifacts under ``reports/<run_id>/``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from harness.context_snapshots.attribution import TreeIndex, extract_payload_text
+from harness.context_snapshots.iteration_analyzer import analyze_run
+from harness.context_snapshots.proxy import RecordingProxy
+from harness.distractors.manifest import load_manifest, manifest_sha256, verify_lockfile
+from harness.runner.metrics import build_run_record, read_changed_paths
+from harness.runner.mock_agent import MockAgent, MockModelServer
+from harness.runner.variant_builder import materialize_variant
+
+
+@dataclass
+class RunConfig:
+    scenario_dir: Path  # holds core/, hidden/, scenario.json, task.md, (pool/)
+    distractors_dir: Path  # ManifestWriter output (manifests/ + generated/ + lock)
+    reports_dir: Path
+    work_root: Path  # fresh variants are materialized under here
+    arm: str = "mock"  # "mock" or "command"
+    agent_command: list[str] | None = None  # for arm="command"; {workdir} expanded
+    upstream_base_url: str | None = None  # real provider for arm="command"
+    mock_behavior: str = "oracle"  # oracle | wrong_file | noop
+    mock_read_distractor_count: int = 2
+    timeout_seconds: float = 1800.0
+    check_baseline: bool = True  # assert visible-pass/hidden-fail before the agent
+
+    def __post_init__(self) -> None:
+        for name in ("scenario_dir", "distractors_dir", "reports_dir", "work_root"):
+            setattr(self, name, Path(getattr(self, name)))
+
+
+@dataclass
+class TrialResult:
+    record: dict
+    report_dir: Path
+
+
+class ExperimentRunner:
+    def __init__(self, config: RunConfig) -> None:
+        self.config = config
+        self.scenario = json.loads(
+            (config.scenario_dir / "scenario.json").read_text(encoding="utf-8")
+        )
+
+    # -- helpers -------------------------------------------------------------
+
+    def _run(self, command: list[str], cwd: Path, env_extra: dict | None = None,
+             timeout: float | None = None) -> subprocess.CompletedProcess:
+        import os
+
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(cwd / "src")
+        env.update(env_extra or {})
+        return subprocess.run(
+            command, cwd=str(cwd), env=env, capture_output=True, text=True,
+            timeout=timeout,
+        )
+
+    def _visible_pass(self, workdir: Path) -> bool:
+        result = self._run(self.scenario["visible_tests"]["command"], cwd=workdir)
+        return result.returncode == 0
+
+    def _hidden_pass(self, workdir: Path) -> bool:
+        hidden_dir = self.config.scenario_dir / self.scenario["hidden_verifier"]["path"]
+        import os
+
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(workdir / "src")
+        result = subprocess.run(
+            self.scenario["hidden_verifier"]["command"],
+            cwd=str(hidden_dir),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0
+
+    def _git(self, workdir: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", *args], cwd=str(workdir), check=True, capture_output=True,
+            env={"PATH": "/usr/bin:/bin:/usr/local/bin",
+                 "GIT_AUTHOR_NAME": "harness", "GIT_AUTHOR_EMAIL": "harness@local",
+                 "GIT_COMMITTER_NAME": "harness", "GIT_COMMITTER_EMAIL": "harness@local",
+                 "HOME": str(workdir)},
+        )
+
+    # -- the run -------------------------------------------------------------
+
+    def run_trial(self, size: int, trial_index: int) -> TrialResult:
+        config = self.config
+        scenario_id = self.scenario["scenario_id"]
+        size_label = f"{size}x"
+        run_id = f"{scenario_id}.{size_label}.trial{trial_index}"
+        report_dir = config.reports_dir / run_id
+        if report_dir.exists():
+            shutil.rmtree(report_dir)
+        report_dir.mkdir(parents=True)
+
+        # 1. Freeze enforcement.
+        manifest_path = (
+            config.distractors_dir / "manifests" / f"{scenario_id}.{size_label}.json"
+        )
+        lock_path = config.distractors_dir / "manifests.lock"
+        if not verify_lockfile(manifest_path, lock_path):
+            raise RuntimeError(
+                f"freeze violation: {manifest_path.name} not verified by {lock_path}"
+            )
+        manifest = load_manifest(manifest_path)
+
+        # 2. Materialize + baseline.
+        workdir = config.work_root / run_id
+        if workdir.exists():
+            shutil.rmtree(workdir)
+        materialize_variant(
+            core_root=config.scenario_dir / self.scenario["core_path"],
+            manifest=manifest,
+            destination=workdir,
+            pool_root=(
+                config.scenario_dir / self.scenario["pool_path"]
+                if self.scenario.get("pool_path")
+                else None
+            ),
+            distractors_dir=config.distractors_dir,
+        )
+        self._git(workdir, "init", "-q")
+        self._git(workdir, "add", "-A")
+        self._git(workdir, "commit", "-qm", "pre-run baseline")
+
+        if config.check_baseline:
+            if not self._visible_pass(workdir):
+                raise RuntimeError("baseline violation: visible tests fail pre-run")
+            if self._hidden_pass(workdir):
+                raise RuntimeError("baseline violation: hidden verifier passes pre-run")
+
+        # 3. Instrumentation.
+        mock_server = None
+        upstream = config.upstream_base_url
+        if config.arm == "mock":
+            mock_server = MockModelServer()
+            upstream = mock_server.start()
+        proxy = RecordingProxy(
+            upstream_base_url=upstream,
+            archive_dir=report_dir,
+            run_id=run_id,
+        )
+        proxy_url = proxy.start()
+
+        # 4. Agent.
+        timed_out = False
+        started = time.monotonic()
+        try:
+            if config.arm == "mock":
+                distractor_reads = [
+                    f["upstream_path"] for f in manifest["files"]
+                ][: config.mock_read_distractor_count]
+                agent = MockAgent(
+                    proxy_base_url=proxy_url,
+                    workdir=workdir,
+                    behavior=config.mock_behavior,
+                    files_to_read=distractor_reads + list(self.scenario["target_files"]),
+                    oracle_edit=self.scenario.get("oracle_edit"),
+                    wrong_file=(manifest["files"][0]["upstream_path"]
+                                if manifest["files"] else None),
+                )
+                task_brief = (
+                    config.scenario_dir / self.scenario["task_brief_path"]
+                ).read_text(encoding="utf-8")
+                agent.run(task_brief=task_brief)
+            else:
+                command = [
+                    part.replace("{workdir}", str(workdir))
+                    for part in (config.agent_command or [])
+                ]
+                try:
+                    self._run(
+                        command,
+                        cwd=workdir,
+                        env_extra={"OPENAI_BASE_URL": f"{proxy_url}/v1"},
+                        timeout=config.timeout_seconds,
+                    )
+                except subprocess.TimeoutExpired:
+                    timed_out = True
+        finally:
+            wall_clock = time.monotonic() - started
+            proxy.stop()
+            if mock_server:
+                mock_server.stop()
+
+        # 5. Verification.
+        visible_pass = self._visible_pass(workdir)
+        hidden_pass = self._hidden_pass(workdir)
+        changed_paths = read_changed_paths(workdir)
+        (report_dir / "post_run.diff").write_text(
+            "\n".join(changed_paths) + "\n", encoding="utf-8"
+        )
+
+        # 6. Attribution + trajectory + record.
+        distractor_paths = [f["upstream_path"] for f in manifest["files"]]
+        tree_index = TreeIndex(workdir, distractor_paths=distractor_paths)
+        request_texts = [
+            extract_payload_text((report_dir / r.payload_path).read_bytes())
+            for r in proxy.records
+        ]
+        attributions = [tree_index.classify_text(text) for text in request_texts]
+        trajectory = analyze_run(proxy.records, attributions)
+
+        core_root = config.scenario_dir / self.scenario["core_path"]
+        core_files = [
+            p.relative_to(core_root).as_posix()
+            for p in core_root.rglob("*")
+            if p.is_file()
+        ]
+        record = build_run_record(
+            run_id=run_id,
+            scenario_id=scenario_id,
+            size=size_label,
+            size_multiplier=size,
+            trial_index=trial_index,
+            arm=config.arm,
+            manifest=manifest,
+            manifest_sha256=manifest_sha256(manifest_path),
+            records=proxy.records,
+            attributions=attributions,
+            trajectory=trajectory,
+            tree_index=tree_index,
+            request_texts=request_texts,
+            changed_paths=changed_paths,
+            target_files=self.scenario["target_files"],
+            allowed_edit_globs=self.scenario.get("allowed_edit_globs", []),
+            core_files=core_files,
+            visible_pass=visible_pass,
+            hidden_pass=hidden_pass,
+            timed_out=timed_out,
+            wall_clock_seconds=wall_clock,
+            timeout_seconds=config.timeout_seconds,
+        )
+        (report_dir / "run_record.json").write_text(
+            json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        with (config.reports_dir / "run_records.jsonl").open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True) + "\n")
+        return TrialResult(record=record, report_dir=report_dir)
+
+    def run_cell(self, size: int, trials: int) -> list[TrialResult]:
+        return [self.run_trial(size, t) for t in range(trials)]

--- a/research/repo-bloat-benchmark/harness/runner/tests/conftest.py
+++ b/research/repo-bloat-benchmark/harness/runner/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Make `harness.*` importable when pytest runs from any directory."""
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parents[3]
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))

--- a/research/repo-bloat-benchmark/harness/runner/tests/test_end_to_end.py
+++ b/research/repo-bloat-benchmark/harness/runner/tests/test_end_to_end.py
@@ -1,0 +1,122 @@
+"""End-to-end pipeline test on the committed example scenario — no model
+tokens, no network beyond loopback.
+
+Exercises: manifest generation + lock → freeze check → sha-verified variant
+materialization → git baseline → mock provider + real recording proxy →
+scripted agent traffic (real file contents surfaced into requests) →
+visible/hidden verification → attribution → trajectory → run record →
+report. This is the §6.6 calibration principle applied to the whole pipeline.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from harness.distractors.generator import GenerationConfig, generate_manifest
+from harness.distractors.manifest import ManifestWriter, write_lockfile
+from harness.runner.report import generate_report
+from harness.runner.runner import ExperimentRunner, RunConfig
+
+SCENARIO_DIR = Path(__file__).resolve().parents[3] / "scenarios" / "example-pagination"
+
+
+@pytest.fixture(scope="module")
+def distractors_dir(tmp_path_factory):
+    """Generate + freeze manifests for the example scenario (1x and 5x)."""
+    out = tmp_path_factory.mktemp("distractors")
+    scenario = json.loads((SCENARIO_DIR / "scenario.json").read_text())
+    config = GenerationConfig(
+        scenario_id=scenario["scenario_id"],
+        core_root=SCENARIO_DIR / "core",
+        pool_root=SCENARIO_DIR / "pool",
+        target_file=scenario["target_files"][0],
+        leak_denylist=tuple(scenario["leak_denylist"]),
+        template_file_tokens=150,
+    )
+    writer = ManifestWriter(out)
+    paths = [writer.write(generate_manifest(config, size)) for size in (1, 5)]
+    write_lockfile(paths, out / "manifests.lock")
+    return out
+
+
+def _runner(tmp_path, distractors_dir, behavior):
+    return ExperimentRunner(
+        RunConfig(
+            scenario_dir=SCENARIO_DIR,
+            distractors_dir=distractors_dir,
+            reports_dir=tmp_path / "reports",
+            work_root=tmp_path / "work",
+            arm="mock",
+            mock_behavior=behavior,
+        )
+    )
+
+
+def test_oracle_agent_passes_hidden_at_1x(tmp_path, distractors_dir):
+    result = _runner(tmp_path, distractors_dir, "oracle").run_trial(1, 0)
+    record = result.record
+    assert record["visible_pass"]
+    assert record["hidden_pass"]
+    assert record["failure_class"] is None
+    assert record["iterations_total"] >= 3
+    assert record["input_tokens_per_run"] > 0
+    assert record["distractor_tokens_on_disk"] == 0
+    # Edit landed on the target, in scope.
+    assert record["edit_classes"]["target"] == ["src/pager/pagination.py"]
+    # Raw artifacts exist for third-party re-derivation.
+    assert (result.report_dir / "context_snapshots.jsonl").is_file()
+    assert (result.report_dir / "run_record.json").is_file()
+
+
+def test_oracle_agent_passes_hidden_at_5x_with_penetration(tmp_path, distractors_dir):
+    result = _runner(tmp_path, distractors_dir, "oracle").run_trial(5, 0)
+    record = result.record
+    assert record["hidden_pass"]
+    # The mock agent read distractor files into context → penetration > 0.
+    assert record["distractor_context_tokens_total"] > 0
+    assert record["distractor_files_entered_context"] >= 1
+    assert 0 < record["distractor_pool_coverage"] <= 1
+    assert record["growth_shape"] in {"gradual", "step", "plateau", "sawtooth"}
+
+
+def test_wrong_file_agent_classified(tmp_path, distractors_dir):
+    result = _runner(tmp_path, distractors_dir, "wrong_file").run_trial(5, 0)
+    record = result.record
+    assert record["visible_pass"]  # nothing behavioral changed in core
+    assert not record["hidden_pass"]
+    assert record["failure_class"] == "wrong_file_edit"
+    assert record["edit_classes"]["wrong_file"]
+    assert record["wrong_file_edit_rate"] == 1.0
+
+
+def test_noop_agent_is_hidden_contract_miss(tmp_path, distractors_dir):
+    result = _runner(tmp_path, distractors_dir, "noop").run_trial(5, 0)
+    record = result.record
+    assert record["visible_pass"]
+    assert not record["hidden_pass"]
+    # The mock agent read the target into context, so not a localization miss.
+    assert record["failure_class"] == "hidden_contract_miss"
+    assert record["iterations_before_first_edit"] is None
+
+
+def test_freeze_violation_refuses_to_run(tmp_path, distractors_dir):
+    manifest_path = (
+        distractors_dir / "manifests" / "example-pagination.5x.json"
+    )
+    original = manifest_path.read_text()
+    manifest_path.write_text(original.replace("example-pagination", "example-pagination") + "\n")
+    try:
+        with pytest.raises(RuntimeError, match="freeze violation"):
+            _runner(tmp_path, distractors_dir, "oracle").run_trial(5, 1)
+    finally:
+        manifest_path.write_text(original)
+
+
+def test_report_renders_from_records(tmp_path, distractors_dir):
+    runner = _runner(tmp_path, distractors_dir, "oracle")
+    records = [runner.run_trial(size, 0).record for size in (1, 5)]
+    report = generate_report(records)
+    assert "`hidden_pass_rate`" in report
+    assert "| Metric | 1x | 5x |" in report
+    assert "Pre-registered thresholds" in report

--- a/research/repo-bloat-benchmark/harness/runner/tests/test_report.py
+++ b/research/repo-bloat-benchmark/harness/runner/tests/test_report.py
@@ -1,0 +1,99 @@
+"""Tests for report generation and the pure-python statistics."""
+
+from harness.runner.report import (
+    evaluate_thresholds,
+    generate_report,
+    least_squares,
+    spearman_rho,
+)
+
+
+def _record(size, trial, hidden, tokens, share, delta=0.05, shape="gradual",
+            failure=None):
+    return {
+        "run_id": f"demo.{size}x.trial{trial}",
+        "scenario_id": "demo",
+        "size": f"{size}x",
+        "size_multiplier": size,
+        "hidden_pass": hidden,
+        "visible_pass": True,
+        "input_tokens_per_run": tokens,
+        "input_tokens_before_first_edit": tokens // 2,
+        "max_request_input_tokens": tokens // 3,
+        "search_or_tool_calls_before_first_edit": 3,
+        "iterations_total": 6,
+        "distractor_tokens_on_disk": (size - 1) * 1000,
+        "distractor_context_share": share,
+        "distractor_pool_coverage": share / 2,
+        "distractor_context_share_delta": delta,
+        "growth_shape": shape,
+        "wrong_file_edit_rate": 0.0,
+        "wall_clock_seconds": 10.0,
+        "failure_class": failure,
+    }
+
+
+def _degrading_records():
+    records = []
+    for trial in range(3):
+        records.append(_record(1, trial, True, 5000, 0.0))
+        records.append(_record(5, trial, True, 9000, 0.15))
+        records.append(
+            _record(20, trial, trial == 0, 14000, 0.30, delta=0.2)
+        )
+        records.append(
+            _record(
+                50, trial, False, 22000, 0.45, delta=0.25,
+                failure="wrong_file_edit",
+            )
+        )
+    return records
+
+
+def test_least_squares_recovers_line():
+    xs = [0, 1, 2, 3, 4]
+    ys = [1, 3, 5, 7, 9]  # y = 1 + 2x
+    alpha, beta, r_squared = least_squares(xs, ys)
+    assert abs(alpha - 1) < 1e-9
+    assert abs(beta - 2) < 1e-9
+    assert abs(r_squared - 1) < 1e-9
+
+
+def test_spearman_monotone_nonlinear():
+    xs = [1, 2, 3, 4, 5]
+    ys = [1, 8, 27, 64, 125]  # monotone, nonlinear
+    assert abs(spearman_rho(xs, ys) - 1.0) < 1e-9
+    assert abs(spearman_rho(xs, list(reversed(ys))) + 1.0) < 1e-9
+
+
+def test_report_contains_table_fits_failures_thresholds():
+    report = generate_report(_degrading_records())
+    assert "| Metric | 1x | 5x | 20x | 50x |" in report
+    assert "`hidden_pass_rate`" in report
+    assert "Trend fits" in report
+    assert "wrong_file_edit: 3" in report
+    assert "Pre-registered thresholds" in report
+
+
+def test_thresholds_crossed_on_degrading_data():
+    verdicts = evaluate_thresholds(_degrading_records())
+    assert verdicts["localization-cost rise (≥2x tokens)"][0] == "CROSSED"
+    assert verdicts["context-penetration rise (≥0.20 share)"][0] == "CROSSED"
+    assert verdicts["hidden-success drop (≥20 pp)"][0] == "CROSSED"
+    assert verdicts["H2 within-run accumulation"][0] == "CROSSED"
+    assert verdicts["H3 breakdown location"][0] == "S* = 20x"
+
+
+def test_thresholds_flat_data_not_crossed():
+    records = []
+    for trial in range(3):
+        for size in (1, 5, 20, 50):
+            records.append(_record(size, trial, True, 5000, 0.02, delta=0.0))
+    verdicts = evaluate_thresholds(records)
+    assert verdicts["localization-cost rise (≥2x tokens)"][0] == "not crossed"
+    assert verdicts["hidden-success drop (≥20 pp)"][0] == "not crossed"
+    assert verdicts["H3 breakdown location"][0].startswith("S* > 50x")
+
+
+def test_empty_report():
+    assert "(no run records)" in generate_report([])

--- a/research/repo-bloat-benchmark/harness/runner/tests/test_variant_builder.py
+++ b/research/repo-bloat-benchmark/harness/runner/tests/test_variant_builder.py
@@ -1,0 +1,82 @@
+"""Tests for sha-verified variant materialization."""
+
+import pytest
+
+from harness.distractors.generator import GenerationConfig, generate_manifest
+from harness.distractors.manifest import ManifestWriter, load_manifest
+from harness.runner.variant_builder import (
+    VariantIntegrityError,
+    materialize_variant,
+    tree_sha256,
+)
+
+CORE = 'def slice_ledger_page(items, page, size):\n    """Slice one ledger export page."""\n    return items[page * size:(page + 1) * size]\n'
+POOL = 'def summarize_ledger_page(page):\n    """Summarize one ledger export page."""\n    return {"entries": len(page)}\n'
+
+
+@pytest.fixture()
+def fixtures(tmp_path):
+    core = tmp_path / "core"
+    (core / "src" / "pkg").mkdir(parents=True)
+    (core / "src" / "pkg" / "pagination.py").write_text(CORE)
+    pool = tmp_path / "pool"
+    (pool / "src" / "pkg").mkdir(parents=True)
+    (pool / "src" / "pkg" / "summary.py").write_text(POOL)
+    config = GenerationConfig(
+        scenario_id="vb-demo",
+        core_root=core,
+        pool_root=pool,
+        target_file="src/pkg/pagination.py",
+        template_file_tokens=100,
+    )
+    manifest = generate_manifest(config, 5)
+    writer = ManifestWriter(tmp_path / "distractors")
+    manifest_path = writer.write(manifest)
+    return tmp_path, core, pool, load_manifest(manifest_path)
+
+
+def test_materialize_is_deterministic_and_verified(fixtures, tmp_path):
+    root, core, pool, manifest = fixtures
+    hash_a = materialize_variant(
+        core, manifest, tmp_path / "v1", pool_root=pool,
+        distractors_dir=root / "distractors",
+    )
+    hash_b = materialize_variant(
+        core, manifest, tmp_path / "v2", pool_root=pool,
+        distractors_dir=root / "distractors",
+    )
+    assert hash_a == hash_b
+    assert (tmp_path / "v1" / "src" / "pkg" / "pagination.py").read_text() == CORE
+    # Every manifest file landed at its recorded path.
+    for entry in manifest["files"]:
+        assert (tmp_path / "v1" / entry["upstream_path"]).is_file()
+
+
+def test_sha_mismatch_aborts(fixtures, tmp_path):
+    root, core, pool, manifest = fixtures
+    regrow = [e for e in manifest["files"] if e["mode"] == "regrow"]
+    assert regrow, "fixture should include a regrow file"
+    (pool / regrow[0]["source_path"]).write_text("tampered = True\n")
+    with pytest.raises(VariantIntegrityError, match="sha256 mismatch"):
+        materialize_variant(
+            core, manifest, tmp_path / "v3", pool_root=pool,
+            distractors_dir=root / "distractors",
+        )
+
+
+def test_core_collision_aborts(fixtures, tmp_path):
+    root, core, pool, manifest = fixtures
+    manifest["files"][0]["upstream_path"] = "src/pkg/pagination.py"
+    with pytest.raises(VariantIntegrityError, match="collides with core"):
+        materialize_variant(
+            core, manifest, tmp_path / "v4", pool_root=pool,
+            distractors_dir=root / "distractors",
+        )
+
+
+def test_tree_hash_changes_with_content(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "f.py").write_text("x = 1\n")
+    (tmp_path / "b").mkdir()
+    (tmp_path / "b" / "f.py").write_text("x = 2\n")
+    assert tree_sha256(tmp_path / "a") != tree_sha256(tmp_path / "b")

--- a/research/repo-bloat-benchmark/harness/runner/variant_builder.py
+++ b/research/repo-bloat-benchmark/harness/runner/variant_builder.py
@@ -1,0 +1,84 @@
+"""Materialize a per-(scenario, size) working repo (design.md §3.2 stage 3).
+
+Pure function of ``(core, manifest)``: copy the core, then place each manifest
+file — verbatim pool files (``regrow``) from the pool root, generated files
+(``mutate``/``template``) from the persisted content store. Every placed file
+is sha256-verified against the manifest, and the resulting tree is hashed so
+byte-identical rebuilds are checkable.
+
+The manifest itself, the pool, and anything under the scenario's ``hidden/``
+tree are never copied into the variant (design §3.3).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from pathlib import Path
+
+
+class VariantIntegrityError(RuntimeError):
+    pass
+
+
+def _hash_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def tree_sha256(root: str | Path) -> str:
+    """Order-stable content hash of a tree (paths + bytes)."""
+    root = Path(root)
+    digest = hashlib.sha256()
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        digest.update(path.relative_to(root).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def materialize_variant(
+    core_root: str | Path,
+    manifest: dict,
+    destination: str | Path,
+    pool_root: str | Path | None = None,
+    distractors_dir: str | Path | None = None,
+) -> str:
+    """Build the working repo; returns the materialized tree's sha256.
+
+    ``distractors_dir`` is the ManifestWriter output dir holding
+    ``generated/<scenario>/<size>/...`` content for non-regrow files.
+    """
+    core_root = Path(core_root)
+    destination = Path(destination)
+    if destination.exists():
+        raise VariantIntegrityError(f"destination already exists: {destination}")
+    shutil.copytree(core_root, destination)
+
+    for entry in manifest.get("files", []):
+        rel = entry["upstream_path"]
+        target_path = destination / rel
+        if target_path.exists():
+            raise VariantIntegrityError(f"manifest path collides with core: {rel}")
+        if entry["mode"] == "regrow":
+            if pool_root is None:
+                raise VariantIntegrityError(f"regrow file {rel} but no pool_root given")
+            source = Path(pool_root) / entry["source_path"]
+        else:
+            if distractors_dir is None or not entry.get("content_path"):
+                raise VariantIntegrityError(
+                    f"generated file {rel} but no content store given"
+                )
+            source = Path(distractors_dir) / entry["content_path"]
+        if not source.is_file():
+            raise VariantIntegrityError(f"missing distractor source: {source}")
+        actual = _hash_file(source)
+        if actual != entry["sha256"]:
+            raise VariantIntegrityError(
+                f"sha256 mismatch for {rel}: manifest {entry['sha256'][:12]}…, "
+                f"source {actual[:12]}…"
+            )
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target_path)
+
+    return tree_sha256(destination)

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/README.md
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/README.md
@@ -1,0 +1,20 @@
+# Example scenario: `example-pagination`
+
+A **committed demo scenario** so the whole pipeline (distractor generation →
+freeze → materialization → instrumented run → verification → report) can be
+exercised end-to-end with **zero model tokens** (mock arm). It is *not* a
+pilot scenario — the pilot uses dependency-sliced PDD cores (design §4.1.0).
+
+- **Seeded bug** (`core/src/pager/pagination.py:count_pages`): ceiling
+  division written as `(n + d) // d` — correct only when `n % d != 0`.
+- **Visible tests** deliberately under-determine the contract (partial last
+  page only) → they **pass** on the buggy baseline.
+- **Hidden verifier** (`hidden/`, never mounted) checks exact-multiple and
+  empty-list cases plus a count-vs-slice consistency sweep → **fails** on
+  baseline, **passes** after the oracle edit in `scenario.json`.
+- **Pool** — five same-vocabulary modules (filters, sorting, summaries,
+  audit, CSV) across `same-package` / `same-layer` / `cross-cutting` tiers.
+
+The baseline expectation (visible pass + hidden fail) is asserted by the
+runner before every trial (`check_baseline`), which is the light form of the
+design §4.1.2 oracle-equivalence gate.

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/core/src/pager/__init__.py
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/core/src/pager/__init__.py
@@ -1,0 +1,1 @@
+"""Pager: pagination helpers for ledger exports."""

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/core/src/pager/pagination.py
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/core/src/pager/pagination.py
@@ -1,0 +1,14 @@
+"""Pagination for ledger export batches."""
+
+
+def slice_page(items, page, page_size):
+    """Return one page of ledger items (0-indexed page)."""
+    start = page * page_size
+    return items[start:start + page_size]
+
+
+def count_pages(items, page_size):
+    """Number of pages needed to export all ledger items."""
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+    return (len(items) + page_size) // page_size

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/core/tests/visible/test_pagination.py
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/core/tests/visible/test_pagination.py
@@ -1,0 +1,23 @@
+"""Visible tests — deliberately under-determine the page-count contract:
+they never exercise an exact-multiple length or the empty list."""
+
+from pager.pagination import count_pages, slice_page
+
+
+def test_slice_page_returns_requested_window():
+    assert slice_page([1, 2, 3, 4], 1, 2) == [3, 4]
+
+
+def test_slice_page_partial_last_page():
+    assert slice_page([1, 2, 3], 1, 2) == [3]
+
+
+def test_count_pages_partial_last_page():
+    assert count_pages([1, 2, 3], 2) == 2
+
+
+def test_count_pages_rejects_bad_page_size():
+    import pytest
+
+    with pytest.raises(ValueError):
+        count_pages([1], 0)

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/hidden/test_hidden_pagination.py
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/hidden/test_hidden_pagination.py
@@ -1,0 +1,29 @@
+"""Hidden verifier — the sole arbiter of success (design §4.4).
+
+Checks exactly what the visible tests under-determine: exact-multiple
+lengths and the empty list. Never mounted into the agent's sandbox.
+"""
+
+from pager.pagination import count_pages, slice_page
+
+
+def test_count_pages_exact_multiple():
+    assert count_pages([1, 2, 3, 4], 2) == 2
+
+
+def test_count_pages_empty():
+    assert count_pages([], 5) == 0
+
+
+def test_count_matches_slicing_for_many_shapes():
+    for length in range(0, 12):
+        items = list(range(length))
+        for page_size in range(1, 6):
+            pages = count_pages(items, page_size)
+            sliced = [
+                slice_page(items, page, page_size) for page in range(pages)
+            ]
+            flattened = [x for chunk in sliced for x in chunk]
+            assert flattened == items
+            if pages:
+                assert sliced[-1] != []

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/exports/csv_writer.py
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/exports/csv_writer.py
@@ -1,0 +1,16 @@
+"""CSV rendering for ledger export pages."""
+
+
+def render_page_as_csv_rows(page, columns):
+    """Render one export page as CSV rows in column order."""
+    rendered_export_rows = []
+    for entry in page:
+        rendered_export_rows.append(
+            ",".join(str(entry.get(column, "")) for column in columns)
+        )
+    return rendered_export_rows
+
+
+def csv_header_for_columns(columns):
+    """Header line matching render_page_as_csv_rows output."""
+    return ",".join(columns)

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/pager/ledger_filters.py
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/pager/ledger_filters.py
@@ -1,0 +1,21 @@
+"""Filtering helpers for ledger export batches."""
+
+
+def filter_exportable_entries(entries, export_config):
+    """Keep only ledger entries eligible for the current export window."""
+    eligible_ledger_entries = []
+    for entry in entries:
+        if entry.get("archived"):
+            continue
+        if entry.get("amount", 0) == 0 and not export_config.get("include_zero"):
+            continue
+        eligible_ledger_entries.append(entry)
+    return eligible_ledger_entries
+
+
+def partition_entries_by_currency(entries):
+    """Group ledger entries by their currency code for per-currency pages."""
+    grouped_ledger_entries = {}
+    for entry in entries:
+        grouped_ledger_entries.setdefault(entry.get("currency", "USD"), []).append(entry)
+    return grouped_ledger_entries

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/pager/ledger_sorting.py
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/pager/ledger_sorting.py
@@ -1,0 +1,18 @@
+"""Sort orders for ledger export pages."""
+
+
+def sort_entries_for_export(entries, sort_key="posted_at"):
+    """Stable sort of ledger entries used before slicing into pages."""
+    return sorted(entries, key=lambda entry: entry.get(sort_key) or "")
+
+
+def interleave_adjustment_entries(entries, adjustments):
+    """Merge adjustment rows next to the ledger entries they amend."""
+    merged_export_rows = []
+    adjustment_index = {a.get("entry_id"): a for a in adjustments}
+    for entry in entries:
+        merged_export_rows.append(entry)
+        adjustment = adjustment_index.get(entry.get("id"))
+        if adjustment is not None:
+            merged_export_rows.append(adjustment)
+    return merged_export_rows

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/reporting/export_audit.py
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/reporting/export_audit.py
@@ -1,0 +1,18 @@
+"""Audit trail entries for ledger export runs."""
+
+
+def record_export_audit_event(events, actor, page_count):
+    """Append an audit event describing one export run."""
+    events.append(
+        {
+            "actor": actor,
+            "action": "ledger_export",
+            "pages": page_count,
+        }
+    )
+    return events
+
+
+def audit_events_for_actor(events, actor):
+    """All export audit events attributed to one actor."""
+    return [event for event in events if event.get("actor") == actor]

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/reporting/export_summary.py
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/reporting/export_summary.py
@@ -1,0 +1,19 @@
+"""Summary lines for completed ledger exports."""
+
+
+def summarize_export_batch(pages, export_config):
+    """One-line summary of an export batch for the reporting feed."""
+    total_entries = sum(len(page) for page in pages)
+    return {
+        "pages": len(pages),
+        "entries": total_entries,
+        "batch_label": export_config.get("label", "ledger-export"),
+    }
+
+
+def format_summary_line(summary):
+    """Render a summary dict for the export activity log."""
+    return (
+        f"{summary['batch_label']}: {summary['entries']} entries "
+        f"across {summary['pages']} pages"
+    )

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/scenario.json
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/scenario.json
@@ -1,0 +1,34 @@
+{
+  "scenario_id": "example-pagination",
+  "schema_version": 1,
+  "language": "python",
+  "purpose": "committed demo scenario for no-token pipeline validation (mock arm); real pilot scenarios are dependency-sliced PDD cores (design §4.1.0)",
+  "core_path": "core",
+  "pool_path": "pool",
+  "target_files": ["src/pager/pagination.py"],
+  "allowed_edit_globs": ["src/pager/**"],
+  "task_brief_path": "task.md",
+  "visible_tests": {
+    "command": ["python3", "-m", "pytest", "tests/visible", "-q"],
+    "expected_exit_code": 0
+  },
+  "hidden_verifier": {
+    "path": "hidden",
+    "command": ["python3", "-m", "pytest", ".", "-q"],
+    "mounted_into_agent_sandbox": false
+  },
+  "oracle_edit": {
+    "file": "src/pager/pagination.py",
+    "old": "return (len(items) + page_size) // page_size",
+    "new": "return (len(items) + page_size - 1) // page_size"
+  },
+  "seed": {
+    "target_site": "src/pager/pagination.py:count_pages",
+    "bug_class": "off_by_one",
+    "description": "ceiling division seeded as (n + d) // d instead of (n + d - 1) // d; correct only when n % d != 0 with the visible test's inputs"
+  },
+  "leak_denylist": [
+    "count_pages([1, 2, 3, 4], 2) == 2",
+    "count_pages([], 5) == 0"
+  ]
+}

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/task.md
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/task.md
@@ -1,0 +1,21 @@
+# Bug report: page count wrong for exports that fill pages exactly
+
+When exporting a ledger whose row count is an exact multiple of the page
+size, the export footer shows one page too many. For example, exporting 4
+rows with `page_size=2` reports **3 pages**; the export itself only has 2.
+
+Empty exports also report 1 page instead of 0.
+
+## Reproduction
+
+```python
+from pager.pagination import count_pages
+count_pages([1, 2, 3, 4], 2)   # expected 2
+count_pages([], 5)             # expected 0
+```
+
+## Acceptance
+
+Page counts must equal the number of pages `slice_page` actually yields, for
+every list length and page size. Existing behavior for partial last pages
+must not change.


### PR DESCRIPTION
**Sub-PR 4 of 5** for epic #1851 (base = `epic/1209-repo-bloat-v2`). **Stacked on PRs #1853 and #1852's siblings**: this branch contains the commits of sub-PRs 2 (#1853) and 3 (#1854) — merge those first and this PR's diff reduces to the runner commit alone. Merge order 1 → 2 → 3 → **4** → 5.

## What changed

New package `harness/runner/` + committed demo scenario `scenarios/example-pagination/`:

- **`variant_builder.py`** — pure-function materialization of `(core, manifest)` into a working repo: every placed file sha256-verified against the manifest, core-collision detection, order-stable tree hash; the hidden tree and the manifest itself are never copied in (design §3.3).
- **`runner.py` — `ExperimentRunner`** — per (scenario, size, trial): `manifests.lock` freeze check (refuses to run on tamper), fresh variant + git baseline, **baseline-expectation assertion** (visible tests pass + hidden verifier fails pre-run — the light §4.1.2 oracle gate), recording proxy wiring (mock provider for the mock arm; `OPENAI_BASE_URL` injection for a real `command` arm), visible/hidden verification, attribution + trajectory analysis, one JSONL run record + raw artifacts per run.
- **`metrics.py`** — the design §6.3 run record from tier-1 evidence only (`fs_tap_enabled: false`): localization cost split at the first-edit boundary, usage-reconciled penetration family (repeat-counted totals, de-duplicated pool coverage), H2 trajectory fields, §6.2 edit-classification precedence (forbidden ⇒ distractor ⇒ target ⇒ allowed-glob ⇒ wrong), §6.4 failure classes.
- **`report.py`** — per-size markdown tables (medians + k/n rates), pure-python least-squares and Spearman-ρ trend fits, failure-class breakdown, and a **computed §7.5 pre-registered-threshold checklist** (cost rise, penetration rise, hidden drop, H2 accumulation, H3 breakdown location S*).
- **`mock_agent.py`** — scripted agent + mock provider so the *entire* pipeline validates with **zero model tokens** (the §6.6 calibration principle applied end-to-end): `oracle` fixes the bug, `wrong_file` edits a distractor, `noop` never edits — each lands in the right outcome/failure class.
- **`scenarios/example-pagination/`** — seeded off-by-one ceiling division; visible tests deliberately under-determine the contract (pass on baseline); isolated hidden verifier (fails on baseline, passes after the oracle edit); 5-file same-vocabulary pool across all three tiers.
- **Fix surfaced by the e2e test** (in `context_snapshots/attribution.py`): request payloads are JSON, so newlines inside message strings are escaped — attribution silently matched nothing. `extract_payload_text` unwraps string values before line matching; also adds the unique-line coverage helper for `distractor_pool_coverage`. This is exactly the class of silent-instrumentation failure the design's calibration gate exists to catch.

## Why it matters to the research

This is the *"set up a repeatable experiment runner"* + *"measure how well the instrumented CLI performs its assigned tasks as distractors increase"* feedback made real: one config runs scenario × ladder × trials, every run leaves auditable raw artifacts, and the report locates the degradation knee against the pre-registered thresholds. The mock arm means reviewers can validate the full measurement chain today, before any Codex pinning or API spend.

## How to run

```bash
cd research/repo-bloat-benchmark
python3 -m pytest harness/ -q          # full suite: 73 passed
# hand-driven demo (writes /tmp/rb-reports/report.md):
#   see harness/runner/README.md — generate ladder → run mock experiment → report
```

## Still incomplete

- The §8.1.1 run-environment freeze (pinned CLI, clean CODEX_HOME, egress lockdown) is documented but not implemented — required before any *real* pilot run.
- `context_overflow` failure detection is a caller-supplied flag (needs provider-error taxonomy from a real arm).
- Real PDD scenario authoring (dependency-sliced cores + seeded bugs + snapshot pool extraction) is the next follow-up after this epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)