### PR TITLE
fix(story): CLI exit codes and link data-safety for story commands

### DIFF
--- a/pdd/commands/generate.py
+++ b/pdd/commands/generate.py
@@ -35,6 +35,17 @@ _GITHUB_ISSUE_RE = re.compile(
 )
 
 
+def _mark_command_failed(ctx: click.Context) -> None:
+    """Mark handled command exceptions so the cli result-callback exits nonzero.
+
+    Mirrors ``pdd.commands.analysis._mark_command_failed`` (#1895): a command
+    that returns ``None`` on a handled error is otherwise treated as "no
+    results" by ``process_commands`` and the process exits 0.
+    """
+    if isinstance(getattr(ctx, "obj", None), dict):
+        ctx.obj["_command_failed"] = True
+
+
 def _estimate_mode_active(ctx: click.Context) -> bool:
     """Return whether the global dry-run cost estimate mode is active."""
     return bool((ctx.obj or {}).get("estimate")) or os.getenv("PDD_ESTIMATE", "").lower() in {
@@ -795,7 +806,15 @@ def test(
                 raise click.UsageError("Estimate mode currently supports `generate` only.")
             from ..story_test_generation import generate_story_regression_test
 
-            generated = generate_story_regression_test(from_story, output=output)
+            try:
+                generated = generate_story_regression_test(from_story, output=output)
+            except (ValueError, FileNotFoundError) as exc:
+                # #1889: surface malformed-story / missing-contract failures as a
+                # clean, nonzero-exit ClickException instead of swallowing them
+                # via handle_error + return None (which exits 0 and hides the
+                # failure from CI). No traceback is shown; the message is
+                # preserved verbatim.
+                raise click.ClickException(str(exc)) from exc
             obj = ctx.obj or {}
             if not obj.get("quiet", False):
                 action = "generated" if generated.changed else "already current"
@@ -1016,5 +1035,11 @@ def test(
         if _is_estimate_only_result(e):
             return _estimate_result_tuple(e)
         quiet = ctx.obj.get("quiet", False) if ctx.obj else False
+        # #1889: mark the command failed so the cli result-callback exits
+        # nonzero. A bare `return None` is treated as "no results" (results is
+        # None -> normalized_results == []) by process_commands, so the None
+        # never triggers the nonzero-exit path and CI silently sees exit 0.
+        # This mirrors the #1895 convention for `detect --stories`.
+        _mark_command_failed(ctx)
         handle_error(e, "test", quiet)
         return None

--- a/pdd/commands/story.py
+++ b/pdd/commands/story.py
@@ -198,7 +198,7 @@ def story() -> None:
 @click.option("--generate-regression", is_flag=True, help="Print the pdd test --from-story handoff command.")
 @click.option("--cross-devunit", is_flag=True, help="Document that multiple linked dev units are intentional.")
 @click.option("--from-changed-files", is_flag=True, help="Use currently changed .prompt files from git status.")
-def add_story(
+def add_story(  # pylint: disable=too-many-branches
     source: Optional[str],
     inline_text: Optional[str],
     title: Optional[str],
@@ -260,6 +260,16 @@ def add_story(
                 f"--output tests/story_regression/test_story_{story_slug}.py`."
             )
         return
+
+    # #1889: `--update` must target an existing story. If we reach here with
+    # --update set, the update branch above did not fire (no story file for this
+    # slug), so fail fast with a clean error BEFORE any LLM-backed generation
+    # (fresh authoring otherwise hangs on interactive device-auth offline).
+    if update:
+        raise click.ClickException(
+            f"No existing story to update at {proposed_path}; "
+            "omit --update to create it."
+        )
 
     issue_source = source or _inline_source_path(inline_text or "", title)
     success, message, _cost, _model, _story_path, _linked_refs = generate_user_story(
@@ -374,6 +384,16 @@ def link_story(story_file: str, prompts: tuple[str, ...], prompts_dir: Optional[
     if not story_path.is_file():
         raise click.ClickException(f"Story file not found: {story_file}")
     _validate_story_inside_user_stories(story_path)
+
+    # #1889: validate explicit --prompt paths BEFORE touching the story. A
+    # nonexistent prompt was previously written into the metadata as a dangling
+    # basename while dropping the story's existing valid links -- and still
+    # exited 0. Fail loudly and leave the story file untouched.
+    missing_prompts = [prompt for prompt in prompts if not Path(prompt).is_file()]
+    if missing_prompts:
+        raise click.ClickException(
+            "Prompt file(s) not found: " + ", ".join(missing_prompts)
+        )
 
     success, message, _cost, _model, _linked_refs = cache_story_prompt_links(
         story_file=str(story_path),

--- a/pdd/user_story_tests.py
+++ b/pdd/user_story_tests.py
@@ -449,6 +449,13 @@ def cache_story_prompt_links(  # pylint: disable=too-many-arguments,too-many-loc
         existing_paths: List[Path] = []
         for ref in _parse_story_prompt_metadata(story_content):
             resolved = _resolve_prompt_path(ref, prompt_files, prompts_root)
+            # #1889: when explicit --prompt inputs are passed, `prompt_files` is
+            # the explicit-only pool, so an already-linked ref that isn't part of
+            # this operation would fail to resolve and be silently dropped. Keep
+            # any existing ref that still points to a real file on disk (relative
+            # to the run CWD) so a relink never destroys valid prior links.
+            if resolved is None and ref and Path(ref).is_file():
+                resolved = Path(ref)
             if resolved:
                 existing_paths.append(resolved)
         linked_prompt_paths = _dedupe_prompt_paths(existing_paths + explicit_prompt_files)

--- a/tests/commands/test_generate.py
+++ b/tests/commands/test_generate.py
@@ -745,6 +745,40 @@ def test_test_from_story_generates_deterministic_regression_file(runner):
         assert "Supported files are accepted." in text
 
 
+def test_test_from_story_malformed_exits_nonzero(runner):
+    """Bug #1889: a malformed story (no ## Oracle contract) must exit nonzero.
+
+    Regression for the #1863 malformed-story class: ``generate_story_regression_test``
+    raises ValueError, which the ``test`` command previously swallowed via
+    ``handle_error`` + ``return None`` and exited 0, hiding the failure from CI.
+    The error message must stay clean (no traceback).
+    """
+    with runner.isolated_filesystem():
+        os.makedirs("user_stories")
+        # Named story__*.md (passes the name check) but has no Oracle / contract,
+        # so generate_story_regression_test raises ValueError.
+        with open("user_stories/story__broken.md", "w", encoding="utf-8") as f:
+            f.write("# User Story: broken\n\nSome prose but no Oracle section.\n")
+        result = runner.invoke(
+            generate_module.test,
+            ["--from-story", "user_stories/story__broken.md"],
+        )
+
+    assert result.exit_code != 0, result.output
+    assert "Oracle" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_test_from_story_nonexistent_file_exits_nonzero(runner):
+    """A nonexistent --from-story path still exits nonzero (click.Path(exists=True) -> 2)."""
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            generate_module.test,
+            ["--from-story", "user_stories/story__missing.md"],
+        )
+    assert result.exit_code != 0
+
+
 def test_test_from_story_rejects_positional_args(runner):
     with runner.isolated_filesystem():
         with open("story__upload_flow.md", "w", encoding="utf-8") as f:

--- a/tests/commands/test_story.py
+++ b/tests/commands/test_story.py
@@ -476,21 +476,26 @@ class TestDuplicateDetection:
     def test_update_flag_allows_overwrite(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
-        """--update allows overwriting an existing story slug."""
-        stories_dir = tmp_path / "user_stories"
-        stories_dir.mkdir(parents=True, exist_ok=True)
-        existing = stories_dir / "story__my_feature.md"
-        existing.write_text("old content\n", encoding="utf-8")
+        """--update on an existing story slug relinks it and exits 0.
 
-        with runner.isolated_filesystem(temp_dir=tmp_path):
-            with patch("pdd.commands.story.generate_user_story") as mock_gen:
-                mock_gen.return_value = (
+        The story must exist in the *resolved* stories dir (the isolated cwd),
+        so the update takes the relink path (cache_story_prompt_links) rather
+        than falling through to fresh LLM generation (#1889 Bug 3).
+        """
+        with runner.isolated_filesystem(temp_dir=tmp_path) as fs:
+            stories_dir = Path(fs) / "user_stories"
+            stories_dir.mkdir(parents=True, exist_ok=True)
+            existing = stories_dir / "story__my_feature.md"
+            existing.write_text("old content\n", encoding="utf-8")
+
+            with patch("pdd.commands.story.cache_story_prompt_links") as mock_link, \
+                 patch("pdd.commands.story.generate_user_story") as mock_gen:
+                mock_link.return_value = (
                     True,
-                    f"Updated story file: {existing}. Story prompt metadata linked.",
-                    0.03,
-                    "claude-sonnet-4-6",
-                    str(existing),
-                    ["commands/x_python.prompt"],
+                    "Story prompt metadata linked.",
+                    0.0,
+                    "",
+                    ["prompts/x_python.prompt"],
                 )
                 result = runner.invoke(
                     story,
@@ -504,6 +509,8 @@ class TestDuplicateDetection:
                     obj={"quiet": True, "verbose": False},
                 )
         assert result.exit_code == 0, result.output
+        mock_link.assert_called_once()
+        mock_gen.assert_not_called()
 
     def test_update_existing_title_merges_metadata_without_regenerating(
         self, runner: CliRunner, tmp_path: Path

--- a/tests/commands/test_story.py
+++ b/tests/commands/test_story.py
@@ -539,6 +539,39 @@ class TestDuplicateDetection:
         mock_link.assert_called_once()
         mock_gen.assert_not_called()
 
+    def test_update_missing_slug_exits_nonzero_without_llm(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Bug #1889: `story add --update <missing-slug>` must fail fast, no LLM.
+
+        Previously --update on a slug with no existing story file fell through to
+        fresh LLM generation (which hangs on interactive device-auth offline)
+        instead of erroring. It must raise a clean ClickException before any LLM
+        call and exit nonzero.
+        """
+        with runner.isolated_filesystem(temp_dir=tmp_path) as fs:
+            stories_dir = Path(fs) / "user_stories"
+            stories_dir.mkdir(parents=True, exist_ok=True)
+            # No story__my_feature.md exists.
+            with patch("pdd.commands.story.generate_user_story") as mock_gen, \
+                 patch("pdd.commands.story.cache_story_prompt_links") as mock_link:
+                result = runner.invoke(
+                    story,
+                    [
+                        "add",
+                        "https://github.com/promptdriven/pdd/issues/1768",
+                        "--title", "My Feature",
+                        "--prompt", "prompts/x_python.prompt",
+                        "--update",
+                    ],
+                    obj={"quiet": True, "verbose": False},
+                )
+
+        assert result.exit_code != 0, result.output
+        assert "update" in result.output.lower()
+        mock_gen.assert_not_called()
+        mock_link.assert_not_called()
+
     def test_case_insensitive_slug_collision_detected(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
@@ -850,6 +883,82 @@ class TestStoryLink:
             obj={"quiet": True, "verbose": False},
         )
         assert result.exit_code != 0
+
+    def test_link_missing_prompt_exits_nonzero_and_preserves_metadata(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Bug #1889: `story link --prompt <missing>` must fail without mutating.
+
+        A nonexistent explicit --prompt path was never existence-checked, so the
+        story's existing valid <!-- pdd-story-prompts: ... --> metadata was
+        re-resolved against the (missing-only) explicit pool, dropping the valid
+        link and writing a dangling basename -- while still exiting 0.
+        """
+        with runner.isolated_filesystem(temp_dir=tmp_path) as fs:
+            root = Path(fs)
+            prompt_file = root / "prompts" / "calc_python.prompt"
+            prompt_file.parent.mkdir(parents=True, exist_ok=True)
+            prompt_file.write_text("% calc prompt\n", encoding="utf-8")
+
+            story_file = root / "user_stories" / "story__calc.md"
+            story_file.parent.mkdir(parents=True, exist_ok=True)
+            original = (
+                "## Story\nAs a user, I want to add numbers.\n\n"
+                "<!-- pdd-story-prompts: prompts/calc_python.prompt -->\n"
+            )
+            story_file.write_text(original, encoding="utf-8")
+
+            result = runner.invoke(
+                story,
+                [
+                    "link",
+                    str(story_file),
+                    "--prompt", "prompts/does_not_exist.prompt",
+                ],
+                obj={"quiet": True, "verbose": False},
+            )
+
+            # Fails non-zero and names the missing prompt.
+            assert result.exit_code != 0, result.output
+            assert "does_not_exist.prompt" in result.output
+            # The story metadata is left completely untouched on failure.
+            assert story_file.read_text(encoding="utf-8") == original
+
+    def test_link_valid_new_prompt_preserves_existing_refs(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """A successful relink with a new valid prompt keeps already-valid refs."""
+        with runner.isolated_filesystem(temp_dir=tmp_path) as fs:
+            root = Path(fs)
+            calc = root / "prompts" / "calc_python.prompt"
+            calc.parent.mkdir(parents=True, exist_ok=True)
+            calc.write_text("% calc prompt\n", encoding="utf-8")
+            adder = root / "prompts" / "adder_python.prompt"
+            adder.write_text("% adder prompt\n", encoding="utf-8")
+
+            story_file = root / "user_stories" / "story__calc.md"
+            story_file.parent.mkdir(parents=True, exist_ok=True)
+            story_file.write_text(
+                "## Story\nAs a user, I want to add numbers.\n\n"
+                "<!-- pdd-story-prompts: prompts/calc_python.prompt -->\n",
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(
+                story,
+                [
+                    "link",
+                    str(story_file),
+                    "--prompt", "prompts/adder_python.prompt",
+                ],
+                obj={"quiet": True, "verbose": False},
+            )
+
+        assert result.exit_code == 0, result.output
+        content = story_file.read_text(encoding="utf-8")
+        # Both the pre-existing valid ref and the newly linked one survive.
+        assert "calc_python.prompt" in content
+        assert "adder_python.prompt" in content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes three P1 CLI-safety bugs in the story commands where errors were invisible to CI/shells or silently corrupted data. Refs PR #1889. The exit-code convention follows #1895 (`_command_failed` result-callback signaling).

### Bug 1 — `pdd test --from-story` printed an error but exited 0
`generate_story_regression_test` raises `ValueError`/`FileNotFoundError` on a malformed story (the #1863 class: missing `## Oracle`/contract). The `test` command caught it via `handle_error` + `return None`. A single command returning `None` is normalized to *no results* by the cli result-callback (`results is None` → `normalized_results == []`), so the `None`-based nonzero-exit path never fires and the process exits 0 — hiding the failure from CI.

**Fix:** convert those to a clean `click.ClickException` (exit 1, message preserved, no traceback), and mark the `test` command failed on any handled error via a `_mark_command_failed(ctx)` helper so the result-callback exits nonzero (mirrors `pdd/commands/analysis.py::_mark_command_failed` from #1895). Nonexistent `--from-story` files still exit 2 via `click.Path(exists=True)`.

### Bug 2 — `pdd story link --prompt <nonexistent>` corrupted metadata and exited 0
Explicit `--prompt` paths were never existence-checked. A missing prompt was written into `<!-- pdd-story-prompts: ... -->` as a dangling basename, while the story's previously-linked valid prompts were dropped (existing refs were re-resolved against the explicit-only pool) — and it exited 0.

**Fix:** validate each explicit `--prompt` path before mutating the story (raise `click.ClickException` listing the missing ones, exit nonzero, leave the story file untouched). Additionally, in `cache_story_prompt_links` the explicit+`force_relink` branch now preserves already-valid refs that still point to a real file on disk, so a successful relink never destroys prior valid links.

### Bug 3 — `pdd story add --update <nonexistent-slug>` fell through to LLM generation
`--update` on a slug with no existing story file didn't error; it fell through to fresh LLM authoring (which hangs on interactive device-auth offline).

**Fix:** fail fast with a clean `click.ClickException` ("No existing story to update at ...; omit --update to create it.") before any LLM call.

## Sibling swallowed-exit-code occurrences (follow-ups, out of scope)
Same `handle_error` + `return None` pattern that swallows the process exit code (analysis.py's detect/conflicts/bug/crash/trace already fixed by #1895). Not fixed here:
- `pdd/commands/generate.py:675` (`generate`)
- `pdd/commands/checkup.py:1294` (`checkup`)
- `pdd/commands/misc.py:97` (`preprocess`)
- `pdd/commands/modify.py` (`split`, `change`, `update`)
- `pdd/commands/utility.py:137` (`verify`)
- `pdd/commands/maintenance.py` (`sync` ×3, `sync-architecture`, `auto-deps`)

## Tests (strict TDD, red → green)
- `tests/commands/test_generate.py`: `test_test_from_story_malformed_exits_nonzero`, `test_test_from_story_nonexistent_file_exits_nonzero`
- `tests/commands/test_story.py`: `test_link_missing_prompt_exits_nonzero_and_preserves_metadata`, `test_link_valid_new_prompt_preserves_existing_refs`, `test_update_missing_slug_exits_nonzero_without_llm`; updated `test_update_flag_allows_overwrite` (it previously encoded Bug 3's buggy fall-through because `isolated_filesystem` hid the pre-created story from the resolved stories-dir).

All touched test files pass (71) and `tests/test_user_story_tests.py` passes (51). Pylint clean (no new E/W; one scoped `# pylint: disable=too-many-branches` on `add_story`).

## Files changed
`pdd/commands/generate.py`, `pdd/commands/story.py`, `pdd/user_story_tests.py`, `tests/commands/test_generate.py`, `tests/commands/test_story.py`. No `pdd/core/cli.py` change needed — the #1895 mechanism was already present on the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
