### PR TITLE
fix(errors): report ClickException as a validated error, not 'unexpected' (#1857 G4)

### DIFF
--- a/pdd/core/errors.py
+++ b/pdd/core/errors.py
@@ -213,6 +213,14 @@ def handle_error(exception: Exception, command_name: str, quiet: bool):
             )
             # click.UsageError should typically exit with 2, so we re-raise it
             raise exception
+        elif isinstance(exception, click.ClickException):
+            # A plain ClickException is a validated, user-facing error raised
+            # deliberately by a command (e.g. "Story file not found") — report
+            # it as a normal error, not an "unexpected" one.
+            console.print(
+                f"  [error]Error:[/error] {escape(exception.format_message())}",
+                style="error",
+            )
         elif isinstance(exception, MarkupError):
             console.print(
                 "  [error]Markup Error:[/error] Invalid Rich markup encountered.",

--- a/tests/test_core_errors.py
+++ b/tests/test_core_errors.py
@@ -138,6 +138,20 @@ def test_handle_error_keyboard_interrupt_messages(mock_console):
 
 
 @patch('pdd.core.errors.console', new_callable=MagicMock)
+def test_handle_error_click_exception_is_not_unexpected(mock_console):
+    """A plain ClickException is a validated error, not an 'unexpected' one (issue #1857 G4)."""
+    from pdd.core.errors import handle_error
+
+    exc = click.ClickException("Story file not found: user_stories/story__nope.md")
+    handle_error(exc, "story", quiet=False)
+
+    output = _console_output(mock_console)
+    assert "An unexpected error occurred" not in output
+    assert "Story file not found: user_stories/story__nope.md" in output
+    assert "Error:" in output
+
+
+@patch('pdd.core.errors.console', new_callable=MagicMock)
 @patch('pdd.core.cli.auto_update')
 @patch.object(_generate_module, 'code_generator_main')
 def test_keyboard_interrupt_reports_correct_command_name(


### PR DESCRIPTION
Closes gap **G4** from the #1857 verification report.

## Problem
`handle_error` special-cases `click.UsageError` but not its parent `click.ClickException`, so validated, deliberately-raised command errors (e.g. `pdd story link` on a missing story file) fell through to the generic branch and printed **"An unexpected error occurred: Story file not found: …"** — mislabeling a validated condition as unexpected.

## Fix
Add a `ClickException` branch after the `UsageError` one (subclass must stay first) that prints the message as a plain `Error:`. Exit-code semantics unchanged.

## Evidence
- Live before: `  An unexpected error occurred: Story file not found: user_stories/story__nope.md`
- Live after: `  Error: Story file not found: user_stories/story__nope.md`
- New regression test `test_handle_error_click_exception_is_not_unexpected`; `tests/test_core_errors.py` otherwise unchanged (2 pre-existing env failures — `auto_update` not invoked in this environment — fail identically at the unmodified epic tip).

Part of #1857 / EPIC #1816. Targets the epic branch, never `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)