### PR TITLE
Research #1209 v2 (7/7): env-freeze hardening — mandatory freeze for command arms, {python} placeholder, HOME redirect, agent-exit diagnostics

### DIFF
--- a/research/repo-bloat-benchmark/harness/runner/README.md
+++ b/research/repo-bloat-benchmark/harness/runner/README.md
@@ -54,31 +54,42 @@ cat /tmp/rb-reports/report.md
 ## Running a real agent arm
 
 Set `"arm": "command"`, `"agent_command": ["codex", "exec", "--cd", "{workdir}", …]`
-and `"upstream_base_url": "https://api.openai.com"`. The runner injects
-`OPENAI_BASE_URL` pointing at the recording proxy; confirming the pinned
-Codex build honors that override is the §10 pre-run blocker.
+and `"upstream_base_url": "https://api.openai.com"`. Command-arm runs require
+`RunConfig.freeze`; set `allow_unfrozen_command=true` only for harness
+development, never for pilot data. The runner injects `OPENAI_BASE_URL`
+pointing at the recording proxy; confirming the pinned Codex build honors that
+override is the §10 pre-run blocker. Nonzero agent exits abort the trial before
+a benchmark record is written and leave `agent_process.json` for diagnosis.
+
+Scenario verifier commands and command-arm `agent_command` entries may use
+`"{workdir}"` for the materialized variant and `"{python}"` for the Python
+interpreter running the harness. Use `"{python}"` for committed Python
+scenario tests so local verification does not depend on whichever `python3`
+appears first on `PATH`.
 
 ### Run-environment freeze (design §8.1.1) — `env_freeze.py`
 
 Real command-arm runs must set `RunConfig.freeze` (a `FreezeConfig`) and
-should set `registered_env_fingerprint`. Per trial the runner then:
+`registered_env_fingerprint`, unless explicitly marked as harness-development
+with `allow_unfrozen_command=true`. Per trial the runner then:
 
 1. captures the CLI version and **aborts on any mismatch** with the pin;
 2. creates a **fresh per-run `CODEX_HOME`** containing only a generated
    config (pinned model + reasoning effort, web search off, history
    persistence off, no MCP servers unless the arm enumerates them, and the
    recording proxy as the model provider);
-3. runs the agent under a **sanitized allowlist environment** — the model API
-   key is the only permitted secret — plus an **egress guard** (proxy vars
-   black-hole all HTTP(S) except loopback, where the recording proxy
-   listens);
+3. runs the agent under a **sanitized allowlist environment** — `HOME` is
+   redirected to the fresh per-run home and the model API key is the only
+   permitted secret — plus an **egress guard** (proxy vars black-hole all
+   HTTP(S) except loopback, where the recording proxy listens);
 4. verifies the built environment's **fingerprint** (port-independent sha256
    of the frozen combination) against the registered value, recording it as
    `env_fingerprint_sha256` in the run record (`null` ⇒ the run was not
    frozen and its numbers are development-only);
-5. after the run, **archives** whatever the CLI wrote into its home
-   (session logs feed the session-parser bypass cross-check) and **deletes
-   the home** — ephemerality by destruction, not by trusting a flag.
+5. after the run, **archives** whatever the CLI wrote into its home, including
+   final `config.toml` bytes (session logs feed the session-parser bypass
+   cross-check), and **deletes the home** — ephemerality by destruction, not by
+   trusting a flag.
 
 The egress guard is the portable layer (honored by mainstream HTTP stacks,
 not kernel enforcement); the Linux-container network lockdown remains the

--- a/research/repo-bloat-benchmark/harness/runner/cli.py
+++ b/research/repo-bloat-benchmark/harness/runner/cli.py
@@ -18,8 +18,10 @@ with ``experiment.json``::
     }
 
 For a real agent arm set ``"arm": "command"`` plus ``"agent_command":
-["codex", "exec", "--cd", "{workdir}", "..."]`` and ``"upstream_base_url"``;
-the runner injects ``OPENAI_BASE_URL`` pointing at the recording proxy.
+["codex", "exec", "--cd", "{workdir}", "..."]``, ``"upstream_base_url"``,
+``"freeze"`` (a ``FreezeConfig`` JSON object), and
+``"registered_env_fingerprint"``; the runner injects ``OPENAI_BASE_URL``
+pointing at the recording proxy.
 """
 
 from __future__ import annotations
@@ -29,8 +31,19 @@ import json
 import sys
 from pathlib import Path
 
+from .env_freeze import FreezeConfig
 from .report import generate_report, load_run_records
 from .runner import ExperimentRunner, RunConfig
+
+
+def load_experiment_config(path: Path) -> tuple[RunConfig, list[int], int]:
+    """Load JSON config and coerce nested dataclass fields."""
+    config_data = json.loads(path.read_text(encoding="utf-8"))
+    sizes = config_data.pop("sizes", [1])
+    trials = config_data.pop("trials", 1)
+    if isinstance(config_data.get("freeze"), dict):
+        config_data["freeze"] = FreezeConfig(**config_data["freeze"])
+    return RunConfig(**config_data), sizes, trials
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -38,10 +51,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--config", required=True, type=Path)
     args = parser.parse_args(argv)
 
-    config_data = json.loads(args.config.read_text(encoding="utf-8"))
-    sizes = config_data.pop("sizes", [1])
-    trials = config_data.pop("trials", 1)
-    run_config = RunConfig(**config_data)
+    run_config, sizes, trials = load_experiment_config(args.config)
     runner = ExperimentRunner(run_config)
 
     for size in sizes:

--- a/research/repo-bloat-benchmark/harness/runner/env_freeze.py
+++ b/research/repo-bloat-benchmark/harness/runner/env_freeze.py
@@ -20,8 +20,9 @@ environment **frozen, isolated, and fingerprinted**:
   Codex build before real runs (design §10 still-to-confirm); the fingerprint
   makes any adjustment visible.
 - **Sanitized environment** — an allowlist of variable *names* is copied from
-  the parent environment; everything else is dropped. The single permitted
-  secret is the model API key, passed through by explicit name.
+  the parent environment; everything else is dropped. ``HOME`` is redirected
+  to the per-run home so ambient user config is not visible. The single
+  permitted secret is the model API key, passed through by explicit name.
 - **Egress guard** — proxy environment variables point all HTTP(S) traffic at
   an unroutable discard address, with ``NO_PROXY`` exempting only loopback
   (where the recording proxy listens). This is the *portable* layer: it is
@@ -29,8 +30,8 @@ environment **frozen, isolated, and fingerprinted**:
   Linux-container network lockdown remains the hard tier, and session-log
   reconciliation (harness.context_snapshots.session_parser) detects bypass.
 - **Fingerprint** — sha256 over the canonical frozen combination (CLI
-  version, model, effort, web search, MCP set, allowlist names, config
-  template with the per-run proxy port *held as a placeholder*, cache
+  version, model, effort, web search, MCP set, allowlist names and values,
+  config template with the per-run proxy port *held as a placeholder*, cache
   policy). Identical across cells and trials by construction; recorded as
   ``env_fingerprint_sha256`` in every run record, and asserted against the
   registered value before each run.
@@ -49,7 +50,7 @@ from urllib.parse import urlparse
 
 # Variable NAMES copied from the parent environment. Everything else is
 # dropped — no inherited dev shell (design §8.1.1 "Shell environment").
-DEFAULT_ENV_ALLOWLIST = ("PATH", "HOME", "LANG", "LC_ALL", "TERM", "TMPDIR")
+DEFAULT_ENV_ALLOWLIST = ("PATH", "LANG", "LC_ALL", "TERM", "TMPDIR")
 
 # All non-loopback HTTP(S) traffic is pointed here: TCP port 9 ("discard"),
 # nothing listens. Requests fail fast instead of leaving the machine.
@@ -122,9 +123,13 @@ class FreezeConfig:
             "web_search_enabled": self.web_search_enabled,
             "mcp_servers": sorted(self.mcp_servers),
             "env_allowlist": sorted(self.env_allowlist),
+            "env_allowlist_values": {
+                name: os.environ.get(name) for name in sorted(self.env_allowlist)
+            },
             "api_key_env_var": self.api_key_env_var,
             "cache_policy": self.cache_policy,
             "home_dir_env_var": self.home_dir_env_var,
+            "home_env_policy": "HOME is set to the fresh per-run home directory",
             "config_template": self.render_config("{PROXY_BASE_URL}"),
         }
         canonical = json.dumps(material, sort_keys=True)
@@ -210,6 +215,7 @@ class FrozenEnvironment:
                 env[name] = os.environ[name]
         if self.config.api_key_env_var and self.config.api_key_env_var in os.environ:
             env[self.config.api_key_env_var] = os.environ[self.config.api_key_env_var]
+        env["HOME"] = str(self.home_dir)
         env[self.config.home_dir_env_var] = str(self.home_dir)
         env["OPENAI_BASE_URL"] = f"{self.proxy_base_url}/v1"
         env.update(egress_guard_env(self.proxy_base_url))
@@ -232,7 +238,7 @@ class FrozenEnvironment:
         """Archive session artifacts, then delete the home (ephemerality).
 
         Everything the CLI wrote into its home during the run (session logs,
-        caches it created despite policy) is moved to
+        final config bytes, caches it created despite policy) is moved to
         ``<run_dir>/codex_home_artifacts/`` for the session-parser
         cross-check; the home itself is removed so nothing can leak into a
         later run. Returns the archived paths (home-relative).
@@ -243,8 +249,6 @@ class FrozenEnvironment:
         archived: list[str] = []
         for path in sorted(p for p in self.home_dir.rglob("*") if p.is_file()):
             rel = path.relative_to(self.home_dir)
-            if rel.as_posix() == "config.toml":
-                continue  # harness-authored; already covered by the fingerprint
             destination = archive / rel
             destination.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(path), destination)

--- a/research/repo-bloat-benchmark/harness/runner/runner.py
+++ b/research/repo-bloat-benchmark/harness/runner/runner.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -39,7 +40,7 @@ class RunConfig:
     reports_dir: Path
     work_root: Path  # fresh variants are materialized under here
     arm: str = "mock"  # "mock" or "command"
-    agent_command: list[str] | None = None  # for arm="command"; {workdir} expanded
+    agent_command: list[str] | None = None  # for arm="command"; placeholders expanded
     upstream_base_url: str | None = None  # real provider for arm="command"
     mock_behavior: str = "oracle"  # oracle | wrong_file | noop
     mock_read_distractor_count: int = 2
@@ -51,10 +52,26 @@ class RunConfig:
     # match the built environment or the run aborts.
     freeze: FreezeConfig | None = None
     registered_env_fingerprint: str | None = None
+    allow_unfrozen_command: bool = False
 
     def __post_init__(self) -> None:
         for name in ("scenario_dir", "distractors_dir", "reports_dir", "work_root"):
             setattr(self, name, Path(getattr(self, name)))
+        if isinstance(self.freeze, dict):
+            self.freeze = FreezeConfig(**self.freeze)
+        if self.arm not in {"mock", "command"}:
+            raise ValueError('RunConfig.arm must be "mock" or "command"')
+        if self.arm == "command" and not self.allow_unfrozen_command:
+            if self.freeze is None:
+                raise ValueError(
+                    'arm="command" requires RunConfig.freeze; set '
+                    "allow_unfrozen_command=True only for harness development runs"
+                )
+            if not self.registered_env_fingerprint:
+                raise ValueError(
+                    'arm="command" requires registered_env_fingerprint; set '
+                    "allow_unfrozen_command=True only for harness development runs"
+                )
 
 
 @dataclass
@@ -72,6 +89,17 @@ class ExperimentRunner:
 
     # -- helpers -------------------------------------------------------------
 
+    def _expand_command(self, command: list[str], workdir: Path) -> list[str]:
+        """Expand harness command placeholders.
+
+        ``{python}`` pins scenario/test helper commands to the interpreter
+        running the harness, avoiding ambient ``python3`` mismatches.
+        """
+        return [
+            part.replace("{workdir}", str(workdir)).replace("{python}", sys.executable)
+            for part in command
+        ]
+
     def _run(self, command: list[str], cwd: Path, env_extra: dict | None = None,
              timeout: float | None = None) -> subprocess.CompletedProcess:
         import os
@@ -80,7 +108,11 @@ class ExperimentRunner:
         env["PYTHONPATH"] = str(cwd / "src")
         env.update(env_extra or {})
         return subprocess.run(
-            command, cwd=str(cwd), env=env, capture_output=True, text=True,
+            self._expand_command(command, cwd),
+            cwd=str(cwd),
+            env=env,
+            capture_output=True,
+            text=True,
             timeout=timeout,
         )
 
@@ -95,7 +127,7 @@ class ExperimentRunner:
         env = dict(os.environ)
         env["PYTHONPATH"] = str(workdir / "src")
         result = subprocess.run(
-            self.scenario["hidden_verifier"]["command"],
+            self._expand_command(self.scenario["hidden_verifier"]["command"], workdir),
             cwd=str(hidden_dir),
             env=env,
             capture_output=True,
@@ -198,10 +230,7 @@ class ExperimentRunner:
                 ).read_text(encoding="utf-8")
                 agent.run(task_brief=task_brief)
             else:
-                command = [
-                    part.replace("{workdir}", str(workdir))
-                    for part in (config.agent_command or [])
-                ]
+                command = self._expand_command(config.agent_command or [], workdir)
                 if config.freeze is not None:
                     frozen = FrozenEnvironment(
                         config=config.freeze,
@@ -221,7 +250,7 @@ class ExperimentRunner:
                     agent_env = dict(os.environ)
                     agent_env["OPENAI_BASE_URL"] = f"{proxy_url}/v1"
                 try:
-                    subprocess.run(
+                    completed = subprocess.run(
                         command,
                         cwd=str(workdir),
                         env=agent_env,
@@ -229,16 +258,53 @@ class ExperimentRunner:
                         text=True,
                         timeout=config.timeout_seconds,
                     )
+                    (report_dir / "agent_process.json").write_text(
+                        json.dumps(
+                            {
+                                "command": command,
+                                "returncode": completed.returncode,
+                                "stdout": completed.stdout,
+                                "stderr": completed.stderr,
+                                "timed_out": False,
+                            },
+                            indent=2,
+                        )
+                        + "\n",
+                        encoding="utf-8",
+                    )
+                    if completed.returncode != 0:
+                        stderr_tail = (completed.stderr or completed.stdout or "").strip()
+                        if len(stderr_tail) > 500:
+                            stderr_tail = stderr_tail[-500:]
+                        raise RuntimeError(
+                            "agent command failed "
+                            f"(exit {completed.returncode}); see "
+                            f"{report_dir / 'agent_process.json'}"
+                            + (f": {stderr_tail}" if stderr_tail else "")
+                        )
                 except subprocess.TimeoutExpired:
                     timed_out = True
-                finally:
-                    if frozen is not None:
-                        archived = frozen.collect_and_destroy()
-                        (report_dir / "codex_home_manifest.json").write_text(
-                            json.dumps({"archived": archived}, indent=2) + "\n",
-                            encoding="utf-8",
+                    (report_dir / "agent_process.json").write_text(
+                        json.dumps(
+                            {
+                                "command": command,
+                                "returncode": None,
+                                "stdout": None,
+                                "stderr": None,
+                                "timed_out": True,
+                            },
+                            indent=2,
                         )
+                        + "\n",
+                        encoding="utf-8",
+                    )
         finally:
+            if frozen is not None and frozen.home_dir.exists():
+                archived = frozen.collect_and_destroy()
+                (report_dir / "codex_home_manifest.json").write_text(
+                    json.dumps({"archived": archived}, indent=2) + "\n",
+                    encoding="utf-8",
+                )
             wall_clock = time.monotonic() - started
             proxy.stop()
             if mock_server:

--- a/research/repo-bloat-benchmark/harness/runner/tests/test_env_freeze.py
+++ b/research/repo-bloat-benchmark/harness/runner/tests/test_env_freeze.py
@@ -6,6 +6,7 @@ guarantees held *inside* the agent process.
 """
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -19,11 +20,12 @@ from harness.runner.env_freeze import (
     capture_cli_version,
     egress_guard_env,
 )
+from harness.runner.cli import load_experiment_config
 from harness.runner.mock_agent import MockModelServer
 from harness.runner.runner import ExperimentRunner, RunConfig
 
 FAKE_VERSION = "codex-cli 0.0-test"
-VERSION_COMMAND = ["python3", "-c", f"print('{FAKE_VERSION}')"]
+VERSION_COMMAND = [sys.executable, "-c", f"print('{FAKE_VERSION}')"]
 
 
 def _freeze_config(**overrides):
@@ -94,7 +96,7 @@ def test_version_mismatch_aborts(tmp_path):
 
 def test_version_command_failure_aborts():
     with pytest.raises(FreezeViolation, match="cannot capture|failed"):
-        capture_cli_version(["python3", "-c", "raise SystemExit(3)"])
+        capture_cli_version([sys.executable, "-c", "raise SystemExit(3)"])
 
 
 # -- fresh home + ephemerality ------------------------------------------------
@@ -116,8 +118,9 @@ def test_collect_and_destroy_archives_then_deletes(tmp_path):
     sessions.mkdir()
     (sessions / "rollout.jsonl").write_text('{"type": "session_meta"}\n')
     archived = env.collect_and_destroy()
-    assert archived == ["sessions/rollout.jsonl"]
+    assert archived == ["config.toml", "sessions/rollout.jsonl"]
     assert not env.home_dir.exists()  # nothing can leak into a later run
+    assert (tmp_path / "codex_home_artifacts" / "config.toml").is_file()
     assert (tmp_path / "codex_home_artifacts" / "sessions" / "rollout.jsonl").is_file()
 
 
@@ -125,6 +128,7 @@ def test_collect_and_destroy_archives_then_deletes(tmp_path):
 
 
 def test_environment_is_allowlist_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", "/ambient-home-should-not-leak")
     monkeypatch.setenv("SUPER_SECRET_TOKEN", "leak-me")
     monkeypatch.setenv("FAKE_API_KEY", "sk-test")
     env = FrozenEnvironment(
@@ -133,6 +137,7 @@ def test_environment_is_allowlist_only(tmp_path, monkeypatch):
     variables = env.environment()
     assert "SUPER_SECRET_TOKEN" not in variables  # dropped: not allowlisted
     assert variables["FAKE_API_KEY"] == "sk-test"  # the one permitted secret
+    assert variables["HOME"] == str(env.home_dir)
     assert variables["CODEX_HOME"] == str(env.home_dir)
     assert variables["OPENAI_BASE_URL"] == "http://127.0.0.1:4321/v1"
     assert "PATH" in variables
@@ -166,6 +171,7 @@ from pathlib import Path
 
 home = Path(os.environ["CODEX_HOME"])
 assert [p.name for p in home.iterdir()] == ["config.toml"], "home not fresh"
+assert os.environ["HOME"] == os.environ["CODEX_HOME"], "HOME not isolated"
 assert "SUPER_SECRET_TOKEN" not in os.environ, "env not sanitized"
 assert os.environ["HTTPS_PROXY"].endswith(":9"), "egress guard missing"
 
@@ -209,7 +215,7 @@ def frozen_run(tmp_path, monkeypatch):
         reports_dir=tmp_path / "reports",
         work_root=tmp_path / "work",
         arm="command",
-        agent_command=["python3", "-c", AGENT_SCRIPT],
+        agent_command=["{python}", "-c", AGENT_SCRIPT],
         upstream_base_url=upstream_url,
         freeze=freeze,
         registered_env_fingerprint=freeze.fingerprint(),
@@ -241,8 +247,131 @@ def test_command_arm_runs_frozen(frozen_run):
     assert record["failure_class"] == "localization_miss"
 
 
+def test_command_arm_nonzero_exit_aborts_before_record(frozen_run):
+    runner, freeze, tmp_path = frozen_run
+    runner.config.agent_command = [
+        "{python}",
+        "-c",
+        "import sys; print('agent exploded', file=sys.stderr); raise SystemExit(3)",
+    ]
+    with pytest.raises(RuntimeError, match="exit 3"):
+        runner.run_trial(1, 0)
+    report_dir = tmp_path / "reports" / "example-pagination.1x.trial0"
+    process = json.loads((report_dir / "agent_process.json").read_text())
+    assert process["returncode"] == 3
+    assert "agent exploded" in process["stderr"]
+    assert not (report_dir / "run_record.json").exists()
+    assert not (report_dir / "codex_home").exists()
+
+
 def test_registered_fingerprint_mismatch_aborts_before_agent(frozen_run):
     runner, freeze, tmp_path = frozen_run
     runner.config.registered_env_fingerprint = "0" * 64
     with pytest.raises(FreezeViolation, match="fingerprint mismatch"):
         runner.run_trial(1, 0)
+    report_dir = tmp_path / "reports" / "example-pagination.1x.trial0"
+    assert not (report_dir / "codex_home").exists()
+
+
+def test_command_arm_requires_freeze_unless_explicit_dev_mode(tmp_path):
+    with pytest.raises(ValueError, match='must be "mock" or "command"'):
+        RunConfig(
+            scenario_dir=SCENARIO_DIR,
+            distractors_dir=tmp_path / "distractors",
+            reports_dir=tmp_path / "reports",
+            work_root=tmp_path / "work",
+            arm="commnad",
+            agent_command=["{python}", "-c", "print('dev')"],
+        )
+
+    with pytest.raises(ValueError, match="requires RunConfig.freeze"):
+        RunConfig(
+            scenario_dir=SCENARIO_DIR,
+            distractors_dir=tmp_path / "distractors",
+            reports_dir=tmp_path / "reports",
+            work_root=tmp_path / "work",
+            arm="command",
+            agent_command=["{python}", "-c", "print('dev')"],
+        )
+
+    with pytest.raises(ValueError, match="requires registered_env_fingerprint"):
+        RunConfig(
+            scenario_dir=SCENARIO_DIR,
+            distractors_dir=tmp_path / "distractors",
+            reports_dir=tmp_path / "reports",
+            work_root=tmp_path / "work",
+            arm="command",
+            agent_command=["{python}", "-c", "print('dev')"],
+            freeze=_freeze_config(),
+        )
+
+    config = RunConfig(
+        scenario_dir=SCENARIO_DIR,
+        distractors_dir=tmp_path / "distractors",
+        reports_dir=tmp_path / "reports",
+        work_root=tmp_path / "work",
+        arm="command",
+        agent_command=["{python}", "-c", "print('dev')"],
+        allow_unfrozen_command=True,
+    )
+    assert config.allow_unfrozen_command
+
+
+def test_cli_loads_freeze_config_from_json(tmp_path):
+    freeze = _freeze_config()
+    config_path = tmp_path / "experiment.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "scenario_dir": str(SCENARIO_DIR),
+                "distractors_dir": str(tmp_path / "distractors"),
+                "reports_dir": str(tmp_path / "reports"),
+                "work_root": str(tmp_path / "work"),
+                "arm": "command",
+                "agent_command": ["{python}", "-c", "print('ok')"],
+                "upstream_base_url": "http://127.0.0.1:1",
+                "freeze": {
+                    "pinned_cli_version": freeze.pinned_cli_version,
+                    "cli_version_command": freeze.cli_version_command,
+                    "model_id": freeze.model_id,
+                    "reasoning_effort": freeze.reasoning_effort,
+                    "api_key_env_var": freeze.api_key_env_var,
+                },
+                "registered_env_fingerprint": freeze.fingerprint(),
+                "sizes": [1, 5],
+                "trials": 2,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config, sizes, trials = load_experiment_config(config_path)
+
+    assert isinstance(run_config.freeze, FreezeConfig)
+    assert run_config.registered_env_fingerprint == freeze.fingerprint()
+    assert sizes == [1, 5]
+    assert trials == 2
+
+
+def test_run_config_coerces_freeze_dict_for_programmatic_callers(tmp_path):
+    freeze = _freeze_config()
+    config = RunConfig(
+        scenario_dir=SCENARIO_DIR,
+        distractors_dir=tmp_path / "distractors",
+        reports_dir=tmp_path / "reports",
+        work_root=tmp_path / "work",
+        arm="command",
+        agent_command=["{python}", "-c", "print('ok')"],
+        upstream_base_url="http://127.0.0.1:1",
+        freeze={
+            "pinned_cli_version": freeze.pinned_cli_version,
+            "cli_version_command": freeze.cli_version_command,
+            "model_id": freeze.model_id,
+            "reasoning_effort": freeze.reasoning_effort,
+            "api_key_env_var": freeze.api_key_env_var,
+        },
+        registered_env_fingerprint=freeze.fingerprint(),
+    )
+
+    assert isinstance(config.freeze, FreezeConfig)

--- a/research/repo-bloat-benchmark/scenarios/example-pagination/scenario.json
+++ b/research/repo-bloat-benchmark/scenarios/example-pagination/scenario.json
@@ -9,12 +9,12 @@
   "allowed_edit_globs": ["src/pager/**"],
   "task_brief_path": "task.md",
   "visible_tests": {
-    "command": ["python3", "-m", "pytest", "tests/visible", "-q"],
+    "command": ["{python}", "-m", "pytest", "tests/visible", "-q"],
     "expected_exit_code": 0
   },
   "hidden_verifier": {
     "path": "hidden",
-    "command": ["python3", "-m", "pytest", ".", "-q"],
+    "command": ["{python}", "-m", "pytest", ".", "-q"],
     "mounted_into_agent_sandbox": false
   },
   "oracle_edit": {


### PR DESCRIPTION
Follow-up hardening to #1858, recovered from the working tree and rebased onto the merged epic. Targets `epic/1209-repo-bloat-v2` (never `main`).

## What changed
- **Command-arm runs now require `RunConfig.freeze`** — an unfrozen command arm can no longer silently produce pilot-looking data. `allow_unfrozen_command=true` is an explicit harness-development escape hatch and is documented as never valid for pilot runs.
- **`{python}` placeholder** for scenario verifier commands and command-arm `agent_command` entries, so committed Python scenario tests run under the harness interpreter instead of whichever `python3` is first on `PATH`.
- **`HOME` redirected into the fresh per-run `CODEX_HOME`** in the sanitized allowlist environment, closing a leak where the CLI could still read the operator's real dotfiles.
- **Nonzero agent exits abort the trial** before a benchmark record is written, leaving `agent_process.json` behind for diagnosis.

## Tests
`python3 -m pytest harness/ -q` → **92 passed** (was 88), stdlib+pytest only, no network/model tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)