### PR TITLE
fix(cli): report deliberate ClickExceptions plainly, not as "unexpected"

### DIFF
--- a/pdd/core/errors.py
+++ b/pdd/core/errors.py
@@ -220,6 +220,16 @@ def handle_error(exception: Exception, command_name: str, quiet: bool):
             )
             # Print the error message safely escaped
             console.print(escape(str(exception)))
+        elif isinstance(exception, click.ClickException):
+            # A ClickException is a deliberate, user-facing error raised by a
+            # command (e.g. `pdd story link` on a missing file). It is not an
+            # internal fault, so report it plainly rather than as an
+            # "unexpected error". (UsageError, a ClickException subclass, is
+            # handled above and re-raised for its exit-code-2 semantics.)
+            console.print(
+                f"  [error]Error:[/error] {escape(exception.format_message())}",
+                style="error",
+            )
         elif isinstance(exception, KeyboardInterrupt):
             reason = error_record.get("reason")
             if reason:

--- a/tests/test_core_errors.py
+++ b/tests/test_core_errors.py
@@ -138,6 +138,25 @@ def test_handle_error_keyboard_interrupt_messages(mock_console):
 
 
 @patch('pdd.core.errors.console', new_callable=MagicMock)
+def test_handle_error_click_exception_is_not_labeled_unexpected(mock_console):
+    """A deliberate ClickException must be reported plainly, not as an
+    'unexpected error' (regression for `pdd story link` on a missing file)."""
+    from pdd.core.errors import handle_error
+
+    handle_error(
+        click.ClickException("Story file not found: user_stories/nope.md"),
+        "story",
+        quiet=False,
+    )
+
+    output = _console_output(mock_console)
+    assert "Error during 'story' command" in output
+    assert "Story file not found: user_stories/nope.md" in output
+    # The whole point: a deliberate user error is not "unexpected".
+    assert "An unexpected error occurred" not in output
+
+
+@patch('pdd.core.errors.console', new_callable=MagicMock)
 @patch('pdd.core.cli.auto_update')
 @patch.object(_generate_module, 'code_generator_main')
 def test_keyboard_interrupt_reports_correct_command_name(


### PR DESCRIPTION
## What
`handle_error` (`pdd/core/errors.py`) routed every non-`UsageError` `click.ClickException` into the generic **"An unexpected error occurred"** branch. Deliberate, validated user errors were therefore mislabeled as internal faults.

## Repro (before)
```
$ pdd story link user_stories/nope.md --prompt prompts/a.prompt
Error during 'story' command:
  An unexpected error occurred: Story file not found: user_stories/nope.md
```
## After
```
Error during 'story' command:
  Error: Story file not found: user_stories/nope.md
```

## Change
Add a `click.ClickException` branch that prints `exception.format_message()` under a plain `Error:` label. **Exit code unchanged** (still 1); `UsageError` (a ClickException subclass) is still handled earlier with its exit-code-2 re-raise.

## Tests
- New `test_handle_error_click_exception_is_not_labeled_unexpected` (direct `handle_error` call; asserts clean message, no "unexpected").
- `tests/test_core_errors.py`: 6 passed. (The 2 pre-existing failures — `test_cli_handle_error_filenotfound` / `_quiet` — fail on the clean epic tip too; they assert `auto_update` is called, which is skipped for dev/offline builds. Unrelated to this change.)

Found during pdd#1857 verification (gap G4). Targets the epic branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)