### PR TITLE
fix(story): honor explicit --prompt inputs in `pdd story link` without an LLM call

### DIFF
--- a/pdd/user_story_tests.py
+++ b/pdd/user_story_tests.py
@@ -431,6 +431,7 @@ def cache_story_prompt_links(  # pylint: disable=too-many-arguments,too-many-loc
     if not story_path.exists() or not story_path.is_file():
         return False, f"User story file not found: {story_file}", 0.0, "", []
 
+    explicit_prompt_files = list(prompt_files) if prompt_files else None
     prompt_files = prompt_files or discover_prompt_files(
         prompts_dir, include_llm=include_llm_prompts
     )
@@ -439,6 +440,36 @@ def cache_story_prompt_links(  # pylint: disable=too-many-arguments,too-many-loc
 
     prompts_root = _resolve_prompts_dir(prompts_dir) if prompts_dir else None
     story_content = _read_story(story_path)
+
+    # Explicit prompt inputs are authoritative: `pdd story link --prompt` and
+    # `pdd story add --update` name the exact prompts to link, so honor them
+    # all (merged with still-resolvable existing refs) without spending an LLM
+    # call second-guessing the caller.
+    if explicit_prompt_files and force_relink:
+        existing_paths: List[Path] = []
+        for ref in _parse_story_prompt_metadata(story_content):
+            resolved = _resolve_prompt_path(ref, prompt_files, prompts_root)
+            if resolved:
+                existing_paths.append(resolved)
+        linked_prompt_paths = _dedupe_prompt_paths(existing_paths + explicit_prompt_files)
+        updated = _upsert_story_prompt_metadata(
+            story_path,
+            story_content,
+            linked_prompt_paths,
+            prompts_root,
+        )
+        linked_refs = sorted(
+            {
+                _prompt_reference_for_metadata(path.resolve(), prompts_root)
+                for path in linked_prompt_paths
+            }
+        )
+        message = (
+            "Story prompt metadata linked from explicit prompt inputs."
+            if updated
+            else "Story prompt metadata already up to date for explicit prompt inputs."
+        )
+        return True, message, 0.0, "", linked_refs
 
     # Keep existing valid metadata unchanged unless force_relink is requested.
     existing_refs = _parse_story_prompt_metadata(story_content)

--- a/tests/test_user_story_tests.py
+++ b/tests/test_user_story_tests.py
@@ -1771,3 +1771,48 @@ def test_user_story_fix_without_contract_passes_story_directly(tmp_path):
     assert success is True
     # No contract => change_main is handed the story path itself.
     assert mock_change.call_args[1]["change_prompt_file"] == str(story_path)
+
+
+def test_cache_story_prompt_links_honors_explicit_prompts(tmp_path, monkeypatch):
+    """Explicit --prompt inputs must all be linked, without an LLM call.
+
+    Regression for `pdd story link STORY --prompt a --prompt b` dropping
+    prompts whenever the story text happened to reference one of them (the
+    story's own metadata comment counts as such a reference).
+    """
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    prompt_a = prompts / "demo_python.prompt"
+    prompt_b = prompts / "demo2_python.prompt"
+    prompt_a.write_text("Demo prompt A.", encoding="utf-8")
+    prompt_b.write_text("Demo prompt B.", encoding="utf-8")
+
+    stories = tmp_path / "user_stories"
+    stories.mkdir()
+    story = stories / "story__demo.md"
+    story.write_text(
+        "<!-- pdd-story-prompts: demo_python.prompt -->\n\n"
+        "# User Story: demo\n\n"
+        "## Story\n"
+        "As a user, I can run the demo, so that I see a response.\n",
+        encoding="utf-8",
+    )
+
+    def _no_llm(*_args, **_kwargs):
+        raise AssertionError("explicit prompt links must not call detect_change")
+
+    monkeypatch.setattr("pdd.user_story_tests.detect_change", _no_llm)
+
+    success, message, cost, _model, linked_refs = cache_story_prompt_links(
+        story_file=str(story),
+        prompts_dir=str(prompts),
+        prompt_files=[prompt_a, prompt_b],
+        force_relink=True,
+    )
+
+    assert success, message
+    assert cost == 0.0
+    assert linked_refs == ["demo2_python.prompt", "demo_python.prompt"]
+    metadata_line = story.read_text(encoding="utf-8").splitlines()[0]
+    assert "demo2_python.prompt" in metadata_line
+    assert "demo_python.prompt" in metadata_line


### PR DESCRIPTION
## What

`pdd story link STORY --prompt a --prompt b` (and `pdd story add --update`) name the exact prompts to link and call `cache_story_prompt_links(..., force_relink=True)`. Previously that fell through to the LLM-backed `detect_change` discovery path.

## Why it's a bug (found during pdd#1857 E2E verification)

The epic promises a **deterministic, credential-free** story-authoring journey. Reproduced with the real CLI in a sandbox (story pre-linked to `demo_python.prompt`, then `pdd story link ... --prompt demo_python.prompt --prompt demo2_python.prompt`):

- **Before:** the command loaded `detect_change_LLM`, started prompt preprocessing, and **blocked on GitHub device-code authentication** — i.e. `story link` was neither deterministic nor credential-free, and could drop an explicitly named prompt when the story's own `<!-- pdd-story-prompts: ... -->` comment already referenced one of them.
- **After:** `cost=0.0`, no LLM call, metadata becomes `<!-- pdd-story-prompts: demo2_python.prompt, demo_python.prompt -->` (both linked).

## Change

When the caller passes explicit prompt files **and** `force_relink=True`, treat those inputs as authoritative: merge them with any still-resolvable existing refs and upsert the metadata directly. Auto-generation flows (`generate.py` — passes neither explicit prompts nor `force_relink`) are unchanged, so LLM-based discovery is preserved where it's actually wanted.

## Tests

- New regression `test_cache_story_prompt_links_honors_explicit_prompts` (monkeypatches `detect_change` to fail if called; asserts both prompts linked, cost 0.0).
- `tests/test_user_story_tests.py`: 51 passed.

Targets the epic branch `codex/issue-1816-story-regression-epic` per pdd#1857 constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)