### PR TITLE
test(stories): seed first behavioral (## Entry Point) story against real pdd code

### DIFF
--- a/tests/story_regression/test_story_pdd_story_gate_identity.py
+++ b/tests/story_regression/test_story_pdd_story_gate_identity.py
@@ -1,0 +1,27 @@
+"""Generated story regression tests. Do not hand-edit."""
+from __future__ import annotations
+
+import importlib
+import pytest
+
+STORY_ID = 'pdd_story_gate_identity'
+STORY_HASH = 'f77dcbd4dfce4f4d'
+ENTRY_MODULE = 'pdd.story_regression_gate'
+ENTRY_CALLABLE = 'story_id_from_path'
+ENTRY_ARGS = ["user_stories/story__pdd_generate.md"]
+ENTRY_KWARGS = {}
+SEAMS = []
+
+
+@pytest.fixture()
+def story_result(monkeypatch):
+    for target, value in SEAMS:
+        monkeypatch.setattr(target, value)
+    module = importlib.import_module(ENTRY_MODULE)
+    entry = getattr(module, ENTRY_CALLABLE)
+    return entry(*ENTRY_ARGS, **ENTRY_KWARGS)
+
+@pytest.mark.story(story_id=STORY_ID, story_hash=STORY_HASH)
+def test_story_pdd_story_gate_identity_R1_oracle_1(story_result):
+    result = story_result
+    assert result == "pdd_generate"

--- a/user_stories/contracts/pdd_story_gate_identity.contract.md
+++ b/user_stories/contracts/pdd_story_gate_identity.contract.md
@@ -1,0 +1,68 @@
+<!-- pdd-story-contract derived-from-story="../story__pdd_story_gate_identity.md" story-hash="f77dcbd4dfce4f4d" issue-ref="https://github.com/promptdriven/pdd/issues/1816" -->
+
+# Contract: pdd story gate identity
+
+> Generated from the human-verified user story + issue. Do not hand-edit:
+> it is regenerated to align whenever the Story changes. Humans verify the
+> Story (`../story__pdd_story_gate_identity.md`), not this contract.
+
+## Covers
+
+- R1: A `user_stories/story__<slug>.md` path resolves to the canonical story id `<slug>`.
+
+## Context
+
+The story-regression gate (`prompts/story_regression_gate_python.prompt`,
+implemented by `pdd/story_regression_gate.py`) traces every
+`@pytest.mark.story` regression test back to its source story through one
+identity primitive: `story_id_from_path`. Every gate verdict — ok, stale,
+missing — keys off this mapping, so it must strip exactly the `story__`
+prefix and `.md` suffix and nothing else.
+
+## Acceptance Criteria
+
+1. Given a path `user_stories/story__pdd_generate.md`, when the gate derives
+   its story id, then the result is exactly `pdd_generate` (directory,
+   `story__` prefix, and `.md` suffix all removed).
+
+## Entry Point
+
+- module: pdd.story_regression_gate
+- callable: story_id_from_path
+- args: ["user_stories/story__pdd_generate.md"]
+- kwargs: {}
+
+## Oracle
+
+- result == "pdd_generate"
+
+## Non-Oracle
+
+These details should not matter:
+
+- whether the path is relative or absolute
+- whether the story file actually exists on disk
+- operating-system path separator conventions
+
+## Negative Cases
+
+The exact-equality oracle already forbids every corrupted identity: a result
+that keeps the `story__` prefix, keeps the `.md` suffix, or includes the
+directory would fail `result == "pdd_generate"`.
+
+## Non-Goals
+
+- This story does not cover marker discovery, hash freshness, or gate modes.
+- This story does not cover paths that never carried the `story__` prefix.
+
+## Candidate Prompts
+
+- `prompts/story_regression_gate_python.prompt` — primary owner of the gate and its identity helper.
+- `prompts/user_story_tests_python.prompt` — related `story_id` helper sharing the same identity space.
+- `prompts/story_regression_python.prompt` — related story-to-test mapping.
+
+## Notes
+
+First behavioral (`## Entry Point`) story seeded against real pdd code, so the
+`pdd test --from-story` behavioral mode is exercised by an in-repo story
+rather than only by unit-test fixtures.

--- a/user_stories/story__pdd_story_gate_identity.md
+++ b/user_stories/story__pdd_story_gate_identity.md
@@ -1,0 +1,9 @@
+<!-- pdd-story-prompts: prompts/story_regression_gate_python.prompt -->
+
+# User Story: pdd story gate identity
+
+## Story
+
+As a maintainer relying on the story-regression gate,
+I want every `story__<slug>.md` file path to resolve to its canonical story id,
+so that regression tests, coverage reports, and the stale/missing gate all trace back to the same story.


### PR DESCRIPTION
Gap G-D from the #1889 hardening pass: all 32 shipped stories were text-pin — the flagship behavioral mode had zero real in-repo usage.

Seeds `story__pdd_story_gate_identity`: the entry point is `pdd.story_regression_gate.story_id_from_path`, the identity primitive every gate verdict keys off. Story + contract (canonical `story-hash` f77dcbd4dfce4f4d verified against `_story_content_hash`) + test generated by the real CLI (`pdd test --from-story`, deterministic, $0.00).

Red/green proven: green on HEAD; removing the `story__` prefix-strip fails with `assert 'story__pdd_generate' == 'pdd_generate'`. Gate moves 9→10 ok / 0 stale / 23 missing; `pytest -m story` 14→15 passed; coverage/backfill suites unaffected (89 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)