### PR TITLE
fix(story): unify story-hash freshness semantics across gate evaluators

### DIFF
--- a/pdd/story_regression.py
+++ b/pdd/story_regression.py
@@ -98,15 +98,48 @@ def _relative_nodeid(item: pytest.Item, root: Path) -> str:
         return item.nodeid.lstrip("/")
 
 
-def _literal_story_id(node: ast.AST) -> Optional[str]:
-    """Return a story id from a literal decorator argument, if present."""
+def _module_string_constants(tree: ast.AST) -> Dict[str, str]:
+    """Return top-level ``NAME = "literal"`` string constants in a module.
+
+    Mirrors the gate's own AST constant resolver so the static fallback can
+    resolve ``story_id=STORY_ID`` / ``story_id=PDD_STORY_ID`` module constants
+    that generated tests emit (pdd#1889 Bug 3), not only bare string literals.
+    """
+    constants: Dict[str, str] = {}
+    for node in getattr(tree, "body", []):
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+        if not (isinstance(value, ast.Constant) and isinstance(value.value, str)):
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name):
+                constants[target.id] = value.value
+    return constants
+
+
+def _literal_story_id(
+    node: ast.AST, constants: Optional[Dict[str, str]] = None
+) -> Optional[str]:
+    """Return a story id from a decorator argument (literal or module constant)."""
     if isinstance(node, ast.Constant) and node.value is not None:
         return _normalize_story_ref(node.value)
+    if constants is not None and isinstance(node, ast.Name):
+        resolved = constants.get(node.id)
+        if resolved is not None:
+            return _normalize_story_ref(resolved)
     return None
 
 
-def _story_id_from_decorator(decorator: ast.AST) -> Optional[str]:
-    """Resolve ``@pytest.mark.story`` decorator literals without executing code."""
+def _story_id_from_decorator(
+    decorator: ast.AST, constants: Optional[Dict[str, str]] = None
+) -> Optional[str]:
+    """Resolve a ``@pytest.mark.story`` decorator's story id without executing code."""
     if not isinstance(decorator, ast.Call):
         return None
 
@@ -124,16 +157,19 @@ def _story_id_from_decorator(decorator: ast.AST) -> Optional[str]:
 
     for keyword in decorator.keywords:
         if keyword.arg == "story_id":
-            return _literal_story_id(keyword.value)
+            return _literal_story_id(keyword.value, constants)
 
     if decorator.args:
-        return _literal_story_id(decorator.args[0])
+        return _literal_story_id(decorator.args[0], constants)
 
     return None
 
 
 def _scan_story_markers_static(tests_dir: Path) -> StoryTestMap:
-    """Best-effort static fallback for literal ``@pytest.mark.story`` decorators."""
+    """Best-effort static fallback for ``@pytest.mark.story`` decorators.
+
+    Resolves both string-literal and module-constant ``story_id`` forms.
+    """
     story_to_tests: Dict[str, Set[str]] = {}
     test_to_stories: Dict[str, Set[str]] = {}
     root = tests_dir.resolve()
@@ -149,6 +185,7 @@ def _scan_story_markers_static(tests_dir: Path) -> StoryTestMap:
         except (ValueError, OSError):
             rel_path = path.name
 
+        constants = _module_string_constants(tree)
         for node in ast.walk(tree):
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
@@ -157,7 +194,7 @@ def _scan_story_markers_static(tests_dir: Path) -> StoryTestMap:
             story_ids = {
                 sid
                 for decorator in node.decorator_list
-                for sid in [_story_id_from_decorator(decorator)]
+                for sid in [_story_id_from_decorator(decorator, constants)]
                 if sid
             }
             if not story_ids:

--- a/pdd/story_regression_gate.py
+++ b/pdd/story_regression_gate.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 
 import ast
 import logging
-import re
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -78,10 +77,6 @@ _GATE_MODES = frozenset({"off", "warn", "strict"})
 _DEFAULT_MODE = "warn"
 _STRICT_FAIL_EXIT = 2
 _DEFAULT_TESTS_DIR = "tests"
-_HASH_ASSIGN_RE = re.compile(
-    r"^(?:PDD_)?STORY_HASH\s*=\s*(?P<value>['\"].*?['\"])",
-    re.MULTILINE,
-)
 
 
 # ---------------------------------------------------------------------------
@@ -321,6 +316,32 @@ def discover_all_story_markers(tests_dir) -> Dict[str, List[StoryMarker]]:
 # ---------------------------------------------------------------------------
 
 
+def _acceptable_story_hashes(
+    story_path, story_text: Optional[str] = None
+) -> set:
+    """Hashes a fresh linked test may legitimately record for *story_path*.
+
+    The union of the content hash (``_story_content_hash``, story prose only)
+    and the bundle hash (``story_bundle_hash``, story + contract). Shared by the
+    full gate (:func:`_classify_story_from_markers`) and the wired coverage
+    evaluator (:func:`evaluate_story_regression`) so the two can never diverge on
+    what "fresh" means (pdd#1889 Bug 1). Both primitives are metadata-insensitive.
+    """
+    path = Path(story_path)
+    if story_text is None:
+        try:
+            story_text = path.read_text(encoding="utf-8")
+        except OSError:
+            story_text = ""
+    acceptable = {_story_content_hash(story_text)}
+    if path.exists():
+        try:
+            acceptable.add(story_bundle_hash(path))
+        except OSError:
+            pass
+    return acceptable
+
+
 def _classify_story_from_markers(
     story_path,
     story_markers: Sequence[StoryMarker],
@@ -339,12 +360,7 @@ def _classify_story_from_markers(
     if story_text is None:
         story_text = path.read_text(encoding="utf-8")
     current_hash = _story_content_hash(story_text)
-    acceptable_hashes = {current_hash}
-    if path.exists():
-        try:
-            acceptable_hashes.add(story_bundle_hash(path))
-        except OSError:
-            pass
+    acceptable_hashes = _acceptable_story_hashes(path, story_text)
 
     if not story_markers:
         return StoryRegressionResult(
@@ -746,18 +762,25 @@ def _test_file_for_nodeid(nodeid: str, tests_dir: Path) -> Optional[Path]:
     return None
 
 
-def _recorded_hash(test_path: Path) -> Optional[str]:
+def _recorded_story_hashes(test_path: Path, sid: str) -> List[str]:
+    """Every ``story_hash`` *test_path* records for story *sid*.
+
+    Resolves BOTH marker ``story_hash=`` kwargs AND module-level
+    ``PDD_STORY_HASH`` / ``STORY_HASH`` constants (via the gate's own AST scan,
+    :func:`_markers_in_source`), so the wired evaluator accepts the same forms as
+    the full gate (pdd#1889 Bug 1). A legacy hashless marker contributes nothing,
+    preserving the #1699 traceability-only "present" verdict.
+    """
     try:
-        text = test_path.read_text(encoding="utf-8")
+        source = test_path.read_text(encoding="utf-8")
     except OSError:
-        return None
-    match = _HASH_ASSIGN_RE.search(text)
-    if not match:
-        return None
-    try:
-        return str(ast.literal_eval(match.group("value")))
-    except (SyntaxError, ValueError):
-        return None
+        return []
+    target = story_id_from_path(sid)
+    hashes: List[str] = []
+    for marker in _markers_in_source(source, str(test_path)):
+        if marker.story_hash and story_id_from_path(marker.story_id) == target:
+            hashes.append(marker.story_hash)
+    return hashes
 
 
 def evaluate_story_regression(
@@ -789,15 +812,15 @@ def evaluate_story_regression(
         test_path = _test_file_for_nodeid(nodeid, tests_dir)
         if test_path is None:
             continue
-        found = _recorded_hash(test_path)
+        found = _recorded_story_hashes(test_path, sid)
         if found:
-            recorded[nodeid] = found
+            recorded[nodeid] = found[0]
 
     if not recorded:
         # Coverage uses this lightweight evaluator to preserve #1699
         # compatibility with legacy story markers that prove traceability but
-        # predate story-hash freshness metadata. The stricter full gate path
-        # still reports hashless markers as stale via classify_story().
+        # predate story-hash freshness metadata. A marker with NO hash at all
+        # stays "present"; a marker WITH a non-matching hash is stale (below).
         return StoryRegressionEvaluation(
             story_id=sid,
             status=STATUS_PASSING,
@@ -806,10 +829,13 @@ def evaluate_story_regression(
             recorded_hashes={},
         )
 
-    if current_hash not in set(recorded.values()):
+    # Same acceptance as the full gate: content hash UNION bundle hash. A
+    # recorded hash matching either form is fresh; otherwise the story changed.
+    acceptable = _acceptable_story_hashes(story_path)
+    if set(recorded.values()) & acceptable:
         return StoryRegressionEvaluation(
             story_id=sid,
-            status=STATUS_STALE,
+            status=STATUS_PASSING,
             current_hash=current_hash,
             tests=tests,
             recorded_hashes=recorded,
@@ -817,7 +843,7 @@ def evaluate_story_regression(
 
     return StoryRegressionEvaluation(
         story_id=sid,
-        status=STATUS_PASSING,
+        status=STATUS_STALE,
         current_hash=current_hash,
         tests=tests,
         recorded_hashes=recorded,

--- a/pdd/story_regression_gate.py
+++ b/pdd/story_regression_gate.py
@@ -808,6 +808,7 @@ def evaluate_story_regression(
         )
 
     recorded: dict[str, str] = {}
+    all_recorded: set = set()
     for nodeid in tests:
         test_path = _test_file_for_nodeid(nodeid, tests_dir)
         if test_path is None:
@@ -815,6 +816,10 @@ def evaluate_story_regression(
         found = _recorded_story_hashes(test_path, sid)
         if found:
             recorded[nodeid] = found[0]
+            # Freshness is decided over EVERY recorded hash, not just the first,
+            # so a stale marker listed before a fresh one in the same file cannot
+            # shadow it -- matching the full gate's any-fresh-wins rule (#1889).
+            all_recorded.update(found)
 
     if not recorded:
         # Coverage uses this lightweight evaluator to preserve #1699
@@ -832,7 +837,7 @@ def evaluate_story_regression(
     # Same acceptance as the full gate: content hash UNION bundle hash. A
     # recorded hash matching either form is fresh; otherwise the story changed.
     acceptable = _acceptable_story_hashes(story_path)
-    if set(recorded.values()) & acceptable:
+    if all_recorded & acceptable:
         return StoryRegressionEvaluation(
             story_id=sid,
             status=STATUS_PASSING,

--- a/pdd/story_test_generation.py
+++ b/pdd/story_test_generation.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from .user_story_tests import story_id
+from .user_story_tests import _normalized_story_for_hash, story_id
 
 
 _HEADING_RE = re.compile(r"^(?P<marks>#{2,6})\s+(?P<title>.+?)\s*$", re.MULTILINE)
@@ -51,9 +51,33 @@ def _read_story_bundle(story_path: Path) -> tuple[str, Optional[Path], str]:
     return story_text, None, story_text
 
 
+def _normalized_bundle(story_text: str, contract_path: Optional[Path]) -> str:
+    """Return the story(+contract) bundle normalized for hashing.
+
+    Both portions run through the canonical ``_normalized_story_for_hash`` so a
+    metadata-only edit (relinking prompts/dev-units, which rewrites the
+    ``<!-- pdd-story-prompts ... -->`` comments) does NOT change the hash
+    (pdd#1889 Bug 2), while any change to the human-facing prose does. The
+    contract stays part of the hash so a contract edit is still a change.
+    """
+    bundle = _normalized_story_for_hash(story_text)
+    if contract_path is not None and contract_path.exists():
+        try:
+            contract_text = contract_path.read_text(encoding="utf-8")
+        except OSError:
+            return bundle
+        bundle = f"{bundle}\n\n{_normalized_story_for_hash(contract_text)}"
+    return bundle
+
+
 def story_bundle_hash(story_path: Path) -> str:
-    """Return the stable hash generated tests record for staleness checks."""
-    _, _, bundle = _read_story_bundle(story_path)
+    """Return the stable hash generated tests record for staleness checks.
+
+    Normalized so a metadata-only prompt/dev-unit relink does not flip it
+    (pdd#1889 Bug 2); see :func:`_normalized_bundle`.
+    """
+    story_text, contract_path, _ = _read_story_bundle(story_path)
+    bundle = _normalized_bundle(story_text, contract_path)
     return hashlib.sha256(bundle.encode("utf-8")).hexdigest()[:16]
 
 
@@ -166,9 +190,12 @@ def _render_test(
             "",
             "",
             "def _bundle_hash() -> str:",
-            "    import hashlib",
+            "    # Reuse the canonical primitive so the recorded PDD_STORY_HASH and",
+            "    # the gate's freshness check can never drift (pdd#1889). A",
+            "    # metadata-only prompt relink does not change this value.",
+            "    from pdd.story_test_generation import story_bundle_hash",
             "",
-            "    return hashlib.sha256(_story_bundle().encode(\"utf-8\")).hexdigest()[:16]",
+            "    return story_bundle_hash(STORY_PATH)",
             "",
             "",
             "@pytest.mark.story(story_id=PDD_STORY_ID)",
@@ -275,7 +302,9 @@ def generate_story_regression_test(
 
     output_path = _resolve_output(story_path, output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    bundle_hash = hashlib.sha256(bundle.encode("utf-8")).hexdigest()[:16]
+    # Record the canonical (normalized) bundle hash, identical to what the gate
+    # recomputes, so a metadata-only relink never falsely stales this test.
+    bundle_hash = story_bundle_hash(story_path)
     rendered = _render_test(
         slug=slug,
         story_path=story_path,

--- a/tests/story_regression/test_story_pdd_bug.py
+++ b/tests/story_regression/test_story_pdd_bug.py
@@ -5,7 +5,7 @@ from pdd.commands.analysis import bug
 
 
 PDD_STORY_ID = "pdd_bug"
-PDD_STORY_HASH = "e04067b53306ba0f"
+PDD_STORY_HASH = "19e588bbffc02cf1"
 
 
 @pytest.mark.story(story_id=PDD_STORY_ID)

--- a/tests/story_regression/test_story_pdd_checkup.py
+++ b/tests/story_regression/test_story_pdd_checkup.py
@@ -5,7 +5,7 @@ from pdd.commands.checkup import checkup
 
 
 PDD_STORY_ID = "pdd_checkup"
-PDD_STORY_HASH = "213cefce7c9bb9de"
+PDD_STORY_HASH = "c182aa91b22551eb"
 
 
 @pytest.mark.story(story_id=PDD_STORY_ID)

--- a/tests/story_regression/test_story_pdd_connect.py
+++ b/tests/story_regression/test_story_pdd_connect.py
@@ -5,7 +5,7 @@ from pdd.commands.connect import connect
 
 
 PDD_STORY_ID = "pdd_connect"
-PDD_STORY_HASH = "941636e0fbab930c"
+PDD_STORY_HASH = "263eed0bff2eb6f9"
 
 
 @pytest.mark.story(story_id=PDD_STORY_ID)

--- a/tests/story_regression/test_story_pdd_generate.py
+++ b/tests/story_regression/test_story_pdd_generate.py
@@ -5,7 +5,7 @@ from pdd.commands.generate import generate
 
 
 PDD_STORY_ID = "pdd_generate"
-PDD_STORY_HASH = "e0e44229295fc640"
+PDD_STORY_HASH = "e23eb1e50140fe63"
 
 
 @pytest.mark.story(story_id=PDD_STORY_ID)

--- a/tests/story_regression/test_story_pdd_test.py
+++ b/tests/story_regression/test_story_pdd_test.py
@@ -5,7 +5,7 @@ from pdd.commands.generate import test
 
 
 PDD_STORY_ID = "pdd_test"
-PDD_STORY_HASH = "254412e41b69ae19"
+PDD_STORY_HASH = "8d7c10cc1b2ca908"
 
 
 @pytest.mark.story(story_id=PDD_STORY_ID)

--- a/tests/story_regression/test_story_pdd_top_flows.py
+++ b/tests/story_regression/test_story_pdd_top_flows.py
@@ -15,7 +15,7 @@ def _help(command: str):
     )
 
 
-@pytest.mark.story(story_id="pdd_generate", story_hash="3660bcd6d6d7e8a8")
+@pytest.mark.story(story_id="pdd_generate", story_hash="e23eb1e50140fe63")
 def test_story_pdd_generate_help_is_public_safe():
     result = _help("generate")
     assert result.exit_code == 0, result.output
@@ -48,7 +48,7 @@ def test_story_pdd_change_help_is_public_safe():
     assert "pdd change ISSUE_URL" in result.output
 
 
-@pytest.mark.story(story_id="pdd_update", story_hash="cf0bc4a2189f81bd")
+@pytest.mark.story(story_id="pdd_update", story_hash="af77d101cb8515bd")
 def test_story_pdd_update_help_is_public_safe():
     result = _help("update")
     assert result.exit_code == 0, result.output

--- a/tests/story_regression/test_story_pdd_update.py
+++ b/tests/story_regression/test_story_pdd_update.py
@@ -5,7 +5,7 @@ from pdd.commands.modify import update
 
 
 PDD_STORY_ID = "pdd_update"
-PDD_STORY_HASH = "cf0bc4a2189f81bd"
+PDD_STORY_HASH = "af77d101cb8515bd"
 
 
 @pytest.mark.story(story_id=PDD_STORY_ID)

--- a/tests/test_coverage_contracts.py
+++ b/tests/test_coverage_contracts.py
@@ -1225,7 +1225,7 @@ class TestStoryRegressionDimension:
                 "has_regression_test": True,
                 "status": "story-regression-present",
                 "tests": ["test_foo.py::test_foo_flow"],
-                "story_hash": "8ca87cfe7267abcb",
+                "story_hash": "95d7a1ca9e45f480",
             }
         ]
         assert "regression_warnings" in d

--- a/tests/test_story_regression.py
+++ b/tests/test_story_regression.py
@@ -317,6 +317,40 @@ class TestStaticFallback:
         assert smap.tests_for_story("refund_flow") == {"test_static.py::test_literal_story_marker"}
         assert not sentinel.exists()
 
+    def test_constant_story_id_markers_survive_empty_pytest_collection(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """pdd#1889 Bug 3: generated tests declare ``story_id=STORY_ID`` (a module
+        constant), not a bare literal. The static fallback (used when pytest
+        collection yields zero markers) must resolve those module constants --
+        exactly as the gate's own AST scanner already does -- or the whole story
+        is (wrongly) reported as having no regression test."""
+        d = tmp_path / "tests"
+        d.mkdir()
+        (d / "test_static_const.py").write_text(
+            "\n".join(
+                [
+                    "import pytest",
+                    'PDD_STORY_ID = "checkout_flow"',
+                    "@pytest.mark.story(story_id=PDD_STORY_ID)",
+                    "def test_const_marker():",
+                    "    assert True",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        def _empty_collect(*_args, **_kwargs):
+            return 0
+
+        monkeypatch.setattr(story_regression.pytest, "main", _empty_collect)
+        smap = build_story_map(d)
+
+        assert smap.tests_for_story("checkout_flow") == {
+            "test_static_const.py::test_const_marker"
+        }
+
 
 # --- R9: graceful degradation --------------------------------------------------
 

--- a/tests/test_story_regression_gate.py
+++ b/tests/test_story_regression_gate.py
@@ -568,6 +568,34 @@ def test_evaluate_story_regression_accepts_recorded_content_hash(tmp_path: Path)
     assert ev.status == STATUS_PASSING
 
 
+def test_evaluate_story_regression_fresh_wins_over_earlier_stale_in_same_file(
+    tmp_path: Path,
+):
+    """A file with two markers for the same story -- a STALE one listed first,
+    a FRESH one second -- must be reported 'present' (any-fresh-wins), matching
+    the full gate. Regression guard for collapsing the recorded-hash list to
+    ``found[0]``, which would re-introduce exactly the evaluator divergence this
+    change eliminates (pdd#1889)."""
+    from pdd.story_regression import build_story_map
+    from pdd.story_regression_gate import STATUS_PASSING, evaluate_story_regression
+
+    stories = tmp_path / "user_stories"
+    tests = tmp_path / "tests"
+    story = _write(stories / "story__refund.md", FRESH_STORY)
+    content_hash = _story_content_hash(FRESH_STORY)
+    # Stale marker FIRST (source order drives AST scan order), fresh SECOND.
+    _write(
+        tests / "test_refund.py",
+        _test_module(
+            _marked("refund", "0000000000000000", "test_refund_stale"),
+            _marked("refund", content_hash, "test_refund_fresh"),
+        ),
+    )
+    smap = build_story_map(tests)
+    ev = evaluate_story_regression(story, tests_dir=tests, story_map=smap)
+    assert ev.status == STATUS_PASSING
+
+
 def test_evaluate_story_regression_stale_on_bogus_marker_kwarg_hash(tmp_path: Path):
     """Direction B (false PASS): a test recording only a bogus ``story_hash=``
     marker kwarg (no module constant) is genuinely stale and must be reported

--- a/tests/test_story_regression_gate.py
+++ b/tests/test_story_regression_gate.py
@@ -531,3 +531,106 @@ def test_evaluate_story_regression_status_never_says_passing(tmp_path: Path):
     ev = evaluate_story_regression(story, tests_dir=tests, story_map=smap)
     assert ev.status == STATUS_PASSING
     assert "pass" not in ev.status
+
+
+# --------------------------------------------------------------------------- #
+# pdd#1889 Bug 1: the wired evaluator must share the full gate's acceptance
+# logic -- accept marker ``story_hash=`` kwargs AND module constants, over the
+# content-hash UNION bundle-hash set -- so it is not wrong in BOTH directions.
+# --------------------------------------------------------------------------- #
+
+
+def test_evaluate_story_regression_accepts_recorded_content_hash(tmp_path: Path):
+    """Direction A (false STALE): a test that records the *content* hash (the
+    form the behavioral generator emits, and the form documented in the module
+    docstring) must be accepted by the wired evaluator even when a contract
+    makes the bundle hash differ -- exactly as the full gate accepts it."""
+    from pdd.story_regression import build_story_map
+    from pdd.story_regression_gate import STATUS_PASSING, evaluate_story_regression
+
+    stories = tmp_path / "user_stories"
+    contracts = stories / "contracts"
+    tests = tmp_path / "tests"
+    story = _write(stories / "story__refund.md", FRESH_STORY)
+    # A contract makes story_bundle_hash != _story_content_hash.
+    _write(contracts / "refund.contract.md", "## Oracle\n\n- Refunds are accepted.\n")
+    content_hash = _story_content_hash(FRESH_STORY)
+    _write(
+        tests / "test_refund.py",
+        _test_module(
+            f'STORY_HASH = "{content_hash}"',
+            '@pytest.mark.story(story_id="refund", story_hash=STORY_HASH)\n'
+            "def test_refund():\n    assert True",
+        ),
+    )
+    smap = build_story_map(tests)
+    ev = evaluate_story_regression(story, tests_dir=tests, story_map=smap)
+    assert ev.status == STATUS_PASSING
+
+
+def test_evaluate_story_regression_stale_on_bogus_marker_kwarg_hash(tmp_path: Path):
+    """Direction B (false PASS): a test recording only a bogus ``story_hash=``
+    marker kwarg (no module constant) is genuinely stale and must be reported
+    stale -- the wired evaluator must not ignore marker kwargs and fall through
+    to the legacy hashless 'present' verdict."""
+    from pdd.story_regression import build_story_map
+    from pdd.story_regression_gate import STATUS_STALE, evaluate_story_regression
+
+    stories = tmp_path / "user_stories"
+    tests = tmp_path / "tests"
+    story = _write(stories / "story__refund.md", FRESH_STORY)
+    _write(
+        tests / "test_refund.py",
+        _test_module(_marked("refund", "0000000000000000", "test_refund")),
+    )
+    smap = build_story_map(tests)
+    ev = evaluate_story_regression(story, tests_dir=tests, story_map=smap)
+    assert ev.status == STATUS_STALE
+
+
+# --------------------------------------------------------------------------- #
+# pdd#1889 Bug 2: a metadata-only prompt relink must not flip the bundle hash,
+# so the gate cannot falsely stale a bundle-recording test after `pdd story link`.
+# --------------------------------------------------------------------------- #
+
+
+def test_metadata_only_relink_does_not_flip_bundle_hash(tmp_path: Path):
+    from pdd.story_regression import build_story_map
+    from pdd.story_regression_gate import STATUS_PASSING, evaluate_story_regression
+    from pdd.story_test_generation import story_bundle_hash
+
+    stories = tmp_path / "user_stories"
+    contracts = stories / "contracts"
+    tests = tmp_path / "tests"
+    story = _write(
+        stories / "story__refund.md",
+        FRESH_STORY + "\n<!-- pdd-story-prompts: pdd/foo.prompt -->\n",
+    )
+    _write(contracts / "refund.contract.md", "## Oracle\n\n- Refunds are accepted.\n")
+
+    before = story_bundle_hash(story)
+    _write(
+        tests / "test_refund.py",
+        _test_module(
+            f'PDD_STORY_HASH = "{before}"',
+            '@pytest.mark.story(story_id="refund")\n'
+            "def test_refund():\n    assert True",
+        ),
+    )
+    smap = build_story_map(tests)
+    assert (
+        evaluate_story_regression(story, tests_dir=tests, story_map=smap).status
+        == STATUS_PASSING
+    )
+
+    # Metadata-only relink: rewrite ONLY the pdd-story-prompts comment.
+    story.write_text(
+        FRESH_STORY + "\n<!-- pdd-story-prompts: pdd/bar.prompt, pdd/baz.prompt -->\n",
+        encoding="utf-8",
+    )
+    after = story_bundle_hash(story)
+    assert after == before, "metadata-only relink must not change the bundle hash"
+    assert (
+        evaluate_story_regression(story, tests_dir=tests, story_map=smap).status
+        == STATUS_PASSING
+    )


### PR DESCRIPTION
Ships a focused correctness sub-PR for the story-regression epic (references PR #1889).

## Root cause — "two of everything"
The epic ships **two hash primitives, two evaluators, two AST scanners** for story-hash freshness, with silently divergent semantics. An adversarial reviewer confirmed all three bugs with reproductions. This PR unifies them so they cannot diverge again.

## Bug 1 (P1) — the only CLI-wired gate uses incompatible hash semantics (wrong in BOTH directions)
`evaluate_story_regression` (the ONLY evaluator wired to a CLI: `pdd checkup coverage --story-regression-gate`) compared **only** `story_bundle_hash` against **only** module-level `STORY_HASH`-constant regex matches, ignoring marker `story_hash=` kwargs — while the full gate `_classify_story_from_markers` accepts content-hash ∪ bundle-hash from kwargs OR constants.
- **Direction A (false STALE):** a test recording the content hash (behavioral generator / documented kwarg form) reported stale when a contract made the bundle hash differ.
- **Direction B (false PASS):** a bogus `story_hash="0000…"` kwarg was never hash-checked and passed.

**Fix:** both evaluators now share `_acceptable_story_hashes` (content ∪ bundle), and `evaluate_story_regression` gathers recorded hashes via the gate's own AST scan (`_recorded_story_hashes`) — resolving marker kwargs AND module constants. Legacy hashless markers stay "present" (#1699 compat); a marker WITH a non-matching hash is stale. The dead `_recorded_hash`/`_HASH_ASSIGN_RE` regex path is removed.

## Bug 2 (P1) — metadata-only relink falsely stales bundle-recording tests
`story_bundle_hash` hashed RAW story text including the `<!-- pdd-story-prompts … -->` / `<!-- pdd-story-dev-units … -->` comments, so `pdd story link` / `story add --update` flipped the bundle hash → false stale.

**Fix:** hash `_normalized_story_for_hash(story) + normalized(contract)` so a metadata-only relink is invariant; the contract stays in the hash. The text-pin generator records `story_bundle_hash` and its inline `_bundle_hash()` reuses the canonical primitive so recorded value and gate check can never drift.

## Bug 3 (P2) — static fallback can't resolve constant-name story_ids
`_scan_story_markers_static` only accepted literal `story_id`s, missing generated `story_id=STORY_ID` / `PDD_STORY_ID` module constants when pytest collection yields zero markers.

**Fix:** the static fallback resolves module-level string constants, mirroring the gate's AST resolver.

## Refreshed seed bundle-hash constants
Only where the normalization changed the value (sync/fix/change already recorded the unchanged content hash):

| story | old | new |
|---|---|---|
| pdd_update | cf0bc4a2189f81bd | af77d101cb8515bd |
| pdd_connect | 941636e0fbab930c | 263eed0bff2eb6f9 |
| pdd_test | 254412e41b69ae19 | 8d7c10cc1b2ca908 |
| pdd_generate | e0e44229295fc640 | e23eb1e50140fe63 |
| pdd_checkup | 213cefce7c9bb9de | c182aa91b22551eb |
| pdd_bug | e04067b53306ba0f | 19e588bbffc02cf1 |
| top_flows pdd_generate | 3660bcd6d6d7e8a8 | e23eb1e50140fe63 |
| top_flows pdd_update | cf0bc4a2189f81bd | af77d101cb8515bd |

## Verification
- New tests red→green (Bug 1 A/B, Bug 2 relink, Bug 3 constant fallback).
- `pytest -m story`: **15 passed**.
- `evaluate_stories` over the repo: **0 stale**, 10 seed stories ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)