### PR TITLE
feat(story): wire the behavioral (## Entry Point) generator into `pdd test --from-story`

### DIFF
--- a/docs/generating_user_stories.md
+++ b/docs/generating_user_stories.md
@@ -134,7 +134,9 @@ pdd test --from-story user_stories/story__checkout_total.md \
   --output tests/story_regression/test_story_checkout_total.py
 ```
 
-The contract must include a machine-readable `## Entry Point` section:
+`pdd test --from-story` generates in one of two modes, chosen from the contract:
+
+**Behavioral (preferred).** If the contract declares a machine-readable `## Entry Point`, the generated test imports the callable, invokes it, and asserts the `## Oracle` / `## Negative Cases` bullets as Python expressions over `result` — a true executable oracle that goes red when the *behavior* regresses.
 
 ```markdown
 ## Entry Point
@@ -153,7 +155,11 @@ Optional `## Seams` bullets patch runtime boundaries before the entry point is c
 - checkout_app.TAX_RATE = 0
 ```
 
-`## Oracle` and `## Negative Cases` bullets are Python assertion expressions over `result`, the return value from the entry point. Generated tests are tagged with `@pytest.mark.story(story_id=..., story_hash=...)`, so `make regression-stories`, story coverage, and the stale/missing gate can trace them back to the source story.
+`## Oracle` and `## Negative Cases` bullets are then Python assertion expressions over `result`, the return value from the entry point.
+
+**Text-pin (fallback).** If the contract has no `## Entry Point`, the generated test pins the story+contract bundle instead: it asserts a content hash and the presence of each `## Oracle` / `## Negative Cases` clause. This still gives deterministic **staleness** detection — the test goes red when the story or contract text drifts — but it does not exercise runtime behavior. Prefer adding an `## Entry Point` when you want outcome-level (behavioral) coverage.
+
+Either way, generated tests are tagged with `@pytest.mark.story(story_id=..., story_hash=...)`, so `make regression-stories`, story coverage, and the stale/missing gate can trace them back to the source story.
 
 Run `pdd test` with `--issue` and one or more `.prompt` files. The prompt files
 are the **validation targets** the story will be linked to — they are *not* shown

--- a/pdd/story_test_generation.py
+++ b/pdd/story_test_generation.py
@@ -199,6 +199,34 @@ def _render_test(
     return "\n".join(lines) + "\n"
 
 
+def _generate_behavioral_test(
+    story_path: Path,
+    output: Optional[str],
+) -> GeneratedStoryTest:
+    """Delegate to the entry-point (behavioral) generator and adapt its result.
+
+    Used when the story's contract declares a ``## Entry Point``. The generated
+    test imports the callable, invokes it (applying any ``## Seams``), and
+    asserts the ``## Oracle`` / ``## Negative Cases`` expressions over the
+    return value — a real behavioral oracle rather than a text pin.
+    """
+    from .story_test_generator import generate_story_test
+
+    output_path = _resolve_output(story_path, output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    before = output_path.read_text(encoding="utf-8") if output_path.exists() else None
+    result = generate_story_test(story_path, output_path)
+    after = result.output_path.read_text(encoding="utf-8")
+    return GeneratedStoryTest(
+        story_id=result.story_id,
+        story_file=story_path,
+        test_file=result.output_path,
+        story_hash=result.story_hash,
+        changed=before != after,
+        test_count=result.test_count,
+    )
+
+
 def generate_story_regression_test(
     story_file: str | Path,
     *,
@@ -214,6 +242,15 @@ def generate_story_regression_test(
     slug = story_id(story_path)
     story_text, contract_path, bundle = _read_story_bundle(story_path)
     md_sections = _sections(bundle)
+
+    # If the contract declares a machine-readable ## Entry Point, generate a
+    # *behavioral* test that calls the entry point and asserts the ## Oracle /
+    # ## Negative Cases as Python expressions over `result` (delegating to
+    # story_test_generator). Contracts without an Entry Point fall through to
+    # the text-pinning generator below, which pins the story/contract clauses.
+    if md_sections.get("entry point"):
+        return _generate_behavioral_test(story_path, output)
+
     oracle_text = _section(md_sections, "Oracle", "Acceptance Criteria", "Story")
     negative_text = _section(md_sections, "Negative Cases", "Non-Oracle")
     covers_text = _section(md_sections, "Covers")

--- a/tests/test_story_test_generation.py
+++ b/tests/test_story_test_generation.py
@@ -48,6 +48,41 @@ def test_generate_story_regression_test_is_marked_and_deterministic(tmp_path: Pa
     assert "Ineligible checkout refunds are rejected." in text
 
 
+def test_generate_routes_to_behavioral_generator_when_entry_point_present(tmp_path: Path) -> None:
+    """When the contract declares a ## Entry Point, `pdd test --from-story`
+    (generate_story_regression_test) must produce a *behavioral* test that
+    calls the entry point and asserts over `result`, not a text-pin."""
+    stories = tmp_path / "user_stories"
+    contracts = stories / "contracts"
+    contracts.mkdir(parents=True)
+    (stories / "story__checkout_total.md").write_text(
+        "# User Story: checkout_total\n\n## Story\n\nAs a shopper, I can see my total.\n",
+        encoding="utf-8",
+    )
+    (contracts / "checkout_total.contract.md").write_text(
+        "# Contract\n\n## Covers\n- R1: total\n\n"
+        "## Entry Point\n- module: checkout_app\n- callable: checkout_total\n"
+        "- args: [1, 2]\n- kwargs: {}\n\n"
+        "## Seams\n- checkout_app.TAX_RATE = 0\n\n"
+        '## Oracle\n- result["total"] == 3\n',
+        encoding="utf-8",
+    )
+
+    result = generate_story_regression_test(stories / "story__checkout_total.md")
+    text = result.test_file.read_text(encoding="utf-8")
+    assert "result = story_result" in text  # behavioral: invokes the entry point
+    assert "@pytest.mark.story(story_id=STORY_ID, story_hash=STORY_HASH)" in text
+
+
+def test_generate_text_pins_when_no_entry_point(tmp_path: Path) -> None:
+    """A contract without an ## Entry Point still yields the text-pinning test."""
+    story = _story(tmp_path)  # helper builds a contract with Oracle but no Entry Point
+    result = generate_story_regression_test(story)
+    text = result.test_file.read_text(encoding="utf-8")
+    assert "_bundle_hash() == PDD_STORY_HASH" in text
+    assert "result = story_result" not in text
+
+
 def test_story_regression_gate_detects_missing_passing_and_stale(tmp_path: Path) -> None:
     story = _story(tmp_path)
 


### PR DESCRIPTION
## What
`pdd test --from-story` (via `generate_story_regression_test`) only ever ran the **text-pinning** generator. The **behavioral** generator in `pdd/story_test_generator.py` — which the docs describe (`## Entry Point`, `## Seams`, assertions over `result`) — was **wired to nothing**, so:
- **0 of 32** shipped contracts declared an `## Entry Point`, and
- generated tests could catch story/contract *text* drift but not runtime *behavior* regressions — short of EPIC #1816's "executable oracle" headline.

(Root of pdd#1857 gap **G2**.)

## Change
Route by contract inside `generate_story_regression_test` (CLI untouched):
- **Behavioral** — when the contract declares a machine-readable `## Entry Point`, delegate to `story_test_generator.generate_story_test`: it imports the callable, applies `## Seams`, and asserts `## Oracle` / `## Negative Cases` as expressions over `result`.
- **Text-pin (fallback)** — contracts without an `## Entry Point` keep the exact current behavior. No shipped story changes output (0/32 have an Entry Point today).

Docs (`generating_user_stories.md` Step 3) rewritten to describe both modes and the fallback accurately (it previously claimed the `## Entry Point` was required).

## Verified end-to-end (no credentials)
With an Entry-Point contract + a real callable, `generate_story_regression_test` now emits a behavioral test that:
- calls the entry point (`result = story_result`), tagged `@pytest.mark.story(story_id=STORY_ID, story_hash=STORY_HASH)`;
- **passes** on correct code, and **goes red when the callable's behavior is mutated** (`subtotal + TAX_RATE` → `subtotal + 1`) — a real behavioral oracle.
- Entry-point-less stories (e.g. `pdd_change`) still text-pin unchanged.

## Tests
- `test_generate_routes_to_behavioral_generator_when_entry_point_present`
- `test_generate_text_pins_when_no_entry_point`
- generator + coverage + gate suites: 45 passed; `pytest -m story` green.

Found during pdd#1857 verification (gap G2). Targets the epic branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)