### PR TITLE
fix(sync): honor PDD_FORCE_LOCAL and forward --local to issue-sync children

### DIFF
--- a/pdd/agentic_sync.py
+++ b/pdd/agentic_sync.py
@@ -2614,6 +2614,7 @@ def run_agentic_sync(
     temperature: Optional[float] = None,
     context_override: Optional[str] = None,
     compressed_context: bool = False,
+    local: bool = False,
 ) -> Tuple[bool, str, float, str]:
     """
     Run agentic sync workflow: identify modules from a GitHub issue and sync in parallel.
@@ -3021,6 +3022,10 @@ def run_agentic_sync(
         "temperature": temperature,
         "context": context_override,
         "compressed_context": compressed_context,
+        # Forward --local so child syncs skip PDD-cloud dispatch on argv, not
+        # just via the inherited PDD_FORCE_LOCAL env (run_global_sync already
+        # forwards this; the issue-URL path previously dropped it).
+        "local": local,
     }
 
     github_info = {

--- a/pdd/commands/maintenance.py
+++ b/pdd/commands/maintenance.py
@@ -569,6 +569,7 @@ def _run_agentic_sync_dispatch(
             temperature=temperature,
             context_override=context_override,
             compressed_context=compressed_context,
+            local=ctx.obj.get("local", False),
         )
 
         if not quiet:

--- a/pdd/core/cli.py
+++ b/pdd/core/cli.py
@@ -778,7 +778,15 @@ def cli(
     ctx.obj["review_examples"] = review_examples
     if review_examples:
         ctx.obj["grounding_review_decisions"] = []
-    ctx.obj["local"] = bool(local or estimate_mode)
+    # PDD_FORCE_LOCAL env must behave like --local: the per-step cloud
+    # dispatchers (generateCode/crashCode/verifyCode/fixCode) gate on
+    # ctx.obj["local"], not on the env var, so an env-only force-local
+    # previously still attempted PDD-cloud auth — including an interactive
+    # GitHub device-flow hang outside CI. Truthy set matches sync_main.
+    env_force_local = os.environ.get(
+        "PDD_FORCE_LOCAL", ""
+    ).strip().lower() in {"1", "true", "yes", "on"}
+    ctx.obj["local"] = bool(local or estimate_mode or env_force_local)
     # Propagate --local flag to environment for llm_invoke cloud detection
     if local or estimate_mode:
         os.environ['PDD_FORCE_LOCAL'] = '1'

--- a/tests/test_force_local_issue_sync.py
+++ b/tests/test_force_local_issue_sync.py
@@ -1,0 +1,135 @@
+"""Tests for --local / PDD_FORCE_LOCAL handling on the issue-URL sync path.
+
+Two defects found by mocked agentic-sync E2E runs:
+
+1. ``run_agentic_sync`` did not accept or forward ``local``, so child
+   ``pdd sync <module>`` subprocesses were spawned without ``--local`` even
+   when the parent got it (``run_global_sync`` already forwarded it).
+2. ``ctx.obj["local"]`` was derived only from the ``--local`` argv flag, so
+   an env-only ``PDD_FORCE_LOCAL=1`` (the documented force-local switch) did
+   not stop the per-step cloud dispatchers (generateCode/crashCode/...),
+   which gate on ``ctx.obj["local"]``. Outside CI this triggered a real
+   interactive GitHub device-flow prompt that hangs the sync child.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from pdd.agentic_sync import run_agentic_sync
+from pdd.agentic_sync_runner import DepGraphFromArchitectureResult
+from pdd.cli import cli
+
+ISSUE_URL = "https://github.com/owner/repo/issues/1"
+
+
+def _run_with_mocks(mock_gh_cmd, mock_load_arch, mock_agentic_task,
+                    mock_dry_run, mock_runner_cls, **kwargs):
+    issue_data = {"title": "Test", "body": "Fix foo", "comments_url": ""}
+    mock_gh_cmd.return_value = (True, json.dumps(issue_data))
+    mock_load_arch.return_value = (
+        [{"filename": "foo_python.prompt", "dependencies": []}],
+        Path("/tmp/architecture.json"),
+    )
+    mock_agentic_task.return_value = (
+        True, 'MODULES_TO_SYNC: ["foo"]\nDEPS_VALID: true', 0.05, "anthropic",
+    )
+    mock_dry_run.return_value = (True, {"foo": Path("/tmp")}, {"foo": "foo"}, [], 0.0)
+    mock_runner = MagicMock()
+    mock_runner.run.return_value = (True, "All 1 modules synced successfully", 0.15)
+    mock_runner_cls.return_value = mock_runner
+    result = run_agentic_sync(ISSUE_URL, quiet=True, **kwargs)
+    return result, mock_runner_cls
+
+
+class TestRunAgenticSyncForwardsLocal:
+    @patch("pdd.agentic_sync.AsyncSyncRunner")
+    @patch("pdd.agentic_sync._filter_already_synced", return_value=["foo"])
+    @patch("pdd.agentic_sync._detect_modules_from_branch_diff", return_value=[])
+    @patch("pdd.agentic_sync._run_dry_run_validation")
+    @patch(
+        "pdd.agentic_sync.build_dep_graph_from_architecture_data",
+        return_value=DepGraphFromArchitectureResult({"foo": []}, []),
+    )
+    @patch("pdd.agentic_sync.load_prompt_template",
+           return_value="template {issue_content} {architecture_json}")
+    @patch("pdd.agentic_sync.run_agentic_task")
+    @patch("pdd.agentic_sync._load_architecture_json")
+    @patch("pdd.agentic_sync._run_gh_command")
+    @patch("pdd.agentic_sync._check_gh_cli", return_value=True)
+    def test_local_true_reaches_runner_sync_options(
+        self, mock_gh_cli, mock_gh_cmd, mock_load_arch, mock_agentic_task,
+        mock_load_prompt, mock_build_graph, mock_dry_run, mock_branch_diff,
+        mock_filter, mock_runner_cls,
+    ):
+        (success, _, _, _), runner_cls = _run_with_mocks(
+            mock_gh_cmd, mock_load_arch, mock_agentic_task, mock_dry_run,
+            mock_runner_cls, local=True,
+        )
+        assert success
+        sync_options = runner_cls.call_args.kwargs["sync_options"]
+        assert sync_options["local"] is True
+
+    @patch("pdd.agentic_sync.AsyncSyncRunner")
+    @patch("pdd.agentic_sync._filter_already_synced", return_value=["foo"])
+    @patch("pdd.agentic_sync._detect_modules_from_branch_diff", return_value=[])
+    @patch("pdd.agentic_sync._run_dry_run_validation")
+    @patch(
+        "pdd.agentic_sync.build_dep_graph_from_architecture_data",
+        return_value=DepGraphFromArchitectureResult({"foo": []}, []),
+    )
+    @patch("pdd.agentic_sync.load_prompt_template",
+           return_value="template {issue_content} {architecture_json}")
+    @patch("pdd.agentic_sync.run_agentic_task")
+    @patch("pdd.agentic_sync._load_architecture_json")
+    @patch("pdd.agentic_sync._run_gh_command")
+    @patch("pdd.agentic_sync._check_gh_cli", return_value=True)
+    def test_local_defaults_false(
+        self, mock_gh_cli, mock_gh_cmd, mock_load_arch, mock_agentic_task,
+        mock_load_prompt, mock_build_graph, mock_dry_run, mock_branch_diff,
+        mock_filter, mock_runner_cls,
+    ):
+        (success, _, _, _), runner_cls = _run_with_mocks(
+            mock_gh_cmd, mock_load_arch, mock_agentic_task, mock_dry_run,
+            mock_runner_cls,
+        )
+        assert success
+        sync_options = runner_cls.call_args.kwargs["sync_options"]
+        assert sync_options["local"] is False
+
+
+class TestCliLocalPlumbing:
+    @patch("pdd.commands.maintenance.run_agentic_sync")
+    def test_local_flag_reaches_agentic_dispatch(self, mock_run):
+        mock_run.return_value = (True, "ok", 0.0, "anthropic")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--force", "--local", "sync", ISSUE_URL], catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.kwargs["local"] is True
+
+    @patch("pdd.commands.maintenance.run_agentic_sync")
+    def test_env_force_local_reaches_agentic_dispatch(self, mock_run, monkeypatch):
+        monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+        mock_run.return_value = (True, "ok", 0.0, "anthropic")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--force", "sync", ISSUE_URL], catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.kwargs["local"] is True
+
+    @patch("pdd.commands.maintenance.run_agentic_sync")
+    def test_no_local_signal_stays_cloud(self, mock_run, monkeypatch):
+        monkeypatch.delenv("PDD_FORCE_LOCAL", raising=False)
+        mock_run.return_value = (True, "ok", 0.0, "anthropic")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--force", "sync", ISSUE_URL], catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.kwargs["local"] is False


### PR DESCRIPTION
Fixes two force-local defects found by mocked (non-billable) agentic-sync E2E runs against `origin/main`.

## Defect 1: env-only `PDD_FORCE_LOCAL=1` did not stop per-step cloud dispatch

`ctx.obj["local"]` was derived only from the `--local` argv flag. The per-step cloud dispatchers (generateCode/crashCode/verifyCode/fixCode) gate on `cli_params['local']` — not on the env var — so a run with `PDD_FORCE_LOCAL=1` but no `--local` still attempted PDD-cloud auth.

Observed impact (reproduced end to end): outside `CI=1`, the generate step launched a **real interactive GitHub device-flow prompt** ("Enter code: …", "Waiting for authentication...") and hung the sync child indefinitely; under `CI=1` it degraded to noisy auth errors and a wasted attempt. `llm_invoke` and auto-submit already honored the env var — the step-mains were the gap.

Fix: the root CLI now maps a truthy `PDD_FORCE_LOCAL` into `ctx.obj["local"]` (same truthy set `sync_main._auto_submit_example` already uses).

## Defect 2: `--local` dropped for issue-sync children

`run_agentic_sync` (issue-URL sync) had no `local` parameter and omitted `"local"` from `sync_options`, so child `pdd sync <module>` subprocesses were spawned **without** `--local` even when the parent got it. `run_global_sync` already forwarded it; `AsyncSyncRunner._build_command` already supported it — the issue-URL path just never passed it. Now forwarded from the CLI dispatch through `sync_options["local"]`.

Verified end to end (hermetic harness): child argv now contains `--local`
(`pdd --force --local sync --agentic --no-steer --one-session ... greeter`), and the previously-hanging env-only scenario completes in <1s with **zero** cloud attempts.

## Tests

`tests/test_force_local_issue_sync.py` (5 tests): `sync_options["local"]` forwarding (true/default-false) with the standard `run_agentic_sync` mock stack, plus CliRunner coverage that `--local`, env `PDD_FORCE_LOCAL=1`, and no-signal each produce the right `local=` at the agentic dispatch boundary.

Full related regression green: `test_agentic_sync.py`, `test_agentic_sync_runner.py`, `test_commands_maintenance.py`, `test_sync_main.py` + new suites.

Part of the agentic-sync E2E validation epic. Related: #1464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
