### PR TITLE
fix(story): reject malformed stories instead of emitting a tautological test

### DIFF
--- a/pdd/story_test_generation.py
+++ b/pdd/story_test_generation.py
@@ -222,7 +222,19 @@ def generate_story_regression_test(
     rule_ids = sorted({match.group(0).upper().replace("-", "") for match in _RULE_RE.finditer(covers_text)})
     if not oracle_items:
         story_sections = _sections(story_text)
-        oracle_items = _bullets(_section(story_sections, "Story")) or [story_text.strip()]
+        oracle_items = _bullets(_section(story_sections, "Story"))
+    if not oracle_items:
+        # Refuse to emit a test whose only assertion is that the raw story text
+        # contains itself — that is a tautology that can never catch a
+        # regression. A malformed story (no ## Oracle / ## Acceptance Criteria /
+        # ## Story clauses in the story or its contract) is a user error, not a
+        # generation target.
+        raise ValueError(
+            f"Story {story_path.name} has no ## Oracle, ## Acceptance Criteria, "
+            "or ## Story clauses to assert. Add at least a ## Story sentence "
+            "(and ideally an ## Oracle / ## Acceptance Criteria contract) before "
+            "generating a regression test."
+        )
 
     output_path = _resolve_output(story_path, output)
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_story_test_generation.py
+++ b/tests/test_story_test_generation.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from pdd.story_regression import build_story_map
 from pdd.story_regression_gate import (
     STATUS_MISSING,
@@ -46,6 +48,35 @@ def test_generate_story_regression_test_is_marked_and_deterministic(tmp_path: Pa
     assert 'PDD_STORY_ID = "checkout_refund"' in text
     assert "Eligible checkout refunds are accepted." in text
     assert "Ineligible checkout refunds are rejected." in text
+
+
+def test_generate_story_regression_test_rejects_malformed_story(tmp_path: Path) -> None:
+    """A story with no ## Oracle / ## Acceptance Criteria / ## Story clauses must
+    raise rather than emit a tautological (self-satisfying) test."""
+    stories = tmp_path / "user_stories"
+    stories.mkdir(parents=True)
+    bad = stories / "story__bad.md"
+    bad.write_text("garbage no sections here", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="no ## Oracle"):
+        generate_story_regression_test(bad)
+    assert not (tmp_path / "tests" / "story_regression").exists()
+
+
+def test_generate_story_regression_test_pins_story_sentence_without_contract(tmp_path: Path) -> None:
+    """A well-formed human story (## Story only, no contract) still generates,
+    pinning the story sentence rather than the whole raw file."""
+    stories = tmp_path / "user_stories"
+    stories.mkdir(parents=True)
+    story = stories / "story__demo.md"
+    story.write_text(
+        "# User Story: demo\n\n## Story\n\nAs a user, I can run the demo.\n",
+        encoding="utf-8",
+    )
+
+    result = generate_story_regression_test(story)
+    text = result.test_file.read_text(encoding="utf-8")
+    assert "As a user, I can run the demo." in text
 
 
 def test_story_regression_gate_detects_missing_passing_and_stale(tmp_path: Path) -> None:


### PR DESCRIPTION
## What
`pdd test --from-story` on a malformed story (no `## Oracle` / `## Acceptance Criteria` / `## Story` clauses) emitted a **vacuously-passing** test.

## Repro (before)
```
$ printf 'garbage no sections here' > user_stories/story__bad.md
$ pdd test --from-story user_stories/story__bad.md --output bad.py   # succeeds
$ pytest bad.py -q                                                   # 1 passed
```
The generated test's only clause was the entire raw body, so it asserted `'garbage no sections here' in bundle` — always true.

## Cause
`pdd/story_test_generation.py`:
```python
if not oracle_items:
    story_sections = _sections(story_text)
    oracle_items = _bullets(_section(story_sections, "Story")) or [story_text.strip()]
```
The `or [story_text.strip()]` turned any malformed story into a self-satisfying test.

## After
```
$ pdd test --from-story user_stories/story__bad.md --output bad.py
Error during 'test' command:
  Input/Output Error: Story story__bad.md has no ## Oracle, ## Acceptance Criteria,
  or ## Story clauses to assert. Add at least a ## Story sentence ...
```
No test file is written. The legitimate `## Story`-only case (well-formed human story, no contract yet) still generates and pins the story sentence.

## Tests
- `test_generate_story_regression_test_rejects_malformed_story` (raises, writes nothing)
- `test_generate_story_regression_test_pins_story_sentence_without_contract` (Story-only still works)
- `tests/test_story_test_generation.py`: 4 passed; `pytest -m story` still green.

Found during pdd#1857 verification (gap G3). Targets the epic branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)