### PR TITLE
fix(sync): enforce protected approved alias policy

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -5715,6 +5715,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/alias_policy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "pdd/sync_core/capabilities.py",
       "role": "human-maintained"
     },
@@ -13075,6 +13081,12 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_sync_core_candidate_artifact_provenance.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_alias_policy.py",
       "role": "human-maintained"
     },
     {

--- a/pdd/commands/sync_core.py
+++ b/pdd/commands/sync_core.py
@@ -317,9 +317,10 @@ def recover(ctx: click.Context, transaction_id: str) -> None:
     """Explicitly recover one crash-durable synchronization transaction."""
     ctx.ensure_object(dict)
     root = Path.cwd()
-    result = TransactionManager(
-        root, approved_aliases=load_committed_aliases(root)
-    ).recover(transaction_id)
+    result = TransactionManager(root).recover(
+        transaction_id,
+        alias_policy_loader=lambda: load_committed_aliases(root),
+    )
     click.echo(
         json.dumps(
             {

--- a/pdd/commands/sync_core.py
+++ b/pdd/commands/sync_core.py
@@ -20,6 +20,7 @@ from ..sync_core import (
     FingerprintStore,
     GlobalCertificateOptions,
     NightlyObservation,
+    PathPolicy,
     PlannedWrite,
     RepositoryTarget,
     SemanticStatus,
@@ -318,9 +319,15 @@ def recover(ctx: click.Context, transaction_id: str) -> None:
     """Explicitly recover one crash-durable synchronization transaction."""
     ctx.ensure_object(dict)
     root = Path.cwd()
+    head = resolve_git_commit(root, "HEAD")
     result = TransactionManager(root).recover(
         transaction_id,
-        alias_policy_loader=lambda: load_committed_aliases(root),
+        alias_policy_loader=lambda: PathPolicy(
+            root,
+            approved_aliases=load_committed_aliases(root, head),
+            base_ref=head,
+            head_ref=head,
+        ),
     )
     click.echo(
         json.dumps(

--- a/pdd/commands/sync_core.py
+++ b/pdd/commands/sync_core.py
@@ -33,6 +33,7 @@ from ..sync_core import (
     checker_identity_from_environment,
     encode_fingerprint,
     finalize_unit,
+    load_committed_aliases,
     load_verification_profiles,
     run_lifecycle_matrix,
     signer_from_environment,
@@ -315,7 +316,10 @@ def certify(
 def recover(ctx: click.Context, transaction_id: str) -> None:
     """Explicitly recover one crash-durable synchronization transaction."""
     ctx.ensure_object(dict)
-    result = TransactionManager(Path.cwd()).recover(transaction_id)
+    root = Path.cwd()
+    result = TransactionManager(
+        root, approved_aliases=load_committed_aliases(root)
+    ).recover(transaction_id)
     click.echo(
         json.dumps(
             {

--- a/pdd/commands/sync_core.py
+++ b/pdd/commands/sync_core.py
@@ -35,6 +35,7 @@ from ..sync_core import (
     finalize_unit,
     load_committed_aliases,
     load_verification_profiles,
+    require_valid_manifest,
     run_lifecycle_matrix,
     signer_from_environment,
 )
@@ -347,6 +348,10 @@ def baseline(ctx: click.Context, module: str, reviewed_by: str, reason: str) -> 
     root = Path.cwd().resolve()
     head = resolve_git_commit(root, "HEAD")
     manifest = build_unit_manifest(root, base_ref=head, head_ref=head)
+    try:
+        require_valid_manifest(manifest)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
     wanted = PurePosixPath(module)
     matches = [
         unit for unit in manifest.managed_units if unit.unit_id.prompt_relpath == wanted

--- a/pdd/continuous_sync.py
+++ b/pdd/continuous_sync.py
@@ -124,6 +124,25 @@ def repository_root(start: Optional[Path] = None) -> Path:
     return Path(result.stdout.strip()).resolve()
 
 
+def lexical_repository_root(start: Optional[Path] = None) -> Path:
+    """Return the Git root enclosing a lexical path without following its leaf."""
+    current = Path(os.path.abspath(start or Path.cwd()))
+    if not current.is_dir():
+        current = current.parent
+    while not current.exists() and current.parent != current:
+        current = current.parent
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=current,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return current
+    return Path(result.stdout.strip()).resolve()
+
+
 def _git_root_from_marker(start: Path) -> Optional[Path]:
     """Resolve the enclosing worktree root without spawning Git."""
     candidate = start if start.is_dir() else start.parent

--- a/pdd/sync_core/__init__.py
+++ b/pdd/sync_core/__init__.py
@@ -71,6 +71,7 @@ from .manifest import (
     ManifestUnit,
     UnitManifest,
     build_unit_manifest,
+    require_valid_manifest,
 )
 from .path_policy import PathPolicy, PathPolicyError, ResolvedPath
 from .alias_policy import ALIAS_POLICY_PATH, load_committed_aliases, load_protected_aliases
@@ -235,6 +236,7 @@ __all__ = [
     "CheckerIdentity",
     "checker_identity_from_environment",
     "build_unit_manifest",
+    "require_valid_manifest",
     "build_unit_snapshot",
     "attestation_signer_from_environment",
     "count_vendored_sync_semantics",

--- a/pdd/sync_core/__init__.py
+++ b/pdd/sync_core/__init__.py
@@ -73,7 +73,7 @@ from .manifest import (
     build_unit_manifest,
 )
 from .path_policy import PathPolicy, PathPolicyError, ResolvedPath
-from .alias_policy import ALIAS_POLICY_PATH, load_protected_aliases
+from .alias_policy import ALIAS_POLICY_PATH, load_committed_aliases, load_protected_aliases
 from .planner import RepairAction, RepairPlan, RepairPolicy, plan_repair
 from .snapshot import SnapshotError, build_unit_snapshot
 from .reporting import (
@@ -243,6 +243,7 @@ __all__ = [
     "load_attestation",
     "load_candidate_artifact_provenance",
     "load_protected_aliases",
+    "load_committed_aliases",
     "load_trust_policy",
     "load_sync_waivers",
     "initialize_repository_identity",

--- a/pdd/sync_core/__init__.py
+++ b/pdd/sync_core/__init__.py
@@ -73,6 +73,7 @@ from .manifest import (
     build_unit_manifest,
 )
 from .path_policy import PathPolicy, PathPolicyError, ResolvedPath
+from .alias_policy import ALIAS_POLICY_PATH, load_protected_aliases
 from .planner import RepairAction, RepairPlan, RepairPolicy, plan_repair
 from .snapshot import SnapshotError, build_unit_snapshot
 from .reporting import (
@@ -136,6 +137,7 @@ from .types import (
 
 __all__ = [
     "ArtifactSnapshot",
+    "ALIAS_POLICY_PATH",
     "AttestationBinding",
     "AttestationEnvelope",
     "AttestationError",
@@ -240,6 +242,7 @@ __all__ = [
     "load_verification_profiles",
     "load_attestation",
     "load_candidate_artifact_provenance",
+    "load_protected_aliases",
     "load_trust_policy",
     "load_sync_waivers",
     "initialize_repository_identity",

--- a/pdd/sync_core/alias_policy.py
+++ b/pdd/sync_core/alias_policy.py
@@ -55,6 +55,10 @@ def parse_protected_alias_policy(raw: bytes) -> Mapping[PurePosixPath, PurePosix
     for left, right in combinations(sorted(aliases.values()), 2):
         if _path_contains(left, right) or _path_contains(right, left):
             raise ValueError("protected alias canonical targets overlap")
+    for alias in aliases:
+        for canonical in aliases.values():
+            if _path_contains(alias, canonical) or _path_contains(canonical, alias):
+                raise ValueError("protected alias and canonical namespaces overlap")
     ordered = dict(sorted(aliases.items()))
     return MappingProxyType(ordered)
 

--- a/pdd/sync_core/alias_policy.py
+++ b/pdd/sync_core/alias_policy.py
@@ -1,0 +1,65 @@
+"""Protected approved-alias policy loading for canonical synchronization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+from typing import Mapping
+
+from .git_io import read_git_blob
+from .manifest import UnitManifest
+
+
+ALIAS_POLICY_PATH = PurePosixPath(".pdd/sync-aliases.json")
+
+
+def _relpath(value: object, field: str) -> PurePosixPath:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"protected alias {field} must be a non-empty path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or not path.parts or ".." in path.parts:
+        raise ValueError(f"protected alias {field} must be repository-relative")
+    return path
+
+
+def _parse(raw: bytes) -> Mapping[PurePosixPath, PurePosixPath]:
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError("protected alias policy is malformed") from exc
+    if (
+        not isinstance(payload, dict)
+        or set(payload) != {"schema_version", "aliases"}
+        or payload["schema_version"] != 1
+        or not isinstance(payload["aliases"], list)
+    ):
+        raise ValueError("protected alias policy schema is invalid")
+    aliases: dict[PurePosixPath, PurePosixPath] = {}
+    for row in payload["aliases"]:
+        if not isinstance(row, dict) or set(row) != {"alias_path", "canonical_path"}:
+            raise ValueError("protected alias entry is malformed")
+        alias = _relpath(row["alias_path"], "path")
+        canonical = _relpath(row["canonical_path"], "canonical path")
+        if alias == canonical or alias in aliases:
+            raise ValueError("protected alias entry is ambiguous")
+        aliases[alias] = canonical
+    ordered = dict(sorted(aliases.items()))
+    return MappingProxyType(ordered)
+
+
+def load_protected_aliases(
+    root: Path, manifest: UnitManifest
+) -> Mapping[PurePosixPath, PurePosixPath]:
+    """Load immutable base aliases and reject candidate policy changes."""
+    base = read_git_blob(root, manifest.base_ref, ALIAS_POLICY_PATH)
+    head = read_git_blob(root, manifest.head_ref, ALIAS_POLICY_PATH)
+    if base is None:
+        if head is not None:
+            raise ValueError("candidate added protected alias policy")
+        return MappingProxyType({})
+    if head is None:
+        raise ValueError("candidate removed protected alias policy")
+    if head != base:
+        raise ValueError("candidate changed protected alias policy")
+    return _parse(base)

--- a/pdd/sync_core/alias_policy.py
+++ b/pdd/sync_core/alias_policy.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+from itertools import combinations
 from pathlib import Path, PurePosixPath
 from types import MappingProxyType
 from typing import Mapping
@@ -45,8 +46,19 @@ def _parse(raw: bytes) -> Mapping[PurePosixPath, PurePosixPath]:
         if alias == canonical or alias in aliases:
             raise ValueError("protected alias entry is ambiguous")
         aliases[alias] = canonical
+    for left, right in combinations(sorted(aliases), 2):
+        if _path_contains(left, right) or _path_contains(right, left):
+            raise ValueError("protected alias entries overlap")
+    for left, right in combinations(sorted(aliases.values()), 2):
+        if _path_contains(left, right) or _path_contains(right, left):
+            raise ValueError("protected alias canonical targets overlap")
     ordered = dict(sorted(aliases.items()))
     return MappingProxyType(ordered)
+
+
+def _path_contains(parent: PurePosixPath, child: PurePosixPath) -> bool:
+    """Return whether ``child`` is equal to or below ``parent``."""
+    return child == parent or child.parts[: len(parent.parts)] == parent.parts
 
 
 def load_protected_aliases(

--- a/pdd/sync_core/alias_policy.py
+++ b/pdd/sync_core/alias_policy.py
@@ -7,10 +7,12 @@ import json
 from itertools import combinations
 from pathlib import Path, PurePosixPath
 from types import MappingProxyType
-from typing import Mapping
+from typing import TYPE_CHECKING, Mapping
 
 from .git_io import read_git_blob
-from .manifest import UnitManifest
+
+if TYPE_CHECKING:
+    from .manifest import UnitManifest
 
 
 ALIAS_POLICY_PATH = PurePosixPath(".pdd/sync-aliases.json")
@@ -25,7 +27,8 @@ def _relpath(value: object, field: str) -> PurePosixPath:
     return path
 
 
-def _parse(raw: bytes) -> Mapping[PurePosixPath, PurePosixPath]:
+def parse_protected_alias_policy(raw: bytes) -> Mapping[PurePosixPath, PurePosixPath]:
+    """Parse protected approved aliases with all ambiguity checks."""
     try:
         payload = json.loads(raw)
     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
@@ -62,7 +65,7 @@ def _path_contains(parent: PurePosixPath, child: PurePosixPath) -> bool:
 
 
 def load_protected_aliases(
-    root: Path, manifest: UnitManifest
+    root: Path, manifest: "UnitManifest"
 ) -> Mapping[PurePosixPath, PurePosixPath]:
     """Load immutable base aliases and reject candidate policy changes."""
     base = read_git_blob(root, manifest.base_ref, ALIAS_POLICY_PATH)
@@ -75,7 +78,7 @@ def load_protected_aliases(
         raise ValueError("candidate removed protected alias policy")
     if head != base:
         raise ValueError("candidate changed protected alias policy")
-    return _parse(base)
+    return parse_protected_alias_policy(base)
 
 
 def load_committed_aliases(
@@ -85,4 +88,4 @@ def load_committed_aliases(
     raw = read_git_blob(root, ref, ALIAS_POLICY_PATH)
     if raw is None:
         return MappingProxyType({})
-    return _parse(raw)
+    return parse_protected_alias_policy(raw)

--- a/pdd/sync_core/alias_policy.py
+++ b/pdd/sync_core/alias_policy.py
@@ -1,4 +1,5 @@
 """Protected approved-alias policy loading for canonical synchronization."""
+# pylint: disable=duplicate-code
 
 from __future__ import annotations
 
@@ -63,3 +64,13 @@ def load_protected_aliases(
     if head != base:
         raise ValueError("candidate changed protected alias policy")
     return _parse(base)
+
+
+def load_committed_aliases(
+    root: Path, ref: str = "HEAD"
+) -> Mapping[PurePosixPath, PurePosixPath]:
+    """Load approved aliases from a committed protected policy blob."""
+    raw = read_git_blob(root, ref, ALIAS_POLICY_PATH)
+    if raw is None:
+        return MappingProxyType({})
+    return _parse(raw)

--- a/pdd/sync_core/finalize.py
+++ b/pdd/sync_core/finalize.py
@@ -21,7 +21,8 @@ from .evidence_store import (
 )
 from .fingerprint_store import FingerprintStore, encode_fingerprint
 from .git_io import resolve_git_commit
-from .manifest import build_unit_manifest
+from .manifest import build_unit_manifest, require_valid_manifest
+from .path_policy import PathPolicy
 from .runner import (
     TRUSTED_RUNNER_VERSION,
     AttestationIssue,
@@ -93,8 +94,9 @@ def finalize_legacy_paths(paths: dict[str, Path] | None) -> bool:
         protected_base = os.environ.get("PDD_SYNC_PROTECTED_BASE_SHA")
         if not protected_base:
             raise ValueError("canonical sync requires PDD_SYNC_PROTECTED_BASE_SHA")
-        prompt = Path(paths["prompt"]).resolve()
-        module = PurePosixPath(prompt.relative_to(root).as_posix())
+        module = lexical_managed_module(
+            root, Path(paths["prompt"]), base_ref=protected_base, head_ref="HEAD"
+        )
         finalize_unit(
             root,
             module,
@@ -107,6 +109,29 @@ def finalize_legacy_paths(paths: dict[str, Path] | None) -> bool:
             f"trusted canonical finalization failed: {exc}"
         ) from exc
     return True
+
+
+def lexical_managed_module(
+    root: Path, prompt: Path, *, base_ref: str, head_ref: str
+) -> PurePosixPath:
+    """Return a policy-validated prompt's lexical repository identity."""
+    repository_root = Path(root).resolve()
+    lexical_prompt = Path(os.path.abspath(prompt))
+    try:
+        module = PurePosixPath(lexical_prompt.relative_to(repository_root).as_posix())
+    except ValueError as exc:
+        raise ValueError("canonical prompt path escapes project root") from exc
+    manifest = build_unit_manifest(
+        repository_root, base_ref=base_ref, head_ref=head_ref
+    )
+    require_valid_manifest(manifest)
+    policy = PathPolicy(
+        repository_root,
+        approved_aliases=load_protected_aliases(repository_root, manifest),
+        base_ref=manifest.base_ref,
+        head_ref=manifest.head_ref,
+    )
+    return policy.resolve(module).logical_relpath
 
 
 def attestation_signer_from_environment() -> AttestationIssuer:

--- a/pdd/sync_core/finalize.py
+++ b/pdd/sync_core/finalize.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 
-from .alias_policy import load_protected_aliases
+from .alias_policy import load_committed_aliases, load_protected_aliases
 from .evidence_store import (
     encode_attestation,
     evidence_relpath,
@@ -121,15 +121,15 @@ def lexical_managed_module(
         module = PurePosixPath(lexical_prompt.relative_to(repository_root).as_posix())
     except ValueError as exc:
         raise ValueError("canonical prompt path escapes project root") from exc
-    manifest = build_unit_manifest(
-        repository_root, base_ref=base_ref, head_ref=head_ref
-    )
-    require_valid_manifest(manifest)
+    base_aliases = load_committed_aliases(repository_root, base_ref)
+    head_aliases = load_committed_aliases(repository_root, head_ref)
+    if base_aliases != head_aliases:
+        raise ValueError("candidate changed protected alias policy")
     policy = PathPolicy(
         repository_root,
-        approved_aliases=load_protected_aliases(repository_root, manifest),
-        base_ref=manifest.base_ref,
-        head_ref=manifest.head_ref,
+        approved_aliases=base_aliases,
+        base_ref=base_ref,
+        head_ref=head_ref,
     )
     return policy.resolve(module).logical_relpath
 

--- a/pdd/sync_core/finalize.py
+++ b/pdd/sync_core/finalize.py
@@ -21,7 +21,7 @@ from .evidence_store import (
 )
 from .fingerprint_store import FingerprintStore, encode_fingerprint
 from .git_io import resolve_git_commit
-from .manifest import build_unit_manifest, require_valid_manifest
+from .manifest import build_unit_manifest
 from .path_policy import PathPolicy
 from .runner import (
     TRUSTED_RUNNER_VERSION,

--- a/pdd/sync_core/finalize.py
+++ b/pdd/sync_core/finalize.py
@@ -78,14 +78,6 @@ def canonical_root_for_paths(paths: dict[str, Path] | None) -> Path | None:
     from ..continuous_sync import canonical_sync_enabled, lexical_repository_root
 
     start = Path(paths.get("prompt", Path.cwd())) if paths else Path.cwd()
-    lexical_start = Path(os.path.abspath(start))
-    if not lexical_start.is_dir():
-        lexical_start = lexical_start.parent
-    if os.environ.get("PDD_SYNC_PROTECTED_BASE_SHA") is None and not any(
-        (candidate / ".pdd/sync-policy.json").is_file()
-        for candidate in (lexical_start, *lexical_start.parents)
-    ):
-        return None
     root = lexical_repository_root(start)
     if not canonical_sync_enabled(root):
         return None

--- a/pdd/sync_core/finalize.py
+++ b/pdd/sync_core/finalize.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 
+from .alias_policy import load_protected_aliases
 from .evidence_store import (
     encode_attestation,
     evidence_relpath,
@@ -358,7 +359,9 @@ def finalize_unit(
         PlannedWrite(evidence_relpath(attestation_id), encode_attestation(envelope), "100644"),
         PlannedWrite(fingerprint, encode_fingerprint(record), "100644"),
     )
-    manager = TransactionManager(repository_root)
+    manager = TransactionManager(
+        repository_root, approved_aliases=load_protected_aliases(repository_root, manifest)
+    )
     manager.prepare(transaction_id, writes)
     transaction = manager.commit(transaction_id)
     return FinalizeResult(transaction, attestation_id, fingerprint)

--- a/pdd/sync_core/finalize.py
+++ b/pdd/sync_core/finalize.py
@@ -75,12 +75,21 @@ def preflight_legacy_mutation(paths: dict[str, Path] | None = None) -> None:
 def canonical_root_for_paths(paths: dict[str, Path] | None) -> Path | None:
     """Return the opted-in Git root for legacy path-based callers."""
     # pylint: disable=import-outside-toplevel
-    from ..continuous_sync import canonical_sync_enabled, repository_root
+    from ..continuous_sync import canonical_sync_enabled, lexical_repository_root
 
     start = Path(paths.get("prompt", Path.cwd())) if paths else Path.cwd()
-    if not canonical_sync_enabled(start):
+    lexical_start = Path(os.path.abspath(start))
+    if not lexical_start.is_dir():
+        lexical_start = lexical_start.parent
+    if os.environ.get("PDD_SYNC_PROTECTED_BASE_SHA") is None and not any(
+        (candidate / ".pdd/sync-policy.json").is_file()
+        for candidate in (lexical_start, *lexical_start.parents)
+    ):
         return None
-    return repository_root(start)
+    root = lexical_repository_root(start)
+    if not canonical_sync_enabled(root):
+        return None
+    return root
 
 
 def finalize_legacy_paths(paths: dict[str, Path] | None) -> bool:

--- a/pdd/sync_core/git_io.py
+++ b/pdd/sync_core/git_io.py
@@ -1,7 +1,17 @@
 """Read-only Git object helpers for protected base/head evaluation."""
 
+from dataclasses import dataclass
 import subprocess
 from pathlib import Path, PurePosixPath
+
+
+@dataclass(frozen=True)
+class GitObjectEntry:
+    """Mode, type, and object identity for one path in an immutable tree."""
+
+    mode: str
+    object_type: str
+    object_id: str
 
 
 def read_git_blob(root: Path, ref: str, path: PurePosixPath) -> bytes | None:
@@ -27,3 +37,23 @@ def resolve_git_commit(root: Path, ref: str) -> str:
     if result.returncode != 0 or not result.stdout.strip():
         raise ValueError(f"cannot resolve Git commit: {ref}")
     return result.stdout.strip()
+
+
+def read_git_tree_entry(
+    root: Path,
+    ref: str,
+    path: PurePosixPath,
+) -> GitObjectEntry | None:
+    """Read one path entry from an immutable tree without recursive fallback."""
+    result = subprocess.run(
+        ["git", "ls-tree", "-z", ref, "--", path.as_posix()],
+        cwd=root,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout:
+        return None
+    record = result.stdout.split(b"\0", 1)[0]
+    metadata, _path_bytes = record.split(b"\t", 1)
+    mode, object_type, object_id = metadata.decode("ascii").split()
+    return GitObjectEntry(mode, object_type, object_id)

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -22,7 +22,7 @@ from .decommission import (
     load_tombstones,
 )
 from .identity import REPOSITORY_ID_RELPATH, canonical_repository_id
-from .git_io import read_git_blob
+from .git_io import read_git_blob, read_git_tree_entry
 from .language import LanguageRegistry, LanguageRegistryError
 from .types import CandidateId, InventoryStatus, UnitId
 
@@ -840,6 +840,37 @@ def _approved_aliases(
         aliases = parse_protected_alias_policy(base)
     except ValueError as exc:
         return {}, [str(exc)]
+    for alias, canonical in aliases.items():
+        base_entry = read_git_tree_entry(root, base_ref, alias)
+        head_entry = read_git_tree_entry(root, head_ref, alias)
+        if (
+            base_entry is None
+            or head_entry is None
+            or base_entry != head_entry
+            or base_entry.mode != "120000"
+            or base_entry.object_type != "blob"
+        ):
+            return {}, [
+                f"protected alias is not an unchanged symlink: {alias.as_posix()}"
+            ]
+        target = read_git_blob(root, base_ref, alias)
+        if target is None:
+            return {}, [f"protected alias target is unreadable: {alias.as_posix()}"]
+        try:
+            target_text = target.decode("utf-8")
+        except UnicodeDecodeError:
+            return {}, [f"protected alias target is not UTF-8: {alias.as_posix()}"]
+        raw_target = PurePosixPath(target_text)
+        normalized = PurePosixPath(
+            posixpath.normpath((alias.parent / raw_target).as_posix())
+        )
+        if (
+            raw_target.is_absolute()
+            or normalized == PurePosixPath(".")
+            or ".." in normalized.parts
+            or normalized != canonical
+        ):
+            return {}, [f"protected alias target changed: {alias.as_posix()}"]
     return dict(sorted(aliases.items())), []
 
 

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -117,6 +117,7 @@ class _CandidateSources:
     prompt_owner: dict[PurePosixPath, UnitId]
     output_owner: dict[PurePosixPath, UnitId]
     ownership_rules: tuple[OwnershipRule, ...]
+    approved_aliases: dict[PurePosixPath, PurePosixPath]
 
 
 @dataclass(frozen=True)
@@ -666,6 +667,14 @@ def _candidate_records(
             role = rule.role
             inventory = rule.inventory
             provenance = f"protected-ownership:{rule.owner}:{rule.pattern}"
+        elif path in sources.approved_aliases:
+            role = "approved-alias"
+            inventory = InventoryStatus.MANAGED
+            provenance = "protected-alias-policy"
+        elif _under_approved_alias_target(path, sources.approved_aliases):
+            role = "approved-alias-target"
+            inventory = InventoryStatus.MANAGED
+            provenance = "protected-alias-policy"
         elif _is_protected_control(path):
             role = "policy"
             inventory = InventoryStatus.MANAGED
@@ -709,6 +718,16 @@ def _candidate_records(
     return candidates, accounted, invalid
 
 
+def _under_approved_alias_target(
+    path: PurePosixPath,
+    approved_aliases: dict[PurePosixPath, PurePosixPath],
+) -> bool:
+    for canonical in approved_aliases.values():
+        if path == canonical or path.parts[: len(canonical.parts)] == canonical.parts:
+            return True
+    return False
+
+
 def _is_protected_control(path: PurePosixPath) -> bool:
     """Return whether a path is an intrinsic canonical policy/config input."""
     under_canonical_state = _is_dynamic_canonical_state(path)
@@ -719,6 +738,7 @@ def _is_protected_control(path: PurePosixPath) -> bool:
             PurePosixPath(".pdd/repository-id"),
             PurePosixPath(".pdd/expected-managed.json"),
             PurePosixPath(".pdd/sync-policy.json"),
+            PurePosixPath(".pdd/sync-aliases.json"),
             PurePosixPath(".pdd/verification-profiles.json"),
             PurePosixPath(".pdd/verification-profile-rotations.json"),
             PurePosixPath(".pdd/attestation-trust.json"),
@@ -784,6 +804,54 @@ def _ownership_rules(root: Path, protected_base_ref: str) -> tuple[OwnershipRule
         patterns.add(pattern)
         rules.append(rule)
     return tuple(sorted(rules))
+
+
+def _alias_relpath(value: object, field: str) -> PurePosixPath:
+    if not isinstance(value, str) or not value:
+        raise ManifestError(f"protected alias {field} must be a non-empty path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or not path.parts or ".." in path.parts:
+        raise ManifestError(f"protected alias {field} must be repository-relative")
+    return path
+
+
+def _approved_aliases(
+    root: Path,
+    base_ref: str,
+    head_ref: str,
+) -> tuple[dict[PurePosixPath, PurePosixPath], list[str]]:
+    path = PurePosixPath(".pdd/sync-aliases.json")
+    base = read_git_blob(root, base_ref, path)
+    head = read_git_blob(root, head_ref, path)
+    if base is None:
+        if head is not None:
+            return {}, ["candidate added protected alias policy"]
+        return {}, []
+    if head is None:
+        return {}, ["candidate removed protected alias policy"]
+    if head != base:
+        return {}, ["candidate changed protected alias policy"]
+    try:
+        payload = json.loads(base)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ManifestError("protected alias policy is malformed") from exc
+    if (
+        not isinstance(payload, dict)
+        or set(payload) != {"schema_version", "aliases"}
+        or payload["schema_version"] != 1
+        or not isinstance(payload["aliases"], list)
+    ):
+        raise ManifestError("protected alias policy schema is invalid")
+    aliases: dict[PurePosixPath, PurePosixPath] = {}
+    for row in payload["aliases"]:
+        if not isinstance(row, dict) or set(row) != {"alias_path", "canonical_path"}:
+            raise ManifestError("protected alias entry is malformed")
+        alias = _alias_relpath(row["alias_path"], "path")
+        canonical = _alias_relpath(row["canonical_path"], "canonical path")
+        if alias == canonical or alias in aliases:
+            raise ManifestError("protected alias entry is ambiguous")
+        aliases[alias] = canonical
+    return dict(sorted(aliases.items())), []
 
 
 def _valid_ownership_rule(rule: OwnershipRule) -> bool:
@@ -903,8 +971,9 @@ def _assemble_manifest(
     tombstones: dict[PurePosixPath, DecommissionTombstone],
     expected_registry: set[UnitId] | None,
     ownership_rules: tuple[OwnershipRule, ...],
+    approved_aliases: dict[PurePosixPath, PurePosixPath],
 ) -> UnitManifest:
-    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     """Combine parsed trees into the final candidate and unit partition."""
     invalid = list(base.invalid_reasons + head.invalid_reasons)
     units, tombstone_invalid = _manifest_units(
@@ -922,6 +991,7 @@ def _assemble_manifest(
             {**base.units, **head.units},
             {**base.outputs, **head.outputs},
             ownership_rules,
+            approved_aliases,
         )
     )
     invalid.extend(ownership_invalid)
@@ -980,20 +1050,33 @@ def build_unit_manifest(
         head_expected_registry = load_expected_registry(
             repository_root, head_ref, repository_id
         )
+        approved_aliases, alias_invalid = _approved_aliases(
+            repository_root, base_ref, head_ref
+        )
     except ValueError as exc:
         raise ManifestError(str(exc)) from exc
+    if alias_invalid:
+        base = _TreeManifest(
+            base.ref,
+            base.entries,
+            base.units,
+            base.outputs,
+            tuple(base.invalid_reasons + tuple(alias_invalid)),
+        )
     transition = _assemble_manifest(repository_id, language_registry.digest(),
                                     base, head, tombstones, expected_registry,
-                                    ownership)
+                                    ownership, approved_aliases)
     if base_ref == head_ref:
         return transition
 
     head_ownership = _ownership_rules(repository_root, head_ref)
+    head_aliases, _ = _approved_aliases(repository_root, head_ref, head_ref)
     stable_base = _tree_manifest(repository_root, head_ref, repository_id,
                                  language_registry, head_ownership)
     stable = _assemble_manifest(repository_id, language_registry.digest(),
                                 stable_base, stable_base, head_tombstones,
-                                head_expected_registry, head_ownership)
+                                head_expected_registry, head_ownership,
+                                head_aliases)
     control_invalid = control_transition_invalid(
         repository_root, base_ref, head_ref, ownership, head_ownership
     )

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -647,9 +647,11 @@ def _candidate_records(
     candidates: list[CandidateRecord] = []
     accounted: set[PurePosixPath] = set()
     invalid: list[str] = []
-    alias_counterparts = _managed_alias_counterparts(
-        {**sources.prompt_owner, **sources.output_owner}, sources.approved_aliases
+    concrete_owners = {**sources.prompt_owner, **sources.output_owner}
+    alias_counterparts, counterpart_invalid = _managed_alias_counterparts(
+        concrete_owners, sources.approved_aliases
     )
+    invalid.extend(counterpart_invalid)
     for path in sorted(set(sources.base_entries) | set(sources.head_entries)):
         unit_id = (
             sources.prompt_owner.get(path)
@@ -729,18 +731,29 @@ def _candidate_records(
 def _managed_alias_counterparts(
     managed_paths: dict[PurePosixPath, UnitId],
     approved_aliases: dict[PurePosixPath, PurePosixPath],
-) -> dict[PurePosixPath, UnitId]:
+) -> tuple[dict[PurePosixPath, UnitId], list[str]]:
     """Map exact managed logical paths to their approved canonical destinations."""
     counterparts: dict[PurePosixPath, UnitId] = {}
+    invalid: list[str] = []
     for path, unit_id in managed_paths.items():
         for alias, canonical in approved_aliases.items():
             if path == alias:
-                counterparts[canonical] = unit_id
+                counterpart = canonical
             elif path.parts[: len(alias.parts)] == alias.parts:
-                counterparts[canonical.joinpath(*path.parts[len(alias.parts) :])] = (
-                    unit_id
+                counterpart = canonical.joinpath(*path.parts[len(alias.parts) :])
+            else:
+                continue
+            concrete_owner = managed_paths.get(counterpart)
+            derived_owner = counterparts.get(counterpart)
+            conflicting_owner = concrete_owner or derived_owner
+            if conflicting_owner is not None and conflicting_owner != unit_id:
+                invalid.append(
+                    f"{counterpart.as_posix()}: canonical counterpart has multiple "
+                    "managed owners"
                 )
-    return counterparts
+                continue
+            counterparts[counterpart] = unit_id
+    return counterparts, invalid
 
 
 def _is_protected_control(path: PurePosixPath) -> bool:

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -294,12 +294,20 @@ def _prompt_units(
     registry: LanguageRegistry,
     ownership_rules: tuple[OwnershipRule, ...],
     protected_owned_paths: set[PurePosixPath],
+    approved_aliases: dict[PurePosixPath, PurePosixPath],
 ) -> tuple[dict[PurePosixPath, UnitId], list[str]]:
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     units: dict[PurePosixPath, UnitId] = {}
     invalid: list[str] = []
+    aliased_prompt_targets = {
+        canonical
+        for alias, canonical in approved_aliases.items()
+        if alias.suffix == ".prompt"
+    }
     for path in sorted(entries):
         if path.suffix != ".prompt" or "_" not in path.stem:
+            continue
+        if path in aliased_prompt_targets:
             continue
         rule, rule_error = (
             _ownership_for(path, ownership_rules)
@@ -675,6 +683,15 @@ def _candidate_records(
                 if item.preauthorize_absent and item.pattern == path.as_posix()
             )
             rule, rule_error = _ownership_for(path, exact_rules)
+        if (
+            path in alias_counterparts
+            and rule is not None
+            and rule.role == "excluded-project"
+        ):
+            invalid.append(
+                f"{path.as_posix()}: managed alias counterpart has an "
+                "excluded-project ownership collision"
+            )
         if path in sources.prompt_owner:
             role = "prompt"
             inventory = InventoryStatus.MANAGED
@@ -953,6 +970,7 @@ def _tree_manifest(
     registry: LanguageRegistry,
     ownership_rules: tuple[OwnershipRule, ...],
     protected_owned_paths: Optional[set[PurePosixPath]] = None,
+    approved_aliases: Optional[dict[PurePosixPath, PurePosixPath]] = None,
 ) -> _TreeManifest:
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     """Parse one immutable tree into canonical units and architecture outputs."""
@@ -964,6 +982,7 @@ def _tree_manifest(
         registry,
         ownership_rules,
         protected_owned_paths or set(entries),
+        approved_aliases or {},
     )
     outputs, architecture_invalid = _architecture_outputs(
         root,
@@ -1114,11 +1133,29 @@ def build_unit_manifest(
     repository_id = base_repository_id
     language_registry = registry or LanguageRegistry.bundled()
     ownership = _ownership_rules(repository_root, base_ref)
+    try:
+        approved_aliases, alias_invalid = _approved_aliases(
+            repository_root, base_ref, head_ref
+        )
+    except ValueError as exc:
+        raise ManifestError(str(exc)) from exc
     base = _tree_manifest(
-        repository_root, base_ref, repository_id, language_registry, ownership
+        repository_root,
+        base_ref,
+        repository_id,
+        language_registry,
+        ownership,
+        approved_aliases=approved_aliases,
     )
-    head = _tree_manifest(repository_root, head_ref, repository_id,
-                          language_registry, ownership, set(base.entries))
+    head = _tree_manifest(
+        repository_root,
+        head_ref,
+        repository_id,
+        language_registry,
+        ownership,
+        set(base.entries),
+        approved_aliases,
+    )
     try:
         tombstones = load_tombstones(repository_root, base_ref)
         head_tombstones = load_tombstones(repository_root, head_ref)
@@ -1127,9 +1164,6 @@ def build_unit_manifest(
         )
         head_expected_registry = load_expected_registry(
             repository_root, head_ref, repository_id
-        )
-        approved_aliases, alias_invalid = _approved_aliases(
-            repository_root, base_ref, head_ref
         )
         managed_paths = (
             set(base.units)
@@ -1163,9 +1197,29 @@ def build_unit_manifest(
         return transition
 
     head_ownership = _ownership_rules(repository_root, head_ref)
-    head_aliases, _ = _approved_aliases(repository_root, head_ref, head_ref)
+    head_aliases, stable_alias_invalid = _approved_aliases(
+        repository_root, head_ref, head_ref
+    )
     stable_base = _tree_manifest(repository_root, head_ref, repository_id,
-                                 language_registry, head_ownership)
+                                 language_registry, head_ownership,
+                                 approved_aliases=head_aliases)
+    stable_alias_invalid.extend(
+        _validate_managed_alias_counterparts(
+            repository_root,
+            set(stable_base.units) | set(stable_base.outputs),
+            head_aliases,
+            base_ref=head_ref,
+            head_ref=head_ref,
+        )
+    )
+    if stable_alias_invalid:
+        stable_base = _TreeManifest(
+            stable_base.ref,
+            stable_base.entries,
+            stable_base.units,
+            stable_base.outputs,
+            tuple(stable_base.invalid_reasons + tuple(stable_alias_invalid)),
+        )
     stable = _assemble_manifest(repository_id, language_registry.digest(),
                                 stable_base, stable_base, head_tombstones,
                                 head_expected_registry, head_ownership,

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -746,7 +746,7 @@ def _managed_alias_counterparts(
             concrete_owner = managed_paths.get(counterpart)
             derived_owner = counterparts.get(counterpart)
             conflicting_owner = concrete_owner or derived_owner
-            if conflicting_owner is not None and conflicting_owner != unit_id:
+            if conflicting_owner is not None:
                 invalid.append(
                     f"{counterpart.as_posix()}: canonical counterpart has multiple "
                     "managed owners"

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -646,8 +646,15 @@ def _candidate_records(
     candidates: list[CandidateRecord] = []
     accounted: set[PurePosixPath] = set()
     invalid: list[str] = []
+    alias_counterparts = _managed_alias_counterparts(
+        {**sources.prompt_owner, **sources.output_owner}, sources.approved_aliases
+    )
     for path in sorted(set(sources.base_entries) | set(sources.head_entries)):
-        unit_id = sources.prompt_owner.get(path) or sources.output_owner.get(path)
+        unit_id = (
+            sources.prompt_owner.get(path)
+            or sources.output_owner.get(path)
+            or alias_counterparts.get(path)
+        )
         if path in sources.base_entries:
             rule, rule_error = _ownership_for(path, sources.ownership_rules)
         else:
@@ -671,10 +678,10 @@ def _candidate_records(
             role = "approved-alias"
             inventory = InventoryStatus.MANAGED
             provenance = "protected-alias-policy"
-        elif _under_approved_alias_target(path, sources.approved_aliases):
-            role = "approved-alias-target"
+        elif path in alias_counterparts:
+            role = "code"
             inventory = InventoryStatus.MANAGED
-            provenance = "protected-alias-policy"
+            provenance = "architecture:protected-alias-policy"
         elif _is_protected_control(path):
             role = "policy"
             inventory = InventoryStatus.MANAGED
@@ -718,14 +725,21 @@ def _candidate_records(
     return candidates, accounted, invalid
 
 
-def _under_approved_alias_target(
-    path: PurePosixPath,
+def _managed_alias_counterparts(
+    managed_paths: dict[PurePosixPath, UnitId],
     approved_aliases: dict[PurePosixPath, PurePosixPath],
-) -> bool:
-    for canonical in approved_aliases.values():
-        if path == canonical or path.parts[: len(canonical.parts)] == canonical.parts:
-            return True
-    return False
+) -> dict[PurePosixPath, UnitId]:
+    """Map exact managed logical paths to their approved canonical destinations."""
+    counterparts: dict[PurePosixPath, UnitId] = {}
+    for path, unit_id in managed_paths.items():
+        for alias, canonical in approved_aliases.items():
+            if path == alias:
+                counterparts[canonical] = unit_id
+            elif path.parts[: len(alias.parts)] == alias.parts:
+                counterparts[canonical.joinpath(*path.parts[len(alias.parts) :])] = (
+                    unit_id
+                )
+    return counterparts
 
 
 def _is_protected_control(path: PurePosixPath) -> bool:

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 import yaml
 
+from .alias_policy import ALIAS_POLICY_PATH, parse_protected_alias_policy
 from .decommission import (
     DecommissionTombstone,
     control_transition_invalid,
@@ -820,23 +821,13 @@ def _ownership_rules(root: Path, protected_base_ref: str) -> tuple[OwnershipRule
     return tuple(sorted(rules))
 
 
-def _alias_relpath(value: object, field: str) -> PurePosixPath:
-    if not isinstance(value, str) or not value:
-        raise ManifestError(f"protected alias {field} must be a non-empty path")
-    path = PurePosixPath(value)
-    if path.is_absolute() or not path.parts or ".." in path.parts:
-        raise ManifestError(f"protected alias {field} must be repository-relative")
-    return path
-
-
 def _approved_aliases(
     root: Path,
     base_ref: str,
     head_ref: str,
 ) -> tuple[dict[PurePosixPath, PurePosixPath], list[str]]:
-    path = PurePosixPath(".pdd/sync-aliases.json")
-    base = read_git_blob(root, base_ref, path)
-    head = read_git_blob(root, head_ref, path)
+    base = read_git_blob(root, base_ref, ALIAS_POLICY_PATH)
+    head = read_git_blob(root, head_ref, ALIAS_POLICY_PATH)
     if base is None:
         if head is not None:
             return {}, ["candidate added protected alias policy"]
@@ -846,25 +837,9 @@ def _approved_aliases(
     if head != base:
         return {}, ["candidate changed protected alias policy"]
     try:
-        payload = json.loads(base)
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-        raise ManifestError("protected alias policy is malformed") from exc
-    if (
-        not isinstance(payload, dict)
-        or set(payload) != {"schema_version", "aliases"}
-        or payload["schema_version"] != 1
-        or not isinstance(payload["aliases"], list)
-    ):
-        raise ManifestError("protected alias policy schema is invalid")
-    aliases: dict[PurePosixPath, PurePosixPath] = {}
-    for row in payload["aliases"]:
-        if not isinstance(row, dict) or set(row) != {"alias_path", "canonical_path"}:
-            raise ManifestError("protected alias entry is malformed")
-        alias = _alias_relpath(row["alias_path"], "path")
-        canonical = _alias_relpath(row["canonical_path"], "canonical path")
-        if alias == canonical or alias in aliases:
-            raise ManifestError("protected alias entry is ambiguous")
-        aliases[alias] = canonical
+        aliases = parse_protected_alias_policy(base)
+    except ValueError as exc:
+        return {}, [str(exc)]
     return dict(sorted(aliases.items())), []
 
 

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -24,6 +24,7 @@ from .decommission import (
 from .identity import REPOSITORY_ID_RELPATH, canonical_repository_id
 from .git_io import read_git_blob, read_git_tree_entry
 from .language import LanguageRegistry, LanguageRegistryError
+from .path_policy import PathPolicyError, validate_canonical_alias_path
 from .types import CandidateId, InventoryStatus, UnitId
 
 
@@ -235,6 +236,13 @@ class UnitManifest:
         }
         encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
         return hashlib.sha256(encoded).hexdigest()
+
+
+def require_valid_manifest(manifest: UnitManifest) -> None:
+    """Fail closed before a caller uses an invalid manifest for mutation."""
+    if manifest.invalid_reasons:
+        detail = "; ".join(manifest.invalid_reasons)
+        raise ManifestError(f"manifest is invalid: {detail}")
 
 
 def _unit_payload(unit_id: UnitId | None) -> dict[str, str] | None:
@@ -884,6 +892,12 @@ def _approved_aliases(
             or normalized != canonical
         ):
             return {}, [f"protected alias target changed: {alias.as_posix()}"]
+        try:
+            validate_canonical_alias_path(
+                root, canonical, base_ref=base_ref, head_ref=head_ref
+            )
+        except PathPolicyError as exc:
+            return {}, [str(exc)]
     return dict(sorted(aliases.items())), []
 
 

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -764,6 +764,37 @@ def _managed_alias_counterparts(
     return counterparts, invalid
 
 
+def _validate_managed_alias_counterparts(
+    root: Path,
+    managed_paths: set[PurePosixPath],
+    approved_aliases: dict[PurePosixPath, PurePosixPath],
+    *,
+    base_ref: str,
+    head_ref: str,
+) -> list[str]:
+    """Validate complete canonical identities derived for managed alias paths."""
+    invalid: list[str] = []
+    for path in sorted(managed_paths):
+        for alias, canonical in approved_aliases.items():
+            if path == alias:
+                suffix: tuple[str, ...] = ()
+            elif path.parts[: len(alias.parts)] == alias.parts:
+                suffix = path.parts[len(alias.parts) :]
+            else:
+                continue
+            counterpart = canonical.joinpath(*suffix)
+            try:
+                validate_canonical_alias_path(
+                    root,
+                    counterpart,
+                    base_ref=base_ref,
+                    head_ref=head_ref,
+                )
+            except PathPolicyError as exc:
+                invalid.append(str(exc))
+    return sorted(set(invalid))
+
+
 def _is_protected_control(path: PurePosixPath) -> bool:
     """Return whether a path is an intrinsic canonical policy/config input."""
     under_canonical_state = _is_dynamic_canonical_state(path)
@@ -1099,6 +1130,21 @@ def build_unit_manifest(
         )
         approved_aliases, alias_invalid = _approved_aliases(
             repository_root, base_ref, head_ref
+        )
+        managed_paths = (
+            set(base.units)
+            | set(head.units)
+            | set(base.outputs)
+            | set(head.outputs)
+        )
+        alias_invalid.extend(
+            _validate_managed_alias_counterparts(
+                repository_root,
+                managed_paths,
+                approved_aliases,
+                base_ref=base_ref,
+                head_ref=head_ref,
+            )
         )
     except ValueError as exc:
         raise ManifestError(str(exc)) from exc

--- a/pdd/sync_core/path_policy.py
+++ b/pdd/sync_core/path_policy.py
@@ -89,6 +89,10 @@ class PathPolicy:
         base_entry = read_git_tree_entry(self.checkout_root, self.base_ref, alias_relpath)
         head_entry = read_git_tree_entry(self.checkout_root, self.head_ref, alias_relpath)
         if base_entry is None and head_entry is None:
+            if required:
+                raise PathPolicyError(
+                    f"approved alias is absent from protected trees: {alias_relpath}"
+                )
             return None
         if base_entry != head_entry or base_entry is None or head_entry is None:
             raise PathPolicyError(f"approved alias changed in protected trees: {alias_relpath}")

--- a/pdd/sync_core/path_policy.py
+++ b/pdd/sync_core/path_policy.py
@@ -178,6 +178,13 @@ class PathPolicy:
             if stat.S_ISLNK(mode):
                 if approved_target is None:
                     raise PathPolicyError(f"unapproved managed symlink: {logical_component}")
+                canonical_relpath = approved_target.joinpath(*parts[index:])
+                validate_canonical_alias_path(
+                    self.checkout_root,
+                    canonical_relpath,
+                    base_ref=self.base_ref,
+                    head_ref=self.head_ref,
+                )
                 target = component.resolve(strict=True)
                 expected = self.checkout_root.joinpath(*approved_target.parts).resolve(strict=True)
                 if target != expected or not self._within_root(target):

--- a/pdd/sync_core/path_policy.py
+++ b/pdd/sync_core/path_policy.py
@@ -155,6 +155,19 @@ class PathPolicy:
         )
         return configured
 
+    def _live_alias_target(
+        self, component: Path, logical_component: PurePosixPath
+    ) -> PurePosixPath:
+        """Normalize one live link target without following intermediates."""
+        try:
+            return self._canonical_alias_target(
+                logical_component, os.readlink(component).encode("utf-8")
+            )
+        except (OSError, UnicodeEncodeError, PathPolicyError) as exc:
+            raise PathPolicyError(
+                f"approved alias target changed: {logical_component}"
+            ) from exc
+
     def resolve(self, relpath: PurePosixPath, *, allow_missing: bool = False) -> ResolvedPath:
         """Resolve a logical path without permitting unapproved link traversal."""
         self._validate_relpath(relpath)
@@ -178,6 +191,13 @@ class PathPolicy:
             if stat.S_ISLNK(mode):
                 if approved_target is None:
                     raise PathPolicyError(f"unapproved managed symlink: {logical_component}")
+                if (
+                    self._live_alias_target(component, logical_component)
+                    != approved_target
+                ):
+                    raise PathPolicyError(
+                        f"approved alias target changed: {logical_component}"
+                    )
                 canonical_relpath = approved_target.joinpath(*parts[index:])
                 validate_canonical_alias_path(
                     self.checkout_root,

--- a/pdd/sync_core/path_policy.py
+++ b/pdd/sync_core/path_policy.py
@@ -109,12 +109,12 @@ class PathPolicy:
         required: bool = False,
     ) -> PurePosixPath | None:
         configured = self.approved_aliases.get(alias_relpath)
+        if configured is None:
+            return None
         immutable = self._immutable_alias_target(
             alias_relpath,
             required=required or configured is not None,
         )
-        if configured is None:
-            return immutable
         self._validate_relpath(configured)
         if immutable is not None and configured != immutable:
             raise PathPolicyError(f"approved alias target changed: {alias_relpath}")

--- a/pdd/sync_core/path_policy.py
+++ b/pdd/sync_core/path_policy.py
@@ -18,6 +18,31 @@ class PathPolicyError(ValueError):
     """Raised when a managed path violates protected repository policy."""
 
 
+def validate_canonical_alias_path(
+    checkout_root: Path,
+    canonical_relpath: PurePosixPath,
+    *,
+    base_ref: str | None = None,
+    head_ref: str | None = None,
+) -> None:
+    """Reject unapproved symlinks along an approved alias's canonical side."""
+    root = Path(checkout_root)
+    for index in range(1, len(canonical_relpath.parts) + 1):
+        relpath = PurePosixPath(*canonical_relpath.parts[:index])
+        component = root.joinpath(*relpath.parts)
+        if component.is_symlink():
+            raise PathPolicyError(f"unapproved managed symlink: {relpath}")
+        if base_ref is None or head_ref is None:
+            continue
+        base_entry = read_git_tree_entry(root, base_ref, relpath)
+        head_entry = read_git_tree_entry(root, head_ref, relpath)
+        if any(
+            entry is not None and entry.mode == "120000"
+            for entry in (base_entry, head_entry)
+        ):
+            raise PathPolicyError(f"unapproved managed symlink: {relpath}")
+
+
 @dataclass(frozen=True)
 class ResolvedPath:
     """Logical identity and prevalidated canonical target for a managed path."""
@@ -122,6 +147,12 @@ class PathPolicy:
         self._validate_relpath(configured)
         if immutable is not None and configured != immutable:
             raise PathPolicyError(f"approved alias target changed: {alias_relpath}")
+        validate_canonical_alias_path(
+            self.checkout_root,
+            configured,
+            base_ref=self.base_ref,
+            head_ref=self.head_ref,
+        )
         return configured
 
     def resolve(self, relpath: PurePosixPath, *, allow_missing: bool = False) -> ResolvedPath:

--- a/pdd/sync_core/path_policy.py
+++ b/pdd/sync_core/path_policy.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import hashlib
 import os
+import posixpath
 import stat
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Mapping
 
+from .git_io import read_git_blob, read_git_tree_entry
 from .types import ArtifactSnapshot
 
 
@@ -32,12 +34,17 @@ class PathPolicy:
         self,
         checkout_root: Path,
         approved_aliases: Mapping[PurePosixPath, PurePosixPath] | None = None,
+        *,
+        base_ref: str | None = None,
+        head_ref: str | None = None,
     ) -> None:
         root = Path(checkout_root)
         if root.is_symlink() or not root.is_dir():
             raise PathPolicyError("checkout root must be a real directory")
         self.checkout_root = root.resolve()
         self.approved_aliases = dict(approved_aliases or {})
+        self.base_ref = base_ref
+        self.head_ref = head_ref
 
     @staticmethod
     def _validate_relpath(relpath: PurePosixPath) -> None:
@@ -51,6 +58,68 @@ class PathPolicy:
         except ValueError:
             return False
 
+    @staticmethod
+    def _canonical_alias_target(
+        alias_relpath: PurePosixPath, raw_target: bytes
+    ) -> PurePosixPath:
+        try:
+            target_text = raw_target.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise PathPolicyError(
+                f"approved alias target is not UTF-8: {alias_relpath}"
+            ) from exc
+        target = PurePosixPath(target_text)
+        if target.is_absolute():
+            raise PathPolicyError(f"approved alias target escapes checkout: {alias_relpath}")
+        normalized = PurePosixPath(
+            posixpath.normpath((alias_relpath.parent / target).as_posix())
+        )
+        if normalized == PurePosixPath(".") or ".." in normalized.parts:
+            raise PathPolicyError(f"approved alias target escapes checkout: {alias_relpath}")
+        return normalized
+
+    def _immutable_alias_target(
+        self,
+        alias_relpath: PurePosixPath,
+        *,
+        required: bool,
+    ) -> PurePosixPath | None:
+        if self.base_ref is None or self.head_ref is None:
+            return None
+        base_entry = read_git_tree_entry(self.checkout_root, self.base_ref, alias_relpath)
+        head_entry = read_git_tree_entry(self.checkout_root, self.head_ref, alias_relpath)
+        if base_entry is None and head_entry is None:
+            return None
+        if base_entry != head_entry or base_entry is None or head_entry is None:
+            raise PathPolicyError(f"approved alias changed in protected trees: {alias_relpath}")
+        if base_entry.mode != "120000" or base_entry.object_type != "blob":
+            if not required:
+                return None
+            raise PathPolicyError(
+                f"approved alias is not an unchanged symlink: {alias_relpath}"
+            )
+        target = read_git_blob(self.checkout_root, self.base_ref, alias_relpath)
+        if target is None:
+            raise PathPolicyError(f"approved alias target is unreadable: {alias_relpath}")
+        return self._canonical_alias_target(alias_relpath, target)
+
+    def _approved_alias_target(
+        self, alias_relpath: PurePosixPath,
+        *,
+        required: bool = False,
+    ) -> PurePosixPath | None:
+        configured = self.approved_aliases.get(alias_relpath)
+        immutable = self._immutable_alias_target(
+            alias_relpath,
+            required=required or configured is not None,
+        )
+        if configured is None:
+            return immutable
+        self._validate_relpath(configured)
+        if immutable is not None and configured != immutable:
+            raise PathPolicyError(f"approved alias target changed: {alias_relpath}")
+        return configured
+
     def resolve(self, relpath: PurePosixPath, *, allow_missing: bool = False) -> ResolvedPath:
         """Resolve a logical path without permitting unapproved link traversal."""
         self._validate_relpath(relpath)
@@ -63,11 +132,17 @@ class PathPolicy:
             if not component.exists() and not component.is_symlink():
                 break
             mode = component.lstat().st_mode
+            approved_target = self._approved_alias_target(
+                logical_component,
+                required=stat.S_ISLNK(mode),
+            )
+            if approved_target is not None and not stat.S_ISLNK(mode):
+                raise PathPolicyError(
+                    f"approved alias is not a symlink: {logical_component}"
+                )
             if stat.S_ISLNK(mode):
-                approved_target = self.approved_aliases.get(logical_component)
                 if approved_target is None:
                     raise PathPolicyError(f"unapproved managed symlink: {logical_component}")
-                self._validate_relpath(approved_target)
                 target = component.resolve(strict=True)
                 expected = self.checkout_root.joinpath(*approved_target.parts).resolve(strict=True)
                 if target != expected or not self._within_root(target):

--- a/pdd/sync_core/reporting.py
+++ b/pdd/sync_core/reporting.py
@@ -174,6 +174,8 @@ def _evidence(
 
 
 def _unit_verdict(context: ReportContext, unit: ManifestUnit) -> SyncVerdict:
+    if context.manifest.invalid_reasons:
+        return _error_verdict(unit, BaselineStatus.CORRUPT, "manifest is invalid")
     profile = context.profiles.for_unit(unit.unit_id)
     if profile is None:
         return _error_verdict(unit, BaselineStatus.CORRUPT, "profile is missing")

--- a/pdd/sync_core/snapshot.py
+++ b/pdd/sync_core/snapshot.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path, PurePosixPath
 
+from .alias_policy import load_protected_aliases
 from .includes import IncludeGraphError, build_include_closure
 from .manifest import ManifestUnit, UnitManifest
 from .path_policy import PathPolicy, PathPolicyError
@@ -34,7 +35,7 @@ def build_unit_snapshot(
         raise SnapshotError("cannot snapshot a unit absent from the checked head")
     if profile.unit_id != unit.unit_id:
         raise SnapshotError("verification profile identity does not match unit")
-    policy = PathPolicy(root)
+    policy = PathPolicy(root, load_protected_aliases(root, manifest))
     artifacts: dict[tuple[str, PurePosixPath], ArtifactSnapshot] = {}
 
     def add(role: str, relpath: PurePosixPath, required: bool = True) -> None:

--- a/pdd/sync_core/snapshot.py
+++ b/pdd/sync_core/snapshot.py
@@ -35,7 +35,12 @@ def build_unit_snapshot(
         raise SnapshotError("cannot snapshot a unit absent from the checked head")
     if profile.unit_id != unit.unit_id:
         raise SnapshotError("verification profile identity does not match unit")
-    policy = PathPolicy(root, load_protected_aliases(root, manifest))
+    policy = PathPolicy(
+        root,
+        load_protected_aliases(root, manifest),
+        base_ref=manifest.base_ref,
+        head_ref=manifest.head_ref,
+    )
     artifacts: dict[tuple[str, PurePosixPath], ArtifactSnapshot] = {}
 
     def add(role: str, relpath: PurePosixPath, required: bool = True) -> None:

--- a/pdd/sync_core/transaction.py
+++ b/pdd/sync_core/transaction.py
@@ -695,11 +695,18 @@ class TransactionManager:
                 pending.append(transaction_dir.name)
         return tuple(pending)
 
-    def recover(self, transaction_id: str) -> TransactionResult:
+    def recover(
+        self,
+        transaction_id: str,
+        *,
+        alias_policy_loader: Callable[
+            [], Mapping[PurePosixPath, PurePosixPath]
+        ]
+        | None = None,
+    ) -> TransactionResult:
         """Complete COMMITTING work or discard a PREPARED transaction idempotently."""
         transaction_dir = self._transaction_dir(transaction_id)
         payload = self._read_journal(transaction_dir)
-        self._adopt_journal_aliases(payload)
         phase = TransactionPhase(str(payload["phase"]))
         if phase is TransactionPhase.COMMITTED:
             return TransactionResult(transaction_id, phase, (), True)
@@ -711,6 +718,9 @@ class TransactionManager:
             )
         if phase is not TransactionPhase.COMMITTING:
             return TransactionResult(transaction_id, phase, (), True)
+        if alias_policy_loader is not None:
+            self.policy = PathPolicy(self.checkout_root, alias_policy_loader())
+        self._adopt_journal_aliases(payload)
         entries = payload.get("entries")
         if not isinstance(entries, list):
             raise TransactionError("transaction entries are malformed")

--- a/pdd/sync_core/transaction.py
+++ b/pdd/sync_core/transaction.py
@@ -494,6 +494,11 @@ class TransactionManager:
         if not isinstance(entries, list):
             raise TransactionError("transaction entries are malformed")
         resources.extend(str(item.get("relpath")) for item in entries if isinstance(item, dict))
+        resources.extend(
+            f"canonical:{item.get('canonical_relpath')}"
+            for item in entries
+            if isinstance(item, dict) and item.get("canonical_relpath") is not None
+        )
         stack = ExitStack()
         for resource in sorted(set(resources)):
             lock_name = hashlib.sha256(resource.encode()).hexdigest() + ".lock"

--- a/pdd/sync_core/transaction.py
+++ b/pdd/sync_core/transaction.py
@@ -81,6 +81,24 @@ def _digest(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
+def _alias_policy_payload(
+    aliases: Mapping[PurePosixPath, PurePosixPath],
+) -> list[dict[str, str]]:
+    return [
+        {"alias_path": alias.as_posix(), "canonical_path": canonical.as_posix()}
+        for alias, canonical in sorted(aliases.items())
+    ]
+
+
+def _alias_policy_digest(aliases: Mapping[PurePosixPath, PurePosixPath]) -> str:
+    encoded = json.dumps(
+        _alias_policy_payload(aliases),
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return _digest(encoded)
+
+
 def _git_mode(mode: int) -> str:
     executable = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
     return "100755" if mode & executable else "100644"
@@ -360,6 +378,11 @@ class TransactionManager:
         paths = [write.relpath for write in writes]
         if len(paths) != len(set(paths)):
             raise TransactionError("transaction plan contains duplicate destinations")
+        canonical_paths = [self._canonical_relpath(write.relpath) for write in writes]
+        if len(canonical_paths) != len(set(canonical_paths)):
+            raise TransactionError(
+                "transaction plan contains duplicate canonical destinations"
+            )
         if any(write.secret for write in writes):
             raise TransactionError(
                 "secret-labeled rollback content requires configured encryption"
@@ -444,10 +467,10 @@ class TransactionManager:
                 "transaction_id": transaction_id,
                 "phase": TransactionPhase.PREPARED.value,
                 "shared_resources": [path.as_posix() for path in sorted(shared_resources)],
-                "approved_aliases": [
-                    {"alias_path": alias.as_posix(), "canonical_path": canonical.as_posix()}
-                    for alias, canonical in self.policy.approved_aliases.items()
-                ],
+                "approved_aliases": _alias_policy_payload(self.policy.approved_aliases),
+                "approved_aliases_digest": _alias_policy_digest(
+                    self.policy.approved_aliases
+                ),
                 "entries": entries,
             }
             self._write_journal(temporary, payload)
@@ -742,6 +765,8 @@ class TransactionManager:
             if invalid_alias or invalid_canonical or alias in aliases:
                 raise TransactionError("transaction alias policy is malformed")
             aliases[alias] = canonical
-        if self.policy.approved_aliases and self.policy.approved_aliases != aliases:
+        digest = payload.get("approved_aliases_digest")
+        if not isinstance(digest, str) or digest != _alias_policy_digest(aliases):
+            raise TransactionError("transaction alias policy digest is malformed")
+        if self.policy.approved_aliases != aliases:
             raise TransactionConflict("transaction alias policy changed before recovery")
-        self.policy = PathPolicy(self.checkout_root, aliases)

--- a/pdd/sync_core/transaction.py
+++ b/pdd/sync_core/transaction.py
@@ -699,10 +699,7 @@ class TransactionManager:
         self,
         transaction_id: str,
         *,
-        alias_policy_loader: Callable[
-            [], Mapping[PurePosixPath, PurePosixPath]
-        ]
-        | None = None,
+        alias_policy_loader: Callable[[], PathPolicy] | None = None,
     ) -> TransactionResult:
         """Complete COMMITTING work or discard a PREPARED transaction idempotently."""
         transaction_dir = self._transaction_dir(transaction_id)
@@ -719,7 +716,7 @@ class TransactionManager:
         if phase is not TransactionPhase.COMMITTING:
             return TransactionResult(transaction_id, phase, (), True)
         if alias_policy_loader is not None:
-            self.policy = PathPolicy(self.checkout_root, alias_policy_loader())
+            self.policy = alias_policy_loader()
         self._adopt_journal_aliases(payload)
         entries = payload.get("entries")
         if not isinstance(entries, list):

--- a/pdd/sync_core/transaction.py
+++ b/pdd/sync_core/transaction.py
@@ -13,12 +13,12 @@ from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path, PurePosixPath
-from typing import Callable, Optional
+from typing import Callable, Mapping, Optional
 
 from filelock import FileLock
 
 from .durability import fsync_directory
-from .path_policy import PathPolicy
+from .path_policy import PathPolicy, PathPolicyError
 
 
 class TransactionError(RuntimeError):
@@ -132,9 +132,14 @@ def _parse_state(payload: dict[str, object]) -> FileState:
 class TransactionManager:
     """Prepare, commit, inspect, and recover repository mutation journals."""
 
-    def __init__(self, checkout_root: Path) -> None:
+    def __init__(
+        self,
+        checkout_root: Path,
+        *,
+        approved_aliases: Mapping[PurePosixPath, PurePosixPath] | None = None,
+    ) -> None:
         self.checkout_root = Path(checkout_root).resolve()
-        self.policy = PathPolicy(self.checkout_root)
+        self.policy = PathPolicy(self.checkout_root, approved_aliases)
         self.state_root = self.checkout_root / ".pdd/transactions"
         self.lock_root = self.checkout_root / ".pdd/locks/transactions"
 
@@ -161,20 +166,37 @@ class TransactionManager:
             raise TransactionError("transaction ID contains unsafe characters")
         return self.state_root / transaction_id
 
-    def _canonical_relpath(self, relpath: PurePosixPath) -> PurePosixPath:
-        resolved = self.policy.resolve(relpath, allow_missing=True)
+    def _canonical_relpath(
+        self,
+        relpath: PurePosixPath,
+        *,
+        expected: PurePosixPath | None = None,
+    ) -> PurePosixPath:
+        try:
+            resolved = self.policy.resolve(relpath, allow_missing=True)
+        except PathPolicyError as exc:
+            raise TransactionConflict(
+                f"destination alias policy changed: {relpath}"
+            ) from exc
         try:
             relative = resolved.canonical_path.relative_to(self.checkout_root)
         except ValueError as exc:
             raise TransactionError(f"destination escapes checkout: {relpath}") from exc
-        return PurePosixPath(relative.as_posix())
+        canonical = PurePosixPath(relative.as_posix())
+        if expected is not None and canonical != expected:
+            raise TransactionConflict(f"destination canonical identity changed: {relpath}")
+        return canonical
 
     @contextmanager
     def _parent_descriptor(
-        self, relpath: PurePosixPath, *, create: bool = False
+        self,
+        relpath: PurePosixPath,
+        *,
+        create: bool = False,
+        canonical_relpath: PurePosixPath | None = None,
     ):
         """Pin and no-follow every parent directory for one destination."""
-        canonical = self._canonical_relpath(relpath)
+        canonical = self._canonical_relpath(relpath, expected=canonical_relpath)
         root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
         directory_flags = (
             os.O_RDONLY
@@ -205,17 +227,25 @@ class TransactionManager:
             for descriptor in reversed(descriptors):
                 os.close(descriptor)
 
-    def _destination_state(self, relpath: PurePosixPath) -> FileState:
+    def _destination_state(
+        self, relpath: PurePosixPath, *, canonical_relpath: PurePosixPath | None = None
+    ) -> FileState:
         try:
-            with self._parent_descriptor(relpath) as (parent_fd, name):
+            with self._parent_descriptor(
+                relpath, canonical_relpath=canonical_relpath
+            ) as (parent_fd, name):
                 return _descriptor_file_state(parent_fd, name)
         except TransactionConflict as exc:
             if isinstance(exc.__cause__, FileNotFoundError):
                 return FileState(False, None, None, "missing")
             raise
 
-    def _read_destination(self, relpath: PurePosixPath) -> bytes:
-        with self._parent_descriptor(relpath) as (parent_fd, name):
+    def _read_destination(
+        self, relpath: PurePosixPath, *, canonical_relpath: PurePosixPath | None = None
+    ) -> bytes:
+        with self._parent_descriptor(
+            relpath, canonical_relpath=canonical_relpath
+        ) as (parent_fd, name):
             flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
             descriptor = os.open(name, flags, dir_fd=parent_fd)
             try:
@@ -229,9 +259,17 @@ class TransactionManager:
                 os.close(descriptor)
 
     def _replace_destination(
-        self, relpath: PurePosixPath, content: bytes, git_mode: str, suffix: str
+        self,
+        relpath: PurePosixPath,
+        content: bytes,
+        git_mode: str,
+        suffix: str,
+        *,
+        canonical_relpath: PurePosixPath | None = None,
     ) -> None:
-        with self._parent_descriptor(relpath, create=True) as (parent_fd, name):
+        with self._parent_descriptor(
+            relpath, create=True, canonical_relpath=canonical_relpath
+        ) as (parent_fd, name):
             temporary_name = f".{name}.{uuid.uuid4().hex}.{suffix}"
             flags = (
                 os.O_WRONLY
@@ -262,8 +300,12 @@ class TransactionManager:
             finally:
                 os.close(descriptor)
 
-    def _unlink_destination(self, relpath: PurePosixPath) -> None:
-        with self._parent_descriptor(relpath) as (parent_fd, name):
+    def _unlink_destination(
+        self, relpath: PurePosixPath, *, canonical_relpath: PurePosixPath | None = None
+    ) -> None:
+        with self._parent_descriptor(
+            relpath, canonical_relpath=canonical_relpath
+        ) as (parent_fd, name):
             try:
                 os.unlink(name, dir_fd=parent_fd)
             except FileNotFoundError:
@@ -336,7 +378,8 @@ class TransactionManager:
         index: int,
         write: PlannedWrite,
     ) -> dict[str, object]:
-        before = self._destination_state(write.relpath)
+        canonical = self._canonical_relpath(write.relpath)
+        before = self._destination_state(write.relpath, canonical_relpath=canonical)
         if write.expected is not None and before != write.expected:
             raise TransactionConflict(
                 f"destination changed before prepare: {write.relpath}"
@@ -349,10 +392,11 @@ class TransactionManager:
         if rollback_name:
             self._write_blob(
                 transaction_dir / rollback_name,
-                self._read_destination(write.relpath),
+                self._read_destination(write.relpath, canonical_relpath=canonical),
             )
         return {
             "relpath": write.relpath.as_posix(),
+            "canonical_relpath": canonical.as_posix(),
             "desired_digest": _digest(write.content),
             "desired_mode": write.git_mode,
             "precondition": _state_payload(write.expected or before),
@@ -396,10 +440,14 @@ class TransactionManager:
         try:
             entries = [self._entry(temporary, index, write) for index, write in enumerate(writes)]
             payload: dict[str, object] = {
-                "schema_version": 1,
+                "schema_version": 2,
                 "transaction_id": transaction_id,
                 "phase": TransactionPhase.PREPARED.value,
                 "shared_resources": [path.as_posix() for path in sorted(shared_resources)],
+                "approved_aliases": [
+                    {"alias_path": alias.as_posix(), "canonical_path": canonical.as_posix()}
+                    for alias, canonical in self.policy.approved_aliases.items()
+                ],
                 "entries": entries,
             }
             self._write_journal(temporary, payload)
@@ -434,8 +482,8 @@ class TransactionManager:
         transaction_dir: Path,
         entry: dict[str, object],
     ) -> None:
-        relpath = PurePosixPath(str(entry["relpath"]))
-        current = self._destination_state(relpath)
+        relpath, canonical = self._entry_paths(entry)
+        current = self._destination_state(relpath, canonical_relpath=canonical)
         desired = FileState(
             True,
             str(entry["desired_digest"]),
@@ -455,7 +503,21 @@ class TransactionManager:
         content = prepared.read_bytes()
         if _digest(content) != desired.digest:
             raise TransactionError(f"prepared transaction blob is corrupt: {relpath}")
-        self._replace_destination(relpath, content, desired.git_mode, "pdd-tmp")
+        self._replace_destination(
+            relpath, content, desired.git_mode, "pdd-tmp", canonical_relpath=canonical
+        )
+
+    def _entry_paths(self, entry: dict[str, object]) -> tuple[PurePosixPath, PurePosixPath | None]:
+        """Return and revalidate the durable logical and canonical identities."""
+        relpath = PurePosixPath(str(entry["relpath"]))
+        raw_canonical = entry.get("canonical_relpath")
+        if raw_canonical is None:
+            return relpath, None
+        canonical = PurePosixPath(str(raw_canonical))
+        if canonical.is_absolute() or not canonical.parts or ".." in canonical.parts:
+            raise TransactionError("transaction canonical destination is malformed")
+        self._canonical_relpath(relpath, expected=canonical)
+        return relpath, canonical
 
     def _validate_prepared_entries(
         self, transaction_dir: Path, entries: list[object]
@@ -464,7 +526,7 @@ class TransactionManager:
         for item in entries:
             if not isinstance(item, dict):
                 raise TransactionError("transaction entry is malformed")
-            relpath = PurePosixPath(str(item["relpath"]))
+            relpath, _canonical = self._entry_paths(item)
             prepared = transaction_dir / str(item["prepared_blob"])
             if prepared.is_symlink() or not prepared.is_file():
                 raise TransactionError(f"prepared transaction blob is unsafe: {relpath}")
@@ -494,7 +556,7 @@ class TransactionManager:
         for item in reversed(entries):
             if not isinstance(item, dict) or item.get("installed") is not True:
                 continue
-            relpath = PurePosixPath(str(item["relpath"]))
+            relpath, canonical = self._entry_paths(item)
             precondition = item.get("precondition")
             if not isinstance(precondition, dict):
                 raise TransactionError("transaction rollback precondition is malformed")
@@ -506,7 +568,7 @@ class TransactionManager:
                 raise TransactionConflict(f"rollback conflict: {relpath}")
             rollback_name = item.get("rollback_blob")
             if not before.exists:
-                self._unlink_destination(relpath)
+                self._unlink_destination(relpath, canonical_relpath=canonical)
                 continue
             rollback = transaction_dir / str(rollback_name)
             if rollback.is_symlink() or not rollback.is_file():
@@ -519,6 +581,7 @@ class TransactionManager:
                 content,
                 str(before.git_mode),
                 "pdd-rollback",
+                canonical_relpath=canonical,
             )
 
     def commit(
@@ -545,8 +608,8 @@ class TransactionManager:
             for item in entries:
                 if not isinstance(item, dict):
                     raise TransactionError("transaction entry is malformed")
-                relpath = PurePosixPath(str(item["relpath"]))
-                current = self._destination_state(relpath)
+                relpath, canonical = self._entry_paths(item)
+                current = self._destination_state(relpath, canonical_relpath=canonical)
                 precondition = item.get("precondition")
                 if not isinstance(precondition, dict) or current != _parse_state(precondition):
                     raise TransactionConflict(f"destination changed: {relpath}")
@@ -608,6 +671,7 @@ class TransactionManager:
         """Complete COMMITTING work or discard a PREPARED transaction idempotently."""
         transaction_dir = self._transaction_dir(transaction_id)
         payload = self._read_journal(transaction_dir)
+        self._adopt_journal_aliases(payload)
         phase = TransactionPhase(str(payload["phase"]))
         if phase is TransactionPhase.COMMITTED:
             return TransactionResult(transaction_id, phase, (), True)
@@ -657,3 +721,27 @@ class TransactionManager:
         return TransactionResult(
             transaction_id, TransactionPhase.COMMITTED, tuple(changed), False
         )
+
+    def _adopt_journal_aliases(self, payload: dict[str, object]) -> None:
+        """Restore the prepared alias authority before COMMITTING recovery."""
+        rows = payload.get("approved_aliases")
+        if rows is None:
+            return
+        if not isinstance(rows, list):
+            raise TransactionError("transaction alias policy is malformed")
+        aliases: dict[PurePosixPath, PurePosixPath] = {}
+        for row in rows:
+            if not isinstance(row, dict):
+                raise TransactionError("transaction alias policy is malformed")
+            alias = PurePosixPath(str(row.get("alias_path", "")))
+            canonical = PurePosixPath(str(row.get("canonical_path", "")))
+            invalid_alias = alias.is_absolute() or not alias.parts or ".." in alias.parts
+            invalid_canonical = (
+                canonical.is_absolute() or not canonical.parts or ".." in canonical.parts
+            )
+            if invalid_alias or invalid_canonical or alias in aliases:
+                raise TransactionError("transaction alias policy is malformed")
+            aliases[alias] = canonical
+        if self.policy.approved_aliases and self.policy.approved_aliases != aliases:
+            raise TransactionConflict("transaction alias policy changed before recovery")
+        self.policy = PathPolicy(self.checkout_root, aliases)

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -385,14 +385,19 @@ def _effective_profile(
 
 def load_verification_profiles(root: Path, manifest: UnitManifest) -> ProfileSet:
     """Load the protected base/candidate union for every expected-managed unit."""
-    approved_aliases = load_protected_aliases(root, manifest)
+    alias_invalid: list[str] = []
+    try:
+        approved_aliases = load_protected_aliases(root, manifest)
+    except ValueError as exc:
+        approved_aliases = {}
+        alias_invalid.append(str(exc))
     base, base_invalid = _load_inputs(
         root, manifest.base_ref, manifest.repository_id, approved_aliases
     )
     head, head_invalid = _load_inputs(
         root, manifest.head_ref, manifest.repository_id, approved_aliases
     )
-    invalid = base_invalid + head_invalid
+    invalid = alias_invalid + base_invalid + head_invalid
     authorized_updates, rotation_invalid = _authorized_rotation_updates(
         root,
         manifest,

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping
 
+from .alias_policy import load_protected_aliases
 from .manifest import UnitManifest
 from .git_io import read_git_blob
 from .types import UnitId, VerificationObligation, VerificationProfile
@@ -116,6 +117,7 @@ def _load_inputs(
     root: Path,
     ref: str,
     repository_id: str,
+    approved_aliases: Mapping[PurePosixPath, PurePosixPath],
 ) -> tuple[dict[UnitId, _ProfileInput], list[str]]:
     # pylint: disable=too-many-branches,too-many-locals
     raw = read_git_blob(root, ref, PROFILE_PATH)
@@ -155,7 +157,17 @@ def _load_inputs(
         except (KeyError, TypeError, VerificationProfileError) as exc:
             invalid.append(f"{ref}: invalid profile entry: {exc}")
             continue
-        prompt_raw = read_git_blob(root, ref, unit_id.prompt_relpath)
+        prompt_relpath = unit_id.prompt_relpath
+        for alias, canonical in approved_aliases.items():
+            if prompt_relpath == alias:
+                prompt_relpath = canonical
+                break
+            if prompt_relpath.parts[: len(alias.parts)] == alias.parts:
+                prompt_relpath = canonical.joinpath(
+                    *prompt_relpath.parts[len(alias.parts) :]
+                )
+                break
+        prompt_raw = read_git_blob(root, ref, prompt_relpath)
         if prompt_raw is None:
             invalid.append(f"{ref}: profile prompt is absent: {unit_id.prompt_relpath}")
             continue
@@ -373,8 +385,13 @@ def _effective_profile(
 
 def load_verification_profiles(root: Path, manifest: UnitManifest) -> ProfileSet:
     """Load the protected base/candidate union for every expected-managed unit."""
-    base, base_invalid = _load_inputs(root, manifest.base_ref, manifest.repository_id)
-    head, head_invalid = _load_inputs(root, manifest.head_ref, manifest.repository_id)
+    approved_aliases = load_protected_aliases(root, manifest)
+    base, base_invalid = _load_inputs(
+        root, manifest.base_ref, manifest.repository_id, approved_aliases
+    )
+    head, head_invalid = _load_inputs(
+        root, manifest.head_ref, manifest.repository_id, approved_aliases
+    )
     invalid = base_invalid + head_invalid
     authorized_updates, rotation_invalid = _authorized_rotation_updates(
         root,

--- a/pdd/sync_determine_operation.py
+++ b/pdd/sync_determine_operation.py
@@ -1238,7 +1238,11 @@ def get_pdd_file_paths(basename: str, language: str, prompts_dir: str = "prompts
             prompt_path_obj = Path(prompt_path)
             prompt_filename_for_lookup = Path(prompt_path).name
             try:
-                prompt_filename_for_lookup = str(prompt_path_obj.resolve().relative_to(prompts_root.resolve())).replace(os.sep, "/")
+                lexical_prompt = Path(os.path.abspath(prompt_path_obj))
+                lexical_prompts_root = Path(os.path.abspath(prompts_root))
+                prompt_filename_for_lookup = str(
+                    lexical_prompt.relative_to(lexical_prompts_root)
+                ).replace(os.sep, "/")
             except ValueError:
                 pass
             arch_filepath, _ = _get_filepath_from_architecture(
@@ -1793,12 +1797,6 @@ def _validated_report_live_includes(
 def _lexical_canonical_root(prompt_path: Path) -> Optional[Path]:
     """Return an active canonical root without resolving the prompt leaf."""
     lexical_prompt = Path(os.path.abspath(prompt_path))
-    lexical_start = lexical_prompt if lexical_prompt.is_dir() else lexical_prompt.parent
-    if os.environ.get("PDD_SYNC_PROTECTED_BASE_SHA") is None and not any(
-        (candidate / ".pdd/sync-policy.json").is_file()
-        for candidate in (lexical_start, *lexical_start.parents)
-    ):
-        return None
     from pdd.continuous_sync import canonical_sync_enabled, lexical_repository_root
 
     root = lexical_repository_root(lexical_prompt)

--- a/pdd/sync_determine_operation.py
+++ b/pdd/sync_determine_operation.py
@@ -1790,6 +1790,21 @@ def _validated_report_live_includes(
     return True, resolved
 
 
+def _lexical_canonical_root(prompt_path: Path) -> Optional[Path]:
+    """Return an active canonical root without resolving the prompt leaf."""
+    lexical_prompt = Path(os.path.abspath(prompt_path))
+    lexical_start = lexical_prompt if lexical_prompt.is_dir() else lexical_prompt.parent
+    if os.environ.get("PDD_SYNC_PROTECTED_BASE_SHA") is None and not any(
+        (candidate / ".pdd/sync-policy.json").is_file()
+        for candidate in (lexical_start, *lexical_start.parents)
+    ):
+        return None
+    from pdd.continuous_sync import canonical_sync_enabled, lexical_repository_root
+
+    root = lexical_repository_root(lexical_prompt)
+    return root if canonical_sync_enabled(root) else None
+
+
 def extract_include_deps(
     prompt_path: Path,
     dependency_root: Optional[Path] = None,
@@ -1802,7 +1817,7 @@ def extract_include_deps(
     Returns a dict mapping resolved dependency paths to their SHA256 hashes.
     Only includes dependencies that exist on disk.
     """
-    from pdd.continuous_sync import canonical_sync_enabled, repository_root
+    from pdd.sync_core.alias_policy import load_committed_aliases
     from pdd.sync_core.includes import (
         IncludeGraphError,
         build_include_closure,
@@ -1810,7 +1825,8 @@ def extract_include_deps(
     )
     from pdd.sync_core.path_policy import PathPolicy, PathPolicyError
 
-    if not canonical_sync_enabled(prompt_path):
+    canonical_root = _lexical_canonical_root(prompt_path)
+    if canonical_root is None:
         if resolved_live_dependencies is not None:
             dependencies: Dict[str, str] = {}
             for _declared, dependency in resolved_live_dependencies:
@@ -1859,13 +1875,21 @@ def extract_include_deps(
                     key = str(dependency)
                 dependencies[key] = digest
         return dependencies
-    canonical_root = repository_root(prompt_path)
     if not prompt_path.exists():
         raise FileNotFoundError(prompt_path)
     try:
-        prompt_relpath = prompt_path.resolve().relative_to(canonical_root)
+        lexical_prompt = Path(os.path.abspath(prompt_path))
+        prompt_relpath = lexical_prompt.relative_to(canonical_root)
+        protected_ref = os.environ.get("PDD_SYNC_PROTECTED_BASE_SHA") or "HEAD"
+        approved_aliases = load_committed_aliases(canonical_root, protected_ref)
         closure = build_include_closure(
-            PurePosixPath(prompt_relpath.as_posix()), PathPolicy(canonical_root)
+            PurePosixPath(prompt_relpath.as_posix()),
+            PathPolicy(
+                canonical_root,
+                approved_aliases=approved_aliases,
+                base_ref=protected_ref,
+                head_ref="HEAD",
+            ),
         )
     except (ValueError, IncludeGraphError, PathPolicyError) as exc:
         raise ValueError(f"canonical include closure failed: {prompt_path}") from exc
@@ -1927,7 +1951,13 @@ def calculate_prompt_hash(
         if hash_version == 1 else
         [reference.path for reference in parse_include_references(prompt_content)]
     )
-    if references and resolved_live_dependencies is not None:
+    lexical_root = _lexical_canonical_root(prompt_path)
+    if references and lexical_root is not None:
+        dependencies = extract_include_deps(prompt_path, version=hash_version)
+        resolved_dependencies = [
+            (lexical_root / dependency).resolve() for dependency in dependencies
+        ]
+    elif references and resolved_live_dependencies is not None:
         validated_dependencies = list(resolved_live_dependencies)
         if hash_version == 1:
             by_declaration = dict(validated_dependencies)
@@ -1967,7 +1997,7 @@ def calculate_prompt_hash(
         for dependency in resolved_dependencies:
             hasher.update(dependency.read_bytes())
     elif hash_version == 2:
-        anchor = prompt_path.resolve().parent
+        anchor = Path(os.path.abspath(prompt_path)).parent
         for dependency in sorted(resolved_dependencies):
             try:
                 key = dependency.relative_to(anchor).as_posix()

--- a/pdd/sync_orchestration.py
+++ b/pdd/sync_orchestration.py
@@ -11,7 +11,7 @@ import datetime
 import subprocess
 import re
 import os
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Dict, Any, Optional, List, Callable
 from dataclasses import asdict, dataclass, field
 import tempfile
@@ -690,6 +690,7 @@ def _save_fingerprint_atomic(basename: str, language: str, operation: str,
             attestation_signer_from_environment,
             finalize_unit,
         )
+        from .sync_core.finalize import lexical_managed_module
 
         root = repository_root(start)
         protected_base = os.environ.get("PDD_SYNC_PROTECTED_BASE_SHA")
@@ -697,11 +698,12 @@ def _save_fingerprint_atomic(basename: str, language: str, operation: str,
             raise RuntimeError(
                 "canonical sync requires PDD_SYNC_PROTECTED_BASE_SHA"
             )
-        prompt_path = Path(paths["prompt"]).resolve()
-        try:
-            module = PurePosixPath(prompt_path.relative_to(root).as_posix())
-        except ValueError as exc:
-            raise RuntimeError("canonical prompt path escapes project root") from exc
+        module = lexical_managed_module(
+            root,
+            Path(paths["prompt"]),
+            base_ref=protected_base,
+            head_ref="HEAD",
+        )
         finalize_unit(
             root,
             module,

--- a/pdd/sync_orchestration.py
+++ b/pdd/sync_orchestration.py
@@ -682,28 +682,32 @@ def _save_fingerprint_atomic(basename: str, language: str, operation: str,
         include_deps_override: Pre-captured include deps (Issue #522). Used when
             auto-deps may have stripped <include> tags before fingerprint save.
     """
-    from .continuous_sync import canonical_sync_enabled, repository_root
+    from .sync_core.finalize import canonical_root_for_paths
 
-    start = Path(paths.get("prompt") or Path.cwd())
-    if canonical_sync_enabled(start):
+    root = canonical_root_for_paths(paths)
+    if root is not None:
         from .sync_core import (
             attestation_signer_from_environment,
             finalize_unit,
         )
         from .sync_core.finalize import lexical_managed_module
 
-        root = repository_root(start)
         protected_base = os.environ.get("PDD_SYNC_PROTECTED_BASE_SHA")
         if not protected_base:
             raise RuntimeError(
                 "canonical sync requires PDD_SYNC_PROTECTED_BASE_SHA"
             )
-        module = lexical_managed_module(
-            root,
-            Path(paths["prompt"]),
-            base_ref=protected_base,
-            head_ref="HEAD",
-        )
+        try:
+            module = lexical_managed_module(
+                root,
+                Path(paths["prompt"]),
+                base_ref=protected_base,
+                head_ref="HEAD",
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise RuntimeError(
+                f"trusted canonical finalization failed: {exc}"
+            ) from exc
         finalize_unit(
             root,
             module,

--- a/tests/test_sync_core_alias_policy.py
+++ b/tests/test_sync_core_alias_policy.py
@@ -7,7 +7,7 @@ from pathlib import Path, PurePosixPath
 import pytest
 
 from pdd.sync_core import build_unit_manifest
-from pdd.sync_core.alias_policy import load_protected_aliases
+from pdd.sync_core.alias_policy import load_committed_aliases, load_protected_aliases
 from pdd.sync_core.identity import initialize_repository_identity
 
 
@@ -76,3 +76,29 @@ def test_protected_alias_policy_requires_unchanged_candidate_copy(tmp_path) -> N
 
     with pytest.raises(ValueError, match="candidate changed protected alias policy"):
         load_protected_aliases(root, manifest)
+
+
+def test_protected_alias_policy_rejects_overlapping_authorities(tmp_path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "aliases@example.com")
+    _git(root, "config", "user.name", "Alias Test")
+    (root / ".pdd").mkdir()
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [
+                    {"alias_path": "src", "canonical_path": "canonical"},
+                    {"alias_path": "src/nested", "canonical_path": "other"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _git(root, "add", ".pdd/sync-aliases.json")
+    _git(root, "commit", "-qm", "overlapping aliases")
+
+    with pytest.raises(ValueError, match="overlap"):
+        load_committed_aliases(root)

--- a/tests/test_sync_core_alias_policy.py
+++ b/tests/test_sync_core_alias_policy.py
@@ -8,6 +8,10 @@ import pytest
 
 from pdd.sync_core import build_unit_manifest
 from pdd.sync_core.alias_policy import load_protected_aliases
+from pdd.sync_core.identity import initialize_repository_identity
+
+
+REPOSITORY_ID = "3b4d7b1c-d6cc-4752-ba93-6b98d1a710e0"
 
 
 def _git(root: Path, *args: str) -> str:
@@ -22,12 +26,13 @@ def test_candidate_alias_policy_cannot_authorize_itself(tmp_path) -> None:
     _git(root, "init", "-q")
     _git(root, "config", "user.email", "aliases@example.com")
     _git(root, "config", "user.name", "Alias Test")
+    initialize_repository_identity(root, REPOSITORY_ID)
     (root / "tracked.txt").write_text("base\n", encoding="utf-8")
     _git(root, "add", ".")
     _git(root, "commit", "-qm", "base")
     base = _git(root, "rev-parse", "HEAD")
 
-    (root / ".pdd").mkdir()
+    (root / ".pdd").mkdir(exist_ok=True)
     (root / ".pdd/sync-aliases.json").write_text(
         json.dumps(
             {
@@ -52,7 +57,8 @@ def test_protected_alias_policy_requires_unchanged_candidate_copy(tmp_path) -> N
     _git(root, "init", "-q")
     _git(root, "config", "user.email", "aliases@example.com")
     _git(root, "config", "user.name", "Alias Test")
-    (root / ".pdd").mkdir()
+    initialize_repository_identity(root, REPOSITORY_ID)
+    (root / ".pdd").mkdir(exist_ok=True)
     policy = {
         "schema_version": 1,
         "aliases": [{"alias_path": "alias", "canonical_path": "canonical"}],

--- a/tests/test_sync_core_alias_policy.py
+++ b/tests/test_sync_core_alias_policy.py
@@ -1,0 +1,72 @@
+"""Protected approved-alias policy tests."""
+
+import json
+import subprocess
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from pdd.sync_core import build_unit_manifest
+from pdd.sync_core.alias_policy import load_protected_aliases
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=root, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def test_candidate_alias_policy_cannot_authorize_itself(tmp_path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "aliases@example.com")
+    _git(root, "config", "user.name", "Alias Test")
+    (root / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "base")
+    base = _git(root, "rev-parse", "HEAD")
+
+    (root / ".pdd").mkdir()
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [{"alias_path": "alias", "canonical_path": "canonical"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _git(root, "add", ".pdd/sync-aliases.json")
+    _git(root, "commit", "-qm", "candidate adds aliases")
+    head = _git(root, "rev-parse", "HEAD")
+    manifest = build_unit_manifest(root, base_ref=base, head_ref=head)
+
+    with pytest.raises(ValueError, match="candidate added protected alias policy"):
+        load_protected_aliases(root, manifest)
+
+
+def test_protected_alias_policy_requires_unchanged_candidate_copy(tmp_path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "aliases@example.com")
+    _git(root, "config", "user.name", "Alias Test")
+    (root / ".pdd").mkdir()
+    policy = {
+        "schema_version": 1,
+        "aliases": [{"alias_path": "alias", "canonical_path": "canonical"}],
+    }
+    (root / ".pdd/sync-aliases.json").write_text(json.dumps(policy), encoding="utf-8")
+    (root / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "protected aliases")
+    base = _git(root, "rev-parse", "HEAD")
+    policy["aliases"][0]["canonical_path"] = "other"
+    (root / ".pdd/sync-aliases.json").write_text(json.dumps(policy), encoding="utf-8")
+    _git(root, "add", ".pdd/sync-aliases.json")
+    _git(root, "commit", "-qm", "candidate retargets aliases")
+    manifest = build_unit_manifest(root, base_ref=base, head_ref="HEAD")
+
+    with pytest.raises(ValueError, match="candidate changed protected alias policy"):
+        load_protected_aliases(root, manifest)

--- a/tests/test_sync_core_alias_policy.py
+++ b/tests/test_sync_core_alias_policy.py
@@ -102,3 +102,29 @@ def test_protected_alias_policy_rejects_overlapping_authorities(tmp_path) -> Non
 
     with pytest.raises(ValueError, match="overlap"):
         load_committed_aliases(root)
+
+
+def test_protected_alias_policy_rejects_alias_targeting_an_alias(tmp_path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "aliases@example.com")
+    _git(root, "config", "user.name", "Alias Test")
+    (root / ".pdd").mkdir()
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [
+                    {"alias_path": "outer", "canonical_path": "inner"},
+                    {"alias_path": "inner", "canonical_path": "canonical"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _git(root, "add", ".pdd/sync-aliases.json")
+    _git(root, "commit", "-qm", "chained aliases")
+
+    with pytest.raises(ValueError, match="namespace"):
+        load_committed_aliases(root)

--- a/tests/test_sync_core_alias_policy.py
+++ b/tests/test_sync_core_alias_policy.py
@@ -2,7 +2,7 @@
 
 import json
 import subprocess
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
 import pytest
 

--- a/tests/test_sync_core_identity_path_policy.py
+++ b/tests/test_sync_core_identity_path_policy.py
@@ -334,6 +334,33 @@ def test_path_policy_rejects_alias_retarget(repository) -> None:
         policy.resolve(PurePosixPath("alias/widget.py"))
 
 
+@pytest.mark.parametrize("outside", [False, True])
+def test_path_policy_rejects_live_alias_retarget_with_same_terminal(
+    tmp_path, outside
+) -> None:
+    _git_repository(tmp_path)
+    (tmp_path / "canonical").mkdir()
+    (tmp_path / "canonical/widget.py").write_text("value = 1\n", encoding="utf-8")
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "protected alias")
+    commit = _git(tmp_path, "rev-parse", "HEAD")
+
+    middle = tmp_path.parent / "outside-middle" if outside else tmp_path / "middle"
+    middle.symlink_to(tmp_path / "canonical", target_is_directory=True)
+    (tmp_path / "alias").unlink()
+    (tmp_path / "alias").symlink_to(middle, target_is_directory=True)
+    policy = PathPolicy(
+        tmp_path,
+        {PurePosixPath("alias"): PurePosixPath("canonical")},
+        base_ref=commit,
+        head_ref=commit,
+    )
+
+    with pytest.raises(PathPolicyError, match="target changed"):
+        policy.resolve(PurePosixPath("alias/widget.py"))
+
+
 def test_path_policy_rejects_special_file(repository) -> None:
     fifo = repository / "src/events"
     os.mkfifo(fifo)

--- a/tests/test_sync_core_identity_path_policy.py
+++ b/tests/test_sync_core_identity_path_policy.py
@@ -191,6 +191,27 @@ def test_path_policy_rejects_alias_retarget_between_immutable_trees(tmp_path) ->
         policy.resolve(PurePosixPath("alias/widget.py"))
 
 
+def test_path_policy_rejects_configured_alias_absent_from_immutable_trees(
+    tmp_path,
+) -> None:
+    _git_repository(tmp_path)
+    (tmp_path / "canonical").mkdir()
+    (tmp_path / "canonical/widget.py").write_text("value = 1\n", encoding="utf-8")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "protected tree without alias")
+    commit = _git(tmp_path, "rev-parse", "HEAD")
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+
+    policy = PathPolicy(
+        tmp_path,
+        {PurePosixPath("alias"): PurePosixPath("canonical")},
+        base_ref=commit,
+        head_ref=commit,
+    )
+    with pytest.raises(PathPolicyError, match="protected trees"):
+        policy.resolve(PurePosixPath("alias/widget.py"))
+
+
 def test_path_policy_rejects_stale_alias_policy_over_real_directory(tmp_path) -> None:
     _git_repository(tmp_path)
     (tmp_path / "alias").mkdir()

--- a/tests/test_sync_core_identity_path_policy.py
+++ b/tests/test_sync_core_identity_path_policy.py
@@ -129,7 +129,7 @@ def _git_repository(root) -> None:
     _git(root, "config", "user.name", "Path Policy")
 
 
-def test_path_policy_accepts_unchanged_alias_from_immutable_trees(tmp_path) -> None:
+def test_path_policy_rejects_unchanged_alias_absent_from_policy(tmp_path) -> None:
     _git_repository(tmp_path)
     (tmp_path / "canonical").mkdir()
     (tmp_path / "canonical/widget.py").write_text("value = 1\n", encoding="utf-8")
@@ -139,10 +139,29 @@ def test_path_policy_accepts_unchanged_alias_from_immutable_trees(tmp_path) -> N
     commit = _git(tmp_path, "rev-parse", "HEAD")
 
     policy = PathPolicy(tmp_path, base_ref=commit, head_ref=commit)
-    resolved = policy.resolve(PurePosixPath("alias/widget.py"))
+    with pytest.raises(PathPolicyError, match="unapproved managed symlink"):
+        policy.resolve(PurePosixPath("alias/widget.py"))
 
-    assert resolved.canonical_path == tmp_path / "canonical/widget.py"
-    assert resolved.alias_relpath == PurePosixPath("alias")
+
+def test_path_policy_allows_regular_file_edit_between_immutable_trees(tmp_path) -> None:
+    _git_repository(tmp_path)
+    (tmp_path / "src").mkdir()
+    widget = tmp_path / "src/widget.py"
+    widget.write_text("value = 1\n", encoding="utf-8")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "base file")
+    base = _git(tmp_path, "rev-parse", "HEAD")
+    widget.write_text("value = 2\n", encoding="utf-8")
+    _git(tmp_path, "add", "src/widget.py")
+    _git(tmp_path, "commit", "-q", "-m", "edit file")
+    head = _git(tmp_path, "rev-parse", "HEAD")
+
+    resolved = PathPolicy(tmp_path, base_ref=base, head_ref=head).resolve(
+        PurePosixPath("src/widget.py")
+    )
+
+    assert resolved.canonical_path == widget
+    assert resolved.alias_relpath is None
 
 
 def test_path_policy_rejects_alias_retarget_between_immutable_trees(tmp_path) -> None:
@@ -162,7 +181,12 @@ def test_path_policy_rejects_alias_retarget_between_immutable_trees(tmp_path) ->
     _git(tmp_path, "commit", "-q", "-m", "retarget alias")
     head = _git(tmp_path, "rev-parse", "HEAD")
 
-    policy = PathPolicy(tmp_path, base_ref=base, head_ref=head)
+    policy = PathPolicy(
+        tmp_path,
+        {PurePosixPath("alias"): PurePosixPath("canonical")},
+        base_ref=base,
+        head_ref=head,
+    )
     with pytest.raises(PathPolicyError, match="changed in protected trees"):
         policy.resolve(PurePosixPath("alias/widget.py"))
 

--- a/tests/test_sync_core_identity_path_policy.py
+++ b/tests/test_sync_core_identity_path_policy.py
@@ -134,6 +134,69 @@ def test_path_policy_rejects_unapproved_symlink_below_approved_target(tmp_path) 
         policy.resolve(PurePosixPath("alias/widget.py"))
 
 
+def test_path_policy_rejects_unapproved_symlink_in_canonical_suffix(tmp_path) -> None:
+    _git_repository(tmp_path)
+    (tmp_path / "canonical").mkdir()
+    (tmp_path / "terminal").mkdir()
+    (tmp_path / "terminal/widget.py").write_text("value = 1\n", encoding="utf-8")
+    (tmp_path / "canonical/nested").symlink_to(
+        "../terminal", target_is_directory=True
+    )
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "tracked descendant alias")
+    commit = _git(tmp_path, "rev-parse", "HEAD")
+
+    policy = PathPolicy(
+        tmp_path,
+        {PurePosixPath("alias"): PurePosixPath("canonical")},
+        base_ref=commit,
+        head_ref=commit,
+    )
+
+    with pytest.raises(
+        PathPolicyError, match="unapproved managed symlink: canonical/nested"
+    ):
+        policy.resolve(PurePosixPath("alias/nested/widget.py"))
+
+
+@pytest.mark.parametrize("replacement_in_head", [False, True])
+def test_path_policy_rejects_canonical_suffix_symlink_replaced_by_directory(
+    tmp_path, replacement_in_head
+) -> None:
+    _git_repository(tmp_path)
+    (tmp_path / "canonical").mkdir()
+    (tmp_path / "terminal").mkdir()
+    (tmp_path / "terminal/widget.py").write_text("terminal = True\n", encoding="utf-8")
+    nested = tmp_path / "canonical/nested"
+    nested.symlink_to("../terminal", target_is_directory=True)
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "base descendant alias")
+    base = _git(tmp_path, "rev-parse", "HEAD")
+
+    nested.unlink()
+    nested.mkdir()
+    (nested / "widget.py").write_text("replacement = True\n", encoding="utf-8")
+    head = base
+    if replacement_in_head:
+        _git(tmp_path, "add", "canonical/nested")
+        _git(tmp_path, "commit", "-q", "-m", "replace descendant alias")
+        head = _git(tmp_path, "rev-parse", "HEAD")
+
+    policy = PathPolicy(
+        tmp_path,
+        {PurePosixPath("alias"): PurePosixPath("canonical")},
+        base_ref=base,
+        head_ref=head,
+    )
+
+    with pytest.raises(
+        PathPolicyError, match="unapproved managed symlink: canonical/nested"
+    ):
+        policy.resolve(PurePosixPath("alias/nested/widget.py"))
+
+
 def _git(root, *args: str) -> str:
     return subprocess.run(
         ["git", *args],

--- a/tests/test_sync_core_identity_path_policy.py
+++ b/tests/test_sync_core_identity_path_policy.py
@@ -113,6 +113,27 @@ def test_path_policy_accepts_unchanged_tracked_alias(repository) -> None:
     assert resolved.alias_relpath == PurePosixPath("alias")
 
 
+def test_path_policy_rejects_unapproved_symlink_below_approved_target(tmp_path) -> None:
+    _git_repository(tmp_path)
+    (tmp_path / "canonical").mkdir()
+    (tmp_path / "canonical/widget.py").write_text("value = 1\n", encoding="utf-8")
+    (tmp_path / "middle").symlink_to("canonical", target_is_directory=True)
+    (tmp_path / "alias").symlink_to("middle", target_is_directory=True)
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "tracked outer alias")
+    commit = _git(tmp_path, "rev-parse", "HEAD")
+
+    policy = PathPolicy(
+        tmp_path,
+        {PurePosixPath("alias"): PurePosixPath("middle")},
+        base_ref=commit,
+        head_ref=commit,
+    )
+
+    with pytest.raises(PathPolicyError, match="unapproved managed symlink: middle"):
+        policy.resolve(PurePosixPath("alias/widget.py"))
+
+
 def _git(root, *args: str) -> str:
     return subprocess.run(
         ["git", *args],

--- a/tests/test_sync_core_identity_path_policy.py
+++ b/tests/test_sync_core_identity_path_policy.py
@@ -3,6 +3,7 @@
 import os
 from concurrent.futures import ThreadPoolExecutor
 from threading import Barrier
+import subprocess
 from pathlib import PurePosixPath
 
 import pytest
@@ -110,6 +111,80 @@ def test_path_policy_accepts_unchanged_tracked_alias(repository) -> None:
     assert resolved.logical_relpath == PurePosixPath("alias/widget.py")
     assert resolved.canonical_path == repository / "canonical/widget.py"
     assert resolved.alias_relpath == PurePosixPath("alias")
+
+
+def _git(root, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _git_repository(root) -> None:
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "path-policy@example.com")
+    _git(root, "config", "user.name", "Path Policy")
+
+
+def test_path_policy_accepts_unchanged_alias_from_immutable_trees(tmp_path) -> None:
+    _git_repository(tmp_path)
+    (tmp_path / "canonical").mkdir()
+    (tmp_path / "canonical/widget.py").write_text("value = 1\n", encoding="utf-8")
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "tracked alias")
+    commit = _git(tmp_path, "rev-parse", "HEAD")
+
+    policy = PathPolicy(tmp_path, base_ref=commit, head_ref=commit)
+    resolved = policy.resolve(PurePosixPath("alias/widget.py"))
+
+    assert resolved.canonical_path == tmp_path / "canonical/widget.py"
+    assert resolved.alias_relpath == PurePosixPath("alias")
+
+
+def test_path_policy_rejects_alias_retarget_between_immutable_trees(tmp_path) -> None:
+    _git_repository(tmp_path)
+    (tmp_path / "canonical").mkdir()
+    (tmp_path / "canonical/widget.py").write_text("value = 1\n", encoding="utf-8")
+    (tmp_path / "other").mkdir()
+    (tmp_path / "other/widget.py").write_text("value = 2\n", encoding="utf-8")
+    alias = tmp_path / "alias"
+    alias.symlink_to("canonical", target_is_directory=True)
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "base alias")
+    base = _git(tmp_path, "rev-parse", "HEAD")
+    alias.unlink()
+    alias.symlink_to("other", target_is_directory=True)
+    _git(tmp_path, "add", "alias")
+    _git(tmp_path, "commit", "-q", "-m", "retarget alias")
+    head = _git(tmp_path, "rev-parse", "HEAD")
+
+    policy = PathPolicy(tmp_path, base_ref=base, head_ref=head)
+    with pytest.raises(PathPolicyError, match="changed in protected trees"):
+        policy.resolve(PurePosixPath("alias/widget.py"))
+
+
+def test_path_policy_rejects_stale_alias_policy_over_real_directory(tmp_path) -> None:
+    _git_repository(tmp_path)
+    (tmp_path / "alias").mkdir()
+    (tmp_path / "alias/widget.py").write_text("candidate = True\n", encoding="utf-8")
+    (tmp_path / "canonical").mkdir()
+    (tmp_path / "canonical/widget.py").write_text("value = 1\n", encoding="utf-8")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "real directory")
+    commit = _git(tmp_path, "rev-parse", "HEAD")
+
+    policy = PathPolicy(
+        tmp_path,
+        {PurePosixPath("alias"): PurePosixPath("canonical")},
+        base_ref=commit,
+        head_ref=commit,
+    )
+    with pytest.raises(PathPolicyError, match="not an unchanged symlink"):
+        policy.resolve(PurePosixPath("alias/widget.py"))
 
 
 def test_path_policy_rejects_alias_retarget(repository) -> None:

--- a/tests/test_sync_core_manifest.py
+++ b/tests/test_sync_core_manifest.py
@@ -399,6 +399,41 @@ def test_alias_counterpart_collision_with_concrete_owner_is_invalid(tmp_path) ->
     )
 
 
+def test_same_unit_alias_and_canonical_outputs_are_invalid(tmp_path) -> None:
+    root = _repository(tmp_path)
+    (root / "canonical").mkdir()
+    (root / "src/widget.py").rename(root / "canonical/widget.py")
+    (root / "src").rmdir()
+    (root / "src").symlink_to("canonical", target_is_directory=True)
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [{"alias_path": "src", "canonical_path": "canonical"}],
+            }
+        )
+    )
+    (root / "architecture.json").write_text(
+        json.dumps(
+            [
+                {"filename": "widget_python.prompt", "filepath": "src/widget.py"},
+                {
+                    "filename": "widget_python.prompt",
+                    "filepath": "canonical/widget.py",
+                },
+            ]
+        )
+    )
+    commit = _commit(root, "same unit alias and canonical outputs")
+
+    manifest = build_unit_manifest(root, base_ref=commit, head_ref=commit)
+
+    assert any(
+        "canonical counterpart" in reason and "canonical/widget.py" in reason
+        for reason in manifest.invalid_reasons
+    )
+
+
 def test_architecture_resolves_prompt_from_repository_prompt_root(tmp_path) -> None:
     root = _repository(tmp_path)
     nested_prompt = root / "prompts/backend/widget_python.prompt"

--- a/tests/test_sync_core_manifest.py
+++ b/tests/test_sync_core_manifest.py
@@ -121,6 +121,68 @@ def test_protected_tombstone_accounts_for_removed_unit(tmp_path) -> None:
     assert len(manifest.expected_managed) == 1
 
 
+def test_retired_unit_stale_alias_cannot_account_canonical_candidate(tmp_path) -> None:
+    root = _repository(tmp_path)
+    (root / "prompts/helper_python.prompt").write_text("Build helper\n")
+    (root / "src/helper.py").write_text("helper = True\n")
+    (root / "architecture.json").write_text(
+        json.dumps(
+            [
+                {"filename": "widget_python.prompt", "filepath": "src/widget.py"},
+                {"filename": "helper_python.prompt", "filepath": "src/helper.py"},
+            ]
+        )
+    )
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [
+                    {"alias_path": "src", "canonical_path": "canonical"}
+                ],
+            }
+        )
+    )
+    (root / ".pdd/sync-tombstones.json").write_text(
+        json.dumps(
+            [
+                {
+                    "prompt_path": "prompts/widget_python.prompt",
+                    "artifact_paths": [
+                        "prompts/widget_python.prompt",
+                        "src/widget.py",
+                    ],
+                    "rationale": "Widget was deliberately retired",
+                    "owner": "sync-owner@example.com",
+                    "baseline_status": "IN_SYNC",
+                }
+            ]
+        )
+    )
+    base = _commit(root, "authorize retirement with stale alias")
+    (root / "canonical").mkdir()
+    (root / "canonical/widget.py").write_text("candidate = True\n")
+    (root / "prompts/widget_python.prompt").unlink()
+    (root / "src/widget.py").unlink()
+    (root / "architecture.json").write_text(
+        json.dumps(
+            [{"filename": "helper_python.prompt", "filepath": "src/helper.py"}]
+        )
+    )
+    head = _commit(root, "retire widget and add canonical candidate")
+
+    manifest = build_unit_manifest(root, base_ref=base, head_ref=head)
+
+    assert any("unchanged symlink" in reason for reason in manifest.invalid_reasons)
+    assert PurePosixPath("canonical/widget.py") in manifest.unaccounted_tracked_paths
+    candidate = next(
+        item
+        for item in manifest.candidates
+        if item.candidate_id.artifact_relpath == PurePosixPath("canonical/widget.py")
+    )
+    assert candidate.inventory is InventoryStatus.INVALID
+
+
 def test_incomplete_tombstone_cannot_reduce_expected_managed(tmp_path) -> None:
     root = _repository(tmp_path)
     _commit(root, "base")

--- a/tests/test_sync_core_manifest.py
+++ b/tests/test_sync_core_manifest.py
@@ -399,46 +399,6 @@ def test_alias_counterpart_collision_with_concrete_owner_is_invalid(tmp_path) ->
     )
 
 
-def test_two_alias_counterparts_with_different_owners_are_invalid(tmp_path) -> None:
-    root = _repository(tmp_path)
-    (root / "prompts/helper_python.prompt").write_text("Build helper\n")
-    (root / "canonical").mkdir()
-    (root / "src/widget.py").rename(root / "canonical/widget.py")
-    (root / "src").rmdir()
-    (root / "src").symlink_to("canonical", target_is_directory=True)
-    (root / "alternate").symlink_to("canonical", target_is_directory=True)
-    (root / ".pdd/sync-aliases.json").write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "aliases": [
-                    {"alias_path": "src", "canonical_path": "canonical"},
-                    {"alias_path": "alternate", "canonical_path": "canonical"},
-                ],
-            }
-        )
-    )
-    (root / "architecture.json").write_text(
-        json.dumps(
-            [
-                {"filename": "widget_python.prompt", "filepath": "src/widget.py"},
-                {
-                    "filename": "helper_python.prompt",
-                    "filepath": "alternate/widget.py",
-                },
-            ]
-        )
-    )
-    commit = _commit(root, "two alias owners")
-
-    manifest = build_unit_manifest(root, base_ref=commit, head_ref=commit)
-
-    assert any(
-        "canonical counterpart" in reason and "canonical/widget.py" in reason
-        for reason in manifest.invalid_reasons
-    )
-
-
 def test_architecture_resolves_prompt_from_repository_prompt_root(tmp_path) -> None:
     root = _repository(tmp_path)
     nested_prompt = root / "prompts/backend/widget_python.prompt"

--- a/tests/test_sync_core_manifest.py
+++ b/tests/test_sync_core_manifest.py
@@ -363,6 +363,82 @@ def test_duplicate_architecture_output_is_invalid(tmp_path) -> None:
     assert any("duplicate output" in reason for reason in manifest.invalid_reasons)
 
 
+def test_alias_counterpart_collision_with_concrete_owner_is_invalid(tmp_path) -> None:
+    root = _repository(tmp_path)
+    (root / "prompts/helper_python.prompt").write_text("Build helper\n")
+    (root / "canonical").mkdir()
+    (root / "src/widget.py").rename(root / "canonical/widget.py")
+    (root / "src").rmdir()
+    (root / "src").symlink_to("canonical", target_is_directory=True)
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [{"alias_path": "src", "canonical_path": "canonical"}],
+            }
+        )
+    )
+    (root / "architecture.json").write_text(
+        json.dumps(
+            [
+                {"filename": "widget_python.prompt", "filepath": "src/widget.py"},
+                {
+                    "filename": "helper_python.prompt",
+                    "filepath": "canonical/widget.py",
+                },
+            ]
+        )
+    )
+    commit = _commit(root, "alias and canonical owners")
+
+    manifest = build_unit_manifest(root, base_ref=commit, head_ref=commit)
+
+    assert any(
+        "canonical counterpart" in reason and "canonical/widget.py" in reason
+        for reason in manifest.invalid_reasons
+    )
+
+
+def test_two_alias_counterparts_with_different_owners_are_invalid(tmp_path) -> None:
+    root = _repository(tmp_path)
+    (root / "prompts/helper_python.prompt").write_text("Build helper\n")
+    (root / "canonical").mkdir()
+    (root / "src/widget.py").rename(root / "canonical/widget.py")
+    (root / "src").rmdir()
+    (root / "src").symlink_to("canonical", target_is_directory=True)
+    (root / "alternate").symlink_to("canonical", target_is_directory=True)
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [
+                    {"alias_path": "src", "canonical_path": "canonical"},
+                    {"alias_path": "alternate", "canonical_path": "canonical"},
+                ],
+            }
+        )
+    )
+    (root / "architecture.json").write_text(
+        json.dumps(
+            [
+                {"filename": "widget_python.prompt", "filepath": "src/widget.py"},
+                {
+                    "filename": "helper_python.prompt",
+                    "filepath": "alternate/widget.py",
+                },
+            ]
+        )
+    )
+    commit = _commit(root, "two alias owners")
+
+    manifest = build_unit_manifest(root, base_ref=commit, head_ref=commit)
+
+    assert any(
+        "canonical counterpart" in reason and "canonical/widget.py" in reason
+        for reason in manifest.invalid_reasons
+    )
+
+
 def test_architecture_resolves_prompt_from_repository_prompt_root(tmp_path) -> None:
     root = _repository(tmp_path)
     nested_prompt = root / "prompts/backend/widget_python.prompt"

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -1134,7 +1134,10 @@ def test_finalizer_rejects_invalid_alias_manifest_before_validation_or_writes(
     with patch("pdd.sync_core.finalize.run_profile") as run_profile, patch(
         "pdd.sync_core.finalize.TransactionManager.prepare"
     ) as prepare:
-        with pytest.raises(ValueError, match="manifest is invalid"):
+        with pytest.raises(
+            ValueError,
+            match="canonical finalization requires a valid protected candidate manifest",
+        ):
             finalize_unit(
                 root,
                 PurePosixPath("prompts/widget_python.prompt"),
@@ -1178,7 +1181,10 @@ def test_excluded_project_alias_counterpart_is_invalid_before_finalization(
     with patch("pdd.sync_core.finalize.run_profile") as run_profile, patch(
         "pdd.sync_core.finalize.TransactionManager.prepare"
     ) as prepare:
-        with pytest.raises(ValueError, match="manifest is invalid"):
+        with pytest.raises(
+            ValueError,
+            match="canonical finalization requires a valid protected candidate manifest",
+        ):
             finalize_unit(
                 root,
                 PurePosixPath("prompts/widget_python.prompt"),

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -834,6 +834,57 @@ def test_unlisted_canonical_symlink_cannot_hide_terminal_owner(tmp_path) -> None
     assert "unapproved" in errors and "middle" in errors
 
 
+def test_descendant_canonical_symlink_cannot_hide_terminal_owner(tmp_path) -> None:
+    root, _commit = _repository(tmp_path, approved_alias=True)
+    (root / "canonical/widget.py").unlink()
+    (root / "terminal").mkdir()
+    (root / "terminal/widget.py").write_text("terminal = True\n")
+    (root / "canonical/nested").symlink_to(
+        "../terminal", target_is_directory=True
+    )
+    (root / "prompts/helper_python.prompt").write_text("REQ-2: Build helper\n")
+    (root / "architecture.json").write_text(
+        json.dumps(
+            [
+                {
+                    "filename": "widget_python.prompt",
+                    "filepath": "src/nested/widget.py",
+                },
+                {
+                    "filename": "helper_python.prompt",
+                    "filepath": "terminal/widget.py",
+                },
+            ]
+        )
+    )
+    ownership = json.loads((root / ".pdd/sync-ownership.json").read_text())
+    ownership["rules"].append(
+        {
+            "pattern": "canonical/nested",
+            "inventory": "HUMAN_OWNED",
+            "role": "compatibility-link",
+            "owner": "platform@example.com",
+        }
+    )
+    (root / ".pdd/sync-ownership.json").write_text(json.dumps(ownership))
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "descendant canonical terminal owner")
+    commit = _git(root, "rev-parse", "HEAD")
+
+    report = build_canonical_report(
+        root,
+        CanonicalReportOptions(
+            base_ref=commit,
+            head_ref=commit,
+            replay_ledger_path=tmp_path / "external-trust/descendant-terminal.json",
+        ),
+    )
+
+    assert report["counts"]["invalid"] > 0
+    errors = "\n".join(report["errors"])
+    assert "unapproved" in errors and "canonical/nested" in errors
+
+
 def _alias_collision_repository(tmp_path: Path, *, different_unit: bool) -> tuple[Path, str]:
     root, _commit = _repository(tmp_path, approved_alias=True)
     prompt = "widget_python.prompt"

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -59,7 +59,7 @@ def _git(root: Path, *args: str) -> str:
     ).stdout.strip()
 
 
-def _repository(tmp_path: Path) -> tuple[Path, str]:
+def _repository(tmp_path: Path, *, approved_alias: bool = False) -> tuple[Path, str]:
     root = tmp_path / "repo"
     root.mkdir()
     _git(root, "init", "-q")
@@ -125,6 +125,21 @@ def _repository(tmp_path: Path) -> tuple[Path, str]:
             }
         )
     )
+    if approved_alias:
+        (root / "canonical").mkdir()
+        (root / "src/widget.py").rename(root / "canonical/widget.py")
+        (root / "src").rmdir()
+        (root / "src").symlink_to("canonical", target_is_directory=True)
+        (root / ".pdd/sync-aliases.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "aliases": [
+                        {"alias_path": "src", "canonical_path": "canonical"}
+                    ],
+                }
+            )
+        )
     (root / ".pdd/attestation-trust.json").write_text(
         json.dumps(
             {
@@ -640,6 +655,20 @@ def test_trusted_finalizer_rejects_invalid_next_protected_base(tmp_path) -> None
             signer=SIGNER,
             replay_ledger_path=tmp_path / "external-trust/invalid-base.json",
         )
+
+
+def test_trusted_finalizer_commits_artifact_through_protected_alias(tmp_path) -> None:
+    root, commit = _repository(tmp_path, approved_alias=True)
+    result = finalize_unit(
+        root,
+        PurePosixPath("prompts/widget_python.prompt"),
+        base_ref=commit,
+        head_ref=commit,
+        signer=SIGNER,
+        replay_ledger_path=tmp_path / "external-trust/finalizer-alias.json",
+    )
+    assert result.transaction.phase.value == "COMMITTED"
+    assert (root / "canonical/widget.py").read_text() == "value = 1\n"
 
 
 def test_trusted_finalizer_second_run_is_zero_write_no_op(tmp_path) -> None:

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -698,6 +698,44 @@ def test_approved_alias_target_does_not_blanket_account_candidate_files(
     assert "canonical/rogue.py" in "\n".join(report["errors"])
 
 
+def test_overlapping_alias_policy_cannot_account_rogue_counterparts(
+    tmp_path,
+) -> None:
+    root, _commit = _repository(tmp_path, approved_alias=True)
+    (root / "canonical/nested").mkdir()
+    (root / "canonical/widget.py").rename(root / "canonical/nested/widget.py")
+    (root / "other").mkdir()
+    (root / "architecture.json").write_text(
+        json.dumps(
+            [{"filename": "widget_python.prompt", "filepath": "src/nested/widget.py"}]
+        )
+    )
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [
+                    {"alias_path": "src", "canonical_path": "canonical"},
+                    {"alias_path": "src/nested", "canonical_path": "other"},
+                ],
+            }
+        )
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "overlapping protected alias policy")
+    base = _git(root, "rev-parse", "HEAD")
+    (root / "other/widget.py").write_text("candidate = 'unowned'\n")
+    _git(root, "add", "other/widget.py")
+    _git(root, "commit", "-q", "-m", "candidate adds alternate alias target")
+    head = _git(root, "rev-parse", "HEAD")
+
+    manifest = build_unit_manifest(root, base_ref=base, head_ref=head)
+
+    errors = "\n".join(manifest.invalid_reasons)
+    assert manifest.invalid_reasons
+    assert "overlap" in errors or "other/widget.py" in errors
+
+
 def test_trusted_finalizer_second_run_is_zero_write_no_op(tmp_path) -> None:
     root, commit = _repository(tmp_path)
     replay = tmp_path / "external-trust/idempotency.json"

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -398,6 +398,62 @@ def test_legacy_finalizers_preserve_approved_prompt_alias_identity(
     )
 
 
+@pytest.mark.parametrize("explicit_protected_base", [False, True])
+@pytest.mark.parametrize("bridge", ["operation_log", "orchestration"])
+def test_legacy_finalizers_fail_closed_when_prompt_alias_is_live_retargeted(
+    tmp_path, monkeypatch, explicit_protected_base, bridge
+) -> None:
+    """Lexical repository activation must precede a dirty alias resolution."""
+    root, _commit = _repository(tmp_path)
+    canonical = root / "canonical-prompts"
+    canonical.mkdir()
+    prompt = root / "prompts/widget_python.prompt"
+    prompt.rename(canonical / prompt.name)
+    prompt.symlink_to("../canonical-prompts/widget_python.prompt")
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [
+                    {
+                        "alias_path": "prompts/widget_python.prompt",
+                        "canonical_path": "canonical-prompts/widget_python.prompt",
+                    }
+                ],
+            }
+        )
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "protected prompt alias")
+    protected_base = _git(root, "rev-parse", "HEAD")
+    outside = tmp_path / "outside.prompt"
+    outside.write_text("untrusted\n")
+    prompt.unlink()
+    prompt.symlink_to(outside)
+    monkeypatch.chdir(root)
+    if explicit_protected_base:
+        monkeypatch.setenv("PDD_SYNC_PROTECTED_BASE_SHA", protected_base)
+    else:
+        monkeypatch.delenv("PDD_SYNC_PROTECTED_BASE_SHA", raising=False)
+
+    legacy_path = root / ".pdd/meta/widget_python.json"
+    if bridge == "operation_log":
+        from pdd.sync_core.finalize import CanonicalFinalizationError
+
+        with pytest.raises(CanonicalFinalizationError):
+            save_fingerprint("widget", "python", "generate", {"prompt": prompt})
+    else:
+        from pdd.sync_orchestration import _save_fingerprint_atomic
+
+        with pytest.raises(RuntimeError):
+            _save_fingerprint_atomic(
+                "widget", "python", "generate", {"prompt": prompt}, 0.0, "test"
+            )
+
+    assert not legacy_path.exists()
+    assert not list((root / ".pdd/meta/v2").glob("*.json"))
+
+
 def test_prompt_alias_uses_canonical_prompt_requirements_and_finalizes(tmp_path) -> None:
     root, _commit = _repository(tmp_path)
     canonical = root / "canonical-prompts"

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -781,6 +781,126 @@ def test_chained_aliases_cannot_hide_terminal_canonical_owner(tmp_path) -> None:
     assert "namespace" in "\n".join(report["errors"])
 
 
+def test_unlisted_canonical_symlink_cannot_hide_terminal_owner(tmp_path) -> None:
+    root, _commit = _repository(tmp_path, approved_alias=True)
+    (root / "src").unlink()
+    (root / "middle").symlink_to("canonical", target_is_directory=True)
+    (root / "src").symlink_to("middle", target_is_directory=True)
+    (root / "prompts/helper_python.prompt").write_text("REQ-2: Build helper\n")
+    (root / "architecture.json").write_text(
+        json.dumps(
+            [
+                {"filename": "widget_python.prompt", "filepath": "src/widget.py"},
+                {
+                    "filename": "helper_python.prompt",
+                    "filepath": "canonical/widget.py",
+                },
+            ]
+        )
+    )
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [{"alias_path": "src", "canonical_path": "middle"}],
+            }
+        )
+    )
+    ownership = json.loads((root / ".pdd/sync-ownership.json").read_text())
+    ownership["rules"].append(
+        {
+            "pattern": "middle",
+            "inventory": "HUMAN_OWNED",
+            "role": "compatibility-link",
+            "owner": "platform@example.com",
+        }
+    )
+    (root / ".pdd/sync-ownership.json").write_text(json.dumps(ownership))
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "unlisted terminal alias owner")
+    commit = _git(root, "rev-parse", "HEAD")
+
+    report = build_canonical_report(
+        root,
+        CanonicalReportOptions(
+            base_ref=commit,
+            head_ref=commit,
+            replay_ledger_path=tmp_path / "external-trust/unlisted-terminal.json",
+        ),
+    )
+
+    assert report["counts"]["invalid"] > 0
+    errors = "\n".join(report["errors"])
+    assert "unapproved" in errors and "middle" in errors
+
+
+def _alias_collision_repository(tmp_path: Path, *, different_unit: bool) -> tuple[Path, str]:
+    root, _commit = _repository(tmp_path, approved_alias=True)
+    prompt = "widget_python.prompt"
+    if different_unit:
+        prompt = "helper_python.prompt"
+        (root / "prompts" / prompt).write_text("REQ-2: Build helper\n")
+    architecture = json.loads((root / "architecture.json").read_text())
+    architecture.append({"filename": prompt, "filepath": "canonical/widget.py"})
+    (root / "architecture.json").write_text(json.dumps(architecture))
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "alias ownership collision")
+    return root, _git(root, "rev-parse", "HEAD")
+
+
+@pytest.mark.parametrize("different_unit", [False, True])
+def test_baseline_rejects_invalid_alias_manifest_before_writes(
+    tmp_path, monkeypatch, different_unit
+) -> None:
+    root, _commit = _alias_collision_repository(
+        tmp_path, different_unit=different_unit
+    )
+    monkeypatch.chdir(root)
+    with patch("pdd.commands.sync_core.TransactionManager.prepare") as prepare:
+        result = CliRunner().invoke(
+            baseline_command,
+            [
+                "--module",
+                "prompts/widget_python.prompt",
+                "--reviewed-by",
+                "reviewer@example.com",
+                "--reason",
+                "collision probe",
+            ],
+        )
+
+    assert result.exit_code != 0
+    assert "manifest is invalid" in result.output
+    prepare.assert_not_called()
+    assert not (root / ".pdd/meta/v2").exists()
+
+
+@pytest.mark.parametrize("different_unit", [False, True])
+def test_finalizer_rejects_invalid_alias_manifest_before_validation_or_writes(
+    tmp_path, different_unit
+) -> None:
+    root, commit = _alias_collision_repository(
+        tmp_path, different_unit=different_unit
+    )
+    with patch("pdd.sync_core.finalize.run_profile") as run_profile, patch(
+        "pdd.sync_core.finalize.TransactionManager.prepare"
+    ) as prepare:
+        with pytest.raises(ValueError, match="manifest is invalid"):
+            finalize_unit(
+                root,
+                PurePosixPath("prompts/widget_python.prompt"),
+                base_ref=commit,
+                head_ref=commit,
+                signer=SIGNER,
+                replay_ledger_path=tmp_path / "external-trust/invalid-manifest.json",
+            )
+
+    run_profile.assert_not_called()
+    prepare.assert_not_called()
+    assert not (root / ".pdd/meta/v2").exists()
+    assert not (root / ".pdd/evidence/v2").exists()
+
+
 def test_trusted_finalizer_second_run_is_zero_write_no_op(tmp_path) -> None:
     root, commit = _repository(tmp_path)
     replay = tmp_path / "external-trust/idempotency.json"

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -659,6 +659,11 @@ def test_trusted_finalizer_rejects_invalid_next_protected_base(tmp_path) -> None
 
 def test_trusted_finalizer_commits_artifact_through_protected_alias(tmp_path) -> None:
     root, commit = _repository(tmp_path, approved_alias=True)
+    report = build_canonical_report(root, _options(tmp_path, commit))
+    assert report["counts"]["invalid"] == 0
+    assert report["counts"]["unaccounted_tracked_paths"] == 0
+    assert ".pdd/sync-aliases.json" not in "\n".join(report["errors"])
+
     result = finalize_unit(
         root,
         PurePosixPath("prompts/widget_python.prompt"),

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -520,6 +520,39 @@ def test_committed_policy_stays_active_when_worktree_policy_is_deleted(tmp_path)
 
 
 @pytest.mark.parametrize("mutation", ["delete", "rename"])
+@pytest.mark.parametrize("bridge", ["operation_log", "orchestration"])
+def test_dirty_worktree_policy_removal_cannot_enable_legacy_mutation(
+    tmp_path, monkeypatch, mutation, bridge
+) -> None:
+    root, _commit = _repository(tmp_path)
+    policy = root / ".pdd/sync-policy.json"
+    if mutation == "delete":
+        policy.unlink()
+    else:
+        policy.rename(policy.with_suffix(".disabled"))
+    monkeypatch.chdir(root)
+    monkeypatch.delenv("PDD_SYNC_PROTECTED_BASE_SHA", raising=False)
+    paths = {"prompt": root / "prompts/widget_python.prompt"}
+    legacy_path = root / ".pdd/meta/widget_python.json"
+
+    if bridge == "operation_log":
+        from pdd.sync_core.finalize import CanonicalFinalizationError
+
+        with pytest.raises(CanonicalFinalizationError):
+            save_fingerprint("widget", "python", "generate", paths)
+    else:
+        from pdd.sync_orchestration import _save_fingerprint_atomic
+
+        with pytest.raises(RuntimeError):
+            _save_fingerprint_atomic(
+                "widget", "python", "generate", paths, 0.0, "test"
+            )
+
+    assert canonical_sync_enabled(root) is True
+    assert not legacy_path.exists()
+
+
+@pytest.mark.parametrize("mutation", ["delete", "rename"])
 def test_linked_worktree_committed_policy_stays_active(tmp_path, mutation) -> None:
     root, _commit = _repository(tmp_path)
     linked = tmp_path / "linked"

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -340,6 +340,106 @@ def test_nested_config_cannot_bypass_repository_canonical_finalizer(
     )
 
 
+def test_legacy_finalizers_preserve_approved_prompt_alias_identity(
+    tmp_path, monkeypatch
+) -> None:
+    root, _commit = _repository(tmp_path)
+    canonical = root / "canonical-prompts"
+    canonical.mkdir()
+    prompt = root / "prompts/widget_python.prompt"
+    prompt.rename(canonical / prompt.name)
+    prompt.symlink_to("../canonical-prompts/widget_python.prompt")
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [
+                    {
+                        "alias_path": "prompts/widget_python.prompt",
+                        "canonical_path": "canonical-prompts/widget_python.prompt",
+                    }
+                ],
+            }
+        )
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "protected prompt alias")
+    head = _git(root, "rev-parse", "HEAD")
+    monkeypatch.setenv("PDD_SYNC_PROTECTED_BASE_SHA", head)
+    signer = object()
+
+    with patch(
+        "pdd.sync_core.finalize.attestation_signer_from_environment",
+        return_value=signer,
+    ), patch("pdd.sync_core.finalize.finalize_unit") as legacy_finalize:
+        save_fingerprint("widget", "python", "generate", {"prompt": prompt})
+    legacy_finalize.assert_called_once_with(
+        root,
+        PurePosixPath("prompts/widget_python.prompt"),
+        base_ref=head,
+        head_ref="HEAD",
+        signer=signer,
+    )
+
+    with patch(
+        "pdd.sync_core.attestation_signer_from_environment", return_value=signer
+    ), patch("pdd.sync_core.finalize_unit") as orchestration_finalize:
+        from pdd.sync_orchestration import _save_fingerprint_atomic
+
+        _save_fingerprint_atomic(
+            "widget", "python", "generate", {"prompt": prompt}, 0.0, "test"
+        )
+    orchestration_finalize.assert_called_once_with(
+        root,
+        PurePosixPath("prompts/widget_python.prompt"),
+        base_ref=head,
+        head_ref="HEAD",
+        signer=signer,
+    )
+
+
+def test_prompt_alias_uses_canonical_prompt_requirements_and_finalizes(tmp_path) -> None:
+    root, _commit = _repository(tmp_path)
+    canonical = root / "canonical-prompts"
+    canonical.mkdir()
+    prompt = root / "prompts/widget_python.prompt"
+    prompt.rename(canonical / prompt.name)
+    prompt.symlink_to("../canonical-prompts/widget_python.prompt")
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [
+                    {
+                        "alias_path": "prompts/widget_python.prompt",
+                        "canonical_path": "canonical-prompts/widget_python.prompt",
+                    }
+                ],
+            }
+        )
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "protected prompt alias")
+    commit = _git(root, "rev-parse", "HEAD")
+
+    manifest = build_unit_manifest(root, base_ref=commit, head_ref=commit)
+    profiles = load_verification_profiles(root, manifest)
+    report = build_canonical_report(root, _options(tmp_path, commit))
+
+    assert not profiles.invalid_reasons
+    assert profiles.profiles[0].required_requirement_ids == ("REQ-1",)
+    assert report["counts"]["invalid"] == 0
+    result = finalize_unit(
+        root,
+        PurePosixPath("prompts/widget_python.prompt"),
+        base_ref=commit,
+        head_ref=commit,
+        signer=SIGNER,
+        replay_ledger_path=tmp_path / "external-trust/prompt-alias.json",
+    )
+    assert result.transaction.phase.value == "COMMITTED"
+
+
 def test_repository_identity_does_not_activate_enforcement_without_policy(
     tmp_path,
 ) -> None:
@@ -950,6 +1050,47 @@ def test_finalizer_rejects_invalid_alias_manifest_before_validation_or_writes(
     prepare.assert_not_called()
     assert not (root / ".pdd/meta/v2").exists()
     assert not (root / ".pdd/evidence/v2").exists()
+
+
+def test_excluded_project_alias_counterpart_is_invalid_before_finalization(
+    tmp_path,
+) -> None:
+    root, _commit = _repository(tmp_path, approved_alias=True)
+    ownership = json.loads((root / ".pdd/sync-ownership.json").read_text())
+    ownership["rules"].append(
+        {
+            "pattern": "canonical/**",
+            "inventory": "HUMAN_OWNED",
+            "role": "excluded-project",
+            "owner": "vendor@example.com",
+        }
+    )
+    (root / ".pdd/sync-ownership.json").write_text(json.dumps(ownership))
+    _git(root, "add", ".pdd/sync-ownership.json")
+    _git(root, "commit", "-q", "-m", "exclude canonical project")
+    commit = _git(root, "rev-parse", "HEAD")
+
+    manifest = build_unit_manifest(root, base_ref=commit, head_ref=commit)
+    report = build_canonical_report(root, _options(tmp_path, commit))
+
+    errors = "\n".join(manifest.invalid_reasons)
+    assert "canonical/widget.py" in errors
+    assert "ownership" in errors
+    assert report["counts"]["invalid"] > 0
+    with patch("pdd.sync_core.finalize.run_profile") as run_profile, patch(
+        "pdd.sync_core.finalize.TransactionManager.prepare"
+    ) as prepare:
+        with pytest.raises(ValueError, match="manifest is invalid"):
+            finalize_unit(
+                root,
+                PurePosixPath("prompts/widget_python.prompt"),
+                base_ref=commit,
+                head_ref=commit,
+                signer=SIGNER,
+                replay_ledger_path=tmp_path / "external-trust/excluded-alias.json",
+            )
+    run_profile.assert_not_called()
+    prepare.assert_not_called()
 
 
 def test_trusted_finalizer_second_run_is_zero_write_no_op(tmp_path) -> None:

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -676,6 +676,28 @@ def test_trusted_finalizer_commits_artifact_through_protected_alias(tmp_path) ->
     assert (root / "canonical/widget.py").read_text() == "value = 1\n"
 
 
+def test_approved_alias_target_does_not_blanket_account_candidate_files(
+    tmp_path,
+) -> None:
+    root, commit = _repository(tmp_path, approved_alias=True)
+    (root / "canonical/rogue.py").write_text("candidate = 'unowned'\n")
+    _git(root, "add", "canonical/rogue.py")
+    _git(root, "commit", "-q", "-m", "candidate adds unowned alias-target file")
+    head = _git(root, "rev-parse", "HEAD")
+
+    report = build_canonical_report(
+        root,
+        CanonicalReportOptions(
+            base_ref=commit,
+            head_ref=head,
+            replay_ledger_path=tmp_path / "external-trust/rogue-alias-target.json",
+        ),
+    )
+
+    assert report["counts"]["invalid"] > 0
+    assert "canonical/rogue.py" in "\n".join(report["errors"])
+
+
 def test_trusted_finalizer_second_run_is_zero_write_no_op(tmp_path) -> None:
     root, commit = _repository(tmp_path)
     replay = tmp_path / "external-trust/idempotency.json"

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -4,6 +4,7 @@ import base64
 import json
 import os
 import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from unittest.mock import patch
@@ -454,6 +455,10 @@ def test_legacy_finalizers_fail_closed_when_prompt_alias_is_live_retargeted(
     assert not list((root / ".pdd/meta/v2").glob("*.json"))
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="protected subprocess validation requires Linux process isolation",
+)
 def test_prompt_alias_uses_canonical_prompt_requirements_and_finalizes(tmp_path) -> None:
     root, _commit = _repository(tmp_path)
     canonical = root / "canonical-prompts"
@@ -813,6 +818,10 @@ def test_trusted_finalizer_rejects_invalid_next_protected_base(tmp_path) -> None
         )
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="protected subprocess validation requires Linux process isolation",
+)
 def test_trusted_finalizer_commits_artifact_through_protected_alias(tmp_path) -> None:
     root, commit = _repository(tmp_path, approved_alias=True)
     report = build_canonical_report(root, _options(tmp_path, commit))

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -736,6 +736,51 @@ def test_overlapping_alias_policy_cannot_account_rogue_counterparts(
     assert "overlap" in errors or "other/widget.py" in errors
 
 
+def test_chained_aliases_cannot_hide_terminal_canonical_owner(tmp_path) -> None:
+    root, _commit = _repository(tmp_path, approved_alias=True)
+    (root / "src").unlink()
+    (root / "middle").symlink_to("canonical", target_is_directory=True)
+    (root / "src").symlink_to("middle", target_is_directory=True)
+    (root / "prompts/helper_python.prompt").write_text("REQ-2: Build helper\n")
+    (root / "architecture.json").write_text(
+        json.dumps(
+            [
+                {"filename": "widget_python.prompt", "filepath": "src/widget.py"},
+                {
+                    "filename": "helper_python.prompt",
+                    "filepath": "canonical/widget.py",
+                },
+            ]
+        )
+    )
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [
+                    {"alias_path": "src", "canonical_path": "middle"},
+                    {"alias_path": "middle", "canonical_path": "canonical"},
+                ],
+            }
+        )
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "immutable chained alias owners")
+    commit = _git(root, "rev-parse", "HEAD")
+
+    report = build_canonical_report(
+        root,
+        CanonicalReportOptions(
+            base_ref=commit,
+            head_ref=commit,
+            replay_ledger_path=tmp_path / "external-trust/chained-alias.json",
+        ),
+    )
+
+    assert report["counts"]["invalid"] > 0
+    assert "namespace" in "\n".join(report["errors"])
+
+
 def test_trusted_finalizer_second_run_is_zero_write_no_op(tmp_path) -> None:
     root, commit = _repository(tmp_path)
     replay = tmp_path / "external-trust/idempotency.json"

--- a/tests/test_sync_core_snapshot.py
+++ b/tests/test_sync_core_snapshot.py
@@ -159,6 +159,21 @@ def test_snapshot_accepts_base_protected_approved_alias(tmp_path) -> None:
     assert any(item.relpath.as_posix() == "src/widget.py" for item in snapshot.artifacts)
 
 
+def test_snapshot_allows_regular_code_edit_between_protected_trees(tmp_path) -> None:
+    root, base = _repository(tmp_path)
+    (root / "src/widget.py").write_text("value = 2\n")
+    _git(root, "add", "src/widget.py")
+    _git(root, "commit", "-q", "-m", "edit managed code")
+    head = _git(root, "rev-parse", "HEAD")
+    manifest = build_unit_manifest(root, base_ref=base, head_ref=head)
+    profile = load_verification_profiles(root, manifest).profiles[0]
+
+    snapshot = build_unit_snapshot(root, manifest, manifest.managed_units[0], profile)
+
+    code = next(item for item in snapshot.artifacts if item.role == "code")
+    assert code.relpath.as_posix() == "src/widget.py"
+
+
 def test_query_expansion_cannot_receive_trusted_verified_status(tmp_path) -> None:
     root, commit = _repository(tmp_path, query=True)
     manifest = build_unit_manifest(root, base_ref=commit, head_ref=commit)

--- a/tests/test_sync_core_snapshot.py
+++ b/tests/test_sync_core_snapshot.py
@@ -22,7 +22,9 @@ def _git(root: Path, *args: str) -> str:
     ).stdout.strip()
 
 
-def _repository(tmp_path: Path, *, query: bool = False) -> tuple[Path, str]:
+def _repository(
+    tmp_path: Path, *, query: bool = False, approved_alias: bool = False
+) -> tuple[Path, str]:
     root = tmp_path / "repo"
     root.mkdir()
     _git(root, "init", "-q")
@@ -90,6 +92,21 @@ def _repository(tmp_path: Path, *, query: bool = False) -> tuple[Path, str]:
             }
         )
     )
+    if approved_alias:
+        (root / "canonical").mkdir()
+        (root / "src/widget.py").rename(root / "canonical/widget.py")
+        (root / "src").rmdir()
+        (root / "src").symlink_to("canonical", target_is_directory=True)
+        (root / ".pdd/sync-aliases.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "aliases": [
+                        {"alias_path": "src", "canonical_path": "canonical"}
+                    ],
+                }
+            )
+        )
     _git(root, "add", ".")
     _git(root, "commit", "-q", "-m", "snapshot fixture")
     return root, _git(root, "rev-parse", "HEAD")
@@ -130,6 +147,16 @@ def test_code_under_test_bytes_invalidate_snapshot(tmp_path) -> None:
         root, changed_manifest, changed_manifest.managed_units[0], changed_profile
     )
     assert before.digest() != after.digest()
+
+
+def test_snapshot_accepts_base_protected_approved_alias(tmp_path) -> None:
+    root, commit = _repository(tmp_path, approved_alias=True)
+    manifest = build_unit_manifest(root, base_ref=commit, head_ref=commit)
+    profile = load_verification_profiles(root, manifest).profiles[0]
+
+    snapshot = build_unit_snapshot(root, manifest, manifest.managed_units[0], profile)
+
+    assert any(item.relpath.as_posix() == "src/widget.py" for item in snapshot.artifacts)
 
 
 def test_query_expansion_cannot_receive_trusted_verified_status(tmp_path) -> None:

--- a/tests/test_sync_core_snapshot.py
+++ b/tests/test_sync_core_snapshot.py
@@ -170,7 +170,11 @@ def test_snapshot_allows_regular_code_edit_between_protected_trees(tmp_path) -> 
 
     snapshot = build_unit_snapshot(root, manifest, manifest.managed_units[0], profile)
 
-    code = next(item for item in snapshot.artifacts if item.role == "code")
+    code = next(
+        item
+        for item in snapshot.artifacts
+        if item.relpath.as_posix() == "src/widget.py"
+    )
     assert code.relpath.as_posix() == "src/widget.py"
 
 

--- a/tests/test_sync_core_transaction.py
+++ b/tests/test_sync_core_transaction.py
@@ -350,6 +350,21 @@ def test_transaction_commits_through_protected_approved_alias(tmp_path) -> None:
     assert target.read_text() == "value = 2\n"
 
 
+def test_plan_rejects_duplicate_canonical_destinations_through_alias(tmp_path) -> None:
+    (tmp_path / "canonical").mkdir()
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+    writes = (
+        PlannedWrite(PurePosixPath("alias/widget.py"), b"alias\n", "100644"),
+        PlannedWrite(PurePosixPath("canonical/widget.py"), b"canonical\n", "100644"),
+    )
+
+    manager = TransactionManager(tmp_path, approved_aliases=_approved_aliases())
+    with pytest.raises(TransactionError, match="duplicate canonical destinations"):
+        manager.prepare("tx-duplicate-canonical", writes)
+
+    assert not (tmp_path / ".pdd/transactions/tx-duplicate-canonical").exists()
+
+
 def test_descriptor_time_approved_alias_swap_cannot_redirect_commit(tmp_path, monkeypatch) -> None:
     canonical = tmp_path / "canonical"
     canonical.mkdir()
@@ -408,3 +423,26 @@ def test_committing_recovery_rejects_retargeted_approved_alias(tmp_path) -> None
         manager.recover("tx-recovery-alias")
     assert target.read_text() == "value = 1\n"
     assert other_target.read_text() == "outside = True\n"
+
+
+def test_recovery_requires_protected_alias_authority_not_only_journal(tmp_path) -> None:
+    canonical = tmp_path / "canonical"
+    canonical.mkdir()
+    target = canonical / "widget.py"
+    target.write_text("value = 1\n")
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+    writes = (PlannedWrite(PurePosixPath("alias/widget.py"), b"value = 2\n", "100644"),)
+    manager = TransactionManager(tmp_path, approved_aliases=_approved_aliases())
+    manager.prepare("tx-recovery-authority", writes)
+
+    with pytest.raises(SystemExit):
+        manager.commit(
+            "tx-recovery-authority",
+            crash_hook=lambda event: (_ for _ in ()).throw(SystemExit())
+            if event == "after_committing"
+            else None,
+        )
+
+    with pytest.raises(TransactionConflict, match="alias policy"):
+        TransactionManager(tmp_path).recover("tx-recovery-authority")
+    assert target.read_text() == "value = 1\n"

--- a/tests/test_sync_core_transaction.py
+++ b/tests/test_sync_core_transaction.py
@@ -288,9 +288,9 @@ def test_descriptor_time_parent_symlink_swap_cannot_redirect_commit(
     original = manager._canonical_relpath  # pylint: disable=protected-access
     armed = True
 
-    def swap_after_resolution(relpath):
+    def swap_after_resolution(relpath, **kwargs):
         nonlocal armed
-        canonical = original(relpath)
+        canonical = original(relpath, **kwargs)
         if armed and relpath == PurePosixPath("src/widget.py"):
             armed = False
             source.rename(tmp_path / "src-before-swap")
@@ -360,8 +360,8 @@ def test_descriptor_time_approved_alias_swap_cannot_redirect_commit(tmp_path, mo
     manager.prepare("tx-alias-swap", writes)
     original = manager._canonical_relpath  # pylint: disable=protected-access
 
-    def swap_after_resolution(relpath):
-        result = original(relpath)
+    def swap_after_resolution(relpath, **kwargs):
+        result = original(relpath, **kwargs)
         alias.unlink()
         alias.symlink_to(outside, target_is_directory=True)
         return result

--- a/tests/test_sync_core_transaction.py
+++ b/tests/test_sync_core_transaction.py
@@ -298,7 +298,13 @@ def test_descriptor_time_parent_symlink_swap_cannot_redirect_commit(
         return canonical
 
     monkeypatch.setattr(manager, "_canonical_relpath", swap_after_resolution)
-    with pytest.raises(TransactionConflict, match="parent changed or is unsafe"):
+    with pytest.raises(
+        TransactionConflict,
+        match=(
+            r"^destination (?:parent changed or is unsafe|alias policy changed): "
+            r"src/widget\.py$"
+        ),
+    ):
         manager.commit("tx-parent-swap")
 
     assert outside_target.read_text() == "outside = True\n"

--- a/tests/test_sync_core_transaction.py
+++ b/tests/test_sync_core_transaction.py
@@ -179,6 +179,50 @@ def test_prepared_transaction_recovers_by_rollback_without_destination_write(tmp
     assert manager.incomplete() == ()
 
 
+def test_prepared_alias_transaction_recovers_after_policy_changes(tmp_path) -> None:
+    (tmp_path / "canonical").mkdir()
+    target = tmp_path / "canonical/widget.py"
+    target.write_text("value = 1\n")
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+    manager = TransactionManager(tmp_path, approved_aliases=_approved_aliases())
+    manager.prepare(
+        "tx-prepared-alias-policy-change",
+        (PlannedWrite(PurePosixPath("alias/widget.py"), b"value = 2\n", "100644"),),
+    )
+
+    recovered = TransactionManager(tmp_path).recover(
+        "tx-prepared-alias-policy-change"
+    )
+
+    assert recovered.phase is TransactionPhase.ROLLED_BACK
+    assert target.read_text() == "value = 1\n"
+
+
+@pytest.mark.parametrize("terminal_phase", ["COMMITTED", "ROLLED_BACK"])
+def test_terminal_alias_transaction_is_idempotent_after_policy_changes(
+    tmp_path, terminal_phase
+) -> None:
+    (tmp_path / "canonical").mkdir()
+    (tmp_path / "canonical/widget.py").write_text("value = 1\n")
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+    manager = TransactionManager(tmp_path, approved_aliases=_approved_aliases())
+    manager.prepare(
+        "tx-terminal-alias-policy-change",
+        (PlannedWrite(PurePosixPath("alias/widget.py"), b"value = 2\n", "100644"),),
+    )
+    if terminal_phase == "COMMITTED":
+        manager.commit("tx-terminal-alias-policy-change")
+    else:
+        manager.recover("tx-terminal-alias-policy-change")
+
+    recovered = TransactionManager(tmp_path).recover(
+        "tx-terminal-alias-policy-change"
+    )
+
+    assert recovered.phase.value == terminal_phase
+    assert recovered.no_op is True
+
+
 def test_corrupt_prepared_blob_never_commits(tmp_path) -> None:
     (tmp_path / "src").mkdir()
     target = tmp_path / "src/widget.py"
@@ -544,3 +588,44 @@ def test_public_recover_loads_committed_protected_alias_policy(
     assert result.exit_code == 0, result.output
     assert '"phase": "COMMITTED"' in result.output
     assert target.read_text() == "value = 2\n"
+
+
+def test_public_recover_defers_removed_alias_policy_for_prepared_journal(
+    tmp_path, monkeypatch
+) -> None:
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "recover@example.com")
+    _git(tmp_path, "config", "user.name", "Recover Test")
+    (tmp_path / ".pdd").mkdir()
+    policy = tmp_path / ".pdd/sync-aliases.json"
+    policy.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [{"alias_path": "alias", "canonical_path": "canonical"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "canonical").mkdir()
+    target = tmp_path / "canonical/widget.py"
+    target.write_text("value = 1\n")
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "protected alias policy")
+    TransactionManager(tmp_path, approved_aliases=_approved_aliases()).prepare(
+        "tx-cli-prepared-policy-removal",
+        (PlannedWrite(PurePosixPath("alias/widget.py"), b"value = 2\n", "100644"),),
+    )
+    policy.unlink()
+    _git(tmp_path, "add", "-u")
+    _git(tmp_path, "commit", "-q", "-m", "remove alias policy")
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli, ["recover", "--transaction", "tx-cli-prepared-policy-removal"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert '"phase": "ROLLED_BACK"' in result.output
+    assert target.read_text() == "value = 1\n"

--- a/tests/test_sync_core_transaction.py
+++ b/tests/test_sync_core_transaction.py
@@ -2,10 +2,13 @@
 
 import json
 import os
+import subprocess
 from pathlib import PurePosixPath
 
+from click.testing import CliRunner
 import pytest
 
+from pdd.cli import cli
 from pdd.sync_core import (
     PlannedWrite,
     TransactionConflict,
@@ -13,6 +16,12 @@ from pdd.sync_core import (
     TransactionManager,
     TransactionPhase,
 )
+
+
+def _git(root, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=root, capture_output=True, text=True, check=True
+    ).stdout.strip()
 
 
 def _writes():
@@ -446,3 +455,46 @@ def test_recovery_requires_protected_alias_authority_not_only_journal(tmp_path) 
     with pytest.raises(TransactionConflict, match="alias policy"):
         TransactionManager(tmp_path).recover("tx-recovery-authority")
     assert target.read_text() == "value = 1\n"
+
+
+def test_public_recover_loads_committed_protected_alias_policy(
+    tmp_path, monkeypatch
+) -> None:
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "recover@example.com")
+    _git(tmp_path, "config", "user.name", "Recover Test")
+    (tmp_path / ".pdd").mkdir()
+    (tmp_path / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [{"alias_path": "alias", "canonical_path": "canonical"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "canonical").mkdir()
+    target = tmp_path / "canonical/widget.py"
+    target.write_text("value = 1\n")
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+    _git(tmp_path, "add", ".pdd/sync-aliases.json", "canonical/widget.py", "alias")
+    _git(tmp_path, "commit", "-q", "-m", "protected alias policy")
+    manager = TransactionManager(tmp_path, approved_aliases=_approved_aliases())
+    manager.prepare(
+        "tx-cli-recovery",
+        (PlannedWrite(PurePosixPath("alias/widget.py"), b"value = 2\n", "100644"),),
+    )
+    with pytest.raises(SystemExit):
+        manager.commit(
+            "tx-cli-recovery",
+            crash_hook=lambda event: (_ for _ in ()).throw(SystemExit())
+            if event == "after_committing"
+            else None,
+        )
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["recover", "--transaction", "tx-cli-recovery"])
+
+    assert result.exit_code == 0, result.output
+    assert '"phase": "COMMITTED"' in result.output
+    assert target.read_text() == "value = 2\n"

--- a/tests/test_sync_core_transaction.py
+++ b/tests/test_sync_core_transaction.py
@@ -390,6 +390,8 @@ def test_alias_and_canonical_transactions_share_destination_lock(tmp_path) -> No
     )
 
     class RecordingLock:
+        """Record lock paths requested by the transaction manager."""
+
         paths: list[str] = []
 
         def __init__(self, path: str) -> None:

--- a/tests/test_sync_core_transaction.py
+++ b/tests/test_sync_core_transaction.py
@@ -325,3 +325,80 @@ def test_prepare_failure_never_publishes_orphan_transaction(tmp_path, monkeypatc
         manager.prepare("tx-failed", _writes())
     assert not (tmp_path / ".pdd/transactions/tx-failed").exists()
     assert manager.incomplete() == ()
+
+
+def _approved_aliases():
+    return {PurePosixPath("alias"): PurePosixPath("canonical")}
+
+
+def test_transaction_commits_through_protected_approved_alias(tmp_path) -> None:
+    (tmp_path / "canonical").mkdir()
+    target = tmp_path / "canonical/widget.py"
+    target.write_text("value = 1\n")
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+    writes = (PlannedWrite(PurePosixPath("alias/widget.py"), b"value = 2\n", "100644"),)
+
+    manager = TransactionManager(tmp_path, approved_aliases=_approved_aliases())
+    manager.prepare("tx-approved-alias", writes)
+    assert manager.commit("tx-approved-alias").phase is TransactionPhase.COMMITTED
+    assert target.read_text() == "value = 2\n"
+
+
+def test_descriptor_time_approved_alias_swap_cannot_redirect_commit(tmp_path, monkeypatch) -> None:
+    canonical = tmp_path / "canonical"
+    canonical.mkdir()
+    target = canonical / "widget.py"
+    target.write_text("value = 1\n")
+    outside = tmp_path.parent / f"{tmp_path.name}-outside-alias"
+    outside.mkdir()
+    outside_target = outside / "widget.py"
+    outside_target.write_text("outside = True\n")
+    alias = tmp_path / "alias"
+    alias.symlink_to("canonical", target_is_directory=True)
+    writes = (PlannedWrite(PurePosixPath("alias/widget.py"), b"value = 2\n", "100644"),)
+    manager = TransactionManager(tmp_path, approved_aliases=_approved_aliases())
+    manager.prepare("tx-alias-swap", writes)
+    original = manager._canonical_relpath  # pylint: disable=protected-access
+
+    def swap_after_resolution(relpath):
+        result = original(relpath)
+        alias.unlink()
+        alias.symlink_to(outside, target_is_directory=True)
+        return result
+
+    monkeypatch.setattr(manager, "_canonical_relpath", swap_after_resolution)
+    with pytest.raises(TransactionConflict):
+        manager.commit("tx-alias-swap")
+    assert outside_target.read_text() == "outside = True\n"
+    assert target.read_text() == "value = 1\n"
+
+
+def test_committing_recovery_rejects_retargeted_approved_alias(tmp_path) -> None:
+    canonical = tmp_path / "canonical"
+    canonical.mkdir()
+    target = canonical / "widget.py"
+    target.write_text("value = 1\n")
+    other = tmp_path / "other"
+    other.mkdir()
+    other_target = other / "widget.py"
+    other_target.write_text("outside = True\n")
+    alias = tmp_path / "alias"
+    alias.symlink_to("canonical", target_is_directory=True)
+    writes = (PlannedWrite(PurePosixPath("alias/widget.py"), b"value = 2\n", "100644"),)
+    manager = TransactionManager(tmp_path, approved_aliases=_approved_aliases())
+    manager.prepare("tx-recovery-alias", writes)
+
+    with pytest.raises(SystemExit):
+        manager.commit(
+            "tx-recovery-alias",
+            crash_hook=lambda event: (_ for _ in ()).throw(SystemExit())
+            if event == "after_committing"
+            else None,
+        )
+    alias.unlink()
+    alias.symlink_to("other", target_is_directory=True)
+
+    with pytest.raises(TransactionConflict, match="alias"):
+        manager.recover("tx-recovery-alias")
+    assert target.read_text() == "value = 1\n"
+    assert other_target.read_text() == "outside = True\n"

--- a/tests/test_sync_core_transaction.py
+++ b/tests/test_sync_core_transaction.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 from pathlib import PurePosixPath
+from unittest.mock import patch
 
 from click.testing import CliRunner
 import pytest
@@ -372,6 +373,49 @@ def test_plan_rejects_duplicate_canonical_destinations_through_alias(tmp_path) -
         manager.prepare("tx-duplicate-canonical", writes)
 
     assert not (tmp_path / ".pdd/transactions/tx-duplicate-canonical").exists()
+
+
+def test_alias_and_canonical_transactions_share_destination_lock(tmp_path) -> None:
+    (tmp_path / "canonical").mkdir()
+    (tmp_path / "canonical/widget.py").write_text("value = 1\n")
+    (tmp_path / "alias").symlink_to("canonical", target_is_directory=True)
+    manager = TransactionManager(tmp_path, approved_aliases=_approved_aliases())
+    manager.prepare(
+        "tx-alias-lock",
+        (PlannedWrite(PurePosixPath("alias/widget.py"), b"alias\n", "100644"),),
+    )
+    manager.prepare(
+        "tx-canonical-lock",
+        (PlannedWrite(PurePosixPath("canonical/widget.py"), b"canonical\n", "100644"),),
+    )
+
+    class RecordingLock:
+        paths: list[str] = []
+
+        def __init__(self, path: str) -> None:
+            self.path = path
+
+        def __enter__(self):
+            self.paths.append(self.path)
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    alias_payload = json.loads(
+        (tmp_path / ".pdd/transactions/tx-alias-lock/journal.json").read_text()
+    )
+    canonical_payload = json.loads(
+        (tmp_path / ".pdd/transactions/tx-canonical-lock/journal.json").read_text()
+    )
+    with patch("pdd.sync_core.transaction.FileLock", RecordingLock):
+        with manager._locks(alias_payload):  # pylint: disable=protected-access
+            alias_locks = set(RecordingLock.paths)
+        RecordingLock.paths.clear()
+        with manager._locks(canonical_payload):  # pylint: disable=protected-access
+            canonical_locks = set(RecordingLock.paths)
+
+    assert alias_locks & canonical_locks
 
 
 def test_descriptor_time_approved_alias_swap_cannot_redirect_commit(tmp_path, monkeypatch) -> None:

--- a/tests/test_sync_core_transaction.py
+++ b/tests/test_sync_core_transaction.py
@@ -590,6 +590,66 @@ def test_public_recover_loads_committed_protected_alias_policy(
     assert target.read_text() == "value = 2\n"
 
 
+@pytest.mark.parametrize("committed_mutation", ["remove", "regular", "retarget"])
+def test_public_recover_rejects_live_alias_absent_from_committed_authority(
+    tmp_path, monkeypatch, committed_mutation
+) -> None:
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "recover@example.com")
+    _git(tmp_path, "config", "user.name", "Recover Test")
+    (tmp_path / ".pdd").mkdir()
+    (tmp_path / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [{"alias_path": "alias", "canonical_path": "canonical"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "canonical").mkdir()
+    target = tmp_path / "canonical/widget.py"
+    target.write_text("before\n")
+    (tmp_path / "other").mkdir()
+    (tmp_path / "other/widget.py").write_text("other\n")
+    alias = tmp_path / "alias"
+    alias.symlink_to("canonical", target_is_directory=True)
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-q", "-m", "protected alias policy")
+    manager = TransactionManager(tmp_path, approved_aliases=_approved_aliases())
+    manager.prepare(
+        "tx-cli-uncommitted-alias",
+        (PlannedWrite(PurePosixPath("alias/widget.py"), b"after\n", "100644"),),
+    )
+    with pytest.raises(SystemExit):
+        manager.commit(
+            "tx-cli-uncommitted-alias",
+            crash_hook=lambda event: (_ for _ in ()).throw(SystemExit())
+            if event == "after_committing"
+            else None,
+        )
+
+    alias.unlink()
+    if committed_mutation == "regular":
+        alias.write_text("not a symlink\n")
+    elif committed_mutation == "retarget":
+        alias.symlink_to("other", target_is_directory=True)
+    _git(tmp_path, "add", "-A", "alias")
+    _git(tmp_path, "commit", "-q", "-m", f"{committed_mutation} committed alias")
+    if alias.exists() or alias.is_symlink():
+        alias.unlink()
+    alias.symlink_to("canonical", target_is_directory=True)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli, ["recover", "--transaction", "tx-cli-uncommitted-alias"]
+    )
+
+    assert result.exit_code != 0
+    assert '"phase": "COMMITTED"' not in result.output
+    assert target.read_text() == "before\n"
+
+
 def test_public_recover_defers_removed_alias_policy_for_prepared_journal(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/test_sync_determine_operation.py
+++ b/tests/test_sync_determine_operation.py
@@ -5663,3 +5663,82 @@ def test_v1_new_grammar_save_reload_rerun_does_not_self_drift(
 
     assert persisted == {}
     assert second == first
+
+
+def test_sync_classifier_preserves_nested_prompt_alias_identity(
+    tmp_path, monkeypatch
+):
+    """Architecture, include closure, and hashing use the approved logical path."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "sync@example.com"], cwd=root, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Sync Test"], cwd=root, check=True
+    )
+    (root / "prompts/nested").mkdir(parents=True)
+    (root / "canonical-prompts").mkdir()
+    (root / ".pdd").mkdir()
+    (root / "src/nested").mkdir(parents=True)
+    canonical_prompt = root / "canonical-prompts/widget_python.prompt"
+    canonical_prompt.write_text("Build widget\n<include>contract.md</include>\n")
+    logical_prompt = root / "prompts/nested/widget_python.prompt"
+    logical_prompt.symlink_to("../../canonical-prompts/widget_python.prompt")
+    contract = root / "prompts/nested/contract.md"
+    contract.write_text("logical contract\n")
+    code = root / "src/nested/widget.py"
+    code.write_text("value = 1\n")
+    (root / "architecture.json").write_text(
+        json.dumps(
+            [
+                {
+                    "filename": "nested/widget_python.prompt",
+                    "filepath": "src/nested/widget.py",
+                }
+            ]
+        )
+    )
+    (root / ".pdd/repository-id").write_text(
+        "3b4d7b1c-d6cc-4752-ba93-6b98d1a710e0\n"
+    )
+    (root / ".pdd/sync-policy.json").write_text(
+        json.dumps({"schema_version": 1, "enforcement": "active"})
+    )
+    (root / ".pdd/sync-aliases.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "aliases": [
+                    {
+                        "alias_path": "prompts/nested/widget_python.prompt",
+                        "canonical_path": "canonical-prompts/widget_python.prompt",
+                    }
+                ],
+            }
+        )
+    )
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "nested prompt alias"], cwd=root, check=True
+    )
+    monkeypatch.chdir(root)
+    monkeypatch.delenv("PDD_SYNC_PROTECTED_BASE_SHA", raising=False)
+
+    paths = get_pdd_file_paths("nested/widget", "python", "prompts")
+    deps = extract_include_deps(paths["prompt"])
+    digest_before = calculate_prompt_hash(paths["prompt"])
+    contract.write_text("changed logical contract\n")
+    digest_after = calculate_prompt_hash(paths["prompt"])
+
+    assert paths["prompt"] == Path("prompts/nested/widget_python.prompt")
+    assert paths["code"].resolve() == code.resolve()
+    assert deps == {
+        "prompts/nested/contract.md": hashlib.sha256(
+            b"logical contract\n"
+        ).hexdigest()
+    }
+    assert digest_before is not None
+    assert digest_after is not None
+    assert digest_after != digest_before

--- a/tests/test_sync_determine_operation.py
+++ b/tests/test_sync_determine_operation.py
@@ -5665,8 +5665,9 @@ def test_v1_new_grammar_save_reload_rerun_does_not_self_drift(
     assert second == first
 
 
+@pytest.mark.parametrize("policy_mutation", [None, "delete", "rename"])
 def test_sync_classifier_preserves_nested_prompt_alias_identity(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, policy_mutation
 ):
     """Architecture, include closure, and hashing use the approved logical path."""
     root = tmp_path / "repo"
@@ -5690,9 +5691,16 @@ def test_sync_classifier_preserves_nested_prompt_alias_identity(
     contract.write_text("logical contract\n")
     code = root / "src/nested/widget.py"
     code.write_text("value = 1\n")
+    wrong_code = root / "wrong/nested/widget.py"
+    wrong_code.parent.mkdir(parents=True)
+    wrong_code.write_text("wrong = True\n")
     (root / "architecture.json").write_text(
         json.dumps(
             [
+                {
+                    "filename": "widget_python.prompt",
+                    "filepath": "wrong/nested/widget.py",
+                },
                 {
                     "filename": "nested/widget_python.prompt",
                     "filepath": "src/nested/widget.py",
@@ -5723,6 +5731,11 @@ def test_sync_classifier_preserves_nested_prompt_alias_identity(
     subprocess.run(
         ["git", "commit", "-q", "-m", "nested prompt alias"], cwd=root, check=True
     )
+    policy = root / ".pdd/sync-policy.json"
+    if policy_mutation == "delete":
+        policy.unlink()
+    elif policy_mutation == "rename":
+        policy.rename(policy.with_suffix(".disabled"))
     monkeypatch.chdir(root)
     monkeypatch.delenv("PDD_SYNC_PROTECTED_BASE_SHA", raising=False)
 

--- a/tests/test_sync_orchestration.py
+++ b/tests/test_sync_orchestration.py
@@ -3162,7 +3162,8 @@ class TestCoverageTargetSelection:
 
         def fake_run(cmd, **kwargs):
             cov_args = [str(c) for c in cmd if str(c).startswith("--cov=")]
-            seen_cov_args["value"] = cov_args
+            if cov_args:
+                seen_cov_args["value"] = cov_args
             stdout = "1 passed in 0.01s\nTOTAL 1 0 100%\n"
             return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
@@ -3206,7 +3207,8 @@ class TestCoverageTargetSelection:
 
         def fake_run(cmd, **kwargs):
             cov_args = [str(c) for c in cmd if str(c).startswith("--cov=")]
-            seen_cov_args["value"] = cov_args
+            if cov_args:
+                seen_cov_args["value"] = cov_args
             stdout = "1 passed in 0.01s\nTOTAL 1 0 100%\n"
             return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
@@ -3265,7 +3267,8 @@ class TestCoverageTargetSelection:
 
         def fake_run(cmd, **kwargs):
             cov_args = [str(c) for c in cmd if str(c).startswith("--cov=")]
-            seen_cov_args["value"] = cov_args
+            if cov_args:
+                seen_cov_args["value"] = cov_args
             stdout = "1 passed in 0.01s\nTOTAL 1 0 100%\n"
             return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
@@ -3318,7 +3321,8 @@ class TestCoverageTargetSelection:
 
         def fake_run(cmd, **kwargs):
             cov_args = [str(c) for c in cmd if str(c).startswith("--cov=")]
-            seen_cov_args["value"] = cov_args
+            if cov_args:
+                seen_cov_args["value"] = cov_args
             # Simulate --cov=pdd output: per-file lines + TOTAL
             stdout = (
                 "pdd/__init__.py           10     10     0%\n"


### PR DESCRIPTION
## Summary
- Load approved aliases only from an immutable base/head-equal policy.
- Wire one policy through snapshots, finalization, transactions, and recovery.
- Persist and revalidate canonical WAL destinations before descriptor-pinned writes.

## Test plan
- Focused sync-core pytest coverage, pylint, diff check, built-wheel smoke, and CLI `pdd recover` crash-recovery workflow.