### PR TITLE
Fix cloud test source artifacts

### DIFF
--- a/ci/cloud-batch/submit.sh
+++ b/ci/cloud-batch/submit.sh
@@ -72,6 +72,7 @@ SOURCE_PATHS=(
     data
     prompts
     context
+    user_stories
     examples
     demos
     research

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -96,3 +96,13 @@ def test_cloud_batch_uploaded_pyproject_registers_story_marker():
     markers = pyproject["tool"]["pytest"]["ini_options"]["markers"]
 
     assert any(marker.startswith("story(") for marker in markers)
+
+
+def test_cloud_batch_uploaded_source_includes_story_artifacts():
+    submit_text = (REPO_ROOT / "ci" / "cloud-batch" / "submit.sh").read_text(
+        encoding="utf-8"
+    )
+    source_paths = re.search(r"SOURCE_PATHS=\((.*?)\)", submit_text, re.DOTALL)
+    assert source_paths, "submit.sh must define SOURCE_PATHS"
+
+    assert re.search(r"^\s*user_stories\s*$", source_paths.group(1), re.MULTILINE)

--- a/tests/test_story_regression.py
+++ b/tests/test_story_regression.py
@@ -16,11 +16,12 @@ R7  ``has_regression_test`` predicate True/False -> TestHasRegressionTest.
 R8  MUST NOT execute test bodies / no e2e side effects -> TestNoExecution.
 R9  Graceful degradation (absent tests dir, unparseable module) -> TestGracefulDegradation.
 Marker registration: ``pytest -m story`` selects exactly story-backed tests
-    -> TestMarkerSelection; pytest.ini registers the marker -> TestMarkerRegistration.
+    -> TestMarkerSelection; pyproject.toml registers the marker -> TestMarkerRegistration.
 Default-map plumbing (set/reset + bare module-level resolvers) -> TestDefaultMap.
 """
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -349,10 +350,15 @@ class TestGracefulDegradation:
 # --- marker registration / selection -------------------------------------------
 
 class TestMarkerRegistration:
-    def test_pytest_ini_registers_story_marker(self):
-        ini = Path(__file__).resolve().parents[1] / "pytest.ini"
-        text = ini.read_text(encoding="utf-8")
-        assert "story(story_id, story_hash):" in text
+    def test_pyproject_registers_story_marker(self):
+        pyproject = tomllib.loads(
+            (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(
+                encoding="utf-8"
+            )
+        )
+        markers = pyproject["tool"]["pytest"]["ini_options"]["markers"]
+
+        assert any(marker.startswith("story(") for marker in markers)
 
 
 class TestMarkerSelection:


### PR DESCRIPTION
## Summary
- include tracked user story artifacts in the Cloud Batch source upload
- assert the Batch upload source contract includes user_stories
- update the story marker registration test to read the active pyproject pytest config

## Test plan
- python -m pytest tests/test_cloud_batch_job_templates.py tests/test_story_regression.py::TestMarkerRegistration -q
- python -m pytest -c pyproject.toml tests/test_story_backfill_cross_unit_flows.py::test_cross_unit_story_backfill_artifacts_are_complete tests/test_story_backfill_top_flows.py::test_top_flow_story_backfill_artifacts_are_complete tests/test_story_backfill_unit_like_flows.py::test_unit_like_story_backfill_artifacts_are_complete -q