### PR TITLE
Reset checkup resume loop after state rewind

### DIFF
--- a/pdd/agentic_checkup_orchestrator.py
+++ b/pdd/agentic_checkup_orchestrator.py
@@ -237,6 +237,73 @@ def _next_step(current: Union[int, float]) -> Union[int, float]:
         return STEP_ORDER[-1]
 
 
+_CHECKUP_STEP_STATE_KEYS: Dict[Union[int, float], str] = {
+    step: str(step).replace(".", "_") for step in STEP_ORDER
+}
+
+
+def _prune_rewound_checkup_state(
+    state: Dict[str, Any],
+    actual_last_success: Union[int, float],
+) -> None:
+    """Drop cached checkup state that is no longer reachable after a rewind.
+
+    Cached-state validation can lower ``last_completed_step`` when an earlier
+    output is missing or starts with ``FAILED:``. Any later step output,
+    telemetry entry, and loop metadata then belongs to an execution path the
+    resumed run must not trust.
+    """
+    try:
+        actual_idx = STEP_ORDER.index(actual_last_success)
+    except ValueError:
+        actual_idx = -1
+
+    completed_step_keys = {
+        _CHECKUP_STEP_STATE_KEYS[step] for step in STEP_ORDER[: actual_idx + 1]
+    }
+    step_outputs = state.get("step_outputs")
+    if isinstance(step_outputs, dict):
+        for key in list(step_outputs):
+            if (
+                key in _CHECKUP_STEP_STATE_KEYS.values()
+                and key not in completed_step_keys
+            ):
+                del step_outputs[key]
+        if actual_last_success < 7:
+            step_outputs.pop("pr_push", None)
+
+    step_by_id = {step_id: step for step, step_id in STEP_ID_MAP.items()}
+
+    def _telemetry_step(entry: Any) -> Optional[Union[int, float]]:
+        if not isinstance(entry, dict):
+            return None
+        raw_step = entry.get("internal_step")
+        if isinstance(raw_step, (int, float)):
+            return raw_step
+        if isinstance(raw_step, str):
+            try:
+                return float(raw_step) if "." in raw_step else int(raw_step)
+            except ValueError:
+                pass
+        raw_step_id = entry.get("step_id")
+        if isinstance(raw_step_id, str):
+            return step_by_id.get(raw_step_id)
+        return None
+
+    telemetry = state.get("step_telemetry")
+    if isinstance(telemetry, list):
+        state["step_telemetry"] = [
+            entry
+            for entry in telemetry
+            if (step := _telemetry_step(entry)) is None
+            or step in STEP_ORDER[: actual_idx + 1]
+        ]
+
+    if actual_last_success < 7:
+        state["fix_verify_iteration"] = 0
+        state["previous_fixes"] = ""
+
+
 # ---------------------------------------------------------------------------
 # Git helpers
 # ---------------------------------------------------------------------------
@@ -3672,6 +3739,7 @@ def _run_agentic_checkup_orchestrator_inner(
                         f"(found FAILED steps in cache)[/yellow]"
                     )
                 last_completed_step = actual_last_success
+                _prune_rewound_checkup_state(state, actual_last_success)
 
         # External review (PR #1215) Finding 2: a loaded state whose run
         # already COMPLETED (last_completed_step is the terminal step) must NOT

--- a/pdd/prompts/agentic_checkup_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_checkup_orchestrator_python.prompt
@@ -109,6 +109,7 @@
     5. Maintain a `context` dictionary that accumulates outputs from previous steps to provide full context to subsequent LLM calls.
     6. In the iterative loop, track `previous_fixes` across iterations and inject them into the prompt context so the agent knows what has already been attempted.
     7. Use `rich.console` for all user-facing status updates and progress bars.
+    8. When cached-state validation corrects `last_completed_step` backward, prune any cached step outputs and telemetry entries after the corrected step. If the corrected step is before Step 7, also reset `fix_verify_iteration` to `0` and clear `previous_fixes` so the resumed run cannot skip the fix/verify loop and fail on an empty stale Step 7 verdict.
 
 5) Deliverable:
     - A Python module `agentic_checkup_orchestrator.py` containing the main entry point function `run_agentic_checkup_orchestrator`.

--- a/tests/test_agentic_checkup_orchestrator.py
+++ b/tests/test_agentic_checkup_orchestrator.py
@@ -33,6 +33,7 @@ from pdd.agentic_checkup_orchestrator import (
     _parse_changed_files,
     _parse_expansion_items,
     _parse_failure_signal_block,
+    _prune_rewound_checkup_state,
     _pr_base_tracking_ref,
     _run_step5_shell_first_evidence,
     _select_step5_python_tests,
@@ -2287,6 +2288,87 @@ class TestResume:
         # All 10 steps should be re-executed since all cached outputs are FAILED
         assert mock_run.call_count == 10
         assert "step1" in executed_steps
+
+    def test_state_rewind_resets_stale_fix_verify_loop(
+        self, mock_dependencies, default_args, tmp_path
+    ):
+        """A rewind must not retain maxed loop state and skip Step 7."""
+        mock_run, _, _, _ = mock_dependencies
+        default_args["cwd"] = tmp_path
+
+        state_dir = _get_state_dir(tmp_path)
+        state_dir.mkdir(parents=True, exist_ok=True)
+        state_file = state_dir / "checkup_state_1.json"
+        state = {
+            "workflow": "checkup",
+            "issue_number": 1,
+            "issue_url": default_args["issue_url"],
+            "last_completed_step": 3,
+            "step_outputs": {
+                "1": "FAILED: provider parser returned empty output",
+                "2": "stale deps output",
+                "3": "stale build output",
+                "7": "",
+                "pr_push": "Skipped push because: stale verdict",
+            },
+            "step_telemetry": [
+                {"internal_step": 1, "step_id": "discover", "status": "failed"},
+                {"internal_step": 7, "step_id": "verify", "status": "failed"},
+            ],
+            "fix_verify_iteration": MAX_FIX_VERIFY_ITERATIONS,
+            "previous_fixes": "stale fixes from exhausted loop",
+            "total_cost": 0.0,
+            "model_used": "",
+        }
+        with open(state_file, "w") as f:
+            json.dump(state, f)
+
+        executed_steps = []
+
+        def side_effect(*args, **kwargs):
+            label = kwargs.get("label", "")
+            executed_steps.append(label)
+            if "step5" in label:
+                return (True, STEP5_CLEAN_OUTPUT, 0.1, "gpt-4")
+            return (True, f"Output for {label}. {ALL_ISSUES_FIXED}", 0.1, "gpt-4")
+
+        mock_run.side_effect = side_effect
+
+        success, msg, _cost, _model = run_agentic_checkup_orchestrator(**default_args)
+
+        assert success is True
+        assert "Checkup complete" in msg
+        assert "step1" in executed_steps
+        assert "step3_iter1" in executed_steps
+        assert "step7_iter1" in executed_steps
+        assert not any("iter3" in label for label in executed_steps)
+
+    def test_rewind_prunes_future_outputs_and_loop_metadata(self):
+        """State pruning keeps rewound resume data internally consistent."""
+        state = {
+            "step_outputs": {
+                "1": "ok",
+                "2": "ok",
+                "3": "stale build",
+                "7": "",
+                "pr_push": "Skipped push because: stale verdict",
+            },
+            "step_telemetry": [
+                {"internal_step": 1, "step_id": "discover", "status": "completed"},
+                {"internal_step": 7, "step_id": "verify", "status": "failed"},
+            ],
+            "fix_verify_iteration": MAX_FIX_VERIFY_ITERATIONS,
+            "previous_fixes": "stale fixes",
+        }
+
+        _prune_rewound_checkup_state(state, 2)
+
+        assert state["step_outputs"] == {"1": "ok", "2": "ok"}
+        assert state["step_telemetry"] == [
+            {"internal_step": 1, "step_id": "discover", "status": "completed"}
+        ]
+        assert state["fix_verify_iteration"] == 0
+        assert state["previous_fixes"] == ""
 
     def test_consecutive_failures_do_not_advance_last_completed_step(
         self, mock_dependencies, default_args, tmp_path


### PR DESCRIPTION
## Summary

Fixes #1934.

When checkup cached-state validation rewinds `last_completed_step`, the orchestrator now also makes the rest of the resume state consistent with that rewind:

- prunes cached step outputs after the corrected successful step
- prunes stale per-step telemetry for steps that will be rerun
- resets `fix_verify_iteration` and `previous_fixes` when the corrected cursor is before Step 7

This prevents a hosted resume from keeping stale maxed-out loop metadata, skipping the fix/verify loop, and failing final-gate with an empty Step 7 verdict.

## Context

A staging `pdd checkup --pr ... --issue ... --final-gate` rerun restored a checkpoint, corrected cached progress backward because earlier step output was failed/invalid, then retained `fix_verify_iteration = 3`. Since the loop condition was already exhausted, Step 7 was never rerun and the command failed with:

`Step 7 verdict JSON could not be parsed: empty step 7 output`

## Test Plan

- `python -m pytest -q tests/test_agentic_checkup_orchestrator.py -k 'state_validation or stale_fix_verify_loop or rewind_prunes or between_iterations_resume'`
- `python -m pytest -q tests/test_agentic_checkup_orchestrator.py`
- `python -m py_compile pdd/agentic_checkup_orchestrator.py tests/test_agentic_checkup_orchestrator.py`
- `git diff --check`
