### PR TITLE
Honor Step 6 test expansion markers in checkup

### DIFF
--- a/pdd/agentic_checkup_orchestrator.py
+++ b/pdd/agentic_checkup_orchestrator.py
@@ -2070,6 +2070,17 @@ def _parse_expansion_items(step6_output: str) -> Tuple[set, set]:
     return paths, justified_paths
 
 
+def _parse_step6_expansion_items(step_outputs: Dict[str, str]) -> Tuple[set, set]:
+    """Parse justified expansion paths from every Step 6 substep output."""
+    all_paths: set = set()
+    all_justified_paths: set = set()
+    for step_key in ("6_1", "6_2", "6_3"):
+        paths, justified_paths = _parse_expansion_items(step_outputs.get(step_key, ""))
+        all_paths.update(paths)
+        all_justified_paths.update(justified_paths)
+    return all_paths, all_justified_paths
+
+
 _FAILURE_SIGNAL_REQUIRED_KEYS = (
     "command",
     "exit_code",
@@ -5590,9 +5601,14 @@ def _run_agentic_checkup_orchestrator_inner(
                     # out-of-scope refusal — a fixer cannot list an
                     # unrelated path on one marker line and let a sibling
                     # marker's justification cover for it.
-                    step6_out = step_outputs.get("6_1", "")
-                    _, justified_paths_set = (
-                        _parse_expansion_items(step6_out)
+                    #
+                    # Issue #1912: Step 6 is split into code-fix, regression
+                    # test, and e2e/integration substeps. Test-writing can be
+                    # the substep that introduces a justified out-of-PR-scope
+                    # path, so the guard must honor markers from all three
+                    # substeps rather than only Step 6.1.
+                    _, justified_paths_set = _parse_step6_expansion_items(
+                        step_outputs
                     )
                     # Codex round-8 Finding 3: the Step 6 prompt
                     # explicitly permits the fixer to edit failing test
@@ -5639,7 +5655,10 @@ def _run_agentic_checkup_orchestrator_inner(
                                 f"{out_of_scope}. Justified expansion paths: "
                                 f"{sorted(justified_paths_set)}."
                             )
-                        elif "EXPANSION_ITEMS:" in step6_out:
+                        elif any(
+                            "EXPANSION_ITEMS:" in step_outputs.get(k, "")
+                            for k in ("6_1", "6_2", "6_3")
+                        ):
                             scope_refusal = (
                                 "Scope guard: fixer emitted an EXPANSION_ITEMS "
                                 "marker but no listed path carried its own "

--- a/pdd/prompts/agentic_checkup_step6_1_fix_LLM.prompt
+++ b/pdd/prompts/agentic_checkup_step6_1_fix_LLM.prompt
@@ -151,10 +151,15 @@ Your comment should follow this format:
 You MUST output the following lines at the end listing all files you created or modified:
 FILES_CREATED: path/to/file1, path/to/file2
 FILES_MODIFIED: path/to/file3, path/to/file4
+EXPANSION_ITEMS: path/to/file5 — causal justification, or none
 
 % Important
 
 - Fix issues in order of severity (critical first)
 - If a test assertion correctly detects a real bug, fix the CODE, not the test
+- In PR-verification mode, if you created or modified any file outside
+  `<pr_scope_changed_files>`, include that path in `EXPANSION_ITEMS:` with its
+  own causal justification. Use `EXPANSION_ITEMS: none` only when every changed
+  file is already in scope.
 - Post your findings as a GitHub comment before completing — EXCEPT in a PR-only review (no linked issue, #1292), where you skip posting and the orchestrator owns the single PR report
 - IMPORTANT: Use the EXACT iteration number ({fix_verify_iteration}) in your comment header — do NOT hardcode "Iteration 1"

--- a/pdd/prompts/agentic_checkup_step6_2_regression_tests_LLM.prompt
+++ b/pdd/prompts/agentic_checkup_step6_2_regression_tests_LLM.prompt
@@ -14,6 +14,13 @@ This is fix-verify iteration {fix_verify_iteration} of {max_fix_verify_iteration
 - Repository: {repo_owner}/{repo_name}
 - Issue Number: {issue_number}
 - Project Root: {project_root}
+- PR-verification mode: {pr_mode}
+- PR URL (PR mode only): {pr_url}
+- PR test scope (PR mode only): {pr_test_scope}
+- PR changed files for test-writer scope (PR mode, ALWAYS populated — authoritative scope list):
+<pr_scope_changed_files>
+{pr_scope_changed_files}
+</pr_scope_changed_files>
 
 % User Request
 <issue_content>
@@ -45,6 +52,15 @@ This is fix-verify iteration {fix_verify_iteration} of {max_fix_verify_iteration
 <step6_1_output>
 {step6_1_output}
 </step6_1_output>
+
+% PR Scope Guard (PR mode only)
+
+When `PR-verification mode` is `true`, constrain test changes to the PR's scope:
+
+- The AUTHORITATIVE scope list is `<pr_scope_changed_files>`.
+- **Allowed without expansion marker**: add or update tests already listed in `<pr_scope_changed_files>`, direct tests for files listed there, and failing tests named by Step 5.
+- **Allowed only with explicit expansion marker**: add or update another regression-test file when it is causally needed to protect a PR-changed file or Step 6a fix. In that case, emit `EXPANSION_ITEMS: <path> — <causal justification>` for every such file.
+- **Not allowed**: unrelated test suites, broad coverage rewrites, dependency-manifest churn, or files unrelated to the PR-changed files and Step 6a fixes.
 
 % Your Task
 
@@ -99,6 +115,7 @@ Your comment should follow this format:
 You MUST output the following lines at the end listing all files you created or modified:
 FILES_CREATED: path/to/file1, path/to/file2
 FILES_MODIFIED: path/to/file3, path/to/file4
+EXPANSION_ITEMS: path/to/file5 — causal justification, or none
 
 % Important
 
@@ -109,5 +126,9 @@ FILES_MODIFIED: path/to/file3, path/to/file4
   an explicit unknown/rejection/conservative-behavior requirement; include a
   regression that would fail for a broad fallback, substring match, default
   value, swallowed error, or other plausible over-acceptance bug
+- In PR-verification mode, if you created or modified any test file outside
+  `<pr_scope_changed_files>`, include that path in `EXPANSION_ITEMS:` with its
+  own causal justification. Use `EXPANSION_ITEMS: none` only when every changed
+  file is already in scope.
 - Post your findings as a GitHub comment before completing — EXCEPT in a PR-only review (no linked issue, #1292), where you skip posting and the orchestrator owns the single PR report
 - IMPORTANT: Use the EXACT iteration number ({fix_verify_iteration}) in your comment header — do NOT hardcode "Iteration 1"

--- a/pdd/prompts/agentic_checkup_step6_3_e2e_tests_LLM.prompt
+++ b/pdd/prompts/agentic_checkup_step6_3_e2e_tests_LLM.prompt
@@ -14,6 +14,13 @@ This is fix-verify iteration {fix_verify_iteration} of {max_fix_verify_iteration
 - Repository: {repo_owner}/{repo_name}
 - Issue Number: {issue_number}
 - Project Root: {project_root}
+- PR-verification mode: {pr_mode}
+- PR URL (PR mode only): {pr_url}
+- PR test scope (PR mode only): {pr_test_scope}
+- PR changed files for test-writer scope (PR mode, ALWAYS populated — authoritative scope list):
+<pr_scope_changed_files>
+{pr_scope_changed_files}
+</pr_scope_changed_files>
 
 % User Request
 <issue_content>
@@ -50,6 +57,15 @@ This is fix-verify iteration {fix_verify_iteration} of {max_fix_verify_iteration
 <step6_2_output>
 {step6_2_output}
 </step6_2_output>
+
+% PR Scope Guard (PR mode only)
+
+When `PR-verification mode` is `true`, constrain integration/e2e test changes to the PR's scope:
+
+- The AUTHORITATIVE scope list is `<pr_scope_changed_files>`.
+- **Allowed without expansion marker**: add or update tests already listed in `<pr_scope_changed_files>`, direct integration tests for files listed there, and failing tests named by Step 5.
+- **Allowed only with explicit expansion marker**: add or update another integration/e2e test file when it is causally needed to protect a PR-changed file, Step 6a fix, or Step 6b regression test. In that case, emit `EXPANSION_ITEMS: <path> — <causal justification>` for every such file.
+- **Not allowed**: unrelated test suites, broad coverage rewrites, dependency-manifest churn, or files unrelated to the PR-changed files and Step 6 fixes.
 
 % Your Task
 
@@ -104,6 +120,7 @@ Your comment should follow this format:
 You MUST output the following lines at the end listing all files you created or modified:
 FILES_CREATED: path/to/file1, path/to/file2
 FILES_MODIFIED: path/to/file3, path/to/file4
+EXPANSION_ITEMS: path/to/file5 — causal justification, or none
 
 % Important
 
@@ -114,5 +131,9 @@ FILES_MODIFIED: path/to/file3, path/to/file4
   depend on conservative matching or unknown preservation; add an integration
   test that would fail if an implementation silently borrowed a default,
   partial-match, or fallback result from another component
+- In PR-verification mode, if you created or modified any test file outside
+  `<pr_scope_changed_files>`, include that path in `EXPANSION_ITEMS:` with its
+  own causal justification. Use `EXPANSION_ITEMS: none` only when every changed
+  file is already in scope.
 - Post your findings as a GitHub comment before completing — EXCEPT in a PR-only review (no linked issue, #1292), where you skip posting and the orchestrator owns the single PR report
 - IMPORTANT: Use the EXACT iteration number ({fix_verify_iteration}) in your comment header — do NOT hardcode "Iteration 1"

--- a/tests/test_agentic_checkup_orchestrator.py
+++ b/tests/test_agentic_checkup_orchestrator.py
@@ -6452,6 +6452,89 @@ class TestIssue1215Round8ScopeGuardAcceptsStep5FailurePaths:
         assert success is True
 
 
+class TestIssue1912Step6TestExpansionItems:
+    """Step 6b/6c test-writing expansions must participate in the PR scope guard."""
+
+    def test_scope_guard_accepts_justified_step6b_test_expansion(self, tmp_path):
+        def step_side_effect(step_num, name, context, **kwargs):
+            if step_num == 5:
+                return (False, "FAILED: tests/test_main.py::test_x", 0.1, "model")
+            if step_num == 6.1:
+                return (True, "FILES_MODIFIED: none\n", 0.1, "model")
+            if step_num == 6.2:
+                return (
+                    True,
+                    "FILES_MODIFIED: tests/test_vector_helpers.py\n"
+                    "EXPANSION_ITEMS: tests/test_vector_helpers.py — needed because "
+                    "the PR change in pdd/main.py must be protected through the "
+                    "vector-cache integration path.\n",
+                    0.1,
+                    "model",
+                )
+            if step_num == 6.3:
+                return (True, "FILES_MODIFIED: none\n", 0.1, "model")
+            if step_num == 7:
+                return (True, ALL_ISSUES_FIXED, 0.1, "model")
+            return (True, f"out-{step_num}", 0.0, "model")
+
+        patches = _pr_patches_1212(
+            tmp_path,
+            step_side_effect=step_side_effect,
+            git_changed_files=["tests/test_vector_helpers.py"],
+            commit_push_return=(True, "Pushed step6b test expansion"),
+            pr_metadata=dict(_PR_META_REAL_API),
+        )
+        with patches[0], patches[1], patches[2], patches[3], patches[4] as push_mock, \
+             patches[5], patches[6], patches[7], patches[8], patches[9], patches[10]:
+            success, msg, _, _ = run_agentic_checkup_orchestrator(
+                **{**_PR_ARGS_1212, "cwd": tmp_path}
+            )
+
+        assert "scope guard" not in (msg or "").lower(), (
+            "Step 6b's own justified EXPANSION_ITEMS marker must allow its "
+            f"causal test expansion; msg={msg!r}"
+        )
+        push_mock.assert_called_once()
+        assert success is True
+
+    def test_scope_guard_rejects_unjustified_step6b_test_expansion(self, tmp_path):
+        def step_side_effect(step_num, name, context, **kwargs):
+            if step_num == 5:
+                return (False, "FAILED: tests/test_main.py::test_x", 0.1, "model")
+            if step_num == 6.1:
+                return (True, "FILES_MODIFIED: none\n", 0.1, "model")
+            if step_num == 6.2:
+                return (
+                    True,
+                    "FILES_MODIFIED: tests/test_vector_helpers.py\n"
+                    "EXPANSION_ITEMS: none\n",
+                    0.1,
+                    "model",
+                )
+            if step_num == 6.3:
+                return (True, "FILES_MODIFIED: none\n", 0.1, "model")
+            if step_num == 7:
+                return (True, ALL_ISSUES_FIXED, 0.1, "model")
+            return (True, f"out-{step_num}", 0.0, "model")
+
+        patches = _pr_patches_1212(
+            tmp_path,
+            step_side_effect=step_side_effect,
+            git_changed_files=["tests/test_vector_helpers.py"],
+            pr_metadata=dict(_PR_META_REAL_API),
+        )
+        with patches[0], patches[1], patches[2], patches[3], patches[4] as push_mock, \
+             patches[5], patches[6], patches[7], patches[8], patches[9], patches[10]:
+            success, msg, _, _ = run_agentic_checkup_orchestrator(
+                **{**_PR_ARGS_1212, "cwd": tmp_path}
+            )
+
+        push_mock.assert_not_called()
+        assert success is False
+        assert "scope guard" in (msg or "").lower(), msg
+        assert "tests/test_vector_helpers.py" in (msg or ""), msg
+
+
 STEP5_SKIPPED_OUTPUT = (
     "Tests did not run.\n"
     "```failure_signal\n"


### PR DESCRIPTION
## Summary

Fixes #1912.

This addresses the stg5 `test_repo_5#28` checkup failure from job `OpH62SbFfAqZj9CZCgPr`:

```text
Final gate Layer 1 failed: Scope guard: fixer touched files outside PR's changed-file set without EXPANSION_ITEMS justification: ['backend/tests/test_vector_helpers.py']
```

The run's Step 7 verification was substantively green: full suite passed, focused probes passed, and `issue_aligned: true`. The failure happened afterward because Step 6b/6c test-writing can introduce a causally relevant out-of-scope test file, but only Step 6a's `EXPANSION_ITEMS` were parsed by the final scope guard.

## Changes

- Parse justified `EXPANSION_ITEMS` from all Step 6 substeps: `6_1`, `6_2`, and `6_3`.
- Update Step 6a/6b/6c prompt contracts to explicitly emit `EXPANSION_ITEMS: ...` or `none`.
- Give Step 6b/6c the PR scope context and explicit rules for justified test-file expansion.
- Add regression coverage proving:
  - a justified Step 6b test expansion is accepted by the PR scope guard;
  - the same out-of-scope Step 6b edit is still rejected when unjustified.

## Test Plan

```text
python -m pytest -q tests/test_agentic_checkup_orchestrator.py -k 'Issue1912 or Round8ScopeGuardAcceptsStep5FailurePaths or Round8ScopeGuardLocalDiffFallback'
python -m pytest -q tests/test_agentic_checkup_orchestrator.py -k 'ExpansionItems or Issue1912'
python -m py_compile pdd/agentic_checkup_orchestrator.py
```

## Notes

This keeps the final-gate scope guard authoritative. It does not allow arbitrary out-of-scope edits; it only honors the same per-path causal justification contract for the test-writing Step 6 substeps that already existed for Step 6a.
