### PR TITLE
fix(cloud-test): register story marker in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ markers = [
     "timeout: mark a test with a custom timeout in seconds",
     "private_prompt: mark a test as exercising a private prompt fixture not shipped in the public repo",
     "uses_real_cli_detector: mark a test that exercises the real CLI detector instead of a stub",
+    "story(story_id, story_hash): mark a story-backed regression test (deterministic/offline executable oracle for a user story)",
 ]
 filterwarnings = [
     "ignore:.*Pydantic V1 style.*deprecated.*",

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -1,5 +1,6 @@
 import json
 import re
+import tomllib
 from pathlib import Path
 
 
@@ -86,3 +87,12 @@ def test_cloud_batch_image_installs_and_verifies_github_cli():
     assert re.search(r"^\s*gh\s*\\$", dockerfile_text, re.MULTILINE)
     assert '"gh"' in cloudbuild_text
     assert "gh --version" in cloudbuild_text or '["gh", "--version"]' in cloudbuild_text
+
+
+def test_cloud_batch_uploaded_pyproject_registers_story_marker():
+    pyproject = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    markers = pyproject["tool"]["pytest"]["ini_options"]["markers"]
+
+    assert any(marker.startswith("story(") for marker in markers)


### PR DESCRIPTION
## Summary

- Register the `story(story_id, story_hash)` pytest marker in `pyproject.toml`, which is the pytest config Cloud Batch sees because the release-gate source upload does not include `pytest.ini`.
- Add a cloud-batch guard test so uploaded pytest config keeps the story marker registered.

## Repro (before fix)

The PDD CLI release gate failed during Cloud Batch preflight for every task:

```text
FATAL: pytest config or marker registration is broken (exit=2)
' story' not found in markers configuration option
```

The local checkout passed because `pytest.ini` registers `story`; the Cloud Batch source allowlist uploads `pyproject.toml` but not `pytest.ini`.

## Test plan

- [x] `/opt/homebrew/Caskroom/miniforge/base/envs/pdd/bin/python -m pytest tests/test_cloud_batch_job_templates.py -q` (`5 passed`)
- [x] `/opt/homebrew/Caskroom/miniforge/base/envs/pdd/bin/python -m pytest -c pyproject.toml --collect-only --quiet --strict-markers --strict-config tests/ -k __nonexistent__` (expected exit `5`, no marker/config errors)
- [x] Docker release-gate image: `python -m pytest -c pyproject.toml --collect-only --quiet --strict-markers --strict-config tests/ -k __nonexistent__` (expected exit `5`, no marker/config errors)

## Risks / out-of-scope

Low risk. This only registers an existing test marker in the config file used by Cloud Batch. It does not change production code or test selection.