### PR TITLE
fix(sync): add trusted Jest verification adapter

### DIFF
--- a/pdd/commands/sync_core.py
+++ b/pdd/commands/sync_core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -37,6 +38,7 @@ from ..sync_core import (
     signer_from_environment,
 )
 from ..sync_core.git_io import resolve_git_commit
+from ..sync_core.runner import RunnerConfig
 from .. import __version__
 
 
@@ -137,6 +139,47 @@ def _load_nightly_observation(path: Path | None) -> NightlyObservation | None:
         payload["post_canary_rerun_writes"],
     )
     return observation
+
+
+def _protected_command(value: str | None, option: str, cwd: Path) -> tuple[str, ...] | None:
+    """Parse a protected validator argv and reject candidate-local path inputs."""
+    if value is None or not value.strip():
+        return None
+    try:
+        command = tuple(shlex.split(value))
+    except ValueError as exc:
+        raise click.ClickException(f"{option} is malformed") from exc
+    if not command:
+        return None
+    first = Path(command[0]).expanduser()
+    if not first.is_absolute():
+        raise click.ClickException(f"{option} must start with an absolute executable path")
+    root = cwd.resolve()
+    for part in command:
+        path = Path(part).expanduser()
+        if not path.is_absolute() and "/" not in part:
+            continue
+        resolved = path.resolve() if path.is_absolute() else (root / path).resolve()
+        try:
+            resolved.relative_to(root)
+        except ValueError:
+            continue
+        raise click.ClickException(f"{option} must not reference the candidate checkout")
+    return command
+
+
+def _runner_config_from_options(
+    options: dict[str, object], cwd: Path
+) -> RunnerConfig:
+    """Build trusted validator configuration from protected CLI/env options."""
+    jest_command = options.get("jest_command")
+    return RunnerConfig(
+        jest_command=_protected_command(
+            jest_command if isinstance(jest_command, str) else None,
+            "--jest-command",
+            cwd,
+        )
+    )
 
 
 @click.command("certify")
@@ -370,16 +413,32 @@ def baseline(ctx: click.Context, module: str, reviewed_by: str, reason: str) -> 
 @click.option("--module", required=True, help="Exact repository-relative prompt path.")
 @click.option("--base-ref", required=True, help="Protected base commit or ref.")
 @click.option("--head-ref", default="HEAD", show_default=True)
+@click.option(
+    "--jest-command",
+    envvar="PDD_SYNC_JEST_COMMAND",
+    help="Protected absolute external Jest command argv.",
+)
 @click.pass_context
-def validate(ctx: click.Context, module: str, base_ref: str, head_ref: str) -> None:
+def validate(
+    ctx: click.Context,
+    module: str,
+    base_ref: str,
+    head_ref: str,
+    jest_command: str | None,
+) -> None:
     """Run protected obligations and transactionally finalize trusted evidence."""
     ctx.ensure_object(dict)
+    root = Path.cwd().resolve()
     result = finalize_unit(
-        Path.cwd(),
+        root,
         PurePosixPath(module),
         base_ref=base_ref,
         head_ref=head_ref,
         signer=attestation_signer_from_environment(),
+        config=_runner_config_from_options(
+            {"jest_command": jest_command},
+            root,
+        ),
     )
     click.echo(
         json.dumps(

--- a/pdd/commands/sync_core.py
+++ b/pdd/commands/sync_core.py
@@ -38,7 +38,7 @@ from ..sync_core import (
     signer_from_environment,
 )
 from ..sync_core.git_io import resolve_git_commit
-from ..sync_core.runner import RunnerConfig
+from ..sync_core.runner import RunnerConfig, _protected_command_error
 from .. import __version__
 
 
@@ -151,20 +151,9 @@ def _protected_command(value: str | None, option: str, cwd: Path) -> tuple[str, 
         raise click.ClickException(f"{option} is malformed") from exc
     if not command:
         return None
-    first = Path(command[0]).expanduser()
-    if not first.is_absolute():
-        raise click.ClickException(f"{option} must start with an absolute executable path")
-    root = cwd.resolve()
-    for part in command:
-        path = Path(part).expanduser()
-        if not path.is_absolute() and "/" not in part:
-            continue
-        resolved = path.resolve() if path.is_absolute() else (root / path).resolve()
-        try:
-            resolved.relative_to(root)
-        except ValueError:
-            continue
-        raise click.ClickException(f"{option} must not reference the candidate checkout")
+    error = _protected_command_error(cwd, command)
+    if error is not None:
+        raise click.ClickException(f"{option}: {error}")
     return command
 
 

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -31,7 +31,7 @@ from .trust import (
     AttestationIssuer,
     AttestationRequest,
 )
-from .isolation import SECRET_ENV_MARKERS, untrusted_child_environment
+from .isolation import untrusted_child_environment
 from .git_io import read_git_blob
 from .types import (
     EvidenceOutcome,
@@ -603,18 +603,71 @@ def _jest_config_references(config: object) -> set[PurePosixPath]:
     return references
 
 
+def _javascript_syntax_mask(text: str) -> str:
+    """Blank JS comments and string bodies while preserving quote boundaries."""
+    masked = list(text)
+    index = 0
+    while index < len(text):
+        if text.startswith("//", index):
+            end = text.find("\n", index)
+            end = len(text) if end < 0 else end
+            masked[index:end] = " " * (end - index)
+            index = end
+            continue
+        if text.startswith("/*", index):
+            end = text.find("*/", index + 2)
+            end = len(text) if end < 0 else end + 2
+            masked[index:end] = " " * (end - index)
+            index = end
+            continue
+        if text[index] in {'"', "'", "`"}:
+            quote = text[index]
+            index += 1
+            while index < len(text):
+                if text[index] == "\\":
+                    masked[index] = " "
+                    if index + 1 < len(text):
+                        masked[index + 1] = " "
+                    index += 2
+                    continue
+                if text[index] == quote:
+                    break
+                masked[index] = " "
+                index += 1
+            index += 1
+            continue
+        index += 1
+    return "".join(masked)
+
+
 def _local_javascript_imports(
     root: Path, ref: str, source_path: PurePosixPath, source: bytes
 ) -> set[PurePosixPath]:
-    """Resolve literal relative JS imports without executing candidate modules."""
+    """Resolve literal local JS imports and reject unresolved dynamic loads."""
     try:
         text = source.decode("utf-8")
-    except UnicodeDecodeError:
-        return set()
-    imports = re.findall(
-        r"(?:from\s+|import\s*\(|import\s+|require\s*\()['\"](\.{1,2}/[^'\"]+)['\"]",
-        text,
+    except UnicodeDecodeError as exc:
+        raise ValueError(
+            f"Jest support module is not UTF-8: {source_path.as_posix()}"
+        ) from exc
+    mask = _javascript_syntax_mask(text)
+    dynamic_load = re.search(
+        r"(?<![.\w$])(?:require|import)\s*\(\s*(?!['\"])", mask
     )
+    if dynamic_load is not None:
+        raise ValueError(
+            "dynamic local require/import is not bound by the Jest adapter: "
+            + source_path.as_posix()
+        )
+    import_pattern = re.compile(
+        r"(?:from\s+|import\s*\(|import\s+|require\s*\()['\"]"
+        r"(\.{1,2}/[^'\"]+)['\"]"
+    )
+    imports = [
+        match.group(1)
+        for match in import_pattern.finditer(text)
+        if not mask[match.start()].isspace()
+    ]
     resolved: set[PurePosixPath] = set()
     for item in imports:
         candidate = _normalize_repo_relative_path(
@@ -668,12 +721,16 @@ def _read_javascript_support_blob(
 
 
 def _jest_support_closure(
-    root: Path, ref: str, test_paths: tuple[PurePosixPath, ...]
+    root: Path,
+    ref: str,
+    test_paths: tuple[PurePosixPath, ...],
+    code_under_test_paths: tuple[PurePosixPath, ...] = (),
 ) -> tuple[tuple[PurePosixPath, bytes], ...]:
     """Return static config and transitive local Jest support modules."""
     config_path, config = _jest_config(root, ref)
     paths = {config_path}
     pending = list(test_paths) + list(_jest_config_references(config))
+    product_paths = set(code_under_test_paths)
     visited: set[PurePosixPath] = set()
     while pending:
         path = pending.pop()
@@ -692,7 +749,8 @@ def _jest_support_closure(
             if path.name == "package.json" and isinstance(nested_config, dict):
                 nested_config = nested_config.get("jest", {})
             pending.extend(_jest_config_references(nested_config) - visited)
-        pending.extend(_local_javascript_imports(root, ref, path, source) - visited)
+        imports = _local_javascript_imports(root, ref, path, source)
+        pending.extend(imports - visited - product_paths)
     return tuple(
         (path, read_git_blob(root, ref, path))
         for path in sorted(paths)
@@ -701,11 +759,16 @@ def _jest_support_closure(
 
 
 def jest_validator_config_digest(
-    root: Path, ref: str, test_paths: tuple[PurePosixPath, ...]
+    root: Path,
+    ref: str,
+    test_paths: tuple[PurePosixPath, ...],
+    code_under_test_paths: tuple[PurePosixPath, ...] = (),
 ) -> str:
     """Hash static Jest config and executable local support closure."""
     digest = hashlib.sha256()
-    for path, content in _jest_support_closure(root, ref, test_paths):
+    for path, content in _jest_support_closure(
+        root, ref, test_paths, code_under_test_paths
+    ):
         digest.update(path.as_posix().encode() + b"\0" + content + b"\0")
     return digest.hexdigest()
 
@@ -755,8 +818,14 @@ def _jest_support_digest(
         if obligation.validator_id == "jest"
         for path in obligation.artifact_paths
     )
+    product = tuple(
+        path
+        for obligation in profile.obligations
+        if obligation.validator_id == "jest"
+        for path in obligation.code_under_test_paths
+    )
     try:
-        closure = _jest_support_closure(root, ref, tests)
+        closure = _jest_support_closure(root, ref, tests, product)
     except ValueError:
         return "invalid-jest-closure", ()
     digest = hashlib.sha256()
@@ -904,17 +973,16 @@ def _command_part_identity(root: Path, part: str) -> str:
     return _file_identity(resolved) if resolved.exists() else part
 
 
-def _is_script_like_operand(value: str) -> bool:
-    """Return true for argv operands that are likely executable script paths."""
-    return Path(value).suffix in _JAVASCRIPT_SUFFIXES + (".py",)
-
-
 def _validator_command_identity_digest(root: Path, config: RunnerConfig) -> str:
     """Bind explicitly supplied validator commands to signed runner evidence."""
     payload: dict[str, object] = {}
     if config.jest_command is not None:
         payload["jest"] = [
             _command_part_identity(root, part) for part in config.jest_command
+        ]
+        payload["jest_toolchain"] = [
+            _directory_identity(path)
+            for path in _jest_toolchain_roots(config.jest_command)
         ]
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
@@ -1207,18 +1275,7 @@ def _pytest_exit_outcome(returncode: int, output: str) -> tuple[EvidenceOutcome,
 
 def _jest_environment(home: Path) -> dict[str, str]:
     """Return a credential-free, non-ambient environment for Jest."""
-    return {
-        key: value
-        for key, value in os.environ.items()
-        if not any(marker in key.upper() for marker in SECRET_ENV_MARKERS)
-        and not key.startswith(("JEST_", "NODE_", "npm_config_", "NPM_CONFIG_"))
-        and key not in {"HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME"}
-    } | {
-        "HOME": str(home),
-        "XDG_CONFIG_HOME": str(home / "config"),
-        "XDG_CACHE_HOME": str(home / "cache"),
-        "NODE_ENV": "test",
-    }
+    return untrusted_child_environment(home=home, extra={"NODE_ENV": "test"})
 
 
 def _jest_command(config: RunnerConfig) -> tuple[str, ...] | None:
@@ -1226,6 +1283,34 @@ def _jest_command(config: RunnerConfig) -> tuple[str, ...] | None:
     if config.jest_command is not None:
         return config.jest_command
     return None
+
+
+def _directory_identity(root: Path) -> str:
+    """Hash every regular file in an external validator package directory."""
+    digest = hashlib.sha256()
+    try:
+        paths = sorted(path for path in root.rglob("*") if path.is_file())
+        for path in paths:
+            digest.update(path.relative_to(root).as_posix().encode() + b"\0")
+            digest.update(path.read_bytes() + b"\0")
+    except OSError:
+        return _file_identity(root)
+    return digest.hexdigest()
+
+
+def _jest_toolchain_roots(command: tuple[str, ...]) -> tuple[Path, ...]:
+    """Return external package roots needed by an absolute Jest entry point."""
+    roots: set[Path] = set()
+    for part in command[1:]:
+        path = Path(part).expanduser()
+        if not path.is_absolute():
+            continue
+        resolved = path.resolve()
+        for parent in resolved.parents:
+            if parent.parent.name == "node_modules":
+                roots.add(parent)
+                break
+    return tuple(sorted(roots))
 
 
 def _command_uses_candidate_checkout(root: Path, command: tuple[str, ...]) -> bool:
@@ -1242,6 +1327,7 @@ def _command_uses_candidate_checkout(root: Path, command: tuple[str, ...]) -> bo
 
 
 def _protected_command_error(root: Path, command: tuple[str, ...]) -> str | None:
+    # pylint: disable=too-many-return-statements,too-many-branches
     """Return a fail-closed reason for unprotected explicit validator argv."""
     if not command:
         return "explicit validator command is empty"
@@ -1250,6 +1336,12 @@ def _protected_command_error(root: Path, command: tuple[str, ...]) -> str | None
     executable = Path(command[0]).expanduser()
     if not executable.is_absolute():
         return "explicit validator command executable must be an absolute path"
+    if executable.name.casefold() in {"npx", "npm", "pnpm", "yarn", "bunx", "env"}:
+        return "validator launcher indirection is not trusted"
+    if not executable.is_file():
+        return "explicit validator command executable is missing"
+    if not os.access(executable, os.X_OK):
+        return "explicit validator command executable is not executable"
     path_operands.append(executable)
     expect_module_operand = False
     for part in command[1:]:
@@ -1267,17 +1359,17 @@ def _protected_command_error(root: Path, command: tuple[str, ...]) -> str | None
             continue
         path = Path(part).expanduser()
         if not path.is_absolute() and "/" not in part:
-            if _is_script_like_operand(part):
-                return (
-                    "pathless validator script operand is not trusted; use an "
-                    "absolute external path"
-                )
-            continue
+            return (
+                "pathless validator entry point operand is not trusted; use an "
+                "absolute digest-bound external path"
+            )
         path_operands.append(path if path.is_absolute() else root / path)
     for operand in path_operands:
         resolved = operand.resolve()
         if _path_is_relative_to(resolved, candidate_root):
             return "explicit validator command inside the candidate checkout is not trusted"
+        if not resolved.is_file():
+            return "explicit validator command path is missing"
     return None
 
 
@@ -1353,6 +1445,7 @@ def _run_jest(
     root: Path, paths: tuple[PurePosixPath, ...], timeout_seconds: int,
     config: RunnerConfig, expected: tuple[str, ...] | None = None,
 ) -> tuple[RunnerExecution, tuple[str, ...]]:
+    # pylint: disable=too-many-return-statements
     """Run exact protected Jest paths using a temporary trusted reporter."""
     command_prefix = _jest_command(config)
     if command_prefix is None:
@@ -1382,9 +1475,15 @@ def _run_jest(
         ), ()
     with tempfile.TemporaryDirectory(prefix="pdd-trusted-jest-") as directory:
         temporary = Path(directory)
-        reporter = temporary / "reporter.cjs"
-        output = temporary / "results.json"
+        controllers = temporary / f"controller-{os.urandom(16).hex()}"
+        controllers.mkdir(mode=0o700)
+        scratch = temporary / "scratch"
+        home = scratch / "home"
+        home.mkdir(mode=0o700, parents=True)
+        reporter = controllers / "reporter.cjs"
+        output = controllers / "results.json"
         reporter.write_text(_JEST_REPORTER, encoding="utf-8")
+        output.touch(mode=0o600)
         command = [
             *command_prefix,
             *(path.as_posix() for path in paths),
@@ -1396,19 +1495,50 @@ def _run_jest(
             json.dumps(command, separators=(",", ":")).encode()
         ).hexdigest()
         try:
-            result = subprocess.run(
+            result, surviving = _managed_subprocess(
                 command,
                 cwd=root,
-                capture_output=True,
-                text=True,
-                check=False,
                 timeout=timeout_seconds,
-                env=_jest_environment(temporary)
+                env=_jest_environment(home)
                 | {"PDD_TRUSTED_JEST_OUTPUT": str(output)},
+                writable_roots=(scratch,),
+                writable_files=(output,),
+                readable_roots=(
+                    root,
+                    reporter,
+                    *(
+                        Path(part).expanduser().resolve()
+                        for part in command_prefix[1:]
+                        if Path(part).expanduser().is_absolute()
+                    ),
+                    *_jest_toolchain_roots(command_prefix),
+                ),
             )
-        except subprocess.TimeoutExpired:
+        except OSError as exc:
+            return RunnerExecution(
+                "jest",
+                EvidenceOutcome.ERROR,
+                digest,
+                f"Jest process launch failed: {exc}",
+            ), ()
+        if surviving:
+            return RunnerExecution(
+                "jest",
+                EvidenceOutcome.ERROR,
+                digest,
+                "Jest left a surviving process-group descendant",
+            ), ()
+        if result.returncode == 124:
             return RunnerExecution(
                 "jest", EvidenceOutcome.TIMEOUT, digest, "Jest execution timed out"
+            ), ()
+        if result.returncode >= 125:
+            diagnostic = (result.stderr or result.stdout).strip()[-500:]
+            detail = "protected sandbox rejected Jest execution"
+            if diagnostic:
+                detail += f": {diagnostic}"
+            return RunnerExecution(
+                "jest", EvidenceOutcome.ERROR, digest, detail
             ), ()
         outcome, detail, identities = _jest_result(output, result.returncode, expected)
         return RunnerExecution("jest", outcome, digest, detail), identities
@@ -1712,16 +1842,22 @@ def _obligation_preflight(
             obligation.validator_config_digest,
             "test obligation declares no artifact paths",
         )
-    digest_function = (
-        pytest_validator_config_digest
-        if obligation.validator_id == "pytest"
-        else jest_validator_config_digest
-    )
     try:
-        expected_config_digests = {
-            digest_function(root, ref, obligation.artifact_paths)
-            for ref in (base_sha, head_sha)
-        }
+        if obligation.validator_id == "pytest":
+            expected_config_digests = {
+                pytest_validator_config_digest(root, ref, obligation.artifact_paths)
+                for ref in (base_sha, head_sha)
+            }
+        else:
+            expected_config_digests = {
+                jest_validator_config_digest(
+                    root,
+                    ref,
+                    obligation.artifact_paths,
+                    obligation.code_under_test_paths,
+                )
+                for ref in (base_sha, head_sha)
+            }
     except ValueError as exc:
         return RunnerExecution(
             obligation.obligation_id,

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -11,6 +11,7 @@ import concurrent.futures
 import json
 import os
 import platform
+import re
 import shlex
 import shutil
 import subprocess
@@ -31,7 +32,7 @@ from .trust import (
     AttestationIssuer,
     AttestationRequest,
 )
-from .isolation import untrusted_child_environment
+from .isolation import SECRET_ENV_MARKERS, untrusted_child_environment
 from .git_io import read_git_blob
 from .types import (
     EvidenceOutcome,
@@ -63,6 +64,24 @@ JEST_CONFIG_PATHS = (
 )
 JEST_DYNAMIC_CONFIG_NAMES = (
     "jest.config.js", "jest.config.cjs", "jest.config.mjs", "jest.config.ts"
+)
+JEST_LOCAL_SCALAR_CONFIG_KEYS = (
+    "dependencyExtractor",
+    "globalSetup",
+    "globalTeardown",
+    "prettierPath",
+    "resolver",
+    "runner",
+    "snapshotResolver",
+    "testEnvironment",
+    "testResultsProcessor",
+    "testRunner",
+)
+JEST_LOCAL_ARRAY_CONFIG_KEYS = (
+    "reporters",
+    "setupFiles",
+    "setupFilesAfterEnv",
+    "watchPlugins",
 )
 
 
@@ -503,7 +522,7 @@ def _jest_config_references(config: object) -> set[PurePosixPath]:
     if not isinstance(config, dict):
         return set()
     references: set[PurePosixPath] = set()
-    for key in ("setupFiles", "setupFilesAfterEnv", "reporters"):
+    for key in JEST_LOCAL_ARRAY_CONFIG_KEYS:
         value = config.get(key, [])
         if not isinstance(value, list):
             raise ValueError(f"Jest {key} must be an array")
@@ -515,13 +534,15 @@ def _jest_config_references(config: object) -> set[PurePosixPath]:
             if path is None:
                 raise ValueError(f"Jest {key} plugin is not bound by this adapter")
             references.add(path)
-    resolver = config.get("resolver")
-    if resolver is not None:
-        if not isinstance(resolver, str):
-            raise ValueError("Jest resolver must be a string")
-        path = _jest_local_path(resolver)
+    for key in JEST_LOCAL_SCALAR_CONFIG_KEYS:
+        value = config.get(key)
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise ValueError(f"Jest {key} must be a string")
+        path = _jest_local_path(value)
         if path is None:
-            raise ValueError("Jest resolver is not bound by this adapter")
+            raise ValueError(f"Jest {key} is not bound by this adapter")
         references.add(path)
     transforms = config.get("transform", {})
     if not isinstance(transforms, dict):
@@ -579,7 +600,7 @@ def _jest_support_closure(
     """Return static config and transitive local Jest support modules."""
     config_path, config = _jest_config(root, ref)
     paths = {config_path}
-    pending = list(_jest_config_references(config))
+    pending = list(test_paths) + list(_jest_config_references(config))
     visited: set[PurePosixPath] = set()
     while pending:
         path = pending.pop()
@@ -606,9 +627,8 @@ def jest_validator_config_digest(
     root: Path, ref: str, test_paths: tuple[PurePosixPath, ...]
 ) -> str:
     """Hash static Jest config and executable local support closure."""
-    del test_paths
     digest = hashlib.sha256()
-    for path, content in _jest_support_closure(root, ref, ()):
+    for path, content in _jest_support_closure(root, ref, test_paths):
         digest.update(path.as_posix().encode() + b"\0" + content + b"\0")
     return digest.hexdigest()
 
@@ -1074,15 +1094,11 @@ def _jest_environment(home: Path) -> dict[str, str]:
     }
 
 
-def _jest_command(root: Path, config: RunnerConfig) -> tuple[str, ...] | None:
+def _jest_command(config: RunnerConfig) -> tuple[str, ...] | None:
     """Return an explicit local Jest argv prefix; never invoke an npm script."""
     if config.jest_command is not None:
         return config.jest_command
-    node = shutil.which("node")
-    binary = root / "node_modules" / "jest" / "bin" / "jest.js"
-    if node is None or not binary.is_file():
-        return None
-    return (node, str(binary))
+    return None
 
 
 _JEST_REPORTER = """class PddTrustedReporter {
@@ -1137,8 +1153,10 @@ def _run_jest(
     config: RunnerConfig, expected: tuple[str, ...] | None = None,
 ) -> tuple[RunnerExecution, tuple[str, ...]]:
     """Run exact protected Jest paths using a temporary trusted reporter."""
-    command_prefix = _jest_command(root, config)
+    command_prefix = _jest_command(config)
     if command_prefix is None:
+        if (root / "node_modules" / "jest" / "bin" / "jest.js").is_file():
+            return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-untrusted", "candidate node_modules Jest runner is not trusted"), ()
         return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-unavailable", "no local Jest binary is available"), ()
     try:
         config_path, _config_data = _jest_config(root, "HEAD")

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -85,6 +85,17 @@ JEST_LOCAL_ARRAY_CONFIG_KEYS = (
     "snapshotSerializers",
     "watchPlugins",
 )
+_JAVASCRIPT_SUFFIXES = (
+    ".js",
+    ".cjs",
+    ".mjs",
+    ".ts",
+    ".cts",
+    ".mts",
+    ".tsx",
+    ".jsx",
+    ".json",
+)
 
 
 @dataclass(frozen=True)
@@ -606,13 +617,54 @@ def _local_javascript_imports(
     )
     resolved: set[PurePosixPath] = set()
     for item in imports:
-        candidate = source_path.parent / PurePosixPath(item)
-        candidates = [candidate]
-        if not candidate.suffix:
-            candidates.extend(candidate.with_suffix(suffix) for suffix in (".js", ".cjs", ".mjs", ".ts", ".tsx", ".jsx", ".json"))
-            candidates.extend(candidate / f"index{suffix}" for suffix in (".js", ".ts", ".tsx"))
-        resolved.update(path for path in candidates if read_git_blob(root, ref, path) is not None)
+        candidate = _normalize_repo_relative_path(
+            source_path.parent / PurePosixPath(item)
+        )
+        if candidate is None:
+            continue
+        candidates = list(_javascript_path_candidates(candidate))
+        resolved.update(
+            path for path in candidates if read_git_blob(root, ref, path) is not None
+        )
     return resolved
+
+
+def _normalize_repo_relative_path(path: PurePosixPath) -> PurePosixPath | None:
+    """Collapse dot segments and reject paths that escape the repository."""
+    parts: list[str] = []
+    for part in path.parts:
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if not parts:
+                return None
+            parts.pop()
+            continue
+        parts.append(part)
+    return PurePosixPath(*parts) if parts else PurePosixPath(".")
+
+
+def _javascript_path_candidates(path: PurePosixPath) -> tuple[PurePosixPath, ...]:
+    """Return file and directory-index candidates for a JS import target."""
+    candidates = [path]
+    if not path.suffix:
+        candidates.extend(path.with_suffix(suffix) for suffix in _JAVASCRIPT_SUFFIXES)
+        candidates.extend(path / f"index{suffix}" for suffix in _JAVASCRIPT_SUFFIXES)
+    return tuple(candidates)
+
+
+def _read_javascript_support_blob(
+    root: Path, ref: str, path: PurePosixPath
+) -> tuple[PurePosixPath, bytes] | tuple[PurePosixPath, None]:
+    """Read a JS support path after applying file and index candidates."""
+    normalized = _normalize_repo_relative_path(path)
+    if normalized is None:
+        return path, None
+    for candidate in _javascript_path_candidates(normalized):
+        source = read_git_blob(root, ref, candidate)
+        if source is not None:
+            return candidate, source
+    return normalized, None
 
 
 def _jest_support_closure(
@@ -628,7 +680,7 @@ def _jest_support_closure(
         if path in visited:
             continue
         visited.add(path)
-        source = read_git_blob(root, ref, path)
+        path, source = _read_javascript_support_blob(root, ref, path)
         if source is None:
             raise ValueError(f"Jest support path is missing: {path.as_posix()}")
         paths.add(path)
@@ -641,7 +693,11 @@ def _jest_support_closure(
                 nested_config = nested_config.get("jest", {})
             pending.extend(_jest_config_references(nested_config) - visited)
         pending.extend(_local_javascript_imports(root, ref, path, source) - visited)
-    return tuple((path, read_git_blob(root, ref, path)) for path in sorted(paths) if read_git_blob(root, ref, path) is not None)
+    return tuple(
+        (path, read_git_blob(root, ref, path))
+        for path in sorted(paths)
+        if read_git_blob(root, ref, path) is not None
+    )
 
 
 def jest_validator_config_digest(

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -503,34 +503,50 @@ def _jest_config_references(config: object) -> set[PurePosixPath]:
     if not isinstance(config, dict):
         return set()
     references: set[PurePosixPath] = set()
-    for key in ("setupFiles", "setupFilesAfterEnv", "reporters", "projects"):
+    for key in ("setupFiles", "setupFilesAfterEnv", "reporters"):
         value = config.get(key, [])
         if not isinstance(value, list):
             raise ValueError(f"Jest {key} must be an array")
         for item in value:
             target = item[0] if isinstance(item, list) and item else item
-            if isinstance(target, str):
-                path = _jest_local_path(target)
-                if path is not None:
-                    references.add(path)
+            if not isinstance(target, str):
+                raise ValueError(f"Jest {key} entry must be a static local path")
+            path = _jest_local_path(target)
+            if path is None:
+                raise ValueError(f"Jest {key} plugin is not bound by this adapter")
+            references.add(path)
     resolver = config.get("resolver")
     if resolver is not None:
         if not isinstance(resolver, str):
             raise ValueError("Jest resolver must be a string")
         path = _jest_local_path(resolver)
-        if path is not None:
-            references.add(path)
+        if path is None:
+            raise ValueError("Jest resolver is not bound by this adapter")
+        references.add(path)
     transforms = config.get("transform", {})
     if not isinstance(transforms, dict):
         raise ValueError("Jest transform must be an object")
     for value in transforms.values():
         target = value[0] if isinstance(value, list) and value else value
-        if isinstance(target, str):
-            path = _jest_local_path(target)
-            if path is not None:
-                references.add(path)
-        elif not isinstance(target, dict):
+        if not isinstance(target, str):
             raise ValueError("Jest transform entry must be a static path")
+        path = _jest_local_path(target)
+        if path is None:
+            raise ValueError("Jest transform is not bound by this adapter")
+        references.add(path)
+    projects = config.get("projects", [])
+    if not isinstance(projects, list):
+        raise ValueError("Jest projects must be an array")
+    for project in projects:
+        if isinstance(project, dict):
+            references.update(_jest_config_references(project))
+        elif isinstance(project, str):
+            path = _jest_local_path(project)
+            if path is None:
+                raise ValueError("Jest project is not bound by this adapter")
+            references.add(path)
+        else:
+            raise ValueError("Jest project must be a static local config")
     return references
 
 
@@ -574,6 +590,14 @@ def _jest_support_closure(
         if source is None:
             raise ValueError(f"Jest support path is missing: {path.as_posix()}")
         paths.add(path)
+        if path.suffix == ".json":
+            try:
+                nested_config = json.loads(source.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise ValueError(f"Jest project config is invalid: {path.as_posix()}") from exc
+            if path.name == "package.json" and isinstance(nested_config, dict):
+                nested_config = nested_config.get("jest", {})
+            pending.extend(_jest_config_references(nested_config) - visited)
         pending.extend(_local_javascript_imports(root, ref, path, source) - visited)
     return tuple((path, read_git_blob(root, ref, path)) for path in sorted(paths) if read_git_blob(root, ref, path) is not None)
 

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -893,16 +893,26 @@ def _file_identity(path: Path) -> str:
     return hashlib.sha256(str(path).encode() + b"\0" + data).hexdigest()
 
 
+def _command_part_identity(root: Path, part: str) -> str:
+    """Return literal argv text or a digest for an explicit path operand."""
+    path = Path(part).expanduser()
+    if not path.is_absolute() and "/" not in part:
+        return part
+    resolved = (path if path.is_absolute() else root / path).resolve()
+    return _file_identity(resolved) if resolved.exists() else part
+
+
+def _is_script_like_operand(value: str) -> bool:
+    """Return true for argv operands that are likely executable script paths."""
+    return Path(value).suffix in _JAVASCRIPT_SUFFIXES + (".py",)
+
+
 def _validator_command_identity_digest(root: Path, config: RunnerConfig) -> str:
     """Bind explicitly supplied validator commands to signed runner evidence."""
     payload: dict[str, object] = {}
     if config.jest_command is not None:
         payload["jest"] = [
-            _file_identity(Path(part).resolve())
-            if (Path(part).is_absolute() or "/" in part)
-            and Path(part).expanduser().exists()
-            else part
-            for part in config.jest_command
+            _command_part_identity(root, part) for part in config.jest_command
         ]
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
@@ -1229,6 +1239,46 @@ def _command_uses_candidate_checkout(root: Path, command: tuple[str, ...]) -> bo
     return False
 
 
+def _protected_command_error(root: Path, command: tuple[str, ...]) -> str | None:
+    """Return a fail-closed reason for unprotected explicit validator argv."""
+    if not command:
+        return "explicit validator command is empty"
+    candidate_root = root.resolve()
+    path_operands: list[Path] = []
+    executable = Path(command[0]).expanduser()
+    if not executable.is_absolute():
+        return "explicit validator command executable must be an absolute path"
+    path_operands.append(executable)
+    expect_module_operand = False
+    for part in command[1:]:
+        if expect_module_operand:
+            if "/" not in part:
+                return (
+                    "pathless validator module operand is not trusted; use an "
+                    "absolute external path or protected module launcher"
+                )
+            expect_module_operand = False
+        if part == "-m":
+            expect_module_operand = True
+            continue
+        if part.startswith("-"):
+            continue
+        path = Path(part).expanduser()
+        if not path.is_absolute() and "/" not in part:
+            if _is_script_like_operand(part):
+                return (
+                    "pathless validator script operand is not trusted; use an "
+                    "absolute external path"
+                )
+            continue
+        path_operands.append(path if path.is_absolute() else root / path)
+    for operand in path_operands:
+        resolved = operand.resolve()
+        if _path_is_relative_to(resolved, candidate_root):
+            return "explicit validator command inside the candidate checkout is not trusted"
+    return None
+
+
 _JEST_REPORTER = """class PddTrustedReporter {
   constructor() { this.tests = []; }
   onTestResult(test, result) {
@@ -1286,8 +1336,11 @@ def _run_jest(
         if (root / "node_modules" / "jest" / "bin" / "jest.js").is_file():
             return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-untrusted", "candidate node_modules Jest runner is not trusted"), ()
         return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-unavailable", "no local Jest binary is available"), ()
-    if _command_uses_candidate_checkout(root, command_prefix):
-        return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-untrusted", "explicit Jest command inside the candidate checkout is not trusted"), ()
+    command_error = _protected_command_error(root, command_prefix)
+    if command_error is not None:
+        return RunnerExecution(
+            "jest", EvidenceOutcome.ERROR, "jest-untrusted", command_error
+        ), ()
     try:
         config_path, _config_data = _jest_config(root, "HEAD")
     except ValueError as exc:

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -73,6 +73,7 @@ JEST_LOCAL_SCALAR_CONFIG_KEYS = (
     "resolver",
     "runner",
     "snapshotResolver",
+    "testSequencer",
     "testEnvironment",
     "testResultsProcessor",
     "testRunner",
@@ -81,6 +82,7 @@ JEST_LOCAL_ARRAY_CONFIG_KEYS = (
     "reporters",
     "setupFiles",
     "setupFilesAfterEnv",
+    "snapshotSerializers",
     "watchPlugins",
 )
 
@@ -568,6 +570,20 @@ def _jest_config_references(config: object) -> set[PurePosixPath]:
             references.add(path)
         else:
             raise ValueError("Jest project must be a static local config")
+    module_name_mapper = config.get("moduleNameMapper", {})
+    if not isinstance(module_name_mapper, dict):
+        raise ValueError("Jest moduleNameMapper must be an object")
+    for value in module_name_mapper.values():
+        targets = value if isinstance(value, list) else [value]
+        for target in targets:
+            if not isinstance(target, str):
+                raise ValueError("Jest moduleNameMapper entry must be a static path")
+            path = _jest_local_path(target)
+            if path is None:
+                raise ValueError("Jest moduleNameMapper target is not bound by this adapter")
+            parts = tuple(part for part in path.parts if not re.search(r"\$[0-9&]", part))
+            if parts:
+                references.add(PurePosixPath(*parts))
     return references
 
 
@@ -580,7 +596,7 @@ def _local_javascript_imports(
     except UnicodeDecodeError:
         return set()
     imports = re.findall(
-        r"(?:from\s+|import\s*\(|require\s*\()['\"](\.{1,2}/[^'\"]+)['\"]",
+        r"(?:from\s+|import\s*\(|import\s+|require\s*\()['\"](\.{1,2}/[^'\"]+)['\"]",
         text,
     )
     resolved: set[PurePosixPath] = set()
@@ -737,7 +753,8 @@ def _managed_subprocess(
 
 
 def runner_identity_digest(
-    profile: VerificationProfile, *, root: Path | None = None, ref: str = "HEAD"
+    profile: VerificationProfile, *, root: Path | None = None, ref: str = "HEAD",
+    config: RunnerConfig = RunnerConfig(),
 ) -> str:
     """Bind evidence to protected adapters, configs, and exact artifact scopes."""
     payload = {
@@ -789,6 +806,43 @@ def runner_identity_digest(
         payload["support_closure_digest"] = hashlib.sha256(
             (_support_digest(root, ref, profile)[0] + _jest_support_digest(root, ref, profile)[0]).encode()
         ).hexdigest()
+        payload["validator_command_digest"] = _validator_command_identity_digest(
+            root, config
+        )
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def _path_is_relative_to(path: Path, parent: Path) -> bool:
+    """Return whether path is inside parent across supported Python versions."""
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _file_identity(path: Path) -> str:
+    """Return a stable identity digest for an executable validator file."""
+    try:
+        data = path.read_bytes()
+    except OSError:
+        data = b"<unreadable>"
+    return hashlib.sha256(str(path).encode() + b"\0" + data).hexdigest()
+
+
+def _validator_command_identity_digest(root: Path, config: RunnerConfig) -> str:
+    """Bind explicitly supplied validator commands to signed runner evidence."""
+    payload: dict[str, object] = {}
+    if config.jest_command is not None:
+        payload["jest"] = [
+            _file_identity(Path(part).resolve())
+            if (Path(part).is_absolute() or "/" in part)
+            and Path(part).expanduser().exists()
+            else part
+            for part in config.jest_command
+        ]
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     ).hexdigest()
@@ -1101,6 +1155,19 @@ def _jest_command(config: RunnerConfig) -> tuple[str, ...] | None:
     return None
 
 
+def _command_uses_candidate_checkout(root: Path, command: tuple[str, ...]) -> bool:
+    """Return true when any explicit command path is inside the candidate repo."""
+    candidate_root = root.resolve()
+    for part in command:
+        path = Path(part).expanduser()
+        if not path.is_absolute() and "/" not in part:
+            continue
+        resolved = path.resolve() if path.is_absolute() else (root / path).resolve()
+        if _path_is_relative_to(resolved, candidate_root):
+            return True
+    return False
+
+
 _JEST_REPORTER = """class PddTrustedReporter {
   constructor() { this.tests = []; }
   onTestResult(test, result) {
@@ -1158,6 +1225,8 @@ def _run_jest(
         if (root / "node_modules" / "jest" / "bin" / "jest.js").is_file():
             return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-untrusted", "candidate node_modules Jest runner is not trusted"), ()
         return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-unavailable", "no local Jest binary is available"), ()
+    if _command_uses_candidate_checkout(root, command_prefix):
+        return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-untrusted", "explicit Jest command inside the candidate checkout is not trusted"), ()
     try:
         config_path, _config_data = _jest_config(root, "HEAD")
     except ValueError as exc:
@@ -1760,7 +1829,7 @@ def run_profile(
         )
         for obligation in profile.obligations
     )
-    runner_digest = runner_identity_digest(profile, root=root, ref=binding.head_sha)
+    runner_digest = runner_identity_digest(profile, root=root, ref=binding.head_sha, config=config)
     binding = AttestationBinding(
         profile.unit_id,
         binding.snapshot_digest,

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -584,6 +584,11 @@ def _jest_config_references(config: object) -> set[PurePosixPath]:
             parts = tuple(part for part in path.parts if not re.search(r"\$[0-9&]", part))
             if parts:
                 references.add(PurePosixPath(*parts))
+    module_directories = config.get("moduleDirectories", [])
+    if not isinstance(module_directories, list):
+        raise ValueError("Jest moduleDirectories must be an array")
+    if module_directories:
+        raise ValueError("Jest moduleDirectories is not bound by this adapter")
     return references
 
 

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -12,6 +12,7 @@ import json
 import os
 import platform
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -56,6 +57,13 @@ _CHECKER_PYTEST_PROBE = Path(__file__).with_name("pytest_probe.py").resolve()
 _runtime_digest_cache: dict[
     str, tuple[tuple[tuple[str, Path], ...], tuple[tuple[str, str, int, int], ...], str]
 ] = {}
+JEST_CONFIG_PATHS = (
+    PurePosixPath("jest.config.json"),
+    PurePosixPath("package.json"),
+)
+JEST_DYNAMIC_CONFIG_NAMES = (
+    "jest.config.js", "jest.config.cjs", "jest.config.mjs", "jest.config.ts"
+)
 
 
 @dataclass(frozen=True)
@@ -63,6 +71,7 @@ class RunnerConfig:
     """Protected execution limits for trusted validation adapters."""
 
     timeout_seconds: int = 300
+    jest_command: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -455,6 +464,131 @@ def _has_external_pytest_plugins(
     return False
 
 
+def _jest_config(root: Path, ref: str) -> tuple[PurePosixPath, dict[str, object]]:
+    """Load the only supported, static Jest configuration forms."""
+    for name in JEST_DYNAMIC_CONFIG_NAMES:
+        if read_git_blob(root, ref, PurePosixPath(name)) is not None:
+            raise ValueError("dynamic Jest configuration is not supported")
+    config_path = PurePosixPath("jest.config.json")
+    content = read_git_blob(root, ref, config_path)
+    if content is None:
+        config_path = PurePosixPath("package.json")
+        content = read_git_blob(root, ref, config_path)
+    if content is None:
+        raise ValueError("no static Jest configuration is present")
+    try:
+        parsed = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Jest configuration must be valid JSON") from exc
+    if config_path.name == "package.json":
+        parsed = parsed.get("jest") if isinstance(parsed, dict) else None
+    if not isinstance(parsed, dict):
+        raise ValueError("Jest configuration must be a JSON object")
+    return config_path, parsed
+
+
+def _jest_local_path(value: str) -> PurePosixPath | None:
+    """Normalize a static config path without accepting package references."""
+    value = value.replace("<rootDir>/", "")
+    if value.startswith("<") or value.startswith("/") or not value:
+        return None
+    path = PurePosixPath(value)
+    if ".." in path.parts:
+        return None
+    return path
+
+
+def _jest_config_references(config: object) -> set[PurePosixPath]:
+    """Find local executable support named by static Jest config keys."""
+    if not isinstance(config, dict):
+        return set()
+    references: set[PurePosixPath] = set()
+    for key in ("setupFiles", "setupFilesAfterEnv", "reporters", "projects"):
+        value = config.get(key, [])
+        if not isinstance(value, list):
+            raise ValueError(f"Jest {key} must be an array")
+        for item in value:
+            target = item[0] if isinstance(item, list) and item else item
+            if isinstance(target, str):
+                path = _jest_local_path(target)
+                if path is not None:
+                    references.add(path)
+    resolver = config.get("resolver")
+    if resolver is not None:
+        if not isinstance(resolver, str):
+            raise ValueError("Jest resolver must be a string")
+        path = _jest_local_path(resolver)
+        if path is not None:
+            references.add(path)
+    transforms = config.get("transform", {})
+    if not isinstance(transforms, dict):
+        raise ValueError("Jest transform must be an object")
+    for value in transforms.values():
+        target = value[0] if isinstance(value, list) and value else value
+        if isinstance(target, str):
+            path = _jest_local_path(target)
+            if path is not None:
+                references.add(path)
+        elif not isinstance(target, dict):
+            raise ValueError("Jest transform entry must be a static path")
+    return references
+
+
+def _local_javascript_imports(
+    root: Path, ref: str, source_path: PurePosixPath, source: bytes
+) -> set[PurePosixPath]:
+    """Resolve literal relative JS imports without executing candidate modules."""
+    try:
+        text = source.decode("utf-8")
+    except UnicodeDecodeError:
+        return set()
+    imports = re.findall(
+        r"(?:from\s+|import\s*\(|require\s*\()['\"](\.{1,2}/[^'\"]+)['\"]",
+        text,
+    )
+    resolved: set[PurePosixPath] = set()
+    for item in imports:
+        candidate = source_path.parent / PurePosixPath(item)
+        candidates = [candidate]
+        if not candidate.suffix:
+            candidates.extend(candidate.with_suffix(suffix) for suffix in (".js", ".cjs", ".mjs", ".ts", ".tsx", ".jsx", ".json"))
+            candidates.extend(candidate / f"index{suffix}" for suffix in (".js", ".ts", ".tsx"))
+        resolved.update(path for path in candidates if read_git_blob(root, ref, path) is not None)
+    return resolved
+
+
+def _jest_support_closure(
+    root: Path, ref: str, test_paths: tuple[PurePosixPath, ...]
+) -> tuple[tuple[PurePosixPath, bytes], ...]:
+    """Return static config and transitive local Jest support modules."""
+    config_path, config = _jest_config(root, ref)
+    paths = {config_path}
+    pending = list(_jest_config_references(config))
+    visited: set[PurePosixPath] = set()
+    while pending:
+        path = pending.pop()
+        if path in visited:
+            continue
+        visited.add(path)
+        source = read_git_blob(root, ref, path)
+        if source is None:
+            raise ValueError(f"Jest support path is missing: {path.as_posix()}")
+        paths.add(path)
+        pending.extend(_local_javascript_imports(root, ref, path, source) - visited)
+    return tuple((path, read_git_blob(root, ref, path)) for path in sorted(paths) if read_git_blob(root, ref, path) is not None)
+
+
+def jest_validator_config_digest(
+    root: Path, ref: str, test_paths: tuple[PurePosixPath, ...]
+) -> str:
+    """Hash static Jest config and executable local support closure."""
+    del test_paths
+    digest = hashlib.sha256()
+    for path, content in _jest_support_closure(root, ref, ()):
+        digest.update(path.as_posix().encode() + b"\0" + content + b"\0")
+    return digest.hexdigest()
+
+
 def _support_digest(
     root: Path, ref: str, profile: VerificationProfile
 ) -> tuple[str, tuple[PurePosixPath, ...]]:
@@ -488,6 +622,26 @@ def _support_digest(
     return digest.hexdigest(), tuple(
         path for path, _content in closure if path not in set(product)
     )
+
+
+def _jest_support_digest(
+    root: Path, ref: str, profile: VerificationProfile
+) -> tuple[str, tuple[PurePosixPath, ...]]:
+    """Hash the protected static Jest support closure for a profile."""
+    tests = tuple(
+        path
+        for obligation in profile.obligations
+        if obligation.validator_id == "jest"
+        for path in obligation.artifact_paths
+    )
+    try:
+        closure = _jest_support_closure(root, ref, tests)
+    except ValueError:
+        return "invalid-jest-closure", ()
+    digest = hashlib.sha256()
+    for path, content in closure:
+        digest.update(path.as_posix().encode() + b"\0" + content + b"\0")
+    return digest.hexdigest(), tuple(path for path, _content in closure)
 
 
 def _config_loads_plugin(root: Path, ref: str) -> bool:
@@ -588,7 +742,9 @@ def runner_identity_digest(
         ],
     }
     if root is not None:
-        payload["support_closure_digest"] = _support_digest(root, ref, profile)[0]
+        payload["support_closure_digest"] = hashlib.sha256(
+            (_support_digest(root, ref, profile)[0] + _jest_support_digest(root, ref, profile)[0]).encode()
+        ).hexdigest()
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     ).hexdigest()
@@ -878,6 +1034,107 @@ def _pytest_exit_outcome(returncode: int, output: str) -> tuple[EvidenceOutcome,
     return EvidenceOutcome.ERROR, "protected pytest failed: " + output[-500:]
 
 
+def _jest_environment(home: Path) -> dict[str, str]:
+    """Return a credential-free, non-ambient environment for Jest."""
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not any(marker in key.upper() for marker in SECRET_ENV_MARKERS)
+        and not key.startswith(("JEST_", "NODE_", "npm_config_", "NPM_CONFIG_"))
+        and key not in {"HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME"}
+    } | {
+        "HOME": str(home),
+        "XDG_CONFIG_HOME": str(home / "config"),
+        "XDG_CACHE_HOME": str(home / "cache"),
+        "NODE_ENV": "test",
+    }
+
+
+def _jest_command(root: Path, config: RunnerConfig) -> tuple[str, ...] | None:
+    """Return an explicit local Jest argv prefix; never invoke an npm script."""
+    if config.jest_command is not None:
+        return config.jest_command
+    node = shutil.which("node")
+    binary = root / "node_modules" / "jest" / "bin" / "jest.js"
+    if node is None or not binary.is_file():
+        return None
+    return (node, str(binary))
+
+
+_JEST_REPORTER = """class PddTrustedReporter {
+  constructor() { this.tests = []; }
+  onTestResult(test, result) {
+    for (const assertion of result.testResults || []) {
+      const names = [...(assertion.ancestorTitles || []), assertion.title].join(' > ');
+      this.tests.push({identity: require('path').relative(process.cwd(), test.path) + '::' + names, status: assertion.status});
+    }
+  }
+  onRunComplete() { require('fs').writeFileSync(process.env.PDD_TRUSTED_JEST_OUTPUT, JSON.stringify({tests: this.tests})); }
+}
+module.exports = PddTrustedReporter;
+"""
+
+
+def _jest_result(
+    output: Path, returncode: int, expected: tuple[str, ...] | None
+) -> tuple[EvidenceOutcome, str, tuple[str, ...]]:
+    """Validate trusted reporter data and normalize every non-pass state."""
+    try:
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        tests = payload["tests"]
+        if not isinstance(tests, list) or not all(
+            isinstance(item, dict)
+            and isinstance(item.get("identity"), str)
+            and isinstance(item.get("status"), str)
+            for item in tests
+        ):
+            raise ValueError("malformed Jest reporter payload")
+    except (OSError, ValueError, json.JSONDecodeError, KeyError):
+        return EvidenceOutcome.COLLECTION_ERROR, "trusted Jest reporter produced malformed JSON", ()
+    identities = tuple(sorted(item["identity"] for item in tests))
+    if not identities:
+        return EvidenceOutcome.NOT_COLLECTED, "zero protected Jest test identities collected", ()
+    if len(set(identities)) != len(identities):
+        return EvidenceOutcome.COLLECTION_ERROR, "Jest reporter emitted duplicate test identities", ()
+    if expected is not None and identities != expected:
+        return EvidenceOutcome.QUARANTINED, "checked-head Jest identities differ from protected base", identities
+    statuses = {item["status"] for item in tests}
+    if statuses - {"passed", "failed", "pending", "todo", "skipped", "disabled"}:
+        return EvidenceOutcome.COLLECTION_ERROR, "Jest reporter emitted an unsupported status", identities
+    if returncode or "failed" in statuses:
+        return EvidenceOutcome.FAIL, "Jest reported failed protected tests", identities
+    if statuses - {"passed"}:
+        return EvidenceOutcome.SKIP, "Jest reported skipped or todo protected tests", identities
+    return EvidenceOutcome.PASS, f"{len(identities)} protected Jest tests passed", identities
+
+
+def _run_jest(
+    root: Path, paths: tuple[PurePosixPath, ...], timeout_seconds: int,
+    config: RunnerConfig, expected: tuple[str, ...] | None = None,
+) -> tuple[RunnerExecution, tuple[str, ...]]:
+    """Run exact protected Jest paths using a temporary trusted reporter."""
+    command_prefix = _jest_command(root, config)
+    if command_prefix is None:
+        return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-unavailable", "no local Jest binary is available"), ()
+    try:
+        config_path, _config_data = _jest_config(root, "HEAD")
+    except ValueError as exc:
+        return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-config", str(exc)), ()
+    with tempfile.TemporaryDirectory(prefix="pdd-trusted-jest-") as directory:
+        temporary = Path(directory)
+        reporter = temporary / "reporter.cjs"
+        output = temporary / "results.json"
+        reporter.write_text(_JEST_REPORTER, encoding="utf-8")
+        command = [*command_prefix, *(path.as_posix() for path in paths), "--runInBand", f"--config={root / config_path}", f"--reporters={reporter}"]
+        digest = hashlib.sha256(json.dumps(command, separators=(",", ":")).encode()).hexdigest()
+        try:
+            result = subprocess.run(command, cwd=root, capture_output=True, text=True, check=False, timeout=timeout_seconds, env=_jest_environment(temporary) | {"PDD_TRUSTED_JEST_OUTPUT": str(output)})
+        except subprocess.TimeoutExpired:
+            return RunnerExecution("jest", EvidenceOutcome.TIMEOUT, digest, "Jest execution timed out"), ()
+        outcome, detail, identities = _jest_result(output, result.returncode, expected)
+        return RunnerExecution("jest", outcome, digest, detail), identities
+
+
 def _run_test_node(
     root: Path,
     node_id: str,
@@ -1110,6 +1367,27 @@ def _dirty_tracked_closure(root: Path) -> set[str]:
     return {line for line in result.stdout.splitlines() if line}
 
 
+def _dirty_jest_support(root: Path) -> set[str]:
+    """Return uncommitted ambient files commonly executable by Jest config."""
+    result = subprocess.run(
+        ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
+        cwd=root, capture_output=True, check=False,
+    )
+    if result.returncode != 0:
+        return {"<unreadable-git-status>"}
+    dirty: set[str] = set()
+    for field in result.stdout.decode(errors="surrogateescape").split("\0"):
+        path = field[3:] if len(field) >= 4 else ""
+        relpath = PurePosixPath(path)
+        if (
+            relpath.name.startswith("jest.config.")
+            or relpath.name == "package.json"
+            or relpath.name.startswith(("setup.", "transform.", "reporter.", "resolver."))
+        ):
+            dirty.add(path)
+    return dirty
+
+
 def _combine(
     obligation: VerificationObligation,
     executions: tuple[RunnerExecution, ...],
@@ -1141,7 +1419,7 @@ def _obligation_preflight(
 ) -> RunnerExecution | None:
     # pylint: disable=too-many-return-statements
     """Return a normalized fail-closed result before executing pytest."""
-    if obligation.kind.casefold() != "test" or obligation.validator_id != "pytest":
+    if obligation.kind.casefold() != "test" or obligation.validator_id not in {"pytest", "jest"}:
         return RunnerExecution(
             obligation.obligation_id,
             EvidenceOutcome.ERROR,
@@ -1155,44 +1433,60 @@ def _obligation_preflight(
             obligation.validator_config_digest,
             "test obligation declares no artifact paths",
         )
-    expected_config_digests = {
-        pytest_validator_config_digest(root, ref, obligation.artifact_paths)
-        for ref in (base_sha, head_sha)
-    }
-    if expected_config_digests != {obligation.validator_config_digest}:
-        support_paths = tuple(
-            path
-            for path, _content in _pytest_support_closure(
-                root,
-                head_sha,
-                obligation.artifact_paths,
-                obligation.code_under_test_paths,
-            )
-        )
-        changed_support = _changed_paths(root, base_sha, head_sha, support_paths)
-        direct_config = {
-            path.as_posix()
-            for path in _pytest_config_paths(root, head_sha, obligation.artifact_paths)
+    digest_function = pytest_validator_config_digest if obligation.validator_id == "pytest" else jest_validator_config_digest
+    try:
+        expected_config_digests = {
+            digest_function(root, ref, obligation.artifact_paths)
+            for ref in (base_sha, head_sha)
         }
-        plugin_support = sorted(set(changed_support) - direct_config)
-        if plugin_support:
-            return RunnerExecution(
-                obligation.obligation_id,
-                EvidenceOutcome.QUARANTINED,
-                obligation.validator_config_digest,
-                "candidate-modified pytest support cannot solely certify itself: "
-                + ", ".join(plugin_support),
+    except ValueError as exc:
+        return RunnerExecution(obligation.obligation_id, EvidenceOutcome.ERROR, obligation.validator_config_digest, str(exc))
+    if expected_config_digests != {obligation.validator_config_digest}:
+        if obligation.validator_id == "pytest":
+            support_paths = tuple(
+                path
+                for path, _content in _pytest_support_closure(
+                    root,
+                    head_sha,
+                    obligation.artifact_paths,
+                    obligation.code_under_test_paths,
+                )
             )
+            changed_support = _changed_paths(root, base_sha, head_sha, support_paths)
+            direct_config = {
+                path.as_posix()
+                for path in _pytest_config_paths(
+                    root, head_sha, obligation.artifact_paths
+                )
+            }
+            plugin_support = sorted(set(changed_support) - direct_config)
+            if plugin_support:
+                return RunnerExecution(
+                    obligation.obligation_id,
+                    EvidenceOutcome.QUARANTINED,
+                    obligation.validator_config_digest,
+                    "candidate-modified pytest support cannot solely certify itself: "
+                    + ", ".join(plugin_support),
+                )
         return RunnerExecution(
             obligation.obligation_id,
             EvidenceOutcome.ERROR,
             obligation.validator_config_digest,
             "declared validator config digest does not match protected closure",
         )
-    if _has_dynamic_pytest_plugins(root, base_sha, obligation.artifact_paths,
-                                   obligation.code_under_test_paths) or (
-        _has_dynamic_pytest_plugins(root, head_sha, obligation.artifact_paths,
-                                    obligation.code_under_test_paths)
+    if obligation.validator_id == "pytest" and (
+        _has_dynamic_pytest_plugins(
+            root,
+            base_sha,
+            obligation.artifact_paths,
+            obligation.code_under_test_paths,
+        )
+        or _has_dynamic_pytest_plugins(
+            root,
+            head_sha,
+            obligation.artifact_paths,
+            obligation.code_under_test_paths,
+        )
     ):
         return RunnerExecution(
             obligation.obligation_id,
@@ -1200,10 +1494,13 @@ def _obligation_preflight(
             obligation.validator_config_digest,
             "dynamic pytest_plugins declarations are not bound by this adapter",
         )
-    if _has_external_pytest_plugins(
-        root, base_sha, obligation.artifact_paths, obligation.code_under_test_paths
-    ) or _has_external_pytest_plugins(
-        root, head_sha, obligation.artifact_paths, obligation.code_under_test_paths
+    if obligation.validator_id == "pytest" and (
+        _has_external_pytest_plugins(
+            root, base_sha, obligation.artifact_paths, obligation.code_under_test_paths
+        )
+        or _has_external_pytest_plugins(
+            root, head_sha, obligation.artifact_paths, obligation.code_under_test_paths
+        )
     ):
         return RunnerExecution(
             obligation.obligation_id,
@@ -1211,7 +1508,10 @@ def _obligation_preflight(
             obligation.validator_config_digest,
             "external pytest_plugins declarations are not bound by this adapter",
         )
-    if _config_loads_plugin(root, base_sha) or _config_loads_plugin(root, head_sha):
+    if obligation.validator_id == "pytest" and (
+        _config_loads_plugin(root, base_sha)
+        or _config_loads_plugin(root, head_sha)
+    ):
         return RunnerExecution(
             obligation.obligation_id,
             EvidenceOutcome.ERROR,
@@ -1219,6 +1519,19 @@ def _obligation_preflight(
             "repository-configured pytest plugins are not bound by this adapter",
         )
     return None
+
+
+def _collect_jest_at_base(
+    root: Path, base_sha: str, paths: tuple[PurePosixPath, ...], config: RunnerConfig
+) -> tuple[RunnerExecution, tuple[str, ...]]:
+    """Run protected-base Jest with the trusted reporter to establish identities."""
+    with tempfile.TemporaryDirectory(prefix="pdd-jest-protected-base-") as directory:
+        clone = Path(directory) / "repository"
+        cloned = subprocess.run(["git", "clone", "-q", "--no-local", "--no-checkout", str(root), str(clone)], capture_output=True, text=True, check=False)
+        checked_out = cloned.returncode == 0 and subprocess.run(["git", "checkout", "-q", "--detach", base_sha], cwd=clone, capture_output=True, check=False).returncode == 0
+        if not checked_out:
+            return RunnerExecution("protected-base-collection", EvidenceOutcome.COLLECTION_ERROR, hashlib.sha256(base_sha.encode()).hexdigest(), "cannot create protected-base Jest clone"), ()
+        return _run_jest(clone, paths, config.timeout_seconds, config)
 
 
 def _protected_node_ids(
@@ -1268,6 +1581,27 @@ def _run_obligation_in_tree(
     preflight = _obligation_preflight(root, obligation, base_sha, head_sha)
     if preflight is not None:
         return preflight
+    if obligation.validator_id == "jest":
+        profile = VerificationProfile(
+            UnitId("runner-closure", PurePosixPath("closure.prompt"), "javascript"),
+            (obligation,), obligation.requirement_ids, "closure",
+        )
+        _digest, support_paths = _jest_support_digest(root, head_sha, profile)
+        protected_paths = tuple(sorted(set(obligation.artifact_paths) | set(support_paths)))
+        changed = _changed_paths(root, base_sha, head_sha, protected_paths)
+        changed.update(_dirty_jest_support(root))
+        if changed:
+            return RunnerExecution(
+                obligation.obligation_id, EvidenceOutcome.QUARANTINED,
+                obligation.validator_config_digest,
+                "candidate-modified Jest support cannot solely certify itself: "
+                + ", ".join(sorted(changed)),
+            )
+        base_execution, base_ids = _collect_jest_at_base(root, base_sha, obligation.artifact_paths, config)
+        if base_execution.outcome is not EvidenceOutcome.PASS:
+            return RunnerExecution(obligation.obligation_id, base_execution.outcome, base_execution.command_digest, base_execution.detail)
+        head_execution, _head_ids = _run_jest(root, obligation.artifact_paths, config.timeout_seconds, config, base_ids)
+        return RunnerExecution(obligation.obligation_id, head_execution.outcome, head_execution.command_digest, head_execution.detail)
     profile = VerificationProfile(
         UnitId("runner-closure", PurePosixPath("closure.prompt"), "python"),
         (obligation,),

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -13,7 +13,6 @@ import os
 import platform
 import re
 import shlex
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -531,6 +530,7 @@ def _jest_local_path(value: str) -> PurePosixPath | None:
 
 
 def _jest_config_references(config: object) -> set[PurePosixPath]:
+    # pylint: disable=too-many-branches,too-many-statements
     """Find local executable support named by static Jest config keys."""
     if not isinstance(config, dict):
         return set()
@@ -864,8 +864,10 @@ def runner_identity_digest(
         ],
     }
     if root is not None:
+        support_closure_digest = _support_digest(root, ref, profile)[0]
+        jest_support_digest = _jest_support_digest(root, ref, profile)[0]
         payload["support_closure_digest"] = hashlib.sha256(
-            (_support_digest(root, ref, profile)[0] + _jest_support_digest(root, ref, profile)[0]).encode()
+            (support_closure_digest + jest_support_digest).encode()
         ).hexdigest()
         payload["validator_command_digest"] = _validator_command_identity_digest(
             root, config
@@ -1296,6 +1298,7 @@ module.exports = PddTrustedReporter;
 def _jest_result(
     output: Path, returncode: int, expected: tuple[str, ...] | None
 ) -> tuple[EvidenceOutcome, str, tuple[str, ...]]:
+    # pylint: disable=too-many-return-statements
     """Validate trusted reporter data and normalize every non-pass state."""
     try:
         payload = json.loads(output.read_text(encoding="utf-8"))
@@ -1311,19 +1314,39 @@ def _jest_result(
         return EvidenceOutcome.COLLECTION_ERROR, "trusted Jest reporter produced malformed JSON", ()
     identities = tuple(sorted(item["identity"] for item in tests))
     if not identities:
-        return EvidenceOutcome.NOT_COLLECTED, "zero protected Jest test identities collected", ()
+        return (
+            EvidenceOutcome.NOT_COLLECTED,
+            "zero protected Jest test identities collected",
+            (),
+        )
     if len(set(identities)) != len(identities):
-        return EvidenceOutcome.COLLECTION_ERROR, "Jest reporter emitted duplicate test identities", ()
+        return (
+            EvidenceOutcome.COLLECTION_ERROR,
+            "Jest reporter emitted duplicate test identities",
+            (),
+        )
     if expected is not None and identities != expected:
-        return EvidenceOutcome.QUARANTINED, "checked-head Jest identities differ from protected base", identities
+        return (
+            EvidenceOutcome.QUARANTINED,
+            "checked-head Jest identities differ from protected base",
+            identities,
+        )
     statuses = {item["status"] for item in tests}
     if statuses - {"passed", "failed", "pending", "todo", "skipped", "disabled"}:
-        return EvidenceOutcome.COLLECTION_ERROR, "Jest reporter emitted an unsupported status", identities
+        return (
+            EvidenceOutcome.COLLECTION_ERROR,
+            "Jest reporter emitted an unsupported status",
+            identities,
+        )
     if returncode or "failed" in statuses:
         return EvidenceOutcome.FAIL, "Jest reported failed protected tests", identities
     if statuses - {"passed"}:
         return EvidenceOutcome.SKIP, "Jest reported skipped or todo protected tests", identities
-    return EvidenceOutcome.PASS, f"{len(identities)} protected Jest tests passed", identities
+    return (
+        EvidenceOutcome.PASS,
+        f"{len(identities)} protected Jest tests passed",
+        identities,
+    )
 
 
 def _run_jest(
@@ -1334,8 +1357,18 @@ def _run_jest(
     command_prefix = _jest_command(config)
     if command_prefix is None:
         if (root / "node_modules" / "jest" / "bin" / "jest.js").is_file():
-            return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-untrusted", "candidate node_modules Jest runner is not trusted"), ()
-        return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-unavailable", "no local Jest binary is available"), ()
+            return RunnerExecution(
+                "jest",
+                EvidenceOutcome.ERROR,
+                "jest-untrusted",
+                "candidate node_modules Jest runner is not trusted",
+            ), ()
+        return RunnerExecution(
+            "jest",
+            EvidenceOutcome.ERROR,
+            "jest-unavailable",
+            "no local Jest binary is available",
+        ), ()
     command_error = _protected_command_error(root, command_prefix)
     if command_error is not None:
         return RunnerExecution(
@@ -1344,18 +1377,39 @@ def _run_jest(
     try:
         config_path, _config_data = _jest_config(root, "HEAD")
     except ValueError as exc:
-        return RunnerExecution("jest", EvidenceOutcome.ERROR, "jest-config", str(exc)), ()
+        return RunnerExecution(
+            "jest", EvidenceOutcome.ERROR, "jest-config", str(exc)
+        ), ()
     with tempfile.TemporaryDirectory(prefix="pdd-trusted-jest-") as directory:
         temporary = Path(directory)
         reporter = temporary / "reporter.cjs"
         output = temporary / "results.json"
         reporter.write_text(_JEST_REPORTER, encoding="utf-8")
-        command = [*command_prefix, *(path.as_posix() for path in paths), "--runInBand", f"--config={root / config_path}", f"--reporters={reporter}"]
-        digest = hashlib.sha256(json.dumps(command, separators=(",", ":")).encode()).hexdigest()
+        command = [
+            *command_prefix,
+            *(path.as_posix() for path in paths),
+            "--runInBand",
+            f"--config={root / config_path}",
+            f"--reporters={reporter}",
+        ]
+        digest = hashlib.sha256(
+            json.dumps(command, separators=(",", ":")).encode()
+        ).hexdigest()
         try:
-            result = subprocess.run(command, cwd=root, capture_output=True, text=True, check=False, timeout=timeout_seconds, env=_jest_environment(temporary) | {"PDD_TRUSTED_JEST_OUTPUT": str(output)})
+            result = subprocess.run(
+                command,
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=timeout_seconds,
+                env=_jest_environment(temporary)
+                | {"PDD_TRUSTED_JEST_OUTPUT": str(output)},
+            )
         except subprocess.TimeoutExpired:
-            return RunnerExecution("jest", EvidenceOutcome.TIMEOUT, digest, "Jest execution timed out"), ()
+            return RunnerExecution(
+                "jest", EvidenceOutcome.TIMEOUT, digest, "Jest execution timed out"
+            ), ()
         outcome, detail, identities = _jest_result(output, result.returncode, expected)
         return RunnerExecution("jest", outcome, digest, detail), identities
 
@@ -1658,14 +1712,23 @@ def _obligation_preflight(
             obligation.validator_config_digest,
             "test obligation declares no artifact paths",
         )
-    digest_function = pytest_validator_config_digest if obligation.validator_id == "pytest" else jest_validator_config_digest
+    digest_function = (
+        pytest_validator_config_digest
+        if obligation.validator_id == "pytest"
+        else jest_validator_config_digest
+    )
     try:
         expected_config_digests = {
             digest_function(root, ref, obligation.artifact_paths)
             for ref in (base_sha, head_sha)
         }
     except ValueError as exc:
-        return RunnerExecution(obligation.obligation_id, EvidenceOutcome.ERROR, obligation.validator_config_digest, str(exc))
+        return RunnerExecution(
+            obligation.obligation_id,
+            EvidenceOutcome.ERROR,
+            obligation.validator_config_digest,
+            str(exc),
+        )
     if expected_config_digests != {obligation.validator_config_digest}:
         if obligation.validator_id == "pytest":
             support_paths = tuple(
@@ -1747,15 +1810,33 @@ def _obligation_preflight(
 
 
 def _collect_jest_at_base(
-    root: Path, base_sha: str, paths: tuple[PurePosixPath, ...], config: RunnerConfig
+    root: Path,
+    base_sha: str,
+    paths: tuple[PurePosixPath, ...],
+    config: RunnerConfig,
 ) -> tuple[RunnerExecution, tuple[str, ...]]:
     """Run protected-base Jest with the trusted reporter to establish identities."""
     with tempfile.TemporaryDirectory(prefix="pdd-jest-protected-base-") as directory:
         clone = Path(directory) / "repository"
-        cloned = subprocess.run(["git", "clone", "-q", "--no-local", "--no-checkout", str(root), str(clone)], capture_output=True, text=True, check=False)
-        checked_out = cloned.returncode == 0 and subprocess.run(["git", "checkout", "-q", "--detach", base_sha], cwd=clone, capture_output=True, check=False).returncode == 0
+        cloned = subprocess.run(
+            ["git", "clone", "-q", "--no-local", "--no-checkout", str(root), str(clone)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        checked_out = cloned.returncode == 0 and subprocess.run(
+            ["git", "checkout", "-q", "--detach", base_sha],
+            cwd=clone,
+            capture_output=True,
+            check=False,
+        ).returncode == 0
         if not checked_out:
-            return RunnerExecution("protected-base-collection", EvidenceOutcome.COLLECTION_ERROR, hashlib.sha256(base_sha.encode()).hexdigest(), "cannot create protected-base Jest clone"), ()
+            return RunnerExecution(
+                "protected-base-collection",
+                EvidenceOutcome.COLLECTION_ERROR,
+                hashlib.sha256(base_sha.encode()).hexdigest(),
+                "cannot create protected-base Jest clone",
+            ), ()
         return _run_jest(clone, paths, config.timeout_seconds, config)
 
 
@@ -1801,18 +1882,24 @@ def _run_obligation_in_tree(
     head_sha: str,
     config: RunnerConfig,
 ) -> RunnerExecution:
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,too-many-return-statements
     """Run one protected obligation with changed-test self-certification guards."""
     preflight = _obligation_preflight(root, obligation, base_sha, head_sha)
     if preflight is not None:
         return preflight
     if obligation.validator_id == "jest":
         profile = VerificationProfile(
-            UnitId("runner-closure", PurePosixPath("closure.prompt"), "javascript"),
-            (obligation,), obligation.requirement_ids, "closure",
+            UnitId(
+                "runner-closure", PurePosixPath("closure.prompt"), "javascript"
+            ),
+            (obligation,),
+            obligation.requirement_ids,
+            "closure",
         )
         _digest, support_paths = _jest_support_digest(root, head_sha, profile)
-        protected_paths = tuple(sorted(set(obligation.artifact_paths) | set(support_paths)))
+        protected_paths = tuple(
+            sorted(set(obligation.artifact_paths) | set(support_paths))
+        )
         changed = _changed_paths(root, base_sha, head_sha, protected_paths)
         changed.update(_dirty_jest_support(root))
         if changed:
@@ -1822,11 +1909,29 @@ def _run_obligation_in_tree(
                 "candidate-modified Jest support cannot solely certify itself: "
                 + ", ".join(sorted(changed)),
             )
-        base_execution, base_ids = _collect_jest_at_base(root, base_sha, obligation.artifact_paths, config)
+        base_execution, base_ids = _collect_jest_at_base(
+            root, base_sha, obligation.artifact_paths, config
+        )
         if base_execution.outcome is not EvidenceOutcome.PASS:
-            return RunnerExecution(obligation.obligation_id, base_execution.outcome, base_execution.command_digest, base_execution.detail)
-        head_execution, _head_ids = _run_jest(root, obligation.artifact_paths, config.timeout_seconds, config, base_ids)
-        return RunnerExecution(obligation.obligation_id, head_execution.outcome, head_execution.command_digest, head_execution.detail)
+            return RunnerExecution(
+                obligation.obligation_id,
+                base_execution.outcome,
+                base_execution.command_digest,
+                base_execution.detail,
+            )
+        head_execution, _head_ids = _run_jest(
+            root,
+            obligation.artifact_paths,
+            config.timeout_seconds,
+            config,
+            base_ids,
+        )
+        return RunnerExecution(
+            obligation.obligation_id,
+            head_execution.outcome,
+            head_execution.command_digest,
+            head_execution.detail,
+        )
     profile = VerificationProfile(
         UnitId("runner-closure", PurePosixPath("closure.prompt"), "python"),
         (obligation,),
@@ -1887,7 +1992,11 @@ def run_obligation(
             "dirty checkout cannot receive committed-head evidence: "
             + ", ".join(dirty_all),
         )
-    dirty = _dirty_pytest_support(root)
+    dirty = (
+        _dirty_jest_support(root)
+        if obligation.validator_id == "jest"
+        else _dirty_pytest_support(root)
+    )
     if dirty:
         return RunnerExecution(
             obligation.obligation_id,
@@ -1896,6 +2005,15 @@ def run_obligation(
             "candidate-modified test cannot solely certify itself: "
             + ", ".join(sorted(dirty)),
         )
+    if obligation.validator_id == "jest" and config.jest_command is not None:
+        command_error = _protected_command_error(root, config.jest_command)
+        if command_error is not None:
+            return RunnerExecution(
+                obligation.obligation_id,
+                EvidenceOutcome.ERROR,
+                obligation.validator_config_digest,
+                command_error,
+            )
     with tempfile.TemporaryDirectory(prefix="pdd-runner-exact-head-") as directory:
         clone = Path(directory) / "repository"
         cloned = subprocess.run(

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -506,23 +506,36 @@ def test_protected_base_pre_authorizes_absent_exact_child_paths(
         }
         for path in PREAUTHORIZED_CHILD_PATHS
     }
-    baseline = build_unit_manifest(ROOT, base_ref="HEAD", head_ref="HEAD")
-    baseline_paths = {
-        item.candidate_id.artifact_relpath.as_posix()
-        for item in baseline.candidates
-    }
-    assert not PREAUTHORIZED_CHILD_PATHS.intersection(baseline_paths)
-    baseline_denominator = len(baseline.expected_managed)
-
     root = tmp_path / "preauthorized-child-paths"
     subprocess.run(
         ["git", "clone", "-q", "--no-hardlinks", str(ROOT), str(root)],
         check=True,
         capture_output=True,
     )
-    base = subprocess.check_output(
-        ["git", "rev-parse", "HEAD"], cwd=root, text=True
-    ).strip()
+
+    # A child PR can itself add a preauthorized path.  Build the protected base
+    # explicitly so this regression continues to exercise absent-path routing
+    # after such a child has merged into another branch.
+    removed_existing_child_paths = False
+    for path in PREAUTHORIZED_CHILD_PATHS:
+        child_path = root / path
+        if child_path.exists():
+            _git(root, "rm", path)
+            removed_existing_child_paths = True
+    base = (
+        _commit(root, "remove preauthorized child paths")
+        if removed_existing_child_paths
+        else subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=root, text=True
+        ).strip()
+    )
+    baseline = build_unit_manifest(root, base_ref=base, head_ref=base)
+    baseline_paths = {
+        item.candidate_id.artifact_relpath.as_posix()
+        for item in baseline.candidates
+    }
+    assert not PREAUTHORIZED_CHILD_PATHS.intersection(baseline_paths)
+    baseline_denominator = len(baseline.expected_managed)
 
     for path in PREAUTHORIZED_CHILD_PATHS:
         child_path = root / path

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -38,6 +38,7 @@ from pdd.sync_core.identity import initialize_repository_identity
 from pdd.sync_core.types import ObligationEvidence
 from pdd.ci_drift_heal import main as ci_drift_heal_main
 from pdd.commands.sync_core import baseline as baseline_command
+from pdd.commands.sync_core import validate as validate_command
 from pdd.continuous_sync import build_report as build_compatibility_report
 from pdd.continuous_sync import (
     canonical_sync_enabled,
@@ -535,6 +536,42 @@ def test_reviewed_baseline_command_records_current_unknown(tmp_path, monkeypatch
     assert report["units"][0]["baseline"] == "CURRENT"
     assert report["units"][0]["semantic"] == "UNKNOWN"
     assert report["counts"]["trusted_in_sync"] == 0
+
+
+def test_validate_command_wires_protected_jest_runner_config(
+    tmp_path, monkeypatch
+) -> None:
+    root, commit = _repository(tmp_path)
+    external = tmp_path / "trusted-tools" / "jest.py"
+    external.parent.mkdir()
+    external.write_text("print('trusted jest')\n")
+    signer = object()
+    monkeypatch.chdir(root)
+    with patch(
+        "pdd.commands.sync_core.attestation_signer_from_environment",
+        return_value=signer,
+    ), patch("pdd.commands.sync_core.finalize_unit") as mocked_finalize:
+        mocked_finalize.return_value.transaction.transaction_id = "tx-1"
+        mocked_finalize.return_value.attestation_id = "att-1"
+        mocked_finalize.return_value.fingerprint_path = PurePosixPath(
+            ".pdd/meta/v2/fingerprint.json"
+        )
+        result = CliRunner().invoke(
+            validate_command,
+            [
+                "--module",
+                "prompts/widget_python.prompt",
+                "--base-ref",
+                commit,
+                "--jest-command",
+                f"{os.sys.executable} {external}",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    call = mocked_finalize.call_args
+    assert call.kwargs["signer"] is signer
+    assert call.kwargs["config"].jest_command == (os.sys.executable, str(external))
 
 
 def test_trusted_finalizer_commits_artifact_closure_evidence_and_fingerprint(

--- a/tests/test_sync_core_runner_jest.py
+++ b/tests/test_sync_core_runner_jest.py
@@ -407,6 +407,48 @@ def test_explicit_candidate_local_jest_command_is_not_trusted(tmp_path: Path) ->
     assert "candidate checkout" in executions[0].detail
 
 
+def test_pathless_jest_script_operand_is_not_resolved_from_candidate(
+    tmp_path: Path,
+) -> None:
+    root, base = _repository(tmp_path)
+    (root / "fake_jest.py").write_text(_fake_jest(tmp_path).read_text())
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add pathless candidate Jest command")
+    base = _git(root, "rev-parse", "HEAD")
+    (root / "fake_jest.py").write_text(_fake_jest(tmp_path).read_text() + "\n# changed\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mutate pathless Jest command")
+    paths = (PurePosixPath("tests/widget.test.js"),)
+    obligation = VerificationObligation(
+        "jest",
+        "test",
+        "jest",
+        jest_validator_config_digest(root, base, paths),
+        ("REQ-1",),
+        paths,
+    )
+    profile = VerificationProfile(UNIT, (obligation,), ("REQ-1",), "profile-v1")
+
+    _envelope, executions = run_profile(
+        root,
+        profile,
+        RunBinding("snapshot-v1", base, _git(root, "rev-parse", "HEAD")),
+        AttestationIssue(
+            AttestationSigner("trusted-ci", b"v" * 32),
+            "id",
+            "nonce",
+            datetime(2026, 7, 10, tzinfo=timezone.utc),
+        ),
+        config=RunnerConfig(
+            timeout_seconds=2,
+            jest_command=(sys.executable, "fake_jest.py"),
+        ),
+    )
+
+    assert executions[0].outcome is EvidenceOutcome.ERROR
+    assert "pathless" in executions[0].detail
+
+
 def test_jest_subprocess_cannot_read_secret(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root, commit = _repository(tmp_path)
     fake = _fake_jest(tmp_path)

--- a/tests/test_sync_core_runner_jest.py
+++ b/tests/test_sync_core_runner_jest.py
@@ -166,6 +166,25 @@ def test_jest_imported_test_helper_mutation_cannot_pass(tmp_path: Path) -> None:
     assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
 
 
+def test_jest_side_effect_import_helper_mutation_cannot_pass(tmp_path: Path) -> None:
+    root, _commit = _repository(tmp_path)
+    (root / "tests/helper.js").write_text("global.expected = true;\n")
+    (root / "tests/widget.test.js").write_text(
+        "import './helper';\n"
+        "test('widget works', () => expect(global.expected).toBe(true));\n"
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add protected side effect helper")
+    base = _git(root, "rev-parse", "HEAD")
+    (root / "tests/helper.js").write_text("global.expected = false;\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mutate side effect helper")
+
+    _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
+
+    assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
+
+
 @pytest.mark.parametrize("config_key", ["globalSetup", "globalTeardown", "testEnvironment"])
 def test_jest_executable_config_hook_mutation_cannot_pass(
     tmp_path: Path, config_key: str
@@ -179,6 +198,33 @@ def test_jest_executable_config_hook_mutation_cannot_pass(
     (root / "hook.js").write_text("module.exports = { changed: true };\n")
     _git(root, "add", ".")
     _git(root, "commit", "-q", "-m", "mutate Jest hook")
+
+    _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
+
+    assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
+
+
+@pytest.mark.parametrize(
+    ("config", "path"),
+    [
+        ('{"snapshotSerializers":["<rootDir>/serializer.js"]}', "serializer.js"),
+        ('{"testSequencer":"<rootDir>/sequencer.js"}', "sequencer.js"),
+        ('{"moduleNameMapper":{"^@/(.*)$":"<rootDir>/src/$1"}}', "src/helper.js"),
+    ],
+)
+def test_jest_additional_executable_config_mutation_cannot_pass(
+    tmp_path: Path, config: str, path: str
+) -> None:
+    root, _commit = _repository(tmp_path, config=config)
+    target = root / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("module.exports = {};\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add protected Jest executable config")
+    base = _git(root, "rev-parse", "HEAD")
+    target.write_text("module.exports = { changed: true };\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mutate protected Jest executable config")
 
     _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
 
@@ -202,6 +248,21 @@ def test_default_candidate_node_modules_jest_is_not_trusted(tmp_path: Path) -> N
 
     assert executions[0].outcome is EvidenceOutcome.ERROR
     assert "candidate node_modules" in executions[0].detail
+
+
+def test_explicit_candidate_local_jest_command_is_not_trusted(tmp_path: Path) -> None:
+    root, commit = _repository(tmp_path)
+    runner = root / "tools" / "jest.py"
+    runner.parent.mkdir()
+    runner.write_text(_fake_jest(tmp_path).read_text())
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add candidate-local Jest command")
+    commit = _git(root, "rev-parse", "HEAD")
+
+    _envelope, executions = _run(root, commit, commit, runner)
+
+    assert executions[0].outcome is EvidenceOutcome.ERROR
+    assert "candidate checkout" in executions[0].detail
 
 
 def test_jest_subprocess_cannot_read_secret(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_sync_core_runner_jest.py
+++ b/tests/test_sync_core_runner_jest.py
@@ -65,8 +65,12 @@ def _repository(tmp_path: Path, *, mode: str = "pass", config: str = '{"testMatc
 
 def _run(root: Path, base: str, head: str, fake_jest: Path, timeout: int = 2):
     paths = (PurePosixPath("tests/widget.test.js"),)
+    try:
+        config_digest = jest_validator_config_digest(root, base, paths)
+    except ValueError:
+        config_digest = "invalid-jest-config"
     obligation = VerificationObligation(
-        "jest", "test", "jest", jest_validator_config_digest(root, base, paths),
+        "jest", "test", "jest", config_digest,
         ("REQ-1",), paths,
     )
     profile = VerificationProfile(UNIT, (obligation,), ("REQ-1",), "profile-v1")

--- a/tests/test_sync_core_runner_jest.py
+++ b/tests/test_sync_core_runner_jest.py
@@ -81,6 +81,20 @@ def _run(root: Path, base: str, head: str, fake_jest: Path, timeout: int = 2):
     )
 
 
+def _run_default_jest(root: Path, base: str, head: str, timeout: int = 2):
+    paths = (PurePosixPath("tests/widget.test.js"),)
+    obligation = VerificationObligation(
+        "jest", "test", "jest", jest_validator_config_digest(root, base, paths),
+        ("REQ-1",), paths,
+    )
+    profile = VerificationProfile(UNIT, (obligation,), ("REQ-1",), "profile-v1")
+    return run_profile(
+        root, profile, RunBinding("snapshot-v1", base, head),
+        AttestationIssue(AttestationSigner("trusted-ci", b"v" * 32), "id", "nonce", datetime(2026, 7, 10, tzinfo=timezone.utc)),
+        config=RunnerConfig(timeout_seconds=timeout),
+    )
+
+
 @pytest.mark.parametrize(
     ("mode", "outcome"),
     [("pass", EvidenceOutcome.PASS), ("fail", EvidenceOutcome.FAIL), ("skip", EvidenceOutcome.SKIP), ("todo", EvidenceOutcome.SKIP), ("zero", EvidenceOutcome.NOT_COLLECTED), ("timeout", EvidenceOutcome.TIMEOUT), ("malformed", EvidenceOutcome.COLLECTION_ERROR)],
@@ -131,6 +145,63 @@ def test_jest_dirty_support_cannot_influence_run(tmp_path: Path) -> None:
     (root / "setup.js").write_text("untracked\n")
     _envelope, executions = _run(root, commit, commit, _fake_jest(tmp_path))
     assert executions[0].outcome is EvidenceOutcome.QUARANTINED
+
+
+def test_jest_imported_test_helper_mutation_cannot_pass(tmp_path: Path) -> None:
+    root, _commit = _repository(tmp_path)
+    (root / "tests/helper.js").write_text("module.exports = { expected: true };\n")
+    (root / "tests/widget.test.js").write_text(
+        "const { expected } = require('./helper');\n"
+        "test('widget works', () => expect(expected).toBe(true));\n"
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add protected Jest helper")
+    base = _git(root, "rev-parse", "HEAD")
+    (root / "tests/helper.js").write_text("module.exports = { expected: false };\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mutate imported Jest helper")
+
+    _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
+
+    assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
+
+
+@pytest.mark.parametrize("config_key", ["globalSetup", "globalTeardown", "testEnvironment"])
+def test_jest_executable_config_hook_mutation_cannot_pass(
+    tmp_path: Path, config_key: str
+) -> None:
+    config = '{"%s":"<rootDir>/hook.js"}' % config_key
+    root, _commit = _repository(tmp_path, config=config)
+    (root / "hook.js").write_text("module.exports = {};\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add protected Jest hook")
+    base = _git(root, "rev-parse", "HEAD")
+    (root / "hook.js").write_text("module.exports = { changed: true };\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mutate Jest hook")
+
+    _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
+
+    assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
+
+
+def test_default_candidate_node_modules_jest_is_not_trusted(tmp_path: Path) -> None:
+    root, commit = _repository(tmp_path)
+    binary = root / "node_modules" / "jest" / "bin" / "jest.js"
+    binary.parent.mkdir(parents=True)
+    binary.write_text(
+        "const fs = require('fs');\n"
+        "fs.writeFileSync(process.env.PDD_TRUSTED_JEST_OUTPUT, "
+        "JSON.stringify({tests:[{identity:'tests/widget.test.js::widget works',status:'passed'}]}));\n"
+    )
+    _git(root, "add", "node_modules/jest/bin/jest.js")
+    _git(root, "commit", "-q", "-m", "add local Jest toolchain")
+    commit = _git(root, "rev-parse", "HEAD")
+
+    _envelope, executions = _run_default_jest(root, commit, commit)
+
+    assert executions[0].outcome is EvidenceOutcome.ERROR
+    assert "candidate node_modules" in executions[0].detail
 
 
 def test_jest_subprocess_cannot_read_secret(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_sync_core_runner_jest.py
+++ b/tests/test_sync_core_runner_jest.py
@@ -1,0 +1,149 @@
+"""Contract tests for the fail-closed trusted Jest adapter."""
+
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from pdd.sync_core import (
+    AttestationIssue,
+    AttestationSigner,
+    EvidenceOutcome,
+    RunBinding,
+    RunnerConfig,
+    UnitId,
+    VerificationObligation,
+    VerificationProfile,
+    run_profile,
+)
+from pdd.sync_core.runner import jest_validator_config_digest
+
+
+UNIT = UnitId("repository-1", PurePosixPath("prompts/widget_js.prompt"), "javascript")
+IDENTITY = "tests/widget.test.js::widget works"
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=root, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _fake_jest(tmp_path: Path) -> Path:
+    runner = tmp_path / "fake_jest.py"
+    runner.write_text(
+        "import json, os, pathlib, time\n"
+        "root = pathlib.Path.cwd()\n"
+        "mode = (root / 'source.js').read_text().strip() if (root / 'source.js').exists() else 'pass'\n"
+        "if mode == 'timeout': time.sleep(5)\n"
+        "if mode == 'malformed': pathlib.Path(os.environ['PDD_TRUSTED_JEST_OUTPUT']).write_text('{')\n"
+        "else:\n"
+        "  tests = [] if mode == 'zero' else [{'identity': 'tests/widget.test.js::widget works', 'status': {'fail': 'failed', 'skip': 'pending', 'todo': 'todo'}.get(mode, 'passed')}]\n"
+        "  if mode == 'mismatch': tests = [{'identity': 'tests/widget.test.js::other', 'status': 'passed'}]\n"
+        "  if mode == 'candidate': tests.append({'identity': 'tests/widget.test.js::candidate only', 'status': 'passed'})\n"
+        "  pathlib.Path(os.environ['PDD_TRUSTED_JEST_OUTPUT']).write_text(json.dumps({'tests': tests}))\n"
+    )
+    return runner
+
+
+def _repository(tmp_path: Path, *, mode: str = "pass", config: str = '{"testMatch":["**/*.test.js"]}') -> tuple[Path, str]:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "runner@example.com")
+    _git(root, "config", "user.name", "Runner Test")
+    (root / "tests").mkdir()
+    (root / "tests/widget.test.js").write_text("test('widget works', () => expect(true).toBe(true));\n")
+    (root / "jest.config.json").write_text(config)
+    (root / "source.js").write_text(mode)
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "protected Jest tests")
+    return root, _git(root, "rev-parse", "HEAD")
+
+
+def _run(root: Path, base: str, head: str, fake_jest: Path, timeout: int = 2):
+    paths = (PurePosixPath("tests/widget.test.js"),)
+    obligation = VerificationObligation(
+        "jest", "test", "jest", jest_validator_config_digest(root, base, paths),
+        ("REQ-1",), paths,
+    )
+    profile = VerificationProfile(UNIT, (obligation,), ("REQ-1",), "profile-v1")
+    return run_profile(
+        root, profile, RunBinding("snapshot-v1", base, head),
+        AttestationIssue(AttestationSigner("trusted-ci", b"v" * 32), "id", "nonce", datetime(2026, 7, 10, tzinfo=timezone.utc)),
+        config=RunnerConfig(timeout_seconds=timeout, jest_command=(sys.executable, str(fake_jest))),
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "outcome"),
+    [("pass", EvidenceOutcome.PASS), ("fail", EvidenceOutcome.FAIL), ("skip", EvidenceOutcome.SKIP), ("todo", EvidenceOutcome.SKIP), ("zero", EvidenceOutcome.NOT_COLLECTED), ("timeout", EvidenceOutcome.TIMEOUT), ("malformed", EvidenceOutcome.COLLECTION_ERROR)],
+)
+def test_jest_normalizes_non_pass_outcomes(tmp_path: Path, mode: str, outcome: EvidenceOutcome) -> None:
+    root, commit = _repository(tmp_path, mode=mode)
+    _envelope, executions = _run(root, commit, commit, _fake_jest(tmp_path), timeout=1)
+    assert executions[0].outcome is outcome
+
+
+@pytest.mark.parametrize("mode", ["mismatch", "candidate"])
+def test_jest_collection_identity_mismatch_cannot_pass(tmp_path: Path, mode: str) -> None:
+    root, base = _repository(tmp_path)
+    (root / "source.js").write_text(mode)
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "change application behavior")
+    _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
+    assert executions[0].outcome is EvidenceOutcome.QUARANTINED
+
+
+def test_jest_removed_protected_test_cannot_pass(tmp_path: Path) -> None:
+    root, base = _repository(tmp_path)
+    (root / "tests/widget.test.js").write_text("// removed\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "remove protected test")
+    _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
+    assert executions[0].outcome is EvidenceOutcome.QUARANTINED
+
+
+@pytest.mark.parametrize("path", ["jest.config.json", "setup.js", "transform.js"])
+def test_jest_config_and_support_mutation_cannot_pass(tmp_path: Path, path: str) -> None:
+    config = '{"setupFilesAfterEnv":["<rootDir>/setup.js"],"transform":{"^.+\\\\.js$":"<rootDir>/transform.js"}}'
+    root, base = _repository(tmp_path, config=config)
+    (root / "setup.js").write_text("export {};\n")
+    (root / "transform.js").write_text("module.exports = {};\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add protected support")
+    base = _git(root, "rev-parse", "HEAD")
+    (root / path).write_text("changed\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mutate protected Jest support")
+    _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
+    assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
+
+
+def test_jest_dirty_support_cannot_influence_run(tmp_path: Path) -> None:
+    root, commit = _repository(tmp_path)
+    (root / "setup.js").write_text("untracked\n")
+    _envelope, executions = _run(root, commit, commit, _fake_jest(tmp_path))
+    assert executions[0].outcome is EvidenceOutcome.QUARANTINED
+
+
+def test_jest_subprocess_cannot_read_secret(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root, commit = _repository(tmp_path)
+    fake = _fake_jest(tmp_path)
+    fake.write_text(fake.read_text() + "\nassert 'PDD_ATTESTATION_SIGNING_KEY' not in os.environ\n")
+    monkeypatch.setenv("PDD_ATTESTATION_SIGNING_KEY", "must-not-leak")
+    _envelope, executions = _run(root, commit, commit, fake)
+    assert executions[0].outcome is EvidenceOutcome.PASS
+
+
+def test_jest_rejects_dynamic_config(tmp_path: Path) -> None:
+    root, commit = _repository(tmp_path, config="{}")
+    (root / "jest.config.json").unlink()
+    (root / "jest.config.js").write_text("module.exports = {};\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "dynamic config")
+    commit = _git(root, "rev-parse", "HEAD")
+    _envelope, executions = _run(root, commit, commit, _fake_jest(tmp_path))
+    assert executions[0].outcome is EvidenceOutcome.ERROR

--- a/tests/test_sync_core_runner_jest.py
+++ b/tests/test_sync_core_runner_jest.py
@@ -1,5 +1,6 @@
 """Contract tests for the fail-closed trusted Jest adapter."""
 
+import json
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -16,6 +17,7 @@ from pdd.sync_core import (
     UnitId,
     VerificationObligation,
     VerificationProfile,
+    runner_identity_digest,
     run_profile,
 )
 from pdd.sync_core.runner import jest_validator_config_digest
@@ -24,6 +26,27 @@ from pdd.sync_core.runner import _local_javascript_imports
 
 UNIT = UnitId("repository-1", PurePosixPath("prompts/widget_js.prompt"), "javascript")
 IDENTITY = "tests/widget.test.js::widget works"
+
+
+@pytest.fixture(autouse=True)
+def _local_managed_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Execute adapter unit tests without requiring a host namespace sandbox."""
+    def execute(command, *, cwd, timeout, env, **_limits):
+        try:
+            result = subprocess.run(
+                command,
+                cwd=cwd,
+                timeout=timeout,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            result = subprocess.CompletedProcess(command, 124, "", "timeout")
+        return result, False
+
+    monkeypatch.setattr("pdd.sync_core.runner._managed_subprocess", execute)
 
 
 def _git(root: Path, *args: str) -> str:
@@ -64,21 +87,36 @@ def _repository(tmp_path: Path, *, mode: str = "pass", config: str = '{"testMatc
     return root, _git(root, "rev-parse", "HEAD")
 
 
-def _run(root: Path, base: str, head: str, fake_jest: Path, timeout: int = 2):
+def _run(
+    root: Path,
+    base: str,
+    head: str,
+    fake_jest: Path,
+    timeout: int = 2,
+    *,
+    code_under_test_paths: tuple[PurePosixPath, ...] = (),
+    command: tuple[str, ...] | None = None,
+):
     paths = (PurePosixPath("tests/widget.test.js"),)
     try:
-        config_digest = jest_validator_config_digest(root, base, paths)
+        config_digest = jest_validator_config_digest(
+            root, base, paths, code_under_test_paths
+        )
     except ValueError:
         config_digest = "invalid-jest-config"
     obligation = VerificationObligation(
         "jest", "test", "jest", config_digest,
         ("REQ-1",), paths,
+        code_under_test_paths=code_under_test_paths,
     )
     profile = VerificationProfile(UNIT, (obligation,), ("REQ-1",), "profile-v1")
     return run_profile(
         root, profile, RunBinding("snapshot-v1", base, head),
         AttestationIssue(AttestationSigner("trusted-ci", b"v" * 32), "id", "nonce", datetime(2026, 7, 10, tzinfo=timezone.utc)),
-        config=RunnerConfig(timeout_seconds=timeout, jest_command=(sys.executable, str(fake_jest))),
+        config=RunnerConfig(
+            timeout_seconds=timeout,
+            jest_command=command or (sys.executable, str(fake_jest)),
+        ),
     )
 
 
@@ -123,6 +161,39 @@ def test_jest_removed_protected_test_cannot_pass(tmp_path: Path) -> None:
     _git(root, "commit", "-q", "-m", "remove protected test")
     _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
     assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
+
+
+def test_jest_application_import_is_excluded_from_support_closure(
+    tmp_path: Path,
+) -> None:
+    root, _commit = _repository(tmp_path)
+    application = PurePosixPath("src/widget.js")
+    (root / "src").mkdir()
+    (root / application).write_text("module.exports = { value: 1 };\n")
+    (root / "tests/widget.test.js").write_text(
+        "const widget = require('../src/widget');\n"
+        "test('widget works', () => expect(widget.value).toBe(1));\n"
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "test real application import")
+    base = _git(root, "rev-parse", "HEAD")
+    paths = (PurePosixPath("tests/widget.test.js"),)
+    base_digest = jest_validator_config_digest(root, base, paths, (application,))
+
+    (root / application).write_text("module.exports = { value: 2 };\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "change application implementation")
+    head = _git(root, "rev-parse", "HEAD")
+
+    assert jest_validator_config_digest(root, head, paths, (application,)) == base_digest
+    _envelope, executions = _run(
+        root,
+        base,
+        head,
+        _fake_jest(tmp_path),
+        code_under_test_paths=(application,),
+    )
+    assert executions[0].outcome is EvidenceOutcome.PASS
 
 
 @pytest.mark.parametrize("path", ["jest.config.json", "setup.js", "transform.js"])
@@ -269,6 +340,50 @@ def test_jest_parent_directory_imports_change_validator_digest(tmp_path: Path) -
     head_digest = jest_validator_config_digest(root, _git(root, "rev-parse", "HEAD"), paths)
 
     assert head_digest != base_digest
+
+
+@pytest.mark.parametrize("transitive", [False, True])
+def test_jest_rejects_unresolved_dynamic_local_loads(
+    tmp_path: Path, transitive: bool
+) -> None:
+    root, _commit = _repository(tmp_path)
+    paths = (PurePosixPath("tests/widget.test.js"),)
+    dynamic_source = "const target = './dynamic'; require(target);\n"
+    if transitive:
+        (root / "tests/widget.test.js").write_text(
+            "require('./helper');\n"
+            "test('widget works', () => expect(true).toBe(true));\n"
+        )
+        (root / "tests/helper.js").write_text(dynamic_source)
+    else:
+        (root / "tests/widget.test.js").write_text(dynamic_source)
+    (root / "tests/dynamic.js").write_text("module.exports = true;\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add dynamic local load")
+    commit = _git(root, "rev-parse", "HEAD")
+
+    with pytest.raises(ValueError, match="dynamic local require/import"):
+        jest_validator_config_digest(root, commit, paths)
+
+
+def test_jest_dynamic_load_detection_ignores_comments_and_strings(
+    tmp_path: Path,
+) -> None:
+    root, _commit = _repository(tmp_path)
+    paths = (PurePosixPath("tests/widget.test.js"),)
+    (root / "tests/helper.js").write_text("module.exports = true;\n")
+    (root / "tests/widget.test.js").write_text(
+        "const note = 'require(dynamic)';\n"
+        "// import(dynamic)\n"
+        "/* require(otherDynamic) */\n"
+        "const helper = require('./helper');\n"
+        "test('widget works', () => expect(helper).toBe(true));\n"
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "retain static Jest imports")
+    commit = _git(root, "rev-parse", "HEAD")
+
+    assert jest_validator_config_digest(root, commit, paths)
 
 
 def test_jest_config_reference_index_candidate_changes_validator_digest(tmp_path: Path) -> None:
@@ -447,6 +562,137 @@ def test_pathless_jest_script_operand_is_not_resolved_from_candidate(
 
     assert executions[0].outcome is EvidenceOutcome.ERROR
     assert "pathless" in executions[0].detail
+
+
+def test_jest_rejects_package_launcher_indirection(tmp_path: Path) -> None:
+    root, commit = _repository(tmp_path)
+    launcher = tmp_path / "npx"
+    launcher.write_text("#!/bin/sh\nexit 0\n")
+    launcher.chmod(0o755)
+
+    _envelope, executions = _run(
+        root,
+        commit,
+        commit,
+        _fake_jest(tmp_path),
+        command=(str(launcher), "jest"),
+    )
+
+    assert executions[0].outcome is EvidenceOutcome.ERROR
+    assert "launcher indirection" in executions[0].detail
+
+
+def test_jest_runner_identity_binds_external_toolchain(tmp_path: Path) -> None:
+    root, commit = _repository(tmp_path)
+    paths = (PurePosixPath("tests/widget.test.js"),)
+    obligation = VerificationObligation(
+        "jest",
+        "test",
+        "jest",
+        jest_validator_config_digest(root, commit, paths),
+        ("REQ-1",),
+        paths,
+    )
+    profile = VerificationProfile(UNIT, (obligation,), ("REQ-1",), "profile-v1")
+    package = tmp_path / "external" / "node_modules" / "jest"
+    entrypoint = package / "bin/jest.js"
+    dependency = package / "build/index.js"
+    entrypoint.parent.mkdir(parents=True)
+    dependency.parent.mkdir(parents=True)
+    entrypoint.write_text("require('../build');\n")
+    dependency.write_text("module.exports = 1;\n")
+    config = RunnerConfig(jest_command=(sys.executable, str(entrypoint)))
+    before = runner_identity_digest(profile, root=root, ref=commit, config=config)
+
+    dependency.write_text("module.exports = 2;\n")
+
+    assert runner_identity_digest(profile, root=root, ref=commit, config=config) != before
+
+
+@pytest.mark.parametrize("failure", ["missing", "non-executable", "os-error"])
+def test_jest_normalizes_launch_failures_as_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    root, commit = _repository(tmp_path)
+    command = tmp_path / "external-jest"
+    if failure != "missing":
+        command.write_text("#!/bin/sh\nexit 0\n")
+        command.chmod(0o755 if failure == "os-error" else 0o644)
+    if failure == "os-error":
+        def fail_launch(*_args, **_kwargs):
+            raise OSError("simulated spawn failure")
+
+        monkeypatch.setattr("pdd.sync_core.runner._managed_subprocess", fail_launch)
+
+    _envelope, executions = _run(
+        root,
+        commit,
+        commit,
+        _fake_jest(tmp_path),
+        command=(str(command),),
+    )
+
+    assert executions[0].outcome is EvidenceOutcome.ERROR
+
+
+def test_jest_uses_managed_containment_and_cleans_scratch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, commit = _repository(tmp_path)
+    calls: list[dict[str, object]] = []
+    monkeypatch.setenv("PDD_ATTESTATION_SIGNER_COMMAND", "must-not-leak")
+    monkeypatch.setenv("PDD_CERTIFICATE_ISSUER", "must-not-leak")
+    monkeypatch.setenv("PDD_RELEASED_CHECKER_COMMAND", "must-not-leak")
+
+    def inspect_managed(command, **kwargs):
+        environment = kwargs["env"]
+        output = Path(environment["PDD_TRUSTED_JEST_OUTPUT"])
+        output.write_text(
+            json.dumps(
+                {"tests": [{"identity": IDENTITY, "status": "passed"}]}
+            )
+        )
+        calls.append({"command": command, **kwargs})
+        return subprocess.CompletedProcess(command, 0, "", ""), False
+
+    monkeypatch.setattr("pdd.sync_core.runner._managed_subprocess", inspect_managed)
+    _envelope, executions = _run(root, commit, commit, _fake_jest(tmp_path))
+
+    assert executions[0].outcome is EvidenceOutcome.PASS
+    assert len(calls) == 2
+    for call in calls:
+        environment = call["env"]
+        assert not {
+            "PDD_ATTESTATION_SIGNER_COMMAND",
+            "PDD_CERTIFICATE_ISSUER",
+            "PDD_RELEASED_CHECKER_COMMAND",
+        } & environment.keys()
+        assert call["cwd"] in call["readable_roots"]
+        assert call["cwd"] not in call["writable_roots"]
+        assert Path(environment["PDD_TRUSTED_JEST_OUTPUT"]) in call["writable_files"]
+        assert not Path(environment["HOME"]).exists()
+
+
+def test_jest_surviving_descendant_is_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, commit = _repository(tmp_path)
+
+    def surviving(command, **kwargs):
+        Path(kwargs["env"]["PDD_TRUSTED_JEST_OUTPUT"]).write_text(
+            json.dumps(
+                {"tests": [{"identity": IDENTITY, "status": "passed"}]}
+            )
+        )
+        return subprocess.CompletedProcess(command, 0, "", ""), True
+
+    monkeypatch.setattr("pdd.sync_core.runner._managed_subprocess", surviving)
+    _envelope, executions = _run(root, commit, commit, _fake_jest(tmp_path))
+
+    assert executions[0].outcome is EvidenceOutcome.ERROR
+    assert "surviving process-group descendant" in executions[0].detail
 
 
 def test_jest_subprocess_cannot_read_secret(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_sync_core_runner_jest.py
+++ b/tests/test_sync_core_runner_jest.py
@@ -19,6 +19,7 @@ from pdd.sync_core import (
     run_profile,
 )
 from pdd.sync_core.runner import jest_validator_config_digest
+from pdd.sync_core.runner import _local_javascript_imports
 
 
 UNIT = UnitId("repository-1", PurePosixPath("prompts/widget_js.prompt"), "javascript")
@@ -183,6 +184,122 @@ def test_jest_side_effect_import_helper_mutation_cannot_pass(tmp_path: Path) -> 
     _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
 
     assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
+
+
+def test_jest_parent_directory_import_helper_mutation_cannot_pass(tmp_path: Path) -> None:
+    root, _commit = _repository(tmp_path)
+    (root / "shared").mkdir()
+    (root / "shared/helper.js").write_text("module.exports = { expected: true };\n")
+    (root / "tests/widget.test.js").write_text(
+        "const { expected } = require('../shared/helper');\n"
+        "test('widget works', () => expect(expected).toBe(true));\n"
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add parent import helper")
+    base = _git(root, "rev-parse", "HEAD")
+    (root / "shared/helper.js").write_text("module.exports = { expected: false };\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mutate parent import helper")
+
+    _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
+
+    assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
+
+
+def test_jest_parent_directory_side_effect_import_mutation_cannot_pass(tmp_path: Path) -> None:
+    root, _commit = _repository(tmp_path)
+    (root / "shared").mkdir()
+    (root / "shared/setup.js").write_text("global.expected = true;\n")
+    (root / "tests/widget.test.js").write_text(
+        "import '../shared/setup';\n"
+        "test('widget works', () => expect(global.expected).toBe(true));\n"
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add parent side effect helper")
+    base = _git(root, "rev-parse", "HEAD")
+    (root / "shared/setup.js").write_text("global.expected = false;\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mutate parent side effect helper")
+
+    _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
+
+    assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
+
+
+def test_jest_parent_directory_index_import_mutation_cannot_pass(tmp_path: Path) -> None:
+    root, _commit = _repository(tmp_path)
+    (root / "shared/helpers").mkdir(parents=True)
+    (root / "shared/helpers/index.ts").write_text("export const expected = true;\n")
+    (root / "tests/widget.test.js").write_text(
+        "import { expected } from '../shared/helpers';\n"
+        "test('widget works', () => expect(expected).toBe(true));\n"
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add parent index helper")
+    base = _git(root, "rev-parse", "HEAD")
+    (root / "shared/helpers/index.ts").write_text("export const expected = false;\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mutate parent index helper")
+
+    _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
+
+    assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
+
+
+def test_jest_parent_directory_imports_change_validator_digest(tmp_path: Path) -> None:
+    root, _commit = _repository(tmp_path)
+    paths = (PurePosixPath("tests/widget.test.js"),)
+    (root / "shared/helpers").mkdir(parents=True)
+    (root / "shared/helpers/index.ts").write_text("export const expected = true;\n")
+    (root / "shared/setup.js").write_text("global.expected = true;\n")
+    (root / "tests/widget.test.js").write_text(
+        "import { expected } from '../shared/helpers';\n"
+        "import '../shared/setup';\n"
+        "test('widget works', () => expect(expected && global.expected).toBe(true));\n"
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add parent import helpers")
+    base = _git(root, "rev-parse", "HEAD")
+    base_digest = jest_validator_config_digest(root, base, paths)
+
+    (root / "shared/helpers/index.ts").write_text("export const expected = false;\n")
+    (root / "shared/setup.js").write_text("global.expected = false;\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mutate parent import helpers")
+    head_digest = jest_validator_config_digest(root, _git(root, "rev-parse", "HEAD"), paths)
+
+    assert head_digest != base_digest
+
+
+def test_jest_config_reference_index_candidate_changes_validator_digest(tmp_path: Path) -> None:
+    config = '{"setupFilesAfterEnv":["<rootDir>/support/setup"]}'
+    root, _commit = _repository(tmp_path, config=config)
+    paths = (PurePosixPath("tests/widget.test.js"),)
+    (root / "support/setup").mkdir(parents=True)
+    (root / "support/setup/index.ts").write_text("global.expected = true;\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add extensionless setup index")
+    base = _git(root, "rev-parse", "HEAD")
+    base_digest = jest_validator_config_digest(root, base, paths)
+
+    (root / "support/setup/index.ts").write_text("global.expected = false;\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mutate extensionless setup index")
+    head_digest = jest_validator_config_digest(root, _git(root, "rev-parse", "HEAD"), paths)
+
+    assert head_digest != base_digest
+
+
+def test_jest_repository_escape_import_is_not_bound(tmp_path: Path) -> None:
+    root, commit = _repository(tmp_path)
+    source = b"import '../../outside.js';\n"
+    imports = _local_javascript_imports(
+        root,
+        commit,
+        PurePosixPath("tests/widget.test.js"),
+        source,
+    )
+    assert imports == set()
 
 
 @pytest.mark.parametrize("config_key", ["globalSetup", "globalTeardown", "testEnvironment"])

--- a/tests/test_sync_core_runner_jest.py
+++ b/tests/test_sync_core_runner_jest.py
@@ -231,6 +231,31 @@ def test_jest_additional_executable_config_mutation_cannot_pass(
     assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
 
 
+def test_jest_module_directories_bare_import_cannot_pass_unbound(
+    tmp_path: Path,
+) -> None:
+    config = '{"moduleDirectories":["src","node_modules"]}'
+    root, _commit = _repository(tmp_path, config=config)
+    (root / "src").mkdir()
+    (root / "src/helper.js").write_text("module.exports = { expected: true };\n")
+    (root / "tests/widget.test.js").write_text(
+        "const { expected } = require('helper');\n"
+        "test('widget works', () => expect(expected).toBe(true));\n"
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "add moduleDirectories support")
+    base = _git(root, "rev-parse", "HEAD")
+    (root / "src/helper.js").write_text("module.exports = { expected: false };\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mutate moduleDirectories support")
+
+    _envelope, executions = _run(
+        root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path)
+    )
+
+    assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
+
+
 def test_default_candidate_node_modules_jest_is_not_trusted(tmp_path: Path) -> None:
     root, commit = _repository(tmp_path)
     binary = root / "node_modules" / "jest" / "bin" / "jest.js"

--- a/tests/test_sync_core_runner_jest.py
+++ b/tests/test_sync_core_runner_jest.py
@@ -121,7 +121,7 @@ def test_jest_removed_protected_test_cannot_pass(tmp_path: Path) -> None:
     _git(root, "add", ".")
     _git(root, "commit", "-q", "-m", "remove protected test")
     _envelope, executions = _run(root, base, _git(root, "rev-parse", "HEAD"), _fake_jest(tmp_path))
-    assert executions[0].outcome is EvidenceOutcome.QUARANTINED
+    assert executions[0].outcome in {EvidenceOutcome.ERROR, EvidenceOutcome.QUARANTINED}
 
 
 @pytest.mark.parametrize("path", ["jest.config.json", "setup.js", "transform.js"])


### PR DESCRIPTION
## Summary
Adds a fail-closed Jest adapter to the trusted sync runner.

## Investigation
- Existing `runner.py` dispatches only `pytest`; the Jest adapter follows its base-clone identity, support-closure, dirty-support, exact execution, and secret-scrubbing conventions.
- Stable identity: `relative-test-file::ancestor title > test title`, emitted only by a temporary trusted reporter. Candidate code never supplies protected expected identities.
- Supported configuration is static JSON (`jest.config.json` or `package.json` `jest` object). The closure binds config and local setup, transform, reporter, resolver, project, and static relative-import support. Executable/dynamic Jest config (`jest.config.js/cjs/mjs/ts`) fails closed.
- pdd_cloud currently has executable Jest configs, so they are deliberately rejected until an independently reviewable static-config policy exists. Vitest and Playwright are not supported or claimed.
- Prior runner hardening: `f39dd6090` established config-closure binding and credential scrubbing; this PR follows that approach. No sibling trusted-runner dispatch sites require changes.

## Test plan
- `conda run -n pdd pytest -q tests/test_sync_core_runner.py tests/test_sync_core_runner_jest.py`
- `conda run -n pdd pylint pdd/sync_core/runner.py`
- `git diff --check`
- Real local Jest 29.7.0 fixture E2E using `/Users/gregtanaka/Developer/pdd_cloud/frontend/node_modules/jest/bin/jest.js`
- `python -m build --wheel --outdir /tmp/pdd-jest-wheel-dist`