### PR TITLE
fix(story): fail on malformed stories instead of emitting a vacuous test (#1857 G3)

### DIFF
--- a/pdd/story_test_generation.py
+++ b/pdd/story_test_generation.py
@@ -222,7 +222,16 @@ def generate_story_regression_test(
     rule_ids = sorted({match.group(0).upper().replace("-", "") for match in _RULE_RE.finditer(covers_text)})
     if not oracle_items:
         story_sections = _sections(story_text)
-        oracle_items = _bullets(_section(story_sections, "Story")) or [story_text.strip()]
+        oracle_items = _bullets(_section(story_sections, "Story"))
+    if not oracle_items:
+        # A story with no ## Oracle / ## Acceptance Criteria / ## Story content
+        # would previously be pinned by its raw body — a vacuous, always-passing
+        # test that gives false regression confidence. Fail with guidance instead.
+        raise ValueError(
+            f'Story "{story_path}" has no ## Oracle, ## Acceptance Criteria, or '
+            "## Story content to generate assertions from. Add a ## Story section "
+            "(or regenerate its contract) before running pdd test --from-story."
+        )
 
     output_path = _resolve_output(story_path, output)
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_story_test_generation.py
+++ b/tests/test_story_test_generation.py
@@ -70,3 +70,23 @@ def test_story_regression_gate_detects_missing_passing_and_stale(tmp_path: Path)
     )
     stale = evaluate_story_regression(story, tests_dir=tmp_path / "tests", story_map=story_map)
     assert stale.status == STATUS_STALE
+
+
+def test_generate_story_regression_test_rejects_malformed_story(tmp_path: Path) -> None:
+    """A story with no Oracle/Acceptance/Story sections must fail loudly, not
+    emit a vacuous raw-body-pin test (issue #1857 G3)."""
+    import pytest
+
+    stories = tmp_path / "user_stories"
+    stories.mkdir(parents=True)
+    story = stories / "story__malformed.md"
+    story.write_text(
+        "garbage content with no recognizable headings\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="has no ## Oracle"):
+        generate_story_regression_test(story)
+
+    # No test file may be left behind for the malformed story.
+    assert not list(tmp_path.rglob("test_story_*.py"))


### PR DESCRIPTION
Closes gap **G3** from the #1857 verification report.

## Problem
`pdd test --from-story` on a story with **no** `## Oracle` / `## Acceptance Criteria` / `## Story` content silently fell back to pinning the **raw story body** — an always-passing test that gives false regression confidence and marks the story covered in the gate.

## Fix
Raise an actionable `ValueError` when no assertion content can be extracted (surfaced by the CLI as an Input/Output error with guidance to add a `## Story` section or regenerate the contract). Stories with proper `## Story` prose keep the existing sentence-pinning fallback; contract-backed generation is unchanged.

## Evidence
- Live before: silently wrote `test_story_malformed.py` asserting its own raw body.
- Live after: `Error during 'test' command: Input/Output Error: Story "…story__malformed.md" has no ## Oracle, ## Acceptance Criteria, or ## Story content…`, no test file written.
- New regression test `test_generate_story_regression_test_rejects_malformed_story`; suite `tests/test_story_test_generation.py` 3/3, plus gate/coverage/backfill suites green.

Part of #1857 / EPIC #1816. Targets the epic branch, never `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)