### PR TITLE
fix(release): record skipped release videos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ help:
 	@echo "  make release-video           - Generate and upload a YouTube video for the current release tag"
 	@echo "  make release-video-status RELEASE_TAG=vX.Y.Z - Show persisted PDS release-video run metadata"
 	@echo "  make release-video-discord-backfill RELEASE_TAG=vX.Y.Z RELEASE_VIDEO_YOUTUBE_URL=url - Post recovered video follow-up to Discord"
+	@echo "  make release-video-skip RELEASE_TAG=vX.Y.Z RELEASE_VIDEO_SKIP_REASON=reason - Mark historical release video as skipped"
 	@echo "  make release-local           - Run release with local SOPS release secrets"
 	@echo "  make check-release-claude-oauth-config-local - Verify local SOPS Claude OAuth rotation slots"
 	@echo "  make check-deps              - Check pyproject.toml and requirements.txt are in sync"
@@ -103,6 +104,7 @@ RELEASE_VIDEO_FORCE_REGENERATE ?= 0
 RELEASE_VIDEO_METADATA_CONFLICT ?=
 RELEASE_VIDEO_STATUS_QUERY ?= 0
 RELEASE_VIDEO_YOUTUBE_URL ?=
+RELEASE_VIDEO_SKIP_REASON ?=
 RELEASE_VIDEO_PDS_CREATE_TIMEOUT ?= 1800
 RELEASE_VIDEO_CLAUDE_MODEL ?= claude-opus-4-8
 RELEASE_VIDEO_PDS_CLAUDE_MODEL ?= glm-5.2
@@ -143,7 +145,7 @@ ifeq ($(CI),true)
 SKIP_MAKEFILE_REGEN := 1
 endif
 
-RELEASE_MAKE_GOALS := release release-video release-video-status release-video-discord-backfill release-local release-sops release-infisical check-release-video-config check-release-video-config-local check-release-video-config-sops check-release-video-config-infisical check-release-claude-oauth-config check-release-claude-oauth-config-local check-release-claude-oauth-config-sops
+RELEASE_MAKE_GOALS := release release-video release-video-status release-video-discord-backfill release-video-skip release-local release-sops release-infisical check-release-video-config check-release-video-config-local check-release-video-config-sops check-release-video-config-infisical check-release-claude-oauth-config check-release-claude-oauth-config-local check-release-claude-oauth-config-sops
 ifneq ($(filter $(RELEASE_MAKE_GOALS),$(MAKECMDGOALS)),)
 SKIP_MAKEFILE_REGEN := 1
 endif
@@ -164,7 +166,7 @@ TEST_OUTPUTS := $(patsubst $(PDD_DIR)/%.py,$(TESTS_DIR)/test_%.py,$(PY_OUTPUTS))
 # All Example files in context directory (recursive)
 EXAMPLE_FILES := $(shell find $(CONTEXT_DIR) -name "*_example.py" 2>/dev/null)
 
-.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release release-local release-sops release-infisical release-video release-video-status release-video-discord-backfill check-release-remote check-release-branch check-release-clean check-release-video-config check-release-video-config-local check-release-video-config-sops check-release-video-config-infisical check-release-claude-oauth-config check-release-claude-oauth-config-local check-release-claude-oauth-config-sops
+.PHONY: all clean test requirements production coverage staging regression regression-public sync-regression all-regression cloud-regression install build upload-pypi analysis fix crash update update-extension generate run-examples verify detect change lint publish publish-public public-ensure public-update public-import public-diff sync-public ensure-dev-deps cloud-test cloud-test-quick cloud-test-build cloud-test-push cloud-test-setup test-frontend release release-local release-sops release-infisical release-video release-video-status release-video-discord-backfill release-video-skip check-release-remote check-release-branch check-release-clean check-release-video-config check-release-video-config-local check-release-video-config-sops check-release-video-config-infisical check-release-claude-oauth-config check-release-claude-oauth-config-local check-release-claude-oauth-config-sops
 
 all: $(PY_OUTPUTS) $(MAKEFILE_OUTPUT) $(CSV_OUTPUTS) $(EXAMPLE_OUTPUTS) $(TEST_OUTPUTS)
 
@@ -913,6 +915,12 @@ release-video-discord-backfill:
 	@python scripts/backfill_release_video_discord.py \
 		--tag "$(RELEASE_TAG)" \
 		--youtube-url "$(RELEASE_VIDEO_YOUTUBE_URL)" \
+		--repo "$${GITHUB_REPOSITORY:-promptdriven/pdd}"
+
+release-video-skip:
+	@python scripts/backfill_release_video_discord.py \
+		--tag "$(RELEASE_TAG)" \
+		--skip-reason "$(RELEASE_VIDEO_SKIP_REASON)" \
 		--repo "$${GITHUB_REPOSITORY:-promptdriven/pdd}"
 
 release: check-deps check-suspicious-files check-release-remote check-release-branch check-release-clean check-release-video-config

--- a/docs/contributors/pdd-cli-release-process.md
+++ b/docs/contributors/pdd-cli-release-process.md
@@ -47,6 +47,19 @@ exact status and Discord backfill commands. Do not rerun package publishing,
 tag creation, or PyPI upload for this recovery path; wait for the PDS run and
 backfill the release-video announcement after YouTube is available.
 
+If a historical release video is intentionally abandoned because upstream PDS
+or GVS blockers prevent safe publication, record that decision on the GitHub
+release instead of leaving the backfill state ambiguous:
+
+```bash
+make release-video-skip \
+  RELEASE_TAG=<tag> \
+  RELEASE_VIDEO_SKIP_REASON="Provider quota and audit gate failures blocked safe publication."
+```
+
+This updates the release body with an idempotent skip marker and does not send a
+Discord follow-up.
+
 Keep `RELEASE_VIDEO_METADATA_CONFLICT` unset for ordinary retries so the PDS
 idempotency key still matches the original create request. Set
 `RELEASE_VIDEO_METADATA_CONFLICT=use-existing` only when PDS explicitly reports

--- a/scripts/backfill_release_video_discord.py
+++ b/scripts/backfill_release_video_discord.py
@@ -225,15 +225,25 @@ def ensure_release_body_has_skip_record(
         return body, False, False
 
     skip_text = f"Release video: skipped for {tag}.\nReason: {reason.strip()}"
-    body_without_old_skip = re.sub(
+    body_without_old_skip = remove_release_video_skip_records(body, tag).strip()
+    if body_without_old_skip:
+        return f"{skip_text}\n\n{body_without_old_skip}\n\n{marker}\n", True, True
+    return f"{skip_text}\n\n{marker}\n", True, True
+
+
+def remove_release_video_skip_records(body: str, tag: str) -> str:
+    body = re.sub(
         rf"(?m)^<!-- {re.escape(SKIP_MARKER_NAME)}: tag={re.escape(tag)} "
         r"reason_sha256=[0-9a-f]{64} -->\n?",
         "",
         body,
-    ).strip()
-    if body_without_old_skip:
-        return f"{skip_text}\n\n{body_without_old_skip}\n\n{marker}\n", True, True
-    return f"{skip_text}\n\n{marker}\n", True, True
+    )
+    return re.sub(
+        rf"(?m)^Release video: skipped for {re.escape(tag)}\.\n"
+        r"Reason: [^\n]*(?:\n\n|\n?\Z)",
+        "",
+        body,
+    )
 
 
 def remove_release_body_pending_marker(body: str, tag: str, youtube_url: str) -> tuple[str, bool]:

--- a/scripts/backfill_release_video_discord.py
+++ b/scripts/backfill_release_video_discord.py
@@ -33,6 +33,7 @@ DISCORD_ERROR_BODY_MAX_BYTES = 4096
 DISCORD_ERROR_BODY_MAX_CHARS = 500
 MARKER_NAME = "pdd-release-video-discord-backfill"
 PENDING_MARKER_NAME = "pdd-release-video-discord-backfill-pending"
+SKIP_MARKER_NAME = "pdd-release-video-skipped"
 POST_MARKER_MAX_ATTEMPTS = 3
 POST_MARKER_RETRY_DELAY_SECONDS = 1.0
 
@@ -171,6 +172,11 @@ def discord_backfill_pending_marker(tag: str, youtube_url: str) -> str:
     return f"<!-- {PENDING_MARKER_NAME}: tag={tag} video_sha256={digest} -->"
 
 
+def release_video_skip_marker(tag: str, reason: str) -> str:
+    digest = hashlib.sha256(f"{tag}\n{reason.strip()}".encode("utf8")).hexdigest()
+    return f"<!-- {SKIP_MARKER_NAME}: tag={tag} reason_sha256={digest} -->"
+
+
 def release_body_has_youtube_video(body: str, video_id: str) -> bool:
     for match in YOUTUBE_URL_IN_TEXT_RE.finditer(body):
         try:
@@ -209,6 +215,25 @@ def ensure_release_body_has_pending_marker(
     if body.strip():
         return f"{body.rstrip()}\n\n{pending_marker}\n", True
     return f"{pending_marker}\n", True
+
+
+def ensure_release_body_has_skip_record(
+    body: str, tag: str, reason: str
+) -> tuple[str, bool, bool]:
+    marker = release_video_skip_marker(tag, reason)
+    if marker in body:
+        return body, False, False
+
+    skip_text = f"Release video: skipped for {tag}.\nReason: {reason.strip()}"
+    body_without_old_skip = re.sub(
+        rf"(?m)^<!-- {re.escape(SKIP_MARKER_NAME)}: tag={re.escape(tag)} "
+        r"reason_sha256=[0-9a-f]{64} -->\n?",
+        "",
+        body,
+    ).strip()
+    if body_without_old_skip:
+        return f"{skip_text}\n\n{body_without_old_skip}\n\n{marker}\n", True, True
+    return f"{skip_text}\n\n{marker}\n", True, True
 
 
 def remove_release_body_pending_marker(body: str, tag: str, youtube_url: str) -> tuple[str, bool]:
@@ -457,6 +482,50 @@ def validate_inputs(tag: str, youtube_url: str, repo: str) -> None:
         raise BackfillError(f"GitHub repo must look like owner/name, got {repo!r}.")
 
 
+def validate_skip_inputs(tag: str, reason: str, repo: str) -> None:
+    if not SEMVER_TAG_RE.fullmatch(tag):
+        raise BackfillError(f"Release tag must look like vX.Y.Z, got {tag!r}.")
+    if not GITHUB_REPO_RE.fullmatch(repo):
+        raise BackfillError(f"GitHub repo must look like owner/name, got {repo!r}.")
+    if not reason.strip():
+        raise BackfillError("Skip reason is required when recording a release-video skip.")
+
+
+def record_release_video_skip(
+    *,
+    tag: str,
+    repo: str,
+    reason: str,
+    github: GitHubReleaseClient,
+    post_discord: Callable[[str, dict[str, Any]], None] | None = None,
+) -> BackfillResult:
+    """Record that a historical release video was intentionally skipped."""
+    del post_discord
+    normalized_reason = " ".join(reason.split())
+    validate_skip_inputs(tag, normalized_reason, repo)
+
+    body = github.get_release_body(tag)
+    marked_body, updated, marker_added = ensure_release_body_has_skip_record(
+        body,
+        tag,
+        normalized_reason,
+    )
+    if updated:
+        github.edit_release_body(tag, marked_body)
+        return BackfillResult(
+            posted=False,
+            release_body_updated=True,
+            marker_added=marker_added,
+            skipped_reason="release-video-skipped",
+        )
+    return BackfillResult(
+        posted=False,
+        release_body_updated=False,
+        marker_added=False,
+        skipped_reason="release-video-skip-already-marked",
+    )
+
+
 def backfill_release_video_discord(
     *,
     tag: str,
@@ -542,11 +611,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Post an idempotent Discord follow-up after a release video is "
-            "recovered outside the normal release workflow."
+            "recovered outside the normal release workflow, or record an "
+            "explicit historical skip decision."
         )
     )
     parser.add_argument("--tag", required=True, help="Release tag, for example v0.0.283.")
-    parser.add_argument("--youtube-url", required=True, help="Recovered YouTube release-video URL.")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--youtube-url", help="Recovered YouTube release-video URL.")
+    mode.add_argument(
+        "--skip-reason",
+        help="Record that no release video will be backfilled for this release.",
+    )
     parser.add_argument(
         "--repo",
         default=os.environ.get("GITHUB_REPOSITORY", "promptdriven/pdd"),
@@ -569,13 +644,21 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     github = GitHubReleaseClient(gh_cli=args.gh_cli, repo=args.repo)
     try:
-        result = backfill_release_video_discord(
-            tag=args.tag,
-            youtube_url=args.youtube_url,
-            repo=args.repo,
-            webhook_url=args.webhook_url,
-            github=github,
-        )
+        if args.skip_reason is not None:
+            result = record_release_video_skip(
+                tag=args.tag,
+                repo=args.repo,
+                reason=args.skip_reason,
+                github=github,
+            )
+        else:
+            result = backfill_release_video_discord(
+                tag=args.tag,
+                youtube_url=args.youtube_url,
+                repo=args.repo,
+                webhook_url=args.webhook_url,
+                github=github,
+            )
     except BackfillError as exc:
         print(f"release-video-discord-backfill: {exc}", file=sys.stderr)
         return 1
@@ -584,6 +667,10 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Posted Discord release-video follow-up for {args.tag}.")
     elif result.skipped_reason == "discord-followup-already-marked":
         print(f"Skipped Discord follow-up for {args.tag}; matching marker already exists.")
+    elif result.skipped_reason == "release-video-skipped":
+        print(f"Recorded release-video skip decision for {args.tag}.")
+    elif result.skipped_reason == "release-video-skip-already-marked":
+        print(f"Skipped release-video skip update for {args.tag}; matching marker already exists.")
     if result.release_body_updated:
         print(f"Updated GitHub release body for {args.tag}.")
     return 0

--- a/tests/test_release_video_discord_backfill.py
+++ b/tests/test_release_video_discord_backfill.py
@@ -236,7 +236,7 @@ def test_backfill_does_not_post_discord_when_release_link_edit_fails():
             post_discord=lambda webhook_url, payload: posts.append((webhook_url, payload)),
         )
 
-    assert posts == []
+    assert not posts
 
 
 def test_backfill_does_not_mark_release_when_discord_post_fails():
@@ -475,7 +475,7 @@ def test_backfill_is_idempotent_when_same_video_marker_exists():
     assert result.posted is False
     assert result.skipped_reason == "discord-followup-already-marked"
     assert posts == []
-    assert github.edits == []
+    assert not github.edits
 
 
 def test_backfill_adds_missing_link_without_reposting_when_marker_exists():

--- a/tests/test_release_video_discord_backfill.py
+++ b/tests/test_release_video_discord_backfill.py
@@ -619,6 +619,33 @@ def test_record_skip_is_idempotent_for_same_reason():
     assert github.edits == []
 
 
+def test_record_skip_replaces_prior_skip_reason():
+    module = load_backfill_module()
+    old_reason = "Provider quota blocked publication."
+    new_reason = "Provider quota and audit gate failures blocked safe publication."
+    old_marker = module.release_video_skip_marker("v0.0.297", old_reason)
+    github = FakeGitHubReleaseClient(
+        "Release video: skipped for v0.0.297.\n"
+        f"Reason: {old_reason}\n\n"
+        "Existing notes\n\n"
+        f"{old_marker}\n"
+    )
+
+    result = module.record_release_video_skip(
+        tag="v0.0.297",
+        repo="promptdriven/pdd",
+        reason=new_reason,
+        github=github,
+    )
+
+    assert result.release_body_updated is True
+    assert result.marker_added is True
+    assert f"Reason: {new_reason}" in github.body
+    assert old_reason not in github.body
+    assert old_marker not in github.body
+    assert module.release_video_skip_marker("v0.0.297", new_reason) in github.body
+
+
 def test_github_client_uses_gh_release_view_and_edit_without_network():
     module = load_backfill_module()
     calls: list[tuple[list[str], str | None]] = []

--- a/tests/test_release_video_discord_backfill.py
+++ b/tests/test_release_video_discord_backfill.py
@@ -568,6 +568,57 @@ def test_backfill_requires_webhook_before_mutating_unmarked_release_body():
     assert github.edits == []
 
 
+def test_record_skip_marks_release_without_discord_or_youtube_url():
+    module = load_backfill_module()
+    github = FakeGitHubReleaseClient("Existing notes\n")
+    posts = []
+
+    result = module.record_release_video_skip(
+        tag="v0.0.297",
+        repo="promptdriven/pdd",
+        reason="Provider quota and audit gate failures blocked safe publication.",
+        github=github,
+        post_discord=lambda webhook_url, payload: posts.append((webhook_url, payload)),
+    )
+
+    assert result.posted is False
+    assert result.release_body_updated is True
+    assert result.marker_added is True
+    assert result.skipped_reason == "release-video-skipped"
+    assert posts == []
+    assert "Release video: skipped for v0.0.297." in github.body
+    assert "Reason: Provider quota and audit gate failures blocked safe publication." in github.body
+    assert module.release_video_skip_marker(
+        "v0.0.297",
+        "Provider quota and audit gate failures blocked safe publication.",
+    ) in github.body
+
+
+def test_record_skip_is_idempotent_for_same_reason():
+    module = load_backfill_module()
+    reason = "Provider quota and audit gate failures blocked safe publication."
+    marker = module.release_video_skip_marker("v0.0.297", reason)
+    github = FakeGitHubReleaseClient(
+        "Release video: skipped for v0.0.297.\n"
+        f"Reason: {reason}\n\n"
+        "Existing notes\n\n"
+        f"{marker}\n"
+    )
+
+    result = module.record_release_video_skip(
+        tag="v0.0.297",
+        repo="promptdriven/pdd",
+        reason=reason,
+        github=github,
+    )
+
+    assert result.posted is False
+    assert result.release_body_updated is False
+    assert result.marker_added is False
+    assert result.skipped_reason == "release-video-skip-already-marked"
+    assert github.edits == []
+
+
 def test_github_client_uses_gh_release_view_and_edit_without_network():
     module = load_backfill_module()
     calls: list[tuple[list[str], str | None]] = []


### PR DESCRIPTION
## Summary

- add an idempotent `--skip-reason` mode to `scripts/backfill_release_video_discord.py` so historical release-video backfills can be explicitly marked skipped when no safe YouTube URL can be produced
- wire `make release-video-skip RELEASE_TAG=... RELEASE_VIDEO_SKIP_REASON=...`
- document the skip path in the release recovery runbook

## Root Cause / Investigation

Issue #1911 is not a single local wrapper failure. The original v0.0.297 release-video path hit three classes:

- local empty `CLAUDE_MODEL` built `claude -p --model ''`; this was already fixed by #1919 (`f4c759830`, test commit `d498c6d84`, fix commit `1fbe58cde`)
- upstream PDS/GVS provider quota/account limits terminalized release-video runs without a YouTube URL; tracked in promptdriven/Generative-Video-Studio#1623
- upstream GVS distribution audit gate correctly blocked publish for substantive visual/content failures; tracked in promptdriven/Generative-Video-Studio#1237

Because no YouTube URL exists, the existing PDD backfill path could only handle success. #1911's acceptance criteria also allows an explicit skip decision, but that previously required an unsafe/manual release edit. This PR makes the skip state first-class and idempotent.

## Sibling Bug Search

Checked release-video recovery/backfill paths for the same class of issue:

- `scripts/release_video.py`: active PDS runs already become pending with status/backfill commands (#1814); terminal failed provider/audit states still correctly do not fabricate a URL
- `scripts/backfill_release_video_discord.py`: had durable pending/completed Discord markers but no marker for intentional historical skip
- `Makefile` and docs: exposed recovery/status/backfill commands but no skip target

Related but not fixed here: PDS terminal failure hints do not yet classify `provider_quota` / `audit_failed` as first-class hints in `scripts/release_video.py`; that is diagnostic-only and should be a follow-up rather than broadening this PR.

## Prior Fix Shape Referenced

Followed the established release-video pattern from:

- #1694 / `3915eca1`: introduce script + Make target + tests for Discord backfill
- #1830 / `a60e1d9f`: use durable release-body markers for idempotency and ambiguous Discord state
- #1843 / `1c40a1841`: keep Discord backfill behavior test-driven and payload-compatible
- #1825 / `810214fc1`: document operator-safe recovery commands and avoid rerunning package/tag/PyPI release work
- #1919 / `f4c759830`: red test commit followed by implementation commit

## Test Plan

Red test evidence before fix:

```text
pytest -q tests/test_release_video_discord_backfill.py -k 'record_skip'
FF
AttributeError: module 'backfill_release_video_discord' has no attribute 'record_release_video_skip'
AttributeError: module 'backfill_release_video_discord' has no attribute 'release_video_skip_marker'
```

Verification after fix:

```text
pytest -q tests/test_release_video_discord_backfill.py
22 passed, 1 warning

pylint --disable=missing-module-docstring,missing-class-docstring,too-few-public-methods,missing-function-docstring,redefined-builtin,too-many-arguments,too-many-locals,duplicate-code,use-implicit-booleaness-not-comparison scripts/backfill_release_video_discord.py tests/test_release_video_discord_backfill.py
10.00/10

git diff --check
# clean

make -n release-video-skip RELEASE_TAG=v0.0.297 RELEASE_VIDEO_SKIP_REASON='Provider quota and audit gate failures blocked safe publication.'
# prints python scripts/backfill_release_video_discord.py --tag ... --skip-reason ...
```

Safe end-to-end CLI check used a fake `gh` executable and did not mutate GitHub or Discord:

```text
Recorded release-video skip decision for v0.0.297.
Updated GitHub release body for v0.0.297.

Release video: skipped for v0.0.297.
Reason: Provider quota and audit gate failures blocked safe publication.

Existing release notes

<!-- pdd-release-video-skipped: tag=v0.0.297 reason_sha256=287ccb448e3e20cea58082fddfab57515cc611c8e2d7b84eef05cca8596ca737 -->
```

## Operational Safety

This PR does not run release-video creation, package publishing, Git tag creation, PyPI publishing, GitHub release edits, or Discord webhook sends. The new command mutates only the GitHub release body when an operator deliberately runs it. Rollback is to revert the release-body edit or rerun with the desired skip reason / later backfill a real YouTube URL.

Fixes #1911
