### PR TITLE
fix: harden release-video Claude model defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,19 @@ RELEASE_VIDEO_METADATA_CONFLICT ?=
 RELEASE_VIDEO_STATUS_QUERY ?= 0
 RELEASE_VIDEO_YOUTUBE_URL ?=
 RELEASE_VIDEO_PDS_CREATE_TIMEOUT ?= 1800
+RELEASE_VIDEO_CLAUDE_MODEL ?= claude-opus-4-8
 RELEASE_VIDEO_PDS_CLAUDE_MODEL ?= glm-5.2
 CLAUDE_CLI ?= claude
 PDS_CLI ?= npx -y @promptdriven/pds@0.1.7 --timeout 120s
+ifeq ($(strip $(RELEASE_VIDEO_CLAUDE_MODEL)),)
+override RELEASE_VIDEO_CLAUDE_MODEL := claude-opus-4-8
+endif
+ifeq ($(strip $(CLAUDE_CLI)),)
+override CLAUDE_CLI := claude
+endif
+ifeq ($(strip $(PDS_CLI)),)
+override PDS_CLI := npx -y @promptdriven/pds@0.1.7 --timeout 120s
+endif
 PDS_API_URL ?= https://video.promptdriven.ai
 SOPS ?= sops
 SOPS_RELEASE_ENV_FILE ?= $(firstword $(wildcard ../secrets/pdd_cloud/shared.prod.sops.env ../pdd_cloud/secrets/pdd_cloud/shared.prod.sops.env secrets/pdd_cloud/shared.prod.sops.env) ../secrets/pdd_cloud/shared.prod.sops.env)
@@ -777,6 +787,7 @@ check-release-video-config:
 	python scripts/release_video.py \
 		--preflight \
 		--pds-cli "$(PDS_CLI)" \
+		--claude-model "$(RELEASE_VIDEO_CLAUDE_MODEL)" \
 		--pds-claude-model "$(RELEASE_VIDEO_PDS_CLAUDE_MODEL)" \
 		--project-id "$(RELEASE_VIDEO_PROJECT_ID)"
 
@@ -867,6 +878,7 @@ release-video:
 	python scripts/release_video.py \
 		--output-dir "$(RELEASE_VIDEO_OUTPUT_DIR)" \
 		--claude-cli "$(CLAUDE_CLI)" \
+		--claude-model "$(RELEASE_VIDEO_CLAUDE_MODEL)" \
 		--script-path "$(RELEASE_VIDEO_SCRIPT_PATH)" \
 		--release-notes-path "$(RELEASE_VIDEO_RELEASE_NOTES_PATH)" \
 		--pds-cli "$(PDS_CLI)" \

--- a/docs/contributors/pdd-cli-release-process.md
+++ b/docs/contributors/pdd-cli-release-process.md
@@ -17,11 +17,17 @@ resolved CLI version:
 make check-release-video-config
 ```
 
-Release-video creation sends `--claude-model glm-5.2` to PDS by default for
-non-vision pipeline stages such as specs and compositions. Override with
+Release-video creation uses `RELEASE_VIDEO_CLAUDE_MODEL=claude-opus-4-8` by
+default for local Claude Code script generation. Override that release-scoped
+setting only when intentionally changing the local script model; direct
+`scripts/release_video.py` invocations also accept non-empty `CLAUDE_MODEL` as
+a fallback. Empty or whitespace-only local model values are treated as unset.
+
+The wrapper sends `--claude-model glm-5.2` to PDS by default for non-vision
+pipeline stages such as specs and compositions. Override with
 `RELEASE_VIDEO_PDS_CLAUDE_MODEL=<model>` only when intentionally changing the
-downstream PDS model; the local script-generation `CLAUDE_MODEL` remains a
-separate setting.
+downstream PDS model; setting it to an empty string intentionally omits the PDS
+model flag and uses the server default.
 
 The release workflow also installs `@promptdriven/pds@0.1.7` by default when
 `PDS_CLI_PACKAGE` is unset and runs the same preflight before creating the

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -293,8 +293,8 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         default=DEFAULT_RELEASE_VIDEO_OUTPUT_DIR,
         help="Directory for generated release-video artifacts.",
     )
-    parser.add_argument("--claude-cli", default=os.environ.get("CLAUDE_CLI", "claude"))
-    parser.add_argument("--claude-model", default=os.environ.get("CLAUDE_MODEL", DEFAULT_CLAUDE_MODEL))
+    parser.add_argument("--claude-cli", default=env_default("CLAUDE_CLI", "claude"))
+    parser.add_argument("--claude-model", default=release_video_claude_model_default())
     parser.add_argument(
         "--pds-claude-model",
         default=os.environ.get(
@@ -338,7 +338,7 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
             "PDS selected-project recovery."
         ),
     )
-    parser.add_argument("--pds-cli", default=os.environ.get("PDS_CLI", "pds"))
+    parser.add_argument("--pds-cli", default=env_default("PDS_CLI", "pds"))
     parser.add_argument(
         "--pds-create-timeout",
         type=float,
@@ -428,10 +428,36 @@ def env_flag(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def env_default(name: str, default: str) -> str:
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return default
+    return value.strip()
+
+
+def release_video_claude_model_default() -> str:
+    return env_default(
+        "RELEASE_VIDEO_CLAUDE_MODEL",
+        env_default("CLAUDE_MODEL", DEFAULT_CLAUDE_MODEL),
+    )
+
+
 def validate_release_video_create_options(args: argparse.Namespace) -> None:
     """Validate options that only apply to PDS release-video creation."""
+    validate_claude_script_model(args)
     validate_release_video_idempotency_options(args)
     validate_release_video_metadata_conflict_options(args)
+
+
+def validate_claude_script_model(args: argparse.Namespace) -> None:
+    model = str(getattr(args, "claude_model", "") or "").strip()
+    if not model:
+        raise ReleaseVideoError(
+            "Claude Code script-generation model must not be empty. "
+            "Set RELEASE_VIDEO_CLAUDE_MODEL, CLAUDE_MODEL, or --claude-model "
+            "to a non-empty value."
+        )
+    args.claude_model = model
 
 
 def validate_release_video_idempotency_options(args: argparse.Namespace) -> None:
@@ -1610,6 +1636,13 @@ def generate_raw_script_with_claude(
     timeout: float,
     cwd: Path,
 ) -> str:
+    claude_model = str(claude_model or "").strip()
+    if not claude_model:
+        raise ReleaseVideoError(
+            "Claude Code script-generation model must not be empty. "
+            "Set RELEASE_VIDEO_CLAUDE_MODEL, CLAUDE_MODEL, or --claude-model "
+            "to a non-empty value."
+        )
     command = split_command(claude_cli)
     ensure_command_exists(command[0], "Claude Code")
     command.extend(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -55,6 +55,29 @@ def test_release_video_env_scrubs_pds_create_timeout(monkeypatch):
     assert "RELEASE_VIDEO_PDS_CREATE_TIMEOUT" not in env
 
 
+def test_release_video_claude_model_env_defaults_ignore_empty(monkeypatch):
+    release_video = load_release_video_module()
+    monkeypatch.delenv("RELEASE_VIDEO_CLAUDE_MODEL", raising=False)
+    monkeypatch.setenv("CLAUDE_MODEL", "")
+
+    empty_args = release_video.parse_args([])
+    monkeypatch.setenv("CLAUDE_MODEL", "   ")
+    whitespace_args = release_video.parse_args([])
+
+    assert empty_args.claude_model == release_video.DEFAULT_CLAUDE_MODEL
+    assert whitespace_args.claude_model == release_video.DEFAULT_CLAUDE_MODEL
+
+
+def test_release_video_specific_claude_model_env_wins_over_global(monkeypatch):
+    release_video = load_release_video_module()
+    monkeypatch.setenv("CLAUDE_MODEL", "claude-global")
+    monkeypatch.setenv("RELEASE_VIDEO_CLAUDE_MODEL", "claude-release-local")
+
+    args = release_video.parse_args([])
+
+    assert args.claude_model == "claude-release-local"
+
+
 def run(command, cwd: Path, **kwargs):
     return subprocess.run(
         command,
@@ -369,6 +392,50 @@ def test_release_video_generates_script_and_invokes_pds_publish(tmp_path: Path):
     assert pds_call[pds_call.index("--claude-model") + 1] == "glm-5.2"
     idempotency_key = pds_call[pds_call.index("--idempotency-key") + 1]
     assert idempotency_key.startswith("pdd-release-video:v1.1.0:")
+
+
+def test_release_video_rejects_explicit_empty_claude_model_before_claude(
+    tmp_path: Path,
+):
+    repo = init_release_repo(tmp_path)
+    capture = tmp_path / "pds-capture.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--claude-model",
+            "   ",
+            "--claude-cli",
+            str(claude_stub(tmp_path)),
+            "--pds-cli",
+            str(
+                pds_stub(
+                    tmp_path,
+                    {
+                        "ok": True,
+                        "summary": {"youtubeUrl": "https://youtu.be/pdd-release"},
+                    },
+                )
+            ),
+            "--output-dir",
+            str(tmp_path / "videos"),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Claude Code script-generation model must not be empty" in result.stderr
+    assert not (repo / "claude_argv.json").exists()
+    assert not capture.exists()
 
 
 def test_release_video_sanitizes_generated_script_before_invoking_pds(tmp_path: Path):
@@ -1931,6 +1998,30 @@ def test_release_video_makefile_pds_cli_default_avoids_stale_global_cli():
         "PDS_CLI ?= npx -y @promptdriven/pds@0.1.7 --timeout 120s"
         in makefile_text
     )
+
+
+def test_release_video_makefile_passes_local_claude_model_default():
+    makefile_text = (ROOT / "Makefile").read_text(encoding="utf8")
+
+    release_video = subprocess.run(
+        ["make", "-n", "release-video", "RELEASE_TAG=v1.1.0"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    preflight = subprocess.run(
+        ["make", "-n", "check-release-video-config"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "RELEASE_VIDEO_CLAUDE_MODEL ?= claude-opus-4-8" in makefile_text
+    assert '--claude-model "$(RELEASE_VIDEO_CLAUDE_MODEL)"' in makefile_text
+    assert '--claude-model "claude-opus-4-8"' in release_video.stdout
+    assert '--claude-model "claude-opus-4-8"' in preflight.stdout
 
 
 def test_release_video_workflow_defaults_and_preflights_recovery_capable_pds_cli():

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -18,10 +18,12 @@ def release_video_env(extra: dict | None = None) -> dict:
     for key in (
         "CLAUDE_MODEL",
         "CLAUDE_TIMEOUT",
+        "CLAUDE_CLI",
         "CLAUDE_CODE_OAUTH_TOKEN",
         "CLAUDE_CODE_OAUTH_TOKEN_1",
         "CLAUDE_CODE_OAUTH_TOKEN_2",
         "CLAUDE_CODE_OAUTH_TOKEN_3",
+        "RELEASE_VIDEO_CLAUDE_MODEL",
         "RELEASE_VIDEO_ATTEMPT_ID",
         "RELEASE_VIDEO_CLAUDE_TOOLS",
         "RELEASE_VIDEO_IDEMPOTENCY_KEY",
@@ -34,6 +36,7 @@ def release_video_env(extra: dict | None = None) -> dict:
         "RELEASE_VIDEO_PDS_CREATE_TIMEOUT",
         "RELEASE_VIDEO_RELEASE_NOTES_PATH",
         "RELEASE_VIDEO_SCRIPT_PATH",
+        "PDS_CLI",
         "PDS_API_URL",
         "PDS_PROFILE",
         "PDS_RELEASE_TOKEN",
@@ -76,6 +79,17 @@ def test_release_video_specific_claude_model_env_wins_over_global(monkeypatch):
     args = release_video.parse_args([])
 
     assert args.claude_model == "claude-release-local"
+
+
+def test_release_video_command_env_defaults_ignore_empty(monkeypatch):
+    release_video = load_release_video_module()
+    monkeypatch.setenv("CLAUDE_CLI", "")
+    monkeypatch.setenv("PDS_CLI", "   ")
+
+    args = release_video.parse_args([])
+
+    assert args.claude_cli == "claude"
+    assert args.pds_cli == "pds"
 
 
 def run(command, cwd: Path, **kwargs):
@@ -1950,6 +1964,18 @@ def test_release_video_recovery_flags_default_to_disabled(tmp_path: Path):
     assert "--metadata-conflict" not in pds_call
 
 
+def test_release_video_empty_pds_claude_model_omits_downstream_override(
+    tmp_path: Path,
+):
+    _result, capture = run_release_video_with_existing_script(
+        tmp_path,
+        extra_args=["--pds-claude-model", "   "],
+    )
+
+    pds_call = pds_capture_argv(capture)
+    assert "--claude-model" not in pds_call
+
+
 def test_release_video_makefile_passes_idempotency_env_vars():
     makefile_text = (ROOT / "Makefile").read_text(encoding="utf8")
 
@@ -2022,6 +2048,47 @@ def test_release_video_makefile_passes_local_claude_model_default():
     assert '--claude-model "$(RELEASE_VIDEO_CLAUDE_MODEL)"' in makefile_text
     assert '--claude-model "claude-opus-4-8"' in release_video.stdout
     assert '--claude-model "claude-opus-4-8"' in preflight.stdout
+
+
+def test_release_video_makefile_empty_local_defaults_are_unset():
+    release_video = subprocess.run(
+        [
+            "make",
+            "-n",
+            "release-video",
+            "RELEASE_TAG=v1.1.0",
+            "RELEASE_VIDEO_CLAUDE_MODEL=   ",
+            "CLAUDE_CLI=",
+            "PDS_CLI=",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    preflight = subprocess.run(
+        [
+            "make",
+            "-n",
+            "check-release-video-config",
+            "RELEASE_VIDEO_CLAUDE_MODEL=",
+            "PDS_CLI=   ",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert '--claude-cli "claude"' in release_video.stdout
+    assert '--claude-model "claude-opus-4-8"' in release_video.stdout
+    assert '--pds-cli "npx -y @promptdriven/pds@0.1.7 --timeout 120s"' in (
+        release_video.stdout
+    )
+    assert '--claude-model "claude-opus-4-8"' in preflight.stdout
+    assert '--pds-cli "npx -y @promptdriven/pds@0.1.7 --timeout 120s"' in (
+        preflight.stdout
+    )
 
 
 def test_release_video_workflow_defaults_and_preflights_recovery_capable_pds_cli():


### PR DESCRIPTION
## Summary
- Fixes #1910 by treating empty/whitespace local release-video Claude model env values as unset.
- Adds `RELEASE_VIDEO_CLAUDE_MODEL` as the release-scoped local script-generation model and passes it through Make preflight/release-video paths.
- Normalizes empty `CLAUDE_CLI` / `PDS_CLI` local release-video command overrides while preserving empty `RELEASE_VIDEO_PDS_CLAUDE_MODEL` as the intentional PDS server-default escape hatch.
- Documents the local script model vs downstream PDS model split.

## Root Cause
The release-video wrapper used `os.environ.get("CLAUDE_MODEL", DEFAULT_CLAUDE_MODEL)`, so a present-but-empty `CLAUDE_MODEL=` bypassed the default and later produced `claude -p --model ''`. History shows this was latent from PR #1326 / `b3377d354`, preserved by PR #1459 / `7a3f92cd`, and unrelated to PR #1786 / `394c3320d` except that PR made the separate PDS model path more visible.

## Related Bug Hunt
- Same root cause found in the release-scoped local model path: `RELEASE_VIDEO_CLAUDE_MODEL=` bypasses Make `?=` and becomes explicit `--claude-model ""`. Fixed here.
- Same root cause found in local release-video command defaults: `CLAUDE_CLI=` and `PDS_CLI=` bypass Make/Python defaults. Fixed here for the release-video wrapper.
- `GH_CLI` in adjacent Discord backfill tooling has a similar empty-env pattern, but it is outside the release-video create path and is left as follow-up scope.
- `RELEASE_VIDEO_PDS_CLAUDE_MODEL=''` is intentionally different: it omits PDS `--claude-model` so PDS can use the server default. Preserved and covered.

## TDD Evidence
RED commit: `d498c6d84 test: cover empty release-video Claude model`

Initial red run failed 4/4 new tests:
- empty `CLAUDE_MODEL` parsed as `''` instead of `claude-opus-4-8`
- `RELEASE_VIDEO_CLAUDE_MODEL` did not override global `CLAUDE_MODEL`
- explicit empty `--claude-model "   "` reached the Claude stub and returned success
- Makefile dry-run did not include `RELEASE_VIDEO_CLAUDE_MODEL` / `--claude-model "claude-opus-4-8"`

Sibling red subset also reproduced empty `CLAUDE_CLI=` / `PDS_CLI=` and empty Make model defaults before the final normalization.

## Test Plan
- `conda run -n pdd --no-capture-output pytest tests/test_release_video.py -k 'claude_model_env_defaults_ignore_empty or specific_claude_model_env_wins_over_global or rejects_explicit_empty_claude_model_before_claude or makefile_passes_local_claude_model_default' -q`
- `conda run -n pdd --no-capture-output pytest tests/test_release_video.py -k 'command_env_defaults_ignore_empty or makefile_empty_local_defaults_are_unset or empty_pds_claude_model_omits_downstream_override' -q`
- `conda run -n pdd --no-capture-output pytest tests/test_release_video.py -q` (`141 passed`)
- `conda run -n pdd --no-capture-output python -m py_compile scripts/release_video.py tests/test_release_video.py`
- `git diff --check`
- `conda run -n pdd --no-capture-output pylint --disable=all --enable=E,F scripts/release_video.py tests/test_release_video.py`

Note: full `pylint scripts/release_video.py tests/test_release_video.py` still fails on pre-existing convention/refactor warnings in these large files; the error/fatal-only pylint pass is clean.