### PR TITLE
fix(cloud-test): serialize cloud auth regression shards

### DIFF
--- a/ci/cloud-batch/collect-results.sh
+++ b/ci/cloud-batch/collect-results.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 
 # ── Arguments ──────────────────────────────────────────────────────────────
-PROJECT_ID="${1:?Usage: collect-results.sh PROJECT_ID BUCKET JOB_RUN_ID JOB_NAME_SPOT [JOB_NAME_STD]}"
+PROJECT_ID="${1:?Usage: collect-results.sh PROJECT_ID BUCKET JOB_RUN_ID JOB_NAME_SPOT [JOB_NAME_STD ...]}"
 BUCKET="${2:?}"
 JOB_RUN_ID="${3:?}"
 JOB_NAME="${4:?}"           # primary (spot) job
-JOB_NAME_STD="${5:-}"       # optional standard job
+shift 4
+EXTRA_JOB_NAMES=("$@")
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -37,7 +38,7 @@ PASSED=0
 FAILED=0
 ERRORS=0
 
-# Derive task count from Cloud Batch job(s) (sum across spot + standard)
+# Derive task count from Cloud Batch job(s) (sum across primary + extras)
 _job_task_count() {
     gcloud batch jobs describe "$1" \
         --project="${PROJECT_ID}" \
@@ -46,13 +47,14 @@ _job_task_count() {
 }
 TOTAL_SPOT=$(_job_task_count "${JOB_NAME}")
 TOTAL_SPOT=${TOTAL_SPOT:-0}
-TOTAL_STD=0
-if [ -n "${JOB_NAME_STD}" ]; then
-    TOTAL_STD=$(_job_task_count "${JOB_NAME_STD}")
-    TOTAL_STD=${TOTAL_STD:-0}
-fi
-TOTAL=$((TOTAL_SPOT + TOTAL_STD))
-[ "${TOTAL}" -eq 0 ] && TOTAL=75
+TOTAL_EXTRA=0
+for _job_name in "${EXTRA_JOB_NAMES[@]}"; do
+    _job_count=$(_job_task_count "${_job_name}")
+    _job_count=${_job_count:-0}
+    TOTAL_EXTRA=$((TOTAL_EXTRA + _job_count))
+done
+TOTAL=$((TOTAL_SPOT + TOTAL_EXTRA))
+[ "${TOTAL}" -eq 0 ] && TOTAL=77
 
 # Parse all JSON results
 TABLE_ROWS=()
@@ -104,7 +106,11 @@ done
 {
     echo "# Cloud Batch Test Results"
     echo ""
-    echo "- **Job**: ${JOB_NAME}${JOB_NAME_STD:+ + ${JOB_NAME_STD}}"
+    JOB_LABEL="${JOB_NAME}"
+    for _job_name in "${EXTRA_JOB_NAMES[@]}"; do
+        JOB_LABEL="${JOB_LABEL} + ${_job_name}"
+    done
+    echo "- **Job**: ${JOB_LABEL}"
     echo "- **Commit**: ${COMMIT_SHA}"
     echo "- **Timestamp**: ${TIMESTAMP}"
     echo ""

--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -3,10 +3,24 @@ set -euo pipefail
 
 # ── Configuration ──────────────────────────────────────────────────────────
 # Support multi-group jobs: FIXED_TASK_INDEX overrides BATCH_TASK_INDEX
-# (used by the STANDARD group for slow tasks). SKIP_INDEX causes the SPOT
-# group to skip one index so effective indices stay contiguous.
+# (used by dedicated STANDARD groups), TASK_INDEX_OFFSET maps a serial group
+# onto a contiguous task range, and SKIP_INDEXES lets the main group skip
+# dedicated task indexes while preserving the global task numbering.
 if [ -n "${FIXED_TASK_INDEX:-}" ]; then
     TASK_INDEX="${FIXED_TASK_INDEX}"
+elif [ -n "${TASK_INDEX_OFFSET:-}" ]; then
+    _RAW="${BATCH_TASK_INDEX:?BATCH_TASK_INDEX not set}"
+    TASK_INDEX=$((_RAW + TASK_INDEX_OFFSET))
+elif [ -n "${SKIP_INDEXES:-}" ]; then
+    _RAW="${BATCH_TASK_INDEX:?BATCH_TASK_INDEX not set}"
+    TASK_INDEX="${_RAW}"
+    IFS=',' read -r -a _SKIP_INDEXES <<< "${SKIP_INDEXES}"
+    for _SKIP_INDEX in "${_SKIP_INDEXES[@]}"; do
+        [ -n "${_SKIP_INDEX}" ] || continue
+        if [ "${_SKIP_INDEX}" -le "${TASK_INDEX}" ]; then
+            TASK_INDEX=$((TASK_INDEX + 1))
+        fi
+    done
 elif [ -n "${SKIP_INDEX:-}" ]; then
     _RAW="${BATCH_TASK_INDEX:?BATCH_TASK_INDEX not set}"
     if [ "${_RAW}" -ge "${SKIP_INDEX}" ]; then

--- a/ci/cloud-batch/job-template-cloud-regression.json
+++ b/ci/cloud-batch/job-template-cloud-regression.json
@@ -13,7 +13,7 @@
                                 "VERTEX_PROJECT": "{{PROJECT_ID}}",
                                 "PDD_TEST_HEADLESS": "1",
                                 "GCS_BUCKET_NAME": "litellm_cache",
-                                "SKIP_INDEXES": "54,68,69,70,71,72,73,74,75",
+                                "TASK_INDEX_OFFSET": "68",
                                 "PDD_CLOUD_URL": "https://{{REGION}}-{{PROJECT_ID}}.cloudfunctions.net",
                                 "PDD_ENV": "staging",
                                 "PDD_CLOUD_TIMEOUT": "1200",
@@ -45,7 +45,7 @@
                         "mountPath": "/mnt/disks/source"
                     }
                 ],
-                "maxRetryCount": 3,
+                "maxRetryCount": 2,
                 "maxRunDuration": "5400s",
                 "lifecyclePolicies": [
                     {
@@ -56,8 +56,8 @@
                     }
                 ]
             },
-            "taskCount": "68",
-            "parallelism": "68"
+            "taskCount": "8",
+            "parallelism": "1"
         }
     ],
     "allocationPolicy": {
@@ -65,7 +65,7 @@
             {
                 "policy": {
                     "machineType": "e2-standard-8",
-                    "provisioningModel": "{{SPOT_PROVISIONING_MODEL}}"
+                    "provisioningModel": "STANDARD"
                 }
             }
         ],

--- a/ci/cloud-batch/submit.sh
+++ b/ci/cloud-batch/submit.sh
@@ -177,13 +177,16 @@ _render_template() {
 
 _render_template "${SCRIPT_DIR}/job-template.json" /tmp/pdd-batch-job-spot.json
 _render_template "${SCRIPT_DIR}/job-template-standard.json" /tmp/pdd-batch-job-std.json
+_render_template "${SCRIPT_DIR}/job-template-cloud-regression.json" /tmp/pdd-batch-job-cloud.json
 
 # ── Submit jobs ───────────────────────────────────────────────────────────
-# Main job (76 tasks — everything except the slow sync_regression case_1).
+# Main job (68 tasks — everything except the slow sync_regression case_1 and
+# the cloud-regression shards, which run serially to avoid Firebase refresh
+# token exchange quota spikes).
 # It defaults to SPOT for normal cloud-test runs, but release gates can opt into
 # STANDARD with PDD_CLOUD_BATCH_SPOT_PROVISIONING_MODEL=STANDARD.
 JOB_NAME_SPOT="${JOB_NAME}"
-echo "=== Submitting ${SPOT_PROVISIONING_MODEL} job: ${JOB_NAME_SPOT} (76 tasks) ==="
+echo "=== Submitting ${SPOT_PROVISIONING_MODEL} job: ${JOB_NAME_SPOT} (68 tasks) ==="
 gcloud batch jobs submit "${JOB_NAME_SPOT}" \
     --project="${PROJECT_ID}" \
     --location="${REGION}" \
@@ -197,15 +200,24 @@ gcloud batch jobs submit "${JOB_NAME_STD}" \
     --location="${REGION}" \
     --config=/tmp/pdd-batch-job-std.json
 
-rm /tmp/pdd-batch-job-spot.json /tmp/pdd-batch-job-std.json
+# STANDARD serial job for cloud_regression cases. These all exchange the same
+# Firebase refresh token; parallel exchange hits quota even with jitter.
+JOB_NAME_CLOUD="${JOB_NAME}-cloud"
+echo "=== Submitting STANDARD serial cloud-regression job: ${JOB_NAME_CLOUD} (8 tasks) ==="
+gcloud batch jobs submit "${JOB_NAME_CLOUD}" \
+    --project="${PROJECT_ID}" \
+    --location="${REGION}" \
+    --config=/tmp/pdd-batch-job-cloud.json
 
-# ── Poll for completion (both jobs) ───────────────────────────────────────
+rm /tmp/pdd-batch-job-spot.json /tmp/pdd-batch-job-std.json /tmp/pdd-batch-job-cloud.json
+
+# ── Poll for completion (all jobs) ────────────────────────────────────────
 echo "=== Polling for completion (${POLL_INTERVAL}s intervals, ${POLL_TIMEOUT}s timeout) ==="
 ELAPSED=0
 STREAMING_DIR=$(mktemp -d)
 trap 'rm -rf "${STREAMING_DIR}"; cleanup_leaked_gcloud_workers' EXIT
 
-TOTAL=77  # 76 (spot) + 1 (standard)
+TOTAL=77  # 68 (main) + 1 (standard slow sync) + 8 (serial cloud regression)
 STREAM_FAILURES=0
 
 _job_status() {
@@ -218,6 +230,7 @@ _job_status() {
 while [ "${ELAPSED}" -lt "${POLL_TIMEOUT}" ]; do
     STATUS_SPOT=$(_job_status "${JOB_NAME_SPOT}")
     STATUS_STD=$(_job_status "${JOB_NAME_STD}")
+    STATUS_CLOUD=$(_job_status "${JOB_NAME_CLOUD}")
 
     # ── Stream completed task results ─────────────────────────────────
     _with_timeout 15 gcloud storage cp --quiet "gs://${BUCKET}/${JOB_RUN_ID}/results/task_*.json" "${STREAMING_DIR}/" 2>/dev/null || true
@@ -266,31 +279,31 @@ while [ "${ELAPSED}" -lt "${POLL_TIMEOUT}" ]; do
 
     # ── Progress line ─────────────────────────────────────────────────
     if [ "${STREAM_FAILURES}" -gt 0 ]; then
-        echo "[$(date +%H:%M:%S)] SPOT: ${STATUS_SPOT} | STD: ${STATUS_STD} | ${COMPLETED}/${TOTAL} complete (${STREAM_FAILURES} failed) (${ELAPSED}s elapsed)"
+        echo "[$(date +%H:%M:%S)] SPOT: ${STATUS_SPOT} | STD: ${STATUS_STD} | CLOUD: ${STATUS_CLOUD} | ${COMPLETED}/${TOTAL} complete (${STREAM_FAILURES} failed) (${ELAPSED}s elapsed)"
     else
-        echo "[$(date +%H:%M:%S)] SPOT: ${STATUS_SPOT} | STD: ${STATUS_STD} | ${COMPLETED}/${TOTAL} complete (${ELAPSED}s elapsed)"
+        echo "[$(date +%H:%M:%S)] SPOT: ${STATUS_SPOT} | STD: ${STATUS_STD} | CLOUD: ${STATUS_CLOUD} | ${COMPLETED}/${TOTAL} complete (${ELAPSED}s elapsed)"
     fi
 
     # ── Check terminal states ─────────────────────────────────────────
-    # Both jobs must reach a terminal state before we exit
+    # All jobs must reach a terminal state before we exit
     _is_terminal() { [[ "$1" == "SUCCEEDED" || "$1" == "FAILED" ]]; }
 
-    if _is_terminal "${STATUS_SPOT}" && _is_terminal "${STATUS_STD}"; then
-        if [ "${STATUS_SPOT}" = "SUCCEEDED" ] && [ "${STATUS_STD}" = "SUCCEEDED" ]; then
-            echo "=== Both jobs completed successfully ==="
+    if _is_terminal "${STATUS_SPOT}" && _is_terminal "${STATUS_STD}" && _is_terminal "${STATUS_CLOUD}"; then
+        if [ "${STATUS_SPOT}" = "SUCCEEDED" ] && [ "${STATUS_STD}" = "SUCCEEDED" ] && [ "${STATUS_CLOUD}" = "SUCCEEDED" ]; then
+            echo "=== All jobs completed successfully ==="
             bash "${SCRIPT_DIR}/collect-results.sh" \
-                "${PROJECT_ID}" "${BUCKET}" "${JOB_RUN_ID}" "${JOB_NAME_SPOT}" "${JOB_NAME_STD}"
+                "${PROJECT_ID}" "${BUCKET}" "${JOB_RUN_ID}" "${JOB_NAME_SPOT}" "${JOB_NAME_STD}" "${JOB_NAME_CLOUD}"
             exit 0
         else
-            echo "=== Job(s) FAILED (spot=${STATUS_SPOT}, std=${STATUS_STD}) ==="
+            echo "=== Job(s) FAILED (spot=${STATUS_SPOT}, std=${STATUS_STD}, cloud=${STATUS_CLOUD}) ==="
             bash "${SCRIPT_DIR}/collect-results.sh" \
-                "${PROJECT_ID}" "${BUCKET}" "${JOB_RUN_ID}" "${JOB_NAME_SPOT}" "${JOB_NAME_STD}"
+                "${PROJECT_ID}" "${BUCKET}" "${JOB_RUN_ID}" "${JOB_NAME_SPOT}" "${JOB_NAME_STD}" "${JOB_NAME_CLOUD}"
             exit 1
         fi
     fi
 
     # Bail on unexpected states
-    for _s in "${STATUS_SPOT}" "${STATUS_STD}"; do
+    for _s in "${STATUS_SPOT}" "${STATUS_STD}" "${STATUS_CLOUD}"; do
         case "${_s}" in
             DELETION_IN_PROGRESS|STATE_UNSPECIFIED)
                 echo "=== Job in unexpected state: ${_s} ==="
@@ -307,4 +320,5 @@ echo "=== TIMEOUT after ${POLL_TIMEOUT}s ==="
 echo "Jobs still running. Check manually:"
 echo "  gcloud batch jobs describe ${JOB_NAME_SPOT} --project=${PROJECT_ID} --location=${REGION}"
 echo "  gcloud batch jobs describe ${JOB_NAME_STD} --project=${PROJECT_ID} --location=${REGION}"
+echo "  gcloud batch jobs describe ${JOB_NAME_CLOUD} --project=${PROJECT_ID} --location=${REGION}"
 exit 1

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -213,8 +213,9 @@ def test_cli_command_help(runner):
 @patch('pdd.core.cli.auto_update')
 @patch('pdd.commands.generate.code_generator_main')
 @patch('pdd.cli.construct_paths')
-def test_cli_global_options_defaults(mock_construct, mock_main, mock_auto_update, runner, create_dummy_files):
+def test_cli_global_options_defaults(mock_construct, mock_main, mock_auto_update, runner, create_dummy_files, monkeypatch):
     """Test default global options are passed in context."""
+    monkeypatch.delenv("PDD_FORCE_LOCAL", raising=False)
     files = create_dummy_files("test.prompt")
     mock_main.return_value = ('code', False, 0.0, 'model')
     

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -24,7 +24,11 @@ def _setup_secret_names() -> set[str]:
 
 
 def test_cloud_batch_templates_route_cloud_regression_to_staging():
-    for template_name in ("job-template.json", "job-template-standard.json"):
+    for template_name in (
+        "job-template.json",
+        "job-template-standard.json",
+        "job-template-cloud-regression.json",
+    ):
         environment = _template_variables(template_name)
         variables = environment["variables"]
         secrets = environment["secretVariables"]
@@ -44,7 +48,11 @@ def test_cloud_batch_templates_route_cloud_regression_to_staging():
 def test_cloud_batch_template_secrets_are_provisioned_by_setup_script():
     setup_secrets = _setup_secret_names()
 
-    for template_name in ("job-template.json", "job-template-standard.json"):
+    for template_name in (
+        "job-template.json",
+        "job-template-standard.json",
+        "job-template-cloud-regression.json",
+    ):
         environment = _template_variables(template_name)
         secret_paths = environment["secretVariables"].values()
         template_secrets = {
@@ -74,6 +82,36 @@ def test_spot_template_provisioning_model_is_release_gate_overridable():
     )
     assert "PDD_CLOUD_BATCH_SPOT_PROVISIONING_MODEL" in submit_text
     assert "{{SPOT_PROVISIONING_MODEL}}" in submit_text
+
+
+def test_cloud_batch_runs_cloud_regression_serially():
+    spot_template_path = REPO_ROOT / "ci" / "cloud-batch" / "job-template.json"
+    spot_template = json.loads(spot_template_path.read_text(encoding="utf-8"))
+    spot_group = spot_template["taskGroups"][0]
+    spot_vars = spot_group["taskSpec"]["runnables"][0]["environment"]["variables"]
+
+    assert spot_group["taskCount"] == "68"
+    assert spot_group["parallelism"] == "68"
+    assert spot_vars["SKIP_INDEXES"] == "54,68,69,70,71,72,73,74,75"
+
+    cloud_template_path = (
+        REPO_ROOT / "ci" / "cloud-batch" / "job-template-cloud-regression.json"
+    )
+    cloud_template = json.loads(cloud_template_path.read_text(encoding="utf-8"))
+    cloud_group = cloud_template["taskGroups"][0]
+    cloud_policy = cloud_template["allocationPolicy"]["instances"][0]["policy"]
+    cloud_vars = cloud_group["taskSpec"]["runnables"][0]["environment"]["variables"]
+
+    assert cloud_group["taskCount"] == "8"
+    assert cloud_group["parallelism"] == "1"
+    assert cloud_vars["TASK_INDEX_OFFSET"] == "68"
+    assert cloud_policy["provisioningModel"] == "STANDARD"
+
+    submit_text = (REPO_ROOT / "ci" / "cloud-batch" / "submit.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "job-template-cloud-regression.json" in submit_text
+    assert "JOB_NAME_CLOUD" in submit_text
 
 
 def test_cloud_batch_image_installs_and_verifies_github_cli():
@@ -133,3 +171,13 @@ def test_cloud_batch_entrypoint_forces_pytest_shards_local_by_default():
     assert pytest_branch, "entrypoint.sh must keep an explicit pytest shard branch"
     assert "PDD_FORCE_LOCAL=1" in pytest_branch.group(0)
     assert "unset PDD_JWT_TOKEN" in pytest_branch.group(0)
+
+
+def test_cloud_batch_entrypoint_maps_skipped_and_offset_task_indexes():
+    entrypoint_text = (
+        REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "TASK_INDEX_OFFSET" in entrypoint_text
+    assert "SKIP_INDEXES" in entrypoint_text
+    assert 'IFS=\',\' read -r -a _SKIP_INDEXES' in entrypoint_text

--- a/tests/test_commands_maintenance.py
+++ b/tests/test_commands_maintenance.py
@@ -90,8 +90,10 @@ def test_sync_without_basename_dispatches_global_sync(
     mock_sync_main,
     mock_auto_update,
     runner,
+    monkeypatch,
 ):
     """No-argument `pdd sync` should run global architecture sync."""
+    monkeypatch.delenv("PDD_FORCE_LOCAL", raising=False)
     mock_global_sync.return_value = (True, "Global sync dry run: 1 module(s) would sync.", 0.0, "global-sync")
 
     result = runner.invoke(cli.cli, ["sync", "--dry-run"])


### PR DESCRIPTION
## Summary
- split cloud_regression tasks into a dedicated STANDARD Batch job with parallelism=1 to avoid Firebase refresh-token quota spikes
- keep the main Batch job parallel by skipping task 54 and cloud tasks 68-75, while preserving global task numbering
- let collect-results sum multiple Batch jobs and isolate PDD_FORCE_LOCAL-sensitive default-option tests

## Release-gate failure addressed
- make test-pdd-cli-release on b584d711a failed in staging with 67 passed, 2 failed, 8 errors
- all 8 errors were cloud_regression JWT exchange QUOTA_EXCEEDED failures
- the 2 pytest failures were default local-mode assertions under the Batch PDD_FORCE_LOCAL guard

## Validation
- bash -n ci/cloud-batch/entrypoint.sh && bash -n ci/cloud-batch/submit.sh && bash -n ci/cloud-batch/collect-results.sh
- PDD_FORCE_LOCAL=1 python -m pytest tests/test_cloud_batch_job_templates.py tests/core/test_cli.py::test_cli_global_options_defaults tests/test_commands_maintenance.py::test_sync_without_basename_dispatches_global_sync -q
- python -m json.tool ci/cloud-batch/job-template.json/job-template-standard.json/job-template-cloud-regression.json
- manual shell check: raw indexes 53,54,66,67 map to 53,55,67,76