### PR TITLE
fix(story): refresh stale top-flow seed regression hashes

### DIFF
--- a/tests/story_regression/test_story_pdd_change.py
+++ b/tests/story_regression/test_story_pdd_change.py
@@ -5,7 +5,7 @@ from pdd.commands.modify import change
 
 
 PDD_STORY_ID = "pdd_change"
-PDD_STORY_HASH = "9cce18652b5bae6b"
+PDD_STORY_HASH = "3d3e24afdcf4ac7e"
 
 
 @pytest.mark.story(story_id=PDD_STORY_ID)

--- a/tests/story_regression/test_story_pdd_fix.py
+++ b/tests/story_regression/test_story_pdd_fix.py
@@ -5,7 +5,7 @@ from pdd.commands.fix import fix
 
 
 PDD_STORY_ID = "pdd_fix"
-PDD_STORY_HASH = "db469b01db51d9a7"
+PDD_STORY_HASH = "b587af4ac2bc2176"
 
 
 @pytest.mark.story(story_id=PDD_STORY_ID)

--- a/tests/story_regression/test_story_pdd_sync.py
+++ b/tests/story_regression/test_story_pdd_sync.py
@@ -5,7 +5,7 @@ from pdd.commands.maintenance import sync
 
 
 PDD_STORY_ID = "pdd_sync"
-PDD_STORY_HASH = "8af64c69836b4aa9"
+PDD_STORY_HASH = "db8793f0c80a101b"
 
 
 @pytest.mark.story(story_id=PDD_STORY_ID)

--- a/tests/story_regression/test_story_pdd_top_flows.py
+++ b/tests/story_regression/test_story_pdd_top_flows.py
@@ -48,7 +48,7 @@ def test_story_pdd_change_help_is_public_safe():
     assert "pdd change ISSUE_URL" in result.output
 
 
-@pytest.mark.story(story_id="pdd_update", story_hash="d633c79daa412aae")
+@pytest.mark.story(story_id="pdd_update", story_hash="cf0bc4a2189f81bd")
 def test_story_pdd_update_help_is_public_safe():
     result = _help("update")
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
## What

Refreshes the recorded story hashes on the 4 seeded **top-flow** story regression tests so the coverage gate reports them fresh.

## Why (found during pdd#1857 E2E verification — gap G1)

At the epic tip, `evaluate_stories()` classified **5 ok / 4 stale / 23 missing**. The 4 stale were `pdd_change`, `pdd_fix`, `pdd_sync`, `pdd_update` — i.e. 4 of the 5 documented "top flow" seeds shipping stale.

Root cause: each top flow is claimed by a `@pytest.mark.story` marker in **two** files — `test_story_pdd_<flow>.py` (module `PDD_STORY_HASH` constant) and `test_story_pdd_top_flows.py` (decorator `story_hash=`). `discover_story_markers` keeps **one marker per `story_id`** (first-wins), so a stale hash in one file shadowed the fresh sibling and the whole story read stale. The tests themselves still pass (they are `CliRunner(--help)` smoke checks), but the gate flagged them stale.

## Change

Set each stale marker to its fresh sibling's hash so both markers per story agree with the current story bundle:

| Story | file | old → new |
|---|---|---|
| pdd_change | `test_story_pdd_change.py` | `9cce1865…` → `3d3e24af…` |
| pdd_fix | `test_story_pdd_fix.py` | `db469b01…` → `b587af4a…` |
| pdd_sync | `test_story_pdd_sync.py` | `8af64c69…` → `db8793f0…` |
| pdd_update | `test_story_pdd_top_flows.py` | `d633c79d…` → `cf0bc4a2…` |

These are hand-authored `--help` smoke tests independent of story text, so refreshing the recorded hash is the correct fix — regenerating via `pdd test --from-story` would replace them with weaker text-pinning tests.

## Verified (no credentials)

- Gate after fix: **9 ok / 0 stale / 23 missing** (was 5 / 4 / 23).
- `pytest -m story`: **16 tests pass, exit 0**.
- `test_story_regression_gate.py` + `test_story_coverage.py`: green.

> Note (tracked separately, not fixed here): `discover_story_markers` collapsing multiple tests that claim one `story_id` into a single first-wins marker contradicts the documented "a story may be claimed by many tests" — worth hardening so duplicate claims can't shadow each other.

Targets the epic branch `codex/issue-1816-story-regression-epic` per pdd#1857 constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)