### PR TITLE
fix(story): harden story gate discovery, exit safety, and CI summary (pdd#1889 P2s)

### DIFF
--- a/pdd/core/dump.py
+++ b/pdd/core/dump.py
@@ -178,6 +178,15 @@ def _write_core_dump(
     if not ctx.obj.get("core_dump"):
         return
 
+    # Skip the auto-snapshot when the run's only error(s) are deliberate,
+    # user-facing click errors (usage mistakes). Framing a usage mistake as a
+    # reportable "bug" snapshot — and littering .pdd/core_dumps for it — is
+    # noise; genuinely unexpected faults (no ``deliberate`` tag) still snapshot
+    # so real bugs stay debuggable (pdd#1889 C-F8).
+    recorded_errors = get_core_dump_errors()
+    if recorded_errors and all(e.get("deliberate") for e in recorded_errors):
+        return
+
     try:
         core_dump_dir = Path.cwd() / ".pdd" / "core_dumps"
         core_dump_dir.mkdir(parents=True, exist_ok=True)

--- a/pdd/core/errors.py
+++ b/pdd/core/errors.py
@@ -171,6 +171,11 @@ def handle_error(exception: Exception, command_name: str, quiet: bool):
         "traceback": "".join(
             traceback.format_exception(type(exception), exception, exception.__traceback__)
         ),
+        # A click.ClickException is a deliberate, user-facing error (a usage
+        # mistake, e.g. `pdd story link` on a missing file), not a reportable
+        # crash. Tag it so the core-dump writer can skip the auto-snapshot for
+        # it while still snapshotting genuinely unexpected faults (pdd#1889 C-F8).
+        "deliberate": isinstance(exception, click.ClickException),
     }
 
     # For KeyboardInterrupt, enrich with agentic progress context if available

--- a/pdd/story_regression_gate.py
+++ b/pdd/story_regression_gate.py
@@ -46,9 +46,9 @@ from .path_resolution import find_project_root_from_path
 from .story_regression import StoryTestMap, build_story_map
 from .story_test_generation import story_bundle_hash
 from .user_story_tests import (
-    DEFAULT_STORIES_DIR,
     STORY_PREFIX,
     STORY_SUFFIX,
+    _resolve_stories_dir,
     _story_content_hash,
     discover_story_files,
     story_id,
@@ -238,8 +238,59 @@ def _marker_from_decorator(
     )
 
 
+def _pytestmark_markers(
+    body: Sequence[ast.AST],
+    *,
+    test_name: str,
+    test_file: str,
+    constants: Dict[str, str],
+) -> List[StoryMarker]:
+    """Collect story markers declared via a ``pytestmark = pytest.mark.story(...)``
+    assignment in *body* (a module or class body).
+
+    ``pytestmark`` may be a single mark or a list/tuple of marks; a story mark in
+    either form claims every test under the enclosing scope, exactly as pytest
+    applies it at collection time.
+    """
+    found: List[StoryMarker] = []
+    for node in body:
+        if isinstance(node, ast.Assign):
+            targets: Sequence[ast.AST] = node.targets
+            value: Optional[ast.AST] = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+        if value is None:
+            continue
+        if not any(
+            isinstance(t, ast.Name) and t.id == "pytestmark" for t in targets
+        ):
+            continue
+        elts = value.elts if isinstance(value, (ast.List, ast.Tuple)) else [value]
+        for elt in elts:
+            marker = _marker_from_decorator(
+                elt,
+                test_name=test_name,
+                test_file=test_file,
+                lineno=getattr(elt, "lineno", getattr(node, "lineno", 1)),
+                constants=constants,
+            )
+            if marker is not None:
+                found.append(marker)
+    return found
+
+
 def _markers_in_source(source: str, test_file: str) -> List[StoryMarker]:
-    """Parse *source* and return every story marker it declares."""
+    """Parse *source* and return every story marker it declares.
+
+    Covers ``@pytest.mark.story`` decorators on a test function OR class (a class
+    marker propagates to its methods in pytest), plus module-level and
+    class-level ``pytestmark = pytest.mark.story(...)`` assignments. Missing any
+    of these would make the gate report a story ``missing`` while pytest
+    collection (and the coverage path) still see it — an evaluator divergence.
+    """
     try:
         tree = ast.parse(source)
     except SyntaxError:
@@ -247,19 +298,37 @@ def _markers_in_source(source: str, test_file: str) -> List[StoryMarker]:
         return []
     constants = _module_string_constants(tree)
     found: List[StoryMarker] = []
+    # Module-level pytestmark claims every test in the module.
+    found.extend(
+        _pytestmark_markers(
+            getattr(tree, "body", []),
+            test_name="<module>",
+            test_file=test_file,
+            constants=constants,
+        )
+    )
     for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        for deco in node.decorator_list:
-            marker = _marker_from_decorator(
-                deco,
-                test_name=node.name,
-                test_file=test_file,
-                lineno=getattr(deco, "lineno", node.lineno),
-                constants=constants,
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            for deco in node.decorator_list:
+                marker = _marker_from_decorator(
+                    deco,
+                    test_name=node.name,
+                    test_file=test_file,
+                    lineno=getattr(deco, "lineno", node.lineno),
+                    constants=constants,
+                )
+                if marker is not None:
+                    found.append(marker)
+        if isinstance(node, ast.ClassDef):
+            # Class-level pytestmark claims every method of the class.
+            found.extend(
+                _pytestmark_markers(
+                    node.body,
+                    test_name=node.name,
+                    test_file=test_file,
+                    constants=constants,
+                )
             )
-            if marker is not None:
-                found.append(marker)
     return found
 
 
@@ -277,7 +346,10 @@ def discover_story_markers(tests_dir) -> Dict[str, StoryMarker]:
     for py in sorted(base.rglob("*.py")):
         try:
             source = py.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, UnicodeDecodeError):
+            # An unreadable / non-UTF8 test file is skipped like a syntax error,
+            # matching the sibling scanner in ``pdd.story_regression`` — a single
+            # bad file must never crash the whole gate (pdd#1889 G-F3).
             continue
         for marker in sorted(
             _markers_in_source(source, str(py)), key=lambda m: m.lineno
@@ -302,7 +374,10 @@ def discover_all_story_markers(tests_dir) -> Dict[str, List[StoryMarker]]:
     for py in sorted(base.rglob("*.py")):
         try:
             source = py.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, UnicodeDecodeError):
+            # An unreadable / non-UTF8 test file is skipped like a syntax error,
+            # matching the sibling scanner in ``pdd.story_regression`` — a single
+            # bad file must never crash the whole gate (pdd#1889 G-F3).
             continue
         for marker in sorted(
             _markers_in_source(source, str(py)), key=lambda m: m.lineno
@@ -689,10 +764,12 @@ def run_story_regression_gate(
 
     cwd = Path.cwd()
     stories_arg = stories_dir
-    if stories_arg is None:
-        candidate = root / DEFAULT_STORIES_DIR
-        if root.resolve() != cwd.resolve():
-            stories_arg = str(candidate)
+    if stories_arg is None and root.resolve() != cwd.resolve():
+        # Anchor to *root* (not cwd) but still honor PDD_USER_STORIES_DIR, so a
+        # custom stories dir is not silently ignored — which would make strict
+        # mode pass vacuously over zero stories (pdd#1889 G-F7). When root == cwd
+        # we leave it None so evaluate_stories resolves relative to cwd itself.
+        stories_arg = str(_resolve_stories_dir(None, root=root))
     tests_arg = tests_dir
     if tests_arg is None:
         tests_arg = str(root / _DEFAULT_TESTS_DIR)

--- a/pdd/story_test_generation.py
+++ b/pdd/story_test_generation.py
@@ -275,7 +275,13 @@ def generate_story_regression_test(
     # ## Negative Cases as Python expressions over `result` (delegating to
     # story_test_generator). Contracts without an Entry Point fall through to
     # the text-pinning generator below, which pins the story/contract clauses.
-    if md_sections.get("entry point"):
+    # Route on heading PRESENCE, not truthiness: a declared but empty/partial
+    # ## Entry Point must surface the behavioral generator's validation error
+    # (missing `- module:`/`- callable:`) instead of silently degrading to a
+    # text-pin that the user would mistake for a real behavioral oracle
+    # (pdd#1889 C-F7). A contract with no ## Entry Point at all still falls
+    # through to the text-pinning generator below.
+    if "entry point" in md_sections:
         return _generate_behavioral_test(story_path, output)
 
     oracle_text = _section(md_sections, "Oracle", "Acceptance Criteria", "Story")

--- a/pdd/user_story_tests.py
+++ b/pdd/user_story_tests.py
@@ -83,11 +83,19 @@ def _resolve_prompts_dir(prompts_dir: Optional[str] = None) -> Path:
 
 
 def discover_story_files(stories_dir: Optional[str] = None) -> List[Path]:
-    """Discover user story files matching story__*.md in the stories directory."""
+    """Discover user story files matching story__*.md in the stories directory.
+
+    Recursive (``rglob``) so nested layouts (``user_stories/<sub>/story__*.md``)
+    are supported. This is the single shared discovery helper for the gate,
+    ``discover_story_ids`` (orphan detection), and — matching the coverage path's
+    own ``rglob`` lookups — keeps a nested story either fully supported or
+    rejected everywhere, never evaluated by one path yet flagged nonexistent by
+    another (pdd#1889 G-F5). The flat default layout is unaffected.
+    """
     base_dir = _resolve_stories_dir(stories_dir)
     if not base_dir.exists() or not base_dir.is_dir():
         return []
-    return sorted(p for p in base_dir.glob(f"{STORY_PREFIX}*{STORY_SUFFIX}") if p.is_file())
+    return sorted(p for p in base_dir.rglob(f"{STORY_PREFIX}*{STORY_SUFFIX}") if p.is_file())
 
 
 def discover_prompt_files(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -507,17 +507,51 @@ _STORY_RESULTS: dict[str, dict[str, int]] = {}
 def _story_id(item: pytest.Item, marker: pytest.Mark) -> str:
     """Resolve a human-readable story identifier from the ``story`` marker.
 
-    Accepts ``@pytest.mark.story("checkout")``, ``@pytest.mark.story(name=...)``,
-    or ``@pytest.mark.story(id=...)``; falls back to the test's file path so a
-    bare ``@pytest.mark.story`` still groups sensibly per module.
+    Accepts ``@pytest.mark.story("checkout")``, ``@pytest.mark.story(story_id=...)``
+    (the form every generated story test actually uses), ``name=...``, or
+    ``id=...``; falls back to the test's file path so a bare ``@pytest.mark.story``
+    still groups sensibly per module. Without ``story_id`` the summary silently
+    counted files instead of stories (pdd#1889 V-F4).
     """
     if marker.args:
         return str(marker.args[0])
+    if "story_id" in marker.kwargs:
+        return str(marker.kwargs["story_id"])
     if "name" in marker.kwargs:
         return str(marker.kwargs["name"])
     if "id" in marker.kwargs:
         return str(marker.kwargs["id"])
     return item.nodeid.split("::", 1)[0]
+
+
+def _story_report_counts(report) -> bool:
+    """Whether *report* should contribute to the per-story tally.
+
+    Counts the ``call`` phase normally, plus a skip that happens during the
+    ``setup`` phase — a ``@pytest.mark.skip``-decorated story emits only a setup
+    skip and no ``call`` report, so without this it would vanish from the summary
+    entirely (pdd#1889 V-F4). A normal (non-skipped) setup phase is not counted,
+    so passing tests are never double-counted.
+    """
+    if report.when == "call":
+        return True
+    return report.when == "setup" and getattr(report, "skipped", False)
+
+
+def _story_summary_status(counts: dict) -> str:
+    """Render the PASS/FAIL/SKIP verdict for a story's outcome bucket.
+
+    A story that only skipped is SKIP, not PASS — reporting a skip-only story as
+    ``[PASS] ...: 0 passed, 1 skipped`` overstated coverage (pdd#1889 V-F4).
+    """
+    failed = counts.get("failed", 0)
+    passed = counts.get("passed", 0)
+    skipped = counts.get("skipped", 0)
+    if failed:
+        return "FAIL"
+    if passed == 0 and skipped:
+        return "SKIP"
+    return "PASS"
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -539,7 +573,7 @@ def pytest_runtest_makereport(item: pytest.Item, call):
             report.wasxfail = ""
             report.longrepr = f"Skipped: Insufficient credits for cloud LLM call"
 
-    if report.when == "call":
+    if _story_report_counts(report):
         marker = item.get_closest_marker("story")
         if marker is not None:
             bucket = _STORY_RESULTS.setdefault(
@@ -568,7 +602,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config) -> None:
     for story in sorted(_STORY_RESULTS):
         counts = _STORY_RESULTS[story]
         failed = counts.get("failed", 0)
-        status = "PASS" if failed == 0 else "FAIL"
+        status = _story_summary_status(counts)
         detail = f"{counts.get('passed', 0)} passed"
         if failed:
             detail += f", {failed} failed"

--- a/tests/test_core_dump.py
+++ b/tests/test_core_dump.py
@@ -1210,3 +1210,53 @@ def test_gc_runs_even_with_no_core_dump_issue_231(
     call_args = mock_gc.call_args_list[0]
     assert call_args.kwargs.get('keep') == 10 or call_args.args == (10,), \
         "Issue #231: GC should be called with keep=10 by default"
+
+
+# ---------------------------------------------------------------------------
+# C-F8 (pdd#1889): a deliberate click.ClickException must NOT write a core dump
+# ---------------------------------------------------------------------------
+
+@patch('pdd.core.cli.auto_update')
+@patch(
+    'pdd.commands.generate.code_generator_main',
+    side_effect=click.ClickException("deliberate user-facing error"),
+)
+def test_click_exception_writes_no_core_dump(
+    mock_main, mock_auto_update, runner, create_dummy_files, tmp_path, monkeypatch
+):
+    """A ClickException is a deliberate, user-facing error (a usage mistake),
+    not a reportable crash — it must not litter .pdd/core_dumps nor advertise a
+    debug snapshot to attach when reporting bugs."""
+    files = create_dummy_files("test_click_exc.prompt")
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(
+        cli.cli,
+        ["--core-dump", "generate", str(files["test_click_exc.prompt"])],
+    )
+    mock_main.assert_called_once()
+    core_dumps = list((tmp_path / ".pdd" / "core_dumps").glob("pdd-core-*.json"))
+    assert core_dumps == [], (
+        f"ClickException must not write a core dump, found: {core_dumps}"
+    )
+    assert "attach when reporting bugs" not in result.output
+
+
+@patch('pdd.core.cli.auto_update')
+@patch(
+    'pdd.commands.generate.code_generator_main',
+    side_effect=RuntimeError("genuinely unexpected crash"),
+)
+def test_unexpected_exception_still_writes_core_dump(
+    mock_main, mock_auto_update, runner, create_dummy_files, tmp_path, monkeypatch
+):
+    """Control for C-F8: a genuinely unexpected exception still writes a core
+    dump so real bugs remain debuggable."""
+    files = create_dummy_files("test_unexpected_exc.prompt")
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(
+        cli.cli,
+        ["--core-dump", "generate", str(files["test_unexpected_exc.prompt"])],
+    )
+    mock_main.assert_called_once()
+    core_dumps = list((tmp_path / ".pdd" / "core_dumps").glob("pdd-core-*.json"))
+    assert len(core_dumps) == 1, "an unexpected exception must still write a core dump"

--- a/tests/test_coverage_contracts.py
+++ b/tests/test_coverage_contracts.py
@@ -1248,6 +1248,44 @@ class TestStoryRegressionDimension:
         # ...and the no-test gap is the *other* direction, kept distinct:
         assert all("ghost_flow" not in s.story_id for s in result.stories)
 
+    def test_nested_story_is_supported_not_self_contradicted(self, tmp_path: Path):
+        """G-F5 (pdd#1889): a nested ``user_stories/<sub>/story__baz.md`` is
+        linked+evaluated by the coverage path (rglob), so the orphan check must
+        also see it (recursive) — otherwise the SAME run both evaluates ``baz``
+        AND warns it "references a story with no story__baz.md on disk"."""
+        prompt, stories, tests_dir = self._setup(tmp_path, with_test=True)
+        # A metadata-less nested story that applies to the prompt set, plus a
+        # marker test that claims it.
+        (stories / "nested").mkdir(exist_ok=True)
+        _make_story(
+            stories / "nested",
+            """\
+            ## Covers
+            - R1: nested rule
+
+            ## Acceptance Criteria
+            - It works nested.
+            """,
+            name="story__baz.md",
+        )
+        _make_test_file(
+            tests_dir,
+            (
+                "import pytest\n"
+                '@pytest.mark.story(story_id="baz")\n'
+                "def test_baz():\n"
+                "    assert True\n"
+            ),
+            name="test_baz.py",
+        )
+        result = build_coverage(prompt, stories_dir=stories, tests_dir=tests_dir)
+        # baz is evaluated as a real story...
+        assert "baz" in {s.story_id for s in result.stories}
+        # ...so it must NOT be reported as a nonexistent-story orphan.
+        assert not any("baz" in w for w in result.regression_warnings), (
+            f"nested story evaluated AND warned as missing: {result.regression_warnings}"
+        )
+
     def test_directory_mode_shares_one_story_map(self, tmp_path: Path):
         prompts = tmp_path / "prompts"
         prompts.mkdir()

--- a/tests/test_story_regression_gate.py
+++ b/tests/test_story_regression_gate.py
@@ -689,6 +689,7 @@ def test_evaluate_survives_non_utf8_test_file(tmp_path: Path):
     stories = tmp_path / "user_stories"
     tests = tmp_path / "tests"
     _write(stories / "story__refund.md", FRESH_STORY)
+    tests.mkdir(parents=True, exist_ok=True)
     (tests / "test_latin1.py").write_bytes(
         b"# caf\xe9 latin-1\ndef test_x():\n    pass\n"
     )

--- a/tests/test_story_regression_gate.py
+++ b/tests/test_story_regression_gate.py
@@ -662,3 +662,107 @@ def test_metadata_only_relink_does_not_flip_bundle_hash(tmp_path: Path):
         evaluate_story_regression(story, tests_dir=tests, story_map=smap).status
         == STATUS_PASSING
     )
+
+
+# --------------------------------------------------------------------------- #
+# pdd#1889 P2 robustness — gate discovery / exit safety
+# --------------------------------------------------------------------------- #
+
+def test_discover_skips_non_utf8_file_without_crashing(tmp_path: Path):
+    """G-F3: a test file that is not valid UTF-8 must be skipped, not crash the
+    whole scan with a UnicodeDecodeError (a ValueError, not OSError)."""
+    # A latin-1 byte (0xe9 = 'é') that is invalid UTF-8.
+    (tmp_path / "test_latin1.py").write_bytes(
+        b"# caf\xe9 latin-1\ndef test_x():\n    pass\n"
+    )
+    _write(tmp_path / "test_ok.py", _test_module(_marked("alpha", "abc123", "test_alpha")))
+    # Must not raise; the readable marker is still discovered.
+    markers = discover_story_markers(tmp_path)
+    assert set(markers) == {"alpha"}
+    all_markers = discover_all_story_markers(tmp_path)
+    assert set(all_markers) == {"alpha"}
+
+
+def test_evaluate_survives_non_utf8_test_file(tmp_path: Path):
+    """G-F3 end-to-end: evaluate_stories must return a verdict even when an
+    undecodable test file lives in the tests dir."""
+    stories = tmp_path / "user_stories"
+    tests = tmp_path / "tests"
+    _write(stories / "story__refund.md", FRESH_STORY)
+    (tests / "test_latin1.py").write_bytes(
+        b"# caf\xe9 latin-1\ndef test_x():\n    pass\n"
+    )
+    fresh = _story_content_hash(FRESH_STORY)
+    _write(tests / "test_ok.py", _test_module(_marked("refund", fresh, "test_refund")))
+    results = evaluate_stories(stories_dir=str(stories), tests_dir=str(tests))
+    by_id = {r.story_id: r.status for r in results}
+    assert by_id["refund"] == STATUS_STORY_REGRESSION_OK
+
+
+def test_discover_finds_class_level_story_marker(tmp_path: Path):
+    """G-F4: a @pytest.mark.story on a test CLASS (propagates to its methods)
+    must be discovered, not reported missing."""
+    src = (
+        "import pytest\n\n"
+        '@pytest.mark.story(story_id="clsflow", story_hash="clshash00")\n'
+        "class TestClsFlow:\n"
+        "    def test_one(self):\n"
+        "        assert True\n"
+    )
+    _write(tmp_path / "test_cls.py", src)
+    markers = discover_story_markers(tmp_path)
+    assert "clsflow" in markers
+    assert markers["clsflow"].story_hash == "clshash00"
+
+
+def test_discover_finds_module_level_pytestmark_story(tmp_path: Path):
+    """G-F4: a module-level ``pytestmark = pytest.mark.story(...)`` claims every
+    test in the module and must be discovered."""
+    src = (
+        "import pytest\n\n"
+        'pytestmark = pytest.mark.story(story_id="modflow", story_hash="modhash00")\n\n'
+        "def test_one():\n    assert True\n"
+    )
+    _write(tmp_path / "test_mod.py", src)
+    markers = discover_story_markers(tmp_path)
+    assert "modflow" in markers
+    assert markers["modflow"].story_hash == "modhash00"
+
+
+def test_evaluate_discovers_nested_story(tmp_path: Path):
+    """G-F5 (gate side): a story in a nested subdir must be discovered by the
+    gate the same way the coverage path (rglob) already sees it."""
+    stories = tmp_path / "user_stories"
+    tests = tmp_path / "tests"
+    _write(stories / "nested" / "story__baz.md", FRESH_STORY)
+    fresh = _story_content_hash(FRESH_STORY)
+    _write(tests / "test_baz.py", _test_module(_marked("baz", fresh, "test_baz")))
+    results = evaluate_stories(stories_dir=str(stories), tests_dir=str(tests))
+    by_id = {r.story_id: r.status for r in results}
+    assert "baz" in by_id, "nested story must be discovered by the gate"
+    assert by_id["baz"] == STATUS_STORY_REGRESSION_OK
+
+
+def test_gate_honors_stories_dir_env_var_when_root_differs(tmp_path, monkeypatch):
+    """G-F7: when stories_dir is None and project_root != cwd, the gate must
+    still honor PDD_USER_STORIES_DIR instead of hardcoding root/user_stories —
+    otherwise strict mode passes vacuously over zero stories."""
+    root = tmp_path / "project"
+    alt = root / "stories_alt"
+    tests = root / "tests"
+    _write(alt / "story__refund.md", FRESH_STORY)
+    _write(tests / "test_noop.py", "def test_noop():\n    assert True\n")
+
+    # cwd must differ from root to trigger the buggy hardcoded branch.
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    monkeypatch.chdir(outside)
+    monkeypatch.setenv("PDD_USER_STORIES_DIR", "stories_alt")
+
+    result = run_story_regression_gate(
+        project_root=root, mode="strict", scope_to_diff=False
+    )
+    # The story has no marker -> missing -> strict must FAIL (exit 2), not pass.
+    assert result.results, "gate must evaluate the env-var stories dir, not zero stories"
+    assert result.ok is False
+    assert result.exit_code == 2

--- a/tests/test_story_summary_conftest.py
+++ b/tests/test_story_summary_conftest.py
@@ -1,0 +1,66 @@
+"""Tests for the story-regression CI summary harness in ``tests/conftest.py``.
+
+Covers pdd#1889 V-F4: the summary miscounts because ``_story_id`` never looked
+up the ``story_id=`` kwarg (the one every story test actually uses), setup-phase
+skips were dropped, and a skip-only story was reported as PASS.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tests.conftest import (
+    _story_id,
+    _story_report_counts,
+    _story_summary_status,
+)
+
+
+class _FakeMark:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _FakeItem:
+    def __init__(self, nodeid: str):
+        self.nodeid = nodeid
+
+
+def test_story_id_resolves_story_id_kwarg():
+    """V-F4: ``@pytest.mark.story(story_id="checkout")`` must resolve to the
+    story id, not fall back to the file path."""
+    item = _FakeItem("tests/story_regression/test_story_checkout.py::test_it")
+    mark = _FakeMark(story_id="checkout")
+    assert _story_id(item, mark) == "checkout"
+
+
+def test_story_id_still_supports_positional_and_name_and_id():
+    item = _FakeItem("tests/test_x.py::test_it")
+    assert _story_id(item, _FakeMark("pos")) == "pos"
+    assert _story_id(item, _FakeMark(name="named")) == "named"
+    assert _story_id(item, _FakeMark(id="ided")) == "ided"
+
+
+def test_story_id_falls_back_to_file_path_when_bare():
+    item = _FakeItem("tests/story_regression/test_bare.py::test_it")
+    assert _story_id(item, _FakeMark()) == "tests/story_regression/test_bare.py"
+
+
+def test_report_counts_includes_setup_phase_skip():
+    """V-F4: a @pytest.mark.skip-decorated story emits only a *setup*-phase skip
+    (no call report) and must still be tallied, not vanish."""
+    setup_skip = SimpleNamespace(when="setup", skipped=True, failed=False, outcome="skipped")
+    assert _story_report_counts(setup_skip) is True
+    # A normal passing setup phase must NOT be counted (only its call phase is).
+    setup_pass = SimpleNamespace(when="setup", skipped=False, failed=False, outcome="passed")
+    assert _story_report_counts(setup_pass) is False
+    call_pass = SimpleNamespace(when="call", skipped=False, failed=False, outcome="passed")
+    assert _story_report_counts(call_pass) is True
+
+
+def test_summary_status_skip_only_is_skip_not_pass():
+    """V-F4: a story that only skipped must render as SKIP, not PASS."""
+    assert _story_summary_status({"passed": 0, "failed": 0, "skipped": 1}) == "SKIP"
+    assert _story_summary_status({"passed": 1, "failed": 0, "skipped": 1}) == "PASS"
+    assert _story_summary_status({"passed": 2, "failed": 0, "skipped": 0}) == "PASS"
+    assert _story_summary_status({"passed": 1, "failed": 1, "skipped": 0}) == "FAIL"

--- a/tests/test_story_test_generation.py
+++ b/tests/test_story_test_generation.py
@@ -85,6 +85,30 @@ def test_generate_text_pins_when_no_entry_point(tmp_path: Path) -> None:
     assert "result = story_result" not in text
 
 
+def test_empty_entry_point_errors_instead_of_silent_text_pin(tmp_path: Path) -> None:
+    """C-F7 (pdd#1889): a contract that declares ``## Entry Point`` but has an
+    EMPTY body must surface the existing validation error, not silently degrade
+    to a text-pin (which would give the user a false behavioral oracle)."""
+    stories = tmp_path / "user_stories"
+    contracts = stories / "contracts"
+    contracts.mkdir(parents=True)
+    (stories / "story__checkout_total.md").write_text(
+        "# User Story: checkout_total\n\n## Story\n\nAs a shopper, I can see my total.\n",
+        encoding="utf-8",
+    )
+    # ## Entry Point present but with NO `- module:`/`- callable:` body yet.
+    (contracts / "checkout_total.contract.md").write_text(
+        "# Contract\n\n## Covers\n- R1: total\n\n"
+        "## Entry Point\n\n"
+        '## Oracle\n- result["total"] == 3\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Entry Point"):
+        generate_story_regression_test(stories / "story__checkout_total.md")
+    # And it must NOT have silently emitted a text-pin test.
+    assert not (tmp_path / "tests" / "story_regression").exists()
+
+
 def test_generate_story_regression_test_rejects_malformed_story(tmp_path: Path) -> None:
     """A story with no ## Oracle / ## Acceptance Criteria / ## Story clauses must
     raise rather than emit a tautological (self-satisfying) test."""

--- a/tests/test_story_test_generation.py
+++ b/tests/test_story_test_generation.py
@@ -105,8 +105,10 @@ def test_empty_entry_point_errors_instead_of_silent_text_pin(tmp_path: Path) -> 
     )
     with pytest.raises(ValueError, match="Entry Point"):
         generate_story_regression_test(stories / "story__checkout_total.md")
-    # And it must NOT have silently emitted a text-pin test.
-    assert not (tmp_path / "tests" / "story_regression").exists()
+    # And it must NOT have silently emitted a text-pin (or any) test file.
+    regression_dir = tmp_path / "tests" / "story_regression"
+    written = list(regression_dir.glob("*.py")) if regression_dir.exists() else []
+    assert written == [], f"empty Entry Point must not emit a test, wrote: {written}"
 
 
 def test_generate_story_regression_test_rejects_malformed_story(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Robustness hardening for the story-regression gate, story-test generation, core-dump handling, and the CI story summary. Fixes seven confirmed P2s from **#1889** via strict TDD (red tests first, then implementation).

### Fixes (each with a red→green test)

- **G-F3 — non-UTF8 test file crashed the whole gate.** `discover_story_markers` / `discover_all_story_markers` guarded `read_text` with `except OSError` only; a `UnicodeDecodeError` (a `ValueError`) escaped and crashed the gate. Now caught alongside `OSError`, matching the sibling scanner in `pdd/story_regression.py`. The bad file is skipped like a syntax error.
- **G-F4 — class- and module-level markers were invisible to AST discovery.** `_markers_in_source` only inspected function decorators. Now also collects `@pytest.mark.story` on test **classes** and module/class-level `pytestmark = pytest.mark.story(...)` (single or list), reusing the existing kwarg/module-constant resolution. Ends the false-`missing` divergence from pytest collection.
- **G-F5 — recursive vs flat discovery diverged.** The gate + orphan check used a non-recursive `glob` while the coverage path uses `rglob`, so a nested `user_stories/<sub>/story__baz.md` was both evaluated by coverage AND warned "references a story with no story__baz.md on disk" in the same run. `discover_story_files` now uses `rglob` — one shared helper for gate, `discover_story_ids` (orphan detection), and coverage lookup. Flat default layout unaffected.
- **G-F7 — `run_story_regression_gate` ignored `PDD_USER_STORIES_DIR` when `project_root != cwd`.** It hardcoded `root/user_stories`, so a custom stories dir was silently skipped and strict mode passed vacuously over zero stories. Now resolves via `_resolve_stories_dir(None, root=root)`.
- **C-F7 — an empty `## Entry Point` silently degraded to a text-pin.** `generate_story_regression_test` routed on section truthiness; an empty Entry Point fell through to text-pinning with no warning. Now routes on heading **presence**, so an empty/partial Entry Point surfaces the existing validation error.
- **C-F8 — deliberate user errors wrote/advertised a "bug" core dump.** A `click.ClickException` (usage mistake) still wrote `.pdd/core_dumps/pdd-core-*.json` and printed "attach when reporting bugs". `handle_error` now tags deliberate ClickExceptions; `_write_core_dump` skips the snapshot when a run's only error(s) are deliberate. Genuinely unexpected faults still snapshot.
- **V-F4 — the CI Story Regression Summary miscounted.** `conftest._story_id` never looked up `story_id=` (the kwarg every story test uses), so it counted files; setup-phase skips were dropped (`@pytest.mark.skip` stories vanished); a skip-only story reported `PASS`. Now resolves `story_id=`, counts setup-phase skips, and renders skip-only as `SKIP`.

### Verification
- Red→green: all target tests fail on the pre-fix tree and pass after.
- `pytest -m story`: **15 passed**, 10 stories — and the summary now shows real story IDs (`pdd_bug`, `pdd_change`, …) instead of file paths (V-F4).
- `test_story_regression_gate.py`, `test_story_regression.py`, `test_coverage_contracts.py`, `test_story_test_generation.py`: all green.
- E2E via real paths: latin-1 file no crash; class+`pytestmark` discovered; nested story discovered with no self-contradiction; strict gate honors the env var (exit 2, not vacuous 0); empty Entry Point errors + writes no test; `pdd story link` on a missing file writes no core dump while a genuine crash still does.
- pylint on touched modules: only pre-existing warnings (9.92/10).

Refs #1889.

🤖 Generated with [Claude Code](https://claude.com/claude-code)