### PR TITLE
chore(sync): establish protected PDD inventory denominator

### DIFF
--- a/.pdd/expected-managed.json
+++ b/.pdd/expected-managed.json
@@ -1,0 +1,1869 @@
+{
+  "schema_version": 1,
+  "units": [
+    {
+      "language_id": "makefile",
+      "prompt_path": "pdd/prompts/Makefile_makefile.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/_keyring_timeout_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step10_completeness_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step11_sync_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step12_deps_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step13_fix_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step1_analyze_prd_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step1b_complexity_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step2_analyze_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step2b_codebase_scan_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step3_research_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step4_data_model_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step5_design_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step5b_completeness_gate_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step5b_fix_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step6_research_deps_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step7_generate_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step7b_review_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step8_5_context_docs_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step8_pddrc_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step9_prompts_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_arch_step9b_cross_audit_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_architecture_orchestrator_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_architecture_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_bug_orchestrator_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_bug_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_bug_step10_verify_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_bug_step11_e2e_test_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_bug_step12_pr_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_bug_step1_duplicate_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_bug_step2_docs_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_bug_step3_triage_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_bug_step4_api_research_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_bug_step5_reproduce_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_bug_step6_root_cause_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_bug_step7_prompt_classification_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_bug_step8_test_plan_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_bug_step9_generate_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_change_orchestrator_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_change_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step10_architecture_update_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step11_identify_issues_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step12_fix_issues_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step13_create_pr_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step1_duplicate_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step2_docs_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step3_research_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step4_clarify_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step5_docs_change_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step6_devunits_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step7_architecture_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step8_analyze_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_change_step9_implement_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_checkup_orchestrator_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_checkup_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_checkup_step1_discover_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_checkup_step2_deps_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_checkup_step3_build_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_checkup_step4_interfaces_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_checkup_step5_test_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_checkup_step6_1_fix_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_checkup_step6_2_regression_tests_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_checkup_step6_3_e2e_tests_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_checkup_step7_verify_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_checkup_step8_create_pr_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_common_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_common_worktree_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_crash_explore_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_crash_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_orchestrator_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_step10_ci_validation_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_step11_code_cleanup_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_step1_unit_tests_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_step2_e2e_tests_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_step3_root_cause_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_step4_fix_e2e_tests_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_step5_identify_devunits_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_step6_create_unit_tests_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_step7_verify_tests_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_step8_run_pdd_fix_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_e2e_fix_step9_verify_all_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_fix_explore_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_fix_nonpython_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_fix_primary_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_fix_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_issue_route_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_langtest_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_multishot_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_split_orchestrator_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_split_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_split_step0_intent_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_split_step1_survey_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_split_step2_diagnose_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_split_step3_investigate_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_split_step4_propose_options_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_split_step6_extract_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_split_step6a_phase_extract_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_split_step7_assess_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_split_step8_repair_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_split_step9_refine_check_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_sync_fix_dry_run_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_sync_identify_modules_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_sync_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_sync_runner_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_generate_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_test_generate_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_test_orchestrator_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_test_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step10_validate_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step11_loop_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step15_plan_validation_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step16_run_tests_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step1_duplicate_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step2_docs_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step3_clarify_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step4_detect_frontend_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step5_test_plan_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step5b_enhance_plan_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step6_coverage_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step6_generate_tests_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step7_checklist_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step7_run_tests_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step8_fix_iterate_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step8_manual_test_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step9_regression_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_test_step9_submit_pr_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_update_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_update_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/agentic_verify_explore_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/agentic_verify_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/api_contract_slicer_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/api_key_scanner_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/architecture_include_validation_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/architecture_registry_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/architecture_sync_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/arrange_graph_layout_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/auth_service_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/auto_deps_architecture_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/auto_deps_main_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/auto_include_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/auto_include_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/auto_update_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/bug_main_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/bug_to_unit_test_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/bug_to_unit_test_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/change_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/change_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/change_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_agent_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_file_selection_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_gates_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_interactive_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_interactive_session_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_planner_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_prompt_apply_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_prompt_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_report_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_review_loop_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_simplify_claude_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_simplify_engines_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/checkup_simplify_invoke_claude_code_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/checkup_simplify_invoke_codex_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/checkup_simplify_invoke_gemini_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/checkup_simplify_invoke_opencode_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_simplify_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/checkup_simplify_workflow_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/checkup_tools_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/ci_detect_changed_modules_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/ci_drift_heal_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/ci_validation_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/cli_branding_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/cli_detector_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/cli_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/cli_status_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/cli_theme_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/cmd_test_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/code_generator_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/code_generator_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/code_patcher_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/codex_subscription_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/__init___python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/analysis_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/auth_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/checkup_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/checkup_simplify_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/connect_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/context_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/contracts_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/firecrawl_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/fix_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/gate_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/generate_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/maintenance_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/misc_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/modify_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/prompt_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/replay_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/report_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/sessions_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/story_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/templates_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/utility_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/commands/which_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/comment_line_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/compressed_sync_context_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/config_resolution_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/conflict_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/conflicts_in_prompts_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/conflicts_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/construct_paths_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/content_selector_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/context_audit_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/context_generator_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/context_generator_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/context_snapshot_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/continue_generation_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/continue_generation_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/contract_check_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/contract_ir_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/core/cli_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/core/cloud_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/core/dump_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/core/duplicate_cli_guard_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/core/errors_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/core/remote_session_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/core/utils_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/core_dump_requirements_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/core_dump_smoke_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/coverage_contracts_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/crash_main_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/cross_issue_reconcile_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/detect_change_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/detect_change_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/detect_change_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/diff_analyzer_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/durable_sync_runner_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/edit_file_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/embed_retrieve_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/evidence_manifest_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/evidence_store_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/example_generator_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/extract_code_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/extract_conflict_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/extract_detect_change_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/extract_program_code_fix_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/extract_prompt_change_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/extract_prompt_split_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/extract_prompt_update_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/extract_promptline_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/extract_unit_code_fix_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/extract_xml_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/extracts_prune_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/failure_classification_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/find_section_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/find_verification_errors_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/firecrawl_cache_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/fix_code_loop_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/fix_code_module_errors_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/fix_code_module_errors_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/fix_error_loop_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/fix_errors_from_unit_tests_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/fix_errors_from_unit_tests_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/fix_focus_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/fix_main_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/fix_verification_errors_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/fix_verification_errors_loop_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/fix_verification_errors_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/fix_verification_main_python.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/App_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescript",
+      "prompt_path": "pdd/prompts/frontend/api_typescript.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/AddModuleModal_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/AddToQueueModal_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/ArchitectureView_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/AuthStatusIndicator_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/BatchFilterDropdown_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/BugModal_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/ChangeModal_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/CommandForm_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/CommandOutput_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/CreatePromptModal_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/DependencyViewer_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/DeviceIndicator_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/ErrorBoundary_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/ExecutionModeToggle_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/FileBrowser_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/FilePickerInput_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/GeneratedCommand_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/GenerationProgressModal_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/GraphToolbar_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/GuidanceSidebar_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/Header_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/Icon_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/InputField_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/JobCard_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/JobDashboard_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/JobOutputPanel_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/ModelSelector_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/ModelSliders_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/ModuleEditModal_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/ModuleNode_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/ProjectSettings_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/PromptCodeDiffModal_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/PromptEditor_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/PromptMetricsBar_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/PromptOrderModal_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/PromptSelector_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/PromptSpace_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/ReauthModal_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/RemoteSessionSelector_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/SyncFromPromptModal_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/SyncOptionsModal_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/SyncStatusBadge_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/Tabs_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/TaskQueueControls_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/TaskQueueItem_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/TaskQueuePanel_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/TextAreaField_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/Toast_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/components/Tooltip_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescript",
+      "prompt_path": "pdd/prompts/frontend/constants_typescript.prompt"
+    },
+    {
+      "language_id": "typescript",
+      "prompt_path": "pdd/prompts/frontend/hooks/useArchitectureHistory_typescript.prompt"
+    },
+    {
+      "language_id": "typescript",
+      "prompt_path": "pdd/prompts/frontend/hooks/useAudioNotification_typescript.prompt"
+    },
+    {
+      "language_id": "typescript",
+      "prompt_path": "pdd/prompts/frontend/hooks/useJobs_typescript.prompt"
+    },
+    {
+      "language_id": "typescript",
+      "prompt_path": "pdd/prompts/frontend/hooks/useTaskQueue_typescript.prompt"
+    },
+    {
+      "language_id": "typescriptreact",
+      "prompt_path": "pdd/prompts/frontend/index_typescriptreact.prompt"
+    },
+    {
+      "language_id": "typescript",
+      "prompt_path": "pdd/prompts/frontend/types_typescript.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/gate_policy_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/gate_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/generate_model_catalog_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/generate_output_paths_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/generate_story_contract_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/generate_test_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/generate_test_from_example_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/generate_test_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/generate_user_story_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/generation_completion_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/get_comment_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/get_extension_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/get_jwt_token_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/get_language_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/get_lint_commands_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/get_run_command_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/get_test_command_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/git_porcelain_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/git_update_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/grounding_policy_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/include_query_extractor_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/include_query_extractor_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/increase_tests_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/increase_tests_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/incremental_code_generator_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/incremental_prd_architecture_patch_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/incremental_prd_architecture_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/insert_includes_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/insert_includes_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/install_completion_python.prompt"
+    },
+    {
+      "language_id": "csv",
+      "prompt_path": "pdd/prompts/language_format_csv.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/llm_invoke_python.prompt"
+    },
+    {
+      "language_id": "csv",
+      "prompt_path": "pdd/prompts/llm_model_csv.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/load_prompt_template_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/logo_animation_python.prompt"
+    },
+    {
+      "language_id": "prompt",
+      "prompt_path": "pdd/prompts/main_gen_prompt.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/metadata_sync_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/model_tester_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/one_session_agent_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/one_session_sync_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/operation_log_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/path_resolution_python.prompt"
+    },
+    {
+      "language_id": "bash",
+      "prompt_path": "pdd/prompts/pdd_completion_bash.prompt"
+    },
+    {
+      "language_id": "fish",
+      "prompt_path": "pdd/prompts/pdd_completion_fish.prompt"
+    },
+    {
+      "language_id": "zsh",
+      "prompt_path": "pdd/prompts/pdd_completion_zsh.prompt"
+    },
+    {
+      "language_id": "json",
+      "prompt_path": "pdd/prompts/pdd_theme_json.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/pddrc_initializer_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/pin_example_hack_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/post_gen_verify_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/postprocess_0_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/postprocess_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/pre_checkup_gate_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/preprocess_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/preprocess_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/process_csv_change_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/prompt_code_diff_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/prompt_diff_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/prompt_lint_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/prompt_lint_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/prompt_repair_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/prompt_tester_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/provider_manager_python.prompt"
+    },
+    {
+      "language_id": "restructuredtext",
+      "prompt_path": "pdd/prompts/pypi_description_restructuredtext.prompt"
+    },
+    {
+      "language_id": "toml",
+      "prompt_path": "pdd/prompts/pyproject_toml.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/pytest_output_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/pytest_slicer_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/python_env_detector_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/reasoning_python.prompt"
+    },
+    {
+      "language_id": "log",
+      "prompt_path": "pdd/prompts/regression_analysis_log.prompt"
+    },
+    {
+      "language_id": "bash",
+      "prompt_path": "pdd/prompts/regression_bash.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/release_video_script_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/remote_session_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/render_mermaid_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/resolved_sync_unit_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/resurface_check_Python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/routing_policy_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/run_generated_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/__init___python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/app_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/click_executor_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/executor_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/jobs_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/models_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/routes/__init___python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/routes/architecture_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/routes/auth_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/routes/commands_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/routes/config_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/routes/extracts_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/routes/files_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/routes/prompts_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/routes/session_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/routes/websocket_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/security_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/terminal_spawner_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/server/token_counter_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/setup_tool_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/split_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/split_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/split_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/split_validation_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/src/clients/github_client_Python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/src/pdd_issue_runner_job_Python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/src/services/pdd_issue_completion_evidence_Python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/story_coverage_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/story_regression_gate_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/story_regression_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/story_test_generator_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/summarize_directory_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/summarize_file_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/sync_analysis_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/sync_animation_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/sync_determine_operation_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/sync_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/sync_orchestration_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/sync_order_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/sync_tui_python.prompt"
+    },
+    {
+      "language_id": "csv",
+      "prompt_path": "pdd/prompts/task_routing_csv.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/template_expander_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/template_registry_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/test_context_packer_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/trace_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/trace_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/trace_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/track_cost_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/trim_results_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/trim_results_start_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/unfinished_prompt_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/unfinished_prompt_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/update_main_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/update_model_costs_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/update_prompt_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/update_prompt_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/user_story_tests_python.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/validate_prompt_includes_python.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/xml/change_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/xml/split_LLM.prompt"
+    },
+    {
+      "language_id": "llm",
+      "prompt_path": "pdd/prompts/xml_convertor_LLM.prompt"
+    },
+    {
+      "language_id": "python",
+      "prompt_path": "pdd/prompts/xml_tagger_python.prompt"
+    }
+  ]
+}

--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -5751,6 +5751,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/descriptor_store.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "pdd/sync_core/durability.py",
       "role": "human-maintained"
     },
@@ -5866,6 +5872,12 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "pdd/sync_core/snapshot.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/supervisor.py",
       "role": "human-maintained"
     },
     {
@@ -13060,6 +13072,12 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_sync_core_cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_descriptor_store.py",
       "role": "human-maintained"
     },
     {

--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -5721,6 +5721,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/artifact_provenance.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "pdd/sync_core/certificate.py",
       "role": "human-maintained"
     },
@@ -13029,6 +13035,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_candidate_artifact_provenance.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "tests/test_sync_core_certificate.py",
       "role": "human-maintained"
     },
@@ -13126,6 +13138,12 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_sync_core_snapshot.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_supervisor.py",
       "role": "human-maintained"
     },
     {

--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -3567,6 +3567,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "examples/arch/architecture.json",
+      "role": "excluded-project"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "examples/arch/architecture_diagram.html",
       "role": "human-maintained"
     },
@@ -3629,6 +3635,12 @@
       "owner": "pdd-maintainers",
       "pattern": "examples/architecture_contract_summary_demo/TOUCHPOINTS.md",
       "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/architecture_contract_summary_demo/architecture.json",
+      "role": "excluded-project"
     },
     {
       "inventory": "HUMAN_OWNED",
@@ -3923,6 +3935,12 @@
       "owner": "pdd-maintainers",
       "pattern": "examples/prompts_linter/README.md",
       "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/architecture.json",
+      "role": "excluded-project"
     },
     {
       "inventory": "HUMAN_OWNED",
@@ -4293,6 +4311,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/architecture.json",
+      "role": "excluded-project"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "examples/template_example/architecture_diagram.html",
       "role": "human-maintained"
     },
@@ -4564,6 +4588,12 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "examples/tictactoe/tictactoe_prd.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd-local.sh",
       "role": "human-maintained"
     },
     {
@@ -5931,12 +5961,6 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
-      "pattern": "pdd-local.sh",
-      "role": "human-maintained"
-    },
-    {
-      "inventory": "HUMAN_OWNED",
-      "owner": "pdd-maintainers",
       "pattern": "pr_summary.md",
       "role": "human-maintained"
     },
@@ -7155,6 +7179,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/manifests.lock",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/manifests/pdd-failure-classification.10x.json",
       "role": "human-maintained"
     },
@@ -7186,12 +7216,6 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/manifests/pdd-failure-classification.5x.json",
-      "role": "human-maintained"
-    },
-    {
-      "inventory": "HUMAN_OWNED",
-      "owner": "pdd-maintainers",
-      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/manifests.lock",
       "role": "human-maintained"
     },
     {
@@ -7905,6 +7929,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/manifests.lock",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/manifests/pdd-find-section.10x.json",
       "role": "human-maintained"
     },
@@ -7936,12 +7966,6 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/manifests/pdd-find-section.5x.json",
-      "role": "human-maintained"
-    },
-    {
-      "inventory": "HUMAN_OWNED",
-      "owner": "pdd-maintainers",
-      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/manifests.lock",
       "role": "human-maintained"
     },
     {
@@ -8589,6 +8613,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/manifests.lock",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/manifests/pdd-language-extensions.10x.json",
       "role": "human-maintained"
     },
@@ -8620,12 +8650,6 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/manifests/pdd-language-extensions.5x.json",
-      "role": "human-maintained"
-    },
-    {
-      "inventory": "HUMAN_OWNED",
-      "owner": "pdd-maintainers",
-      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/manifests.lock",
       "role": "human-maintained"
     },
     {
@@ -9735,6 +9759,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/arch_include_validate_ok/architecture.json",
+      "role": "excluded-project"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "tests/fixtures/arch_include_validate_ok/prompts/child_Python.prompt",
       "role": "human-maintained"
     },
@@ -10479,6 +10509,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "tests/story_regression/test_story_pdd_bug.py",
       "role": "human-maintained"
     },
@@ -10540,12 +10576,6 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/story_regression/test_story_pdd_update.py",
-      "role": "human-maintained"
-    },
-    {
-      "inventory": "HUMAN_OWNED",
-      "owner": "pdd-maintainers",
-      "pattern": "tests/story_regression.sh",
       "role": "human-maintained"
     },
     {

--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -1,0 +1,14098 @@
+{
+  "rules": [
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".env.example",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".envrc",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".gitattributes",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".github/dependabot.yml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".github/workflows/auto-heal.yml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".github/workflows/backfill-release-notes.yml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".github/workflows/backfill-release-video-discord.yml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".github/workflows/pdd-secrets-dispatch.yml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".github/workflows/release.yml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".github/workflows/unit-tests.yml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".gitignore",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_architecture_orchestrator_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_bug_orchestrator_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_bug_orchestrator_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_bug_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_change_orchestrator_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_change_orchestrator_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_checkup_orchestrator_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_checkup_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_checkup_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_common_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_e2e_fix_orchestrator_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_e2e_fix_orchestrator_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_multishot_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_split_orchestrator_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_split_orchestrator_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_sync_runner_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_sync_runner_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/architecture_sync_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/checkup_review_loop_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/checkup_review_loop_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/ci_drift_heal_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/ci_drift_heal_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/cli_theme_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/cli_theme_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/code_generator_main_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/commands_checkup_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/commands_checkup_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/commands_modify_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/commands_modify_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/commands_prompt_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/construct_paths_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/construct_paths_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/context_audit_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/context_snapshot_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/core_cloud_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/durable_sync_runner_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/durable_sync_runner_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/failure_classification_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/fix_code_loop_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/fix_error_loop_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/get_comment_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/get_test_command_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/git_update_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/llm_invoke_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/llm_invoke_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/metadata_sync_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/metadata_sync_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/pin_example_hack_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/pin_example_hack_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/preprocess_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/prompt_lint_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/provider_manager_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/provider_manager_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/server_jobs_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/summarize_directory_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/summarize_directory_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/sync_animation_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/sync_animation_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/sync_determine_operation_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/sync_determine_operation_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/sync_orchestration_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/sync_orchestration_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/sync_tui_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/sync_tui_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/track_cost_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/track_cost_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pddignore",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".sync-config.yml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "AGENTS.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "CHANGELOG.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "CLAUDE.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "CONTRIBUTING.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "GEMINI.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "LICENSE",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "SETUP_WITH_GEMINI.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "SETUP_WITH_WINDOWS.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/Dockerfile",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/balance-chunks.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/cloudbuild.yaml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/collect-results.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/entrypoint.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/job-template-cloud-regression.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/job-template-standard.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/job-template.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/setup-gcp.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/submit.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/test-durations.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/DSPy_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/__init__example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/_keyring_timeout_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_architecture_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_architecture_orchestrator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_bug_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_bug_orchestrator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_change_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_change_orchestrator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_checkup_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_checkup_orchestrator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_common_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_crash_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_e2e_fix_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_e2e_fix_orchestrator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_fix_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_langtest_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_multishot_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_split_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_split_orchestrator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_sync_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_sync_runner_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_test_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_test_generate_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_test_orchestrator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_update_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/agentic_verify_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/anthropic_counter_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/anthropic_tool_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/api_contract_slicer_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/api_key_scanner_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/architecture_registry_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/architecture_sync_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/auth_service_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/auto_deps_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/auto_include_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/auto_update_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/autotokenizer_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/bug_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/bug_to_unit_test_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/bug_to_unit_test_failure_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/1/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/1/final_code_generator_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/1/initial_code_generator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/1/initial_code_generator_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/10/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/10/final_fix_errors_from_unit_tests_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/10/initial_fix_errors_from_unit_tests.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/10/initial_fix_errors_from_unit_tests_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/11/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/11/initial_code_generator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/11/initial_code_generator_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/11/initial_split_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/12/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/12/final_unfinished_prompt_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/12/initial_postprocess.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/12/initial_postprocess_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/13/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/13/initial_split.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/13/initial_split_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/13/modified_initial_split.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/14/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/14/initial_change.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/14/initial_change_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/14/modified_initial_change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/15/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/15/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/15/initial_cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/15/initial_cli_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/15/modified_initial_cli.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/16/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/16/fix_code_module_errors_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/16/fix_code_module_errors_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/16/fix_error_loop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/16/fix_error_loop_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/16/fix_errors_from_unit_tests_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/16/modified_fix_error_loop_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/17/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/17/continue_generation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/17/continue_generation_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/17/unfinished_prompt_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/17/updated_continue_generation_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/17/updated_unfinished_prompt_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/18/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/18/code_generator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/18/code_generator_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/18/unfinished_prompt_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/18/updated_code_generator_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/18/updated_unfinished_prompt_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/19/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/19/context_generator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/19/context_generator_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/19/unfinished_prompt_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/19/updated_context_generator_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/19/updated_unfinished_prompt_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/2/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/2/final_context_generator_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/2/initial_context_generator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/2/initial_context_generator_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/20/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/20/generate_test.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/20/generate_test_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/20/updated_generate_test_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/21/auto_deps_main_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/21/auto_include.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/21/auto_include_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/21/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/22/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/22/preprocess.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/22/preprocess_main_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/22/preprocess_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/3/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/3/final_test_generator_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/3/initial_test_generator_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/3/intial_test_generator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/4/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/4/final_postprocess_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/4/initial_postprocess.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/4/initial_postprocess_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/5/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/5/final_split_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/5/initial_split.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/5/initial_split_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/6/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/6/final_xml_tagger_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/6/initial_xml_tagger.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/6/initial_xml_tagger_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/7/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/7/final_fix_errors_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/7/initial_fix_errors.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/7/initial_fix_errors_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/8/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/8/final_fix_errors_from_unit_tests_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/8/initial_fix_errors_from_unit_tests.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/8/initial_fix_errors_from_unit_tests_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/9/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/9/final_fix_error_loop_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/9/initial_fix_error_loop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/9/initial_fix_error_loop_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change/simple_math/change.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/change_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/checkup_gates_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/checkup_interactive_session_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/checkup_prompt_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/checkup_review_loop_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/ci_detect_changed_modules_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/ci_drift_heal_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/ci_validation_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/cli_detector_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/cli_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/cli_theme_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/click_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/click_executor_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/cloud_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/cloud_function_call.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/cmd_test_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/code_generator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/code_generator_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/__init___example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/analysis_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/auth_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/checkup_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/connect_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/fix_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/generate_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/maintenance_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/misc_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/modify_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/sessions_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/templates_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/commands/utility_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/comment_line_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/config_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/conflicts_in_prompts_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/conflicts_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/construct_paths_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/content_selector_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/context_audit_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/context_generator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/context_generator_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/context_snapshot_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/continue_generation_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/core/cli_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/core/cloud_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/core/dump_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/core/duplicate_cli_guard_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/core/errors_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/core/utils_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/crash_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/ctx_obj_params.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/detect_change_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/detect_change_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/dict_utils_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/edit_file_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/embed_retrieve_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/example.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/extracts_prune_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/failure_classification_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/fastapi_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/find_section_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/firecrawl_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/fix_code_loop_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/fix_code_module_errors_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/fix_error_loop_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/fix_errors_from_unit_tests_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/fix_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/fix_verification_errors_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/fix_verification_errors_loop_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/fix_verification_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/gemini_may_pro_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/generate_model_catalog_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/generate_output_paths_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/generate_test_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/generation_completion_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/get_comment_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/get_extension_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/get_jwt_token_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/get_language_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/get_run_command_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/get_test_command_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/git_update_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/include_query_extractor_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/increase_tests_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/incremental_code_generator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/insert_includes_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/install_completion_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/job_manager_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/langchain_lcel_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/list_stats_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/llm_invoke_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/llm_model_ranges_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/llm_selector_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/load_prompt_template_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/logo_animation_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/metadata_sync_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/model_tester_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/one_session_sync_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/operation_log_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/path_resolution_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/pdd_completion_example.fish",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/pdd_completion_example.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/pdd_completion_example.zsh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/pddrc_initializer_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/pin_example_hack_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/postprocess_0_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/postprocess_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/pre_checkup_gate_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/preprocess_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/preprocess_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/process_csv_change_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/provider_manager_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/pytest_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/pytest_isolation_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/pytest_output_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/pytest_slicer_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/python_env_detector_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/python_preamble.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/range_validator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/remote_session_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/render_mermaid_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/resolve_effective_config_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/__init___example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/app_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/click_executor_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/executor_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/jobs_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/models_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/routes/__init___example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/routes/architecture_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/routes/auth_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/routes/commands_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/routes/config_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/routes/extracts_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/routes/files_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/routes/prompts_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/routes/session_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/routes/websocket_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/security_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/terminal_spawner_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/server/token_counter_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/setup_tool_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/split/simple_math/split_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/split_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/split_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/split_validation_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/story_coverage_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/story_regression_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/story_regression_gate_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/summarize_directory_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/sync_animation_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/sync_code_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/sync_determine_operation_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/sync_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/sync_orchestration_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/sync_order_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/sync_tui_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/test.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/test_context_packer_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/tiktoken_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/trace_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/trace_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/track_cost_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/unfinished_prompt_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/update_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/update_model_costs_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/update_prompt_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/user_story_tests_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/validate_prompt_includes_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/websocket_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/xml_tagger_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "data",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demo/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demo/prompts/agentic_change_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demo/prompts/fix_main_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demo/prompts/prompt_lint_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demo/run_scenarios.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demo_sync_animation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/FULL_WORKFLOW.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/context/github_issues_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/drift_workspace/prompts/drift_candidate_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/drift_workspace/src/drift_candidate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/expected/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/prompts/01_clean_task.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/prompts/02_vague_clarification.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/prompts/03_formatting_edge_case.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/prompts/04_contract_sensitive.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/prompts/05_coverage_sensitive.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/prompts/06_snapshot_candidate.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/prompts/07_drift_candidate.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "demos/checkup_interactive/run_demo.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/ONBOARDING.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/Software Development Costs and Maintenance_ 2022\u20132025 Trends and AI Impact.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/TUTORIALS.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/architecture_include_validation.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/architecture_postcheck_waivers.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/checkup_interactive_session.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/checkup_interactive_session_pi_sample.jsonl",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/checkup_interactive_session_spike.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/checkup_interactive_session_tty_sample.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/checkup_prompt_quality_gate.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/checkup_simplify.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/checkup_simplify_providers.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/checkup_verifier.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/ci.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/comparison.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/context.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/contract_check.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/contributors/pdd-cli-release-process.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/coverage_contracts.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/EPIC-1540-design-refresh.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/EPIC-1560-design-refresh-phase-2.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/color-system.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/context-token-colors.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/demos/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/demos/demo-pr1-color-system.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/demos/demo-pr1-color-system.svg",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/demos/demo-pr2-status-messaging.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/demos/demo-pr2-status-messaging.svg",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/demos/demo-pr3-context-tokens.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/demos/demo-pr3-context-tokens.svg",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/demos/generate_demos.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/design/status-messaging.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/drift.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/evidence_manifest.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/examples/prompt_with_metadata.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/faq.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/generating_user_stories.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/global_sync_resolution_plan.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/goldilocks_prompt.jpeg",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/grounding_policy.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/issue_820_user_story_template.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/issues/issue_1431_task_routing_v1_plan.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/issues/issue_813_verification_plan.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/mid_run_steering_validation.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/new_whitepaper.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/o3_whitepaper.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/orig_whitepaper.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/path_resolution_resolver.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/pdd_vs_agentic_cli_definitive_proof_plan.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/prompt-driven-development-doctrine.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/prompt_lint.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/prompt_repair.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/prompting_guide.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/routing_policy.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/runbooks/pr-loop-process.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/skills/checkup-simplify/SKILL.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/standup_notes.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/story_regression_backfill.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/sync_architecture_analysis.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/sync_determination_analysis.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/sync_solution_o3pro.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/sync_solution_opus.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/the-last-programming-language.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/videos/handpaint_demo.gif",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_before_4.5.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/evidence/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/evidence/SHA256SUMS.txt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/evidence/_session_classification.tsv",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/evidence/prompts_pdd.jsonl",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/evidence/prompts_pdd.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/evidence/prompts_vibe.jsonl",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/evidence/prompts_vibe.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/evidence/quote_map.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/images/loop.mmd",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/images/loop.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/images/oscillation.mmd",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/images/oscillation.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/images/pdd_cycle.mmd",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/images/pdd_cycle.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/images/pipeline.mmd",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/images/pipeline.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/images/threshold.mmd",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/images/threshold.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_specification_drift/whitepaper.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/avg_api_cost_by_edit_type.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/avg_api_cost_by_file_size.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/avg_api_cost_by_language.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/avg_execution_time_by_edit_type.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/avg_execution_time_by_file_size.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/avg_execution_time_by_language.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/cost_per_successful_task.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/overall_avg_api_cost.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/overall_avg_execution_time.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/overall_success_rate.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/success_rate_by_edit_type.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/success_rate_by_file_size.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/success_rate_by_language.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/time_vs_cost_scatter.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/analysis_report/total_api_cost_comparison.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/creation_report/claude_cost_per_run_dist.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/creation_report/claude_lines_added_removed_dist.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/creation_report/claude_wall_duration_dist.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/creation_report/pdd_avg_cost_per_module_dist.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/creation_report/pdd_top_modules_by_cost.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/creation_report/pdd_top_modules_by_time.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/creation_report/pdd_total_time_per_module_dist.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/creation_report/total_cost_comparison.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/creation_report/total_time_comparison.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "docs/whitepaper_with_benchmarks/whitepaper_w_benchmarks.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "environment.yml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_bug_orchestrator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_change_orchestrator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_checkup_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_common_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_common_worktree_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_e2e_fix_orchestrator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example/main_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example/src/main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example/src/utils.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example/tests/test_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example/utils_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/.gitignore",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/build.gradle",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/gradle/wrapper/gradle-wrapper.jar",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/gradle/wrapper/gradle-wrapper.properties",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/gradlew",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/gradlew.bat",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/main_java.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/settings.gradle",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/src/main/java/Main.java",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/src/main/java/Util.java",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/src/test/java/TestMain.java",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_gradle/util_java.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_maven/.gitignore",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_maven/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_maven/main_java.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_maven/pom.xml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_maven/src/main/java/Main.java",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_maven/src/main/java/Util.java",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_maven/src/test/java/TestMain.java",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_java_maven/util_java.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_javascript/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_javascript/main_javascript.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_javascript/package.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_javascript/src/main.js",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_javascript/src/utils.js",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_javascript/tests/test_main.js",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_javascript/utils_javascript.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_typescript/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_typescript/main_typescript.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_typescript/package.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_typescript/src/main.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_typescript/src/utils.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_typescript/tests/test_main.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_typescript/tsconfig.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_fallback_example_typescript/utils_typescript.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_split_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/agentic_split_orchestrator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/arch/ORDER_MANAGEMENT_PRD.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/arch/architecture_diagram.html",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/arch/prompts/create_order_page_TypeScriptReact.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/arch/prompts/database_config_Python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/arch/prompts/order_api_Python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/arch/prompts/order_components_TypeScriptReact.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/arch/prompts/order_models_Python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/arch/prompts/orders_page_TypeScriptReact.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/arch/prompts/view_order_page_TypeScriptReact.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/arch/tech_stack.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/architecture_contract_summary_demo/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/architecture_contract_summary_demo/TOUCHPOINTS.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/architecture_contract_summary_demo/prompts/legacy_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/architecture_contract_summary_demo/prompts/refund_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/architecture_contract_summary_demo/run_demo.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/architecture_contract_summary_demo/run_demo.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/architecture_contract_summary_demo/user_stories/story__refund_cap.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/checkup_review_loop_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/checkup_simplify_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/context_snapshot_demo/.gitignore",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/context_snapshot_demo/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/context_snapshot_demo/context/note.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/context_snapshot_demo/pdd/.gitkeep",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/context_snapshot_demo/prompts/dynamic_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/context_snapshot_demo/prompts/foo_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/context_snapshot_demo/prompts/static_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/context_snapshot_demo/prompts/with_shell_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/context_snapshot_demo/run_demo.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/context_snapshot_demo/run_test_plan_manual.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/get_lint_commands_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/git_porcelain_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/handpaint/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/handpaint/cursor/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/handpaint/cursor/handpaint.html",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/handpaint/pdd/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/handpaint/pdd/handpaint_html.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/handpaint/pdd/handpaint_pdd.html",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/hello/.pdd/meta/hello_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/hello/examples/hello_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/hello/hello_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/hello/src/hello.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/hello/tests/test_hello.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/hello_you/hello_you_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/image_prompt_example/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/image_prompt_example/describe.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/image_prompt_example/describe_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/image_prompt_example/image.heic",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/image_prompt_example/image.jpeg",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/pi_calc/.pdd/meta/pi_calc_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/pi_calc/.pdd/meta/pi_calc_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/pi_calc/examples/pi_calc_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/pi_calc/examples/pi_calc_example_iteration_1.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/pi_calc/examples/pi_calc_example_iteration_2.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/pi_calc/pdd/pi_calc.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/pi_calc/pdd/pi_calc_1_2_2_0_20250715_122550.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/pi_calc/pdd/pi_calc_iteration_1.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/pi_calc/pdd/pi_calc_iteration_2.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/pi_calc/pi_calc_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/pi_calc/tests/test_pi_calc.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/Makefile",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/architecture_diagram.html",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/docs/specs.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/docs/tech_stack.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/examples/backend_api_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/examples/cli_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/examples/fix_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/examples/frontend_streamlit_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/examples/helpers_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/examples/llm_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/examples/models_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/examples/pipeline_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/examples/report_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/examples/report_output.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/examples/report_output.txt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/examples/rules_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/project_dependencies.csv",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/prompts/backend_api_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/prompts/cli_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/prompts/fix_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/prompts/frontend_streamlit_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/prompts/helpers_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/prompts/llm_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/prompts/models_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/prompts/pipeline_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/prompts/report_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/prompts/rules_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/requirements.txt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/src/backend/backend_api.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/src/cli/cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/src/frontend/frontend_streamlit.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/src/utils/fix.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/src/utils/helpers.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/src/utils/llm.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/src/utils/models.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/src/utils/pipeline.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/src/utils/report.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/src/utils/rules.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/tests/test_backend_api.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/tests/test_cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/tests/test_fix.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/tests/test_frontend_streamlit.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/tests/test_helpers.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/tests/test_llm.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/tests/test_models.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/tests/test_pipeline.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/tests/test_report.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/prompts_linter/tests/test_rules.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/qrcode_sandwich/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/qrcode_sandwich/qrcode_sandwich.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/qrcode_sandwich/qrcode_sandwich.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/qrcode_sandwich/qrcode_sandwich_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/split_main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/split_validation_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/story_regression_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/story_regression_gate_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/.gitignore",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/API_FAILURE_ANALYSIS.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/API_KEY_SETUP.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/EDIT_FILE_TOOL_README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/Makefile",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/architecture_diagram.html",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/data/llm_model.csv",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/example2.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/project_dependencies.csv",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/prompts/__init___Python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/prompts/architecture/architecture_json.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/prompts/cache_manager_utility_Python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/prompts/cli_Python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/prompts/core_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/prompts/cost_tracker_utility_Python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/prompts/pyproject_TOML.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/prompts/think_tool_capability_Python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/pyproject.toml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/edit_file_tool/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/edit_file_tool/cache_manager_utility.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/edit_file_tool/cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/edit_file_tool/core.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/edit_file_tool/cost_tracker_utility.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/edit_file_tool/think_tool_capability.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/examples/__init___example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/examples/cache_manager_utility_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/examples/cli_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/examples/core_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/examples/cost_tracker_utility_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/examples/generated_xml/example_mod.xml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/examples/think_tool_capability_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/tests/test___init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/tests/test_cache_manager_utility.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/tests/test_cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/tests/test_core.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/tests/test_cost_tracker_utility.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/template_example/src/tests/test_think_tool_capability.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/test_generation_benchmark/ANALYSIS.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/test_generation_benchmark/DISCORD_SUMMARY.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/test_generation_benchmark/Makefile",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/test_generation_benchmark/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/test_generation_benchmark/benchmark_results/code_based/test_email_validator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/test_generation_benchmark/benchmark_results/example_based/test_email_validator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/test_generation_benchmark/email_validator_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/test_generation_benchmark/examples/email_validator_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/test_generation_benchmark/src/email_validator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/tictactoe/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/tictactoe/tictactoe_architecture.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/tictactoe/tictactoe_architecture_diagram.html",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "examples/tictactoe/tictactoe_prd.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/__main__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/_selector_parse.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/api_key_scanner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/architecture_include_validation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/architecture_sync_helper.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/auto_deps_architecture.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/checkup_target.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/ci_detect_changed_modules.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/cli_status.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/cli_theme.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/analysis.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/auth.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/checkup_simplify.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/checkup_snapshot.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/connect.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/coverage.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/drift.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/extracts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/firecrawl.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/reconcile.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/report.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/sessions.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/sync_core.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/templates.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/utility.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/commands/which.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/compression_reporting.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/config_resolution.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/conflicts_in_prompts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/construct_paths.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/context_snapshot_policy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/continuous_sync.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/core/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/core/dump.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/core/llm_trace.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/core/remote_session.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/core/utils.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/data/agentic_harness_capabilities.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/data/arena_elo_manifest.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/data/deepswe_manifest.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/data/harness_registry.csv",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/docs/prompting_guide.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/drift_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/edit_file.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/extracts_prune.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/firecrawl_cache.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/fix_code_module_errors.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/.gitignore",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/App.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/api.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/AddModuleModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/AddToQueueModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/ArchitectureView.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/AuthStatusIndicator.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/BatchFilterDropdown.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/BugModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/ChangeModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/CommandForm.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/CommandOutput.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/CreatePromptModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/DependencyViewer.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/DeviceIndicator.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/ErrorBoundary.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/ExecutionModeToggle.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/ExtractsPanel.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/FileBrowser.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/FilePickerInput.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/GeneratedCommand.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/GenerationProgressModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/GraphToolbar.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/GroupEditModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/GroupNode.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/GuidanceSidebar.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/Header.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/Icon.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/InputField.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/JobCard.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/JobDashboard.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/JobOutputPanel.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/ModelSelector.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/ModelSliders.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/ModuleEditModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/ModuleNode.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/ProjectSettings.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/PromptCodeDiffModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/PromptEditor.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/PromptMetricsBar.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/PromptOrderModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/PromptSelector.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/PromptSpace.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/ReauthModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/RemoteSessionSelector.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/SyncFromPromptModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/SyncOptionsModal.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/SyncStatusBadge.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/Tabs.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/TaskQueueControls.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/TaskQueueItem.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/TaskQueuePanel.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/TextAreaField.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/Toast.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/components/Tooltip.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/data/mockPrd.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/data/mockPrompts.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/hooks/useArchitectureHistory.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/hooks/useAudioNotification.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/hooks/useJobs.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/hooks/useTaskQueue.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/index.html",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/index.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/lib/batchUtils.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/lib/commandBuilder.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/lib/format.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/lib/includeAnalyzer.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/lib/modelResolver.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/lib/pddAutocomplete.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/lib/pddDirectives.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/metadata.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/package-lock.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/package.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/public/logo.svg",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/command-builder.test.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/compact-font-direct-zoom.test.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/compact-font-size.test.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/context-audit-wiring.test.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/group-layout.test.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/group-subflow-nodes.test.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/module-needs-sync.test.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/rearrange-discard.test.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/rearrange-positions.test.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/setup.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/sync-completed-refresh.test.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/vp-zoom-sync.test.tsx",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tests/waypoint-edge.test.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/tsconfig.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/frontend/vite.config.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/generation_completion.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/get_extension.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/get_run_command.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/grounding_provenance.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/include_query_extractor.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/interface_semantics.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/json_atomic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/json_invocation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/language_extensions.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/list_drift_detection.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/load_prompt_template.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/mcp_config.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/model_tester.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/one_session_sync.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/pddrc_initializer.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/pin_example_hack.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/prompt_gate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/prompts/combine.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/prompts/combined_output.txt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/prompts/xml/change_example_full.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/prompts/xml/change_example_partial.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/prompts/xml/change_example_partial_processed.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/provider_manager.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/python_env_detector.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/reasoning.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/schemas/architecture_contract_summary.schema.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/schemas/evidence_manifest.schema.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/schemas/story_coverage.schema.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/app.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/click_executor.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/executor.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/models.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/routes/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/routes/architecture.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/routes/auth.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/routes/commands.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/routes/config.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/routes/extracts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/routes/files.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/routes/prompts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/routes/websocket.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/security.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/terminal_spawner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/server/token_counter.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/source_set_model.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/story_test_generation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/capabilities.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/certificate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/certificate_verifier.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/classifier.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/decommission.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/durability.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/evidence_store.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/finalize.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/fingerprint_store.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/git_io.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/identity.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/includes.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/isolation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/lifecycle.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/manifest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/path_policy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/planner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/pytest_probe.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/released_checker.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/reporting.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/runner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/scenario_contract.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/scenario_harness.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/snapshot.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/transaction.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/trust.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/types.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/verification.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/waivers.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_graph_order_consistency.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/template_expander.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/templates/architecture/architecture_json.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/templates/architecture/example_nextjs_task_notes.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/templates/architecture/example_python_backend.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/templates/architecture/pdd_path_construction_guide.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/templates/generic/generate_pddrc_YAML.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/templates/generic/generate_prompt.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/test_result.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/validate_prompt_includes.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/waiver_policy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd-local.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pr_summary.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "project_dependencies.csv",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "prompts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pyrightconfig.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pytest.ini",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "requirements.txt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/agentic-config-benchmark/benchmark_config_axis.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/agentic-config-benchmark/design.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/agentic-config-benchmark/generate_report.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/agentic-config-benchmark/reports/.gitkeep",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/agentic-config-benchmark/run_benchmark.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/agentic_cli_routing.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/agentic_cli_search.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/design.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/comment_line_cover.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/comment_line_hint.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/comment_line_hints.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/comment_line_sub.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/comment_line_truncated.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/compression_reporting_classify.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/compression_reporting_flaky.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/compression_reporting_lower.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/compression_reporting_pytest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/compression_reporting_sig.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/compression_reporting_signature.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/get_lint_commands_len.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/get_lint_commands_logic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/get_lint_commands_pattern.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/get_lint_commands_stable.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/get_lint_commands_truncated.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/json_atomic_import.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/json_atomic_lower.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/json_atomic_mark.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/json_atomic_sig.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/10x/src/pdd/json_atomic_text.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_cover.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_extract.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_hint.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_hints.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_match.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_parametrize.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_search.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_sig.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_strip.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_sub.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_timeout.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_truncated.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/comment_line_truncates.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/compression_reporting_assertion.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/compression_reporting_budget.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/compression_reporting_classify.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/compression_reporting_compile.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/compression_reporting_empty.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/compression_reporting_flaky.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/compression_reporting_len.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/compression_reporting_line.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/compression_reporting_lower.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/compression_reporting_pytest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/compression_reporting_sig.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/compression_reporting_signature.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/get_lint_commands_file.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/get_lint_commands_flaky.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/get_lint_commands_hints.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/get_lint_commands_ignorecase.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/get_lint_commands_len.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/get_lint_commands_logic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/get_lint_commands_multiline.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/get_lint_commands_pattern.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/get_lint_commands_stable.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/get_lint_commands_syntax.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/get_lint_commands_truncated.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/get_lint_commands_truncates.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/json_atomic_budget.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/json_atomic_classify.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/json_atomic_flaky.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/json_atomic_import.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/json_atomic_lower.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/json_atomic_mark.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/json_atomic_sig.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/json_atomic_syntax.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/json_atomic_text.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/json_atomic_timeout.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/20x/src/pdd/json_atomic_truncated.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/2x/src/service/str_service_0.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/adapters/assertion_adapters_33.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/adapters/empty_adapters_43.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/adapters/file_adapters_23.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/adapters/infrastructure_adapters_38.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/adapters/long_adapters_18.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/adapters/lowered_adapters_3.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/adapters/path_adapters_8.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/adapters/signature_adapters_13.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/adapters/strip_adapters_28.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/handler/classification_handler_1.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/handler/file_handler_31.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/handler/hint_handler_6.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/handler/hints_handler_16.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/handler/sig_handler_41.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/handler/stable_handler_11.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/handler/str_handler_36.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/handler/syntax_handler_21.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/handler/timeout_handler_26.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/helpers/classification_helpers_27.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/helpers/compile_helpers_12.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/helpers/cover_helpers_37.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/helpers/empty_helpers_2.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/helpers/error_helpers_32.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/helpers/import_helpers_7.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/helpers/len_helpers_17.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/helpers/parametrize_helpers_22.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/helpers/syntax_helpers_42.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_assertion.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_cover.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_extract.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_hint.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_hints.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_match.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_out.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_parametrize.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_search.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_sig.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_signature.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_strip.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_sub.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_timeout.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_truncated.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/comment_line_truncates.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_assertion.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_budget.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_classify.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_compile.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_empty.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_exception.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_expected.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_extract.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_flaky.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_group.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_len.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_line.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_lower.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_pytest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_sig.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/compression_reporting_signature.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_assertion.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_budget.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_file.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_flaky.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_hints.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_ignorecase.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_len.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_logic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_multiline.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_path.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_pattern.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_pytest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_search.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_stable.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_str.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_syntax.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_truncated.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/get_lint_commands_truncates.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_budget.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_classify.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_empty.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_file.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_flaky.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_import.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_lower.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_mark.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_match.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_sig.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_str.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_syntax.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_text.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_timeout.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_truncated.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/pdd/json_atomic_truncates.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/service/assertion_service_25.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/service/ignorecase_service_20.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/service/infrastructure_service_5.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/service/pattern_service_40.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/service/search_service_10.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/service/search_service_15.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/service/stable_service_30.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/service/str_service_0.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/service/strip_service_35.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/validation/budget_validation_44.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/validation/exception_validation_34.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/validation/file_validation_4.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/validation/group_validation_14.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/validation/group_validation_29.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/validation/multiline_validation_19.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/validation/pytest_validation_24.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/validation/pytest_validation_9.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/50x/src/validation/timeout_validation_39.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/5x/src/pdd/comment_line_cover.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/5x/src/pdd/compression_reporting_classify.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/5x/src/pdd/compression_reporting_lower.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/5x/src/pdd/get_lint_commands_logic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/5x/src/pdd/get_lint_commands_truncated.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/5x/src/pdd/json_atomic_import.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/generated/pdd-failure-classification/5x/src/pdd/json_atomic_mark.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/manifests/pdd-failure-classification.10x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/manifests/pdd-failure-classification.1x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/manifests/pdd-failure-classification.20x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/manifests/pdd-failure-classification.2x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/manifests/pdd-failure-classification.50x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/manifests/pdd-failure-classification.5x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-failure-classification/manifests.lock",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/10x/src/pdd/comment_line_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/10x/src/pdd/comment_line_strip.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/10x/src/pdd/compression_reporting_empty.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/10x/src/pdd/compression_reporting_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/10x/src/pdd/compression_reporting_open.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/10x/src/pdd/get_lint_commands_lines.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/10x/src/pdd/get_lint_commands_raw.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/10x/src/pdd/get_lint_commands_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/10x/src/pdd/json_atomic_expected.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/10x/src/pdd/json_atomic_section.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/10x/src/pdd/json_atomic_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/10x/src/service/language_service_0.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/comment_line_expected.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/comment_line_found.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/comment_line_len.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/comment_line_lines.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/comment_line_nested.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/comment_line_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/comment_line_strip.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/compression_reporting_empty.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/compression_reporting_fence.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/compression_reporting_found.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/compression_reporting_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/compression_reporting_multiple.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/compression_reporting_open.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/compression_reporting_section.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/compression_reporting_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/get_lint_commands_basic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/get_lint_commands_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/get_lint_commands_lines.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/get_lint_commands_pop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/get_lint_commands_raw.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/get_lint_commands_start.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/get_lint_commands_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/json_atomic_basic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/json_atomic_blocks.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/json_atomic_enumerate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/json_atomic_expected.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/json_atomic_find.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/json_atomic_section.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/20x/src/pdd/json_atomic_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/2x/src/handler/blocks_handler_6.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/adapters/lines_adapters_3.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/adapters/section_adapters_8.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/adapters/startswith_adapters_13.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/handler/blocks_handler_6.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/handler/found_handler_11.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/handler/section_handler_1.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/helpers/found_helpers_2.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/helpers/section_helpers_12.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/helpers/sub_helpers_7.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_basic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_blocks.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_enumerate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_expected.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_found.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_len.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_lines.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_nested.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_open.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_pop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_section.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/comment_line_strip.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_append.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_basic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_blocks.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_empty.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_enumerate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_fence.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_find.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_found.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_multiple.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_open.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_pop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_section.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_start.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/compression_reporting_sub.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_basic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_enumerate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_expected.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_found.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_len.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_lines.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_multiple.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_pop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_raw.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_section.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_start.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/get_lint_commands_sub.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_append.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_basic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_blocks.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_enumerate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_expected.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_find.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_found.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_index.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_nested.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_pop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_raw.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_section.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_strip.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/pdd/json_atomic_sub.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/service/empty_service_10.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/service/language_service_0.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/service/strip_service_5.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/validation/empty_validation_9.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/50x/src/validation/start_validation_4.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/5x/src/pdd/compression_reporting_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/5x/src/pdd/get_lint_commands_raw.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/generated/pdd-find-section/5x/src/service/language_service_0.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/manifests/pdd-find-section.10x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/manifests/pdd-find-section.1x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/manifests/pdd-find-section.20x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/manifests/pdd-find-section.2x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/manifests/pdd-find-section.50x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/manifests/pdd-find-section.5x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-find-section/manifests.lock",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/10x/src/pdd/comment_line_file.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/10x/src/pdd/comment_line_leading.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/10x/src/pdd/compression_reporting_languages.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/10x/src/pdd/compression_reporting_reader.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/10x/src/pdd/compression_reporting_row.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/10x/src/pdd/get_lint_commands_exc.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/10x/src/pdd/get_lint_commands_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/10x/src/pdd/get_lint_commands_lookup.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/10x/src/pdd/json_atomic_common.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/10x/src/pdd/json_atomic_values.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/comment_line_file.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/comment_line_insensitive.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/comment_line_known.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/comment_line_languages.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/comment_line_leading.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/comment_line_reader.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/compression_reporting_languages.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/compression_reporting_leading.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/compression_reporting_lstrip.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/compression_reporting_makefile.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/compression_reporting_map.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/compression_reporting_reader.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/compression_reporting_row.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/get_lint_commands_cache.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/get_lint_commands_exc.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/get_lint_commands_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/get_lint_commands_lookup.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/get_lint_commands_parent.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/get_lint_commands_str.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/json_atomic_common.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/json_atomic_exc.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/json_atomic_leading.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/json_atomic_oserror.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/json_atomic_row.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/20x/src/pdd/json_atomic_values.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/2x/src/service/dict_service_0.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_case.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_debug.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_dict.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_file.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_insensitive.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_known.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_languages.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_leading.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_logging.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_lower.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_lru.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_mapping.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_path.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_reader.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/comment_line_row.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_but.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_csv.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_dict.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_empty.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_handle.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_languages.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_leading.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_lookup.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_lru.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_lstrip.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_makefile.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_map.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_path.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_reader.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_row.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_str.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/compression_reporting_values.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_cache.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_csv.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_debug.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_dot.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_exc.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_file.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_languages.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_leading.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_lookup.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_lstrip.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_mapping.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_open.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_parent.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_startswith.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/get_lint_commands_str.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_all.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_common.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_debug.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_dot.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_error.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_exc.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_ext.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_file.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_known.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_languages.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_leading.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_logger.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_lstrip.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_name.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_open.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_oserror.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_parent.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_row.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/50x/src/pdd/json_atomic_values.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/5x/src/pdd/compression_reporting_row.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/generated/pdd-language-extensions/5x/src/pdd/get_lint_commands_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/manifests/pdd-language-extensions.10x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/manifests/pdd-language-extensions.1x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/manifests/pdd-language-extensions.20x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/manifests/pdd-language-extensions.2x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/manifests/pdd-language-extensions.50x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/manifests/pdd-language-extensions.5x.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/distractors/pdd-language-extensions/manifests.lock",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/epic-1209-v2.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/context_snapshots/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/context_snapshots/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/context_snapshots/attribution.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/context_snapshots/iteration_analyzer.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/context_snapshots/proxy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/context_snapshots/schema.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/context_snapshots/session_parser.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/context_snapshots/tests/conftest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/context_snapshots/tests/test_attribution.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/context_snapshots/tests/test_iteration_analyzer.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/context_snapshots/tests/test_proxy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/context_snapshots/tests/test_session_parser.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/distractors/DEFINITION.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/distractors/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/distractors/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/distractors/cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/distractors/definition.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/distractors/generator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/distractors/manifest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/distractors/tests/conftest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/distractors/tests/test_definition.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/distractors/tests/test_generator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/distractors/tests/test_vocabulary.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/distractors/vocabulary.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/CODEX_PIN.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/PREREGISTRATION.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/agent_launcher.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/codex_probe.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/container/Dockerfile",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/container/Dockerfile.gateway",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/container/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/container/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/container/agent_worker.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/container/docker-compose.yml",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/container/egress_check.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/container/filter",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/container/integration_check.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/container/tinyproxy.conf",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/env_freeze.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/first_run_calibration.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/metrics.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/mock_agent.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/pilot_arm_codex.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/preflight.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/register_env.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/report.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/runner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/tests/conftest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/tests/test_agent_launcher.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/tests/test_codex_probe.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/tests/test_egress_check.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/tests/test_end_to_end.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/tests/test_env_freeze.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/tests/test_metrics_failure_classes.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/tests/test_preflight.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/tests/test_real_scenario.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/tests/test_registration_and_calibration.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/tests/test_report.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/tests/test_variant_builder.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/harness/runner/variant_builder.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/paper/paper.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/pdd_direct_generation_routing.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/presentation.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/research-context/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/research-context/integration-with-existing-studies.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/research-context/literature-review.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/research-context/possible-collaborators.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/research-context/presentation.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/core/pytest.ini",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/core/src/pager/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/core/src/pager/pagination.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/core/tests/visible/test_pagination.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/hidden/pytest.ini",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/hidden/test_hidden_pagination.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/exports/csv_writer.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/pager/ledger_filters.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/pager/ledger_sorting.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/reporting/export_audit.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/pool/src/reporting/export_summary.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/scenario.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/example-pagination/task.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/core/pytest.ini",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/core/src/pdd/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/core/src/pdd/failure_classification.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/core/tests/visible/test_failure_classification.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/core_files.txt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/hidden/pytest.ini",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/hidden/test_hidden_failure_classification.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/leak_denylist.txt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/pool/src/pdd/comment_line.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/pool/src/pdd/compression_reporting.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/pool/src/pdd/get_lint_commands.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/pool/src/pdd/json_atomic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/preflight.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/scenario.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/seed.patch",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/seed_novelty.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-failure-classification/task.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/core/pytest.ini",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/core/src/pdd/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/core/src/pdd/find_section.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/core/tests/visible/test_find_section.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/core_files.txt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/hidden/pytest.ini",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/hidden/test_hidden_find_section.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/leak_denylist.txt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/pool/src/pdd/comment_line.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/pool/src/pdd/compression_reporting.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/pool/src/pdd/get_lint_commands.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/pool/src/pdd/json_atomic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/preflight.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/scenario.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/seed.patch",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/seed_novelty.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-find-section/task.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/core/pytest.ini",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/core/src/pdd/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/core/src/pdd/data/language_format.csv",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/core/src/pdd/language_extensions.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/core/tests/visible/test_language_extensions.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/core_files.txt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/hidden/pytest.ini",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/hidden/test_hidden_language_extensions.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/leak_denylist.txt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/pool/src/pdd/comment_line.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/pool/src/pdd/compression_reporting.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/pool/src/pdd/get_lint_commands.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/pool/src/pdd/json_atomic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/preflight.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/scenario.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/seed.patch",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/seed_novelty.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "research/repo-bloat-benchmark/scenarios/pdd-language-extensions/task.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "scripts/backfill_release_video_discord.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "scripts/check_deps.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "scripts/ci_detect_changed_modules.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "scripts/claude_code_oauth_retry.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "scripts/copy_package_data_to_public.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "scripts/demo_test_packing_e2e.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "scripts/e2e_story_workflow_demo.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "scripts/extract_wheel.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "scripts/preprocess_wheel.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "scripts/release_video.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "scripts/sops_release_env.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/cloud_regression.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_analysis.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_auth.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_checkup.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_checkup_contracts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_checkup_interactive_demo.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_checkup_simplify.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_connect.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_context.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_contract_rule_test_smoke.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_coverage.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_drift_cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_evidence.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_fix.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_gate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_generate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_maintenance.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_modify.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_sessions.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_story.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/commands/test_utility.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/conftest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/core/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/core/test_cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/core/test_cloud.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/core/test_remote_session.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/e2e/test_checkup_lifecycle.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/e2e/test_issue_1932_continuous_sync_guarantee.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/arch_include_validate_ok/prompts/child_Python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/arch_include_validate_ok/prompts/parent_Python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/autoheal_1187_post.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/autoheal_1187_pre.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/conftest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/auth_service_clean_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/capabilities_no_modal_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/coverage_unchecked_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/duplicate_ids_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/legacy_no_sections_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/malformed_ids_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/missing_modal_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/non_sequential_ids_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/payment_api_clean_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/payment_api_issues_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/rate_limiter_issues_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/story__covers_rule_ids.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/story__cross_module_covers.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/story__payment_bad_refs.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/story__payment_flow.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/story__unknown_rule_ids.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/uncovered_mustnot_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/unknown_coverage_refs_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/vague_no_vocab_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/vague_with_vocab_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/valid_contract_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/waiver_expired_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/waiver_missing_fields_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/waiver_ref_missing_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/waiver_valid_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_check/with_coverage_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/contract_rules_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/coverage_contracts/failed_receipt_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/coverage_contracts/fake_tests/test_receipt_failed.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/coverage_contracts/fake_tests/test_refund.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/coverage_contracts/legacy_no_contracts_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/coverage_contracts/refund_payment_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/coverage_contracts/stories/story__receipt_missing_acceptance.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/coverage_contracts/stories/story__refund_idempotency.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/coverage_contracts/stories/story__refund_invalid.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/encode_message_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/generate_estimate_accuracy/includes/shared_helpers.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/generate_estimate_accuracy/manifest.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/generate_estimate_accuracy/prompts/code_heavy_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/generate_estimate_accuracy/prompts/docs_heavy_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/generate_estimate_accuracy/prompts/include_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/generate_estimate_accuracy/prompts/interface_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/generate_estimate_accuracy/prompts/large_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/generate_estimate_accuracy/prompts/medium_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/generate_estimate_accuracy/prompts/reason_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/generate_estimate_accuracy/prompts/tests_examples_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/generate_estimate_accuracy/prompts/tiny_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/generate_estimate_accuracy/prompts/unknown_price_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/issue591_behavioral_signal_test.py.fixture",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/issue591_dockerfile_test.py.fixture",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/issue591_structural_getsource_test.py.fixture",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/one_session_agent_LLM_original.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s7_large_code_bug/examples/llm_client_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s7_large_code_bug/prompts/llm_client_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s7_large_code_bug/scenario.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s7_large_code_bug/src/llm_client.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s7_large_code_bug/tests/test_llm_client.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s8_large_minimal_tests/examples/workflow_engine_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s8_large_minimal_tests/prompts/workflow_engine_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s8_large_minimal_tests/scenario.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s8_large_minimal_tests/src/workflow_engine.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s8_large_minimal_tests/tests/test_workflow_engine.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s9_large_wrong_tests/examples/config_manager_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s9_large_wrong_tests/prompts/config_manager_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s9_large_wrong_tests/scenario.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s9_large_wrong_tests/src/config_manager.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/one_session_eval/s9_large_wrong_tests/tests/test_config_manager.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/clean.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/llm_template_empty_LLM.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/payment_api.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/payment_api_clean_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/payment_api_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/story__clean.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/story__covers.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/story__payment_api.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/story__payment_vague.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/story__vague_criteria.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/strict_terms_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/upload_handler_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/upload_handler_with_vocab_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/vague_defined.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/prompt_lint/vague_undefined.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/simple_math.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/simple_math_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/simple_math_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/sub_simple_math.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/test_generation/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/test_generation/refund_policy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/test_generation/refund_policy_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/test_other_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/test_simple_math.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/fixtures/updated_simple_math_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/isolated_verify.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/prompt_tester.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/regression.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/regression_public.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/scripts/source_set_repair_cli_smoke.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/conftest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/routes/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/routes/conftest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/routes/test_architecture.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/routes/test_auth.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/routes/test_commands.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/routes/test_config.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/routes/test_extracts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/routes/test_files.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/routes/test_prompts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/routes/test_routes_init.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/routes/test_websocket.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/test___init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/test_app.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/test_click_executor.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/test_executor.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/test_jobs.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/test_models.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/test_security.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/test_terminal_spawner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/server/test_token_counter.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression/test_story_pdd_bug.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression/test_story_pdd_change.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression/test_story_pdd_checkup.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression/test_story_pdd_connect.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression/test_story_pdd_fix.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression/test_story_pdd_generate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression/test_story_pdd_story_gate_identity.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression/test_story_pdd_sync.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression/test_story_pdd_test.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression/test_story_pdd_top_flows.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression/test_story_pdd_update.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/story_regression.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/sync_regression.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/sync_regression_parallel.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_739_complete.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_739_e2e_synthetic.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_739_fixtures.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_arch_complexity_prompt.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_architecture.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_architecture_orchestrator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_bug.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_bug_orchestrator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_bug_orchestrator_1.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_bug_orchestrator_step_comments.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_bug_step10_prompt.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_bug_step11_prompt.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_bug_step7_prompt.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_change.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_change_orchestrator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_checkup.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_checkup_orchestrator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_checkup_step5_pass_evidence.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_common.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_common_issue_813_anthropic_api_key_oauth_shadow.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_common_worktree.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_config_benchmark.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_config_benchmark_integration.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_crash.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_e2e_fix.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_e2e_fix_orchestrator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_e2e_fix_orchestrator_resume_prompt.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_e2e_fix_step10_prompt.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_fix.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_issue_route_prompt.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_langtest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_multishot.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_split.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_split_orchestrator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_split_real.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_split_v2.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_sync.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_sync_fallback_realgit.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_sync_mocked_e2e.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_sync_nearest_config.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_sync_runner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_test.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_test_generate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_test_orchestrator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_update.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_agentic_verify.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_antigravity_provider.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_api_contract_slicer.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_api_key_scanner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_architecture.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_architecture_include_validation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_architecture_registry.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_architecture_sync.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_auth_service.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_auto_deps_architecture.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_auto_deps_entry_wipe.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_auto_deps_lock.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_auto_deps_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_auto_heal_workflow.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_auto_include.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_auto_update.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_balance_chunks.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_bug_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_bug_to_unit_test.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_change.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_change_call_site_and_retry.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_change_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_agent.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_artifact_hygiene.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_freshness_lease_integration.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_gates.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_interactive.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_interactive_session.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_interactive_session_spike.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_pr_mode.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_prompt_apply.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_prompt_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_report.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_review_loop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_simplify_engines.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_checkup_target.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_ci_detect_changed_modules.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_ci_drift_heal.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_ci_drift_heal_e2e.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_ci_validation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_circular_includes.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_cli_binary_isolation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_cli_detector.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_cli_status.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_cli_theme.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_cloud_batch_job_templates.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_cloud_batch_source_upload.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_cloud_noninteractive_auth.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_cmd_test_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_code_generator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_code_generator_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_code_patcher_prompt_json_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_codex_subscription.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_commands_auth.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_commands_firecrawl.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_commands_fix.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_commands_generate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_commands_maintenance.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_commands_modify.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_commands_templates.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_commands_utility.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_comment_line.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_compressed_sync_context.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_conflicts_in_prompts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_conflicts_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_construct_paths.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_content_selector.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_context_audit.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_context_compression.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_context_example_isolation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_context_generator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_context_generator_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_context_snapshot.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_context_snapshot_policy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_context_snapshot_replay.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_context_token_colors.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_continue_generation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_contract_check.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_copy_package_data_to_public.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_core_dump.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_core_errors.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_core_utils.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_coverage_contracts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_crash_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_cross_step_consistency_prompts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_cross_unit_story_coverage.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_detect_change.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_detect_change_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_discover_associated_documents.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_drift_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_duplicate_cli_guard.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_durable_sync_runner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_auto_deps_pipeline.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_bug_step9_verification.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_change_cli_json_artifacts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_1201_output_paths.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_1205_example_output_extension.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_1211_parent_dir_path.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_1827_zai_integration.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_219_duplicate_includes.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_295_openai_schema.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_296_custom_csv.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_305_false_success.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_309_oauth_rate_limit.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_319_json_braces.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_340_report_core_no_default.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_342_syspath_isolation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_349_sys_modules_pollution.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_357_step9_keyerror.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_358_jwt_cache_null.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_364_cumulative_cost.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_373_step5_keyerror.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_375_malformed_json.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_379_auth_null_expires.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_383_commit_intermediate_files.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_399_ssh_url_message.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_419_cli_unpushed_commits.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_419_unpushed_commits.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_426_include_path_validation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_429_prompt_files_in_pr.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_445_worktree_resume.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_448_change_orchestrator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_448_step5_keyerror.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_449_auth_logout_message.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_467_false_cached_steps.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_468_not_a_bug_early_exit.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_469_cleanup_messages.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_469_duplicate_unresolved.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_470_sessions_cleanup_auth_message.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_481_pagination.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_485_warning_false_negative.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_493_update_output_subdir.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_508_budget_test_cost.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_508_sync_budget_tracking.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_509_retry_cost.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_521_circular_includes.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_522_include_fingerprint.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_545_no_changes_to_commit.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_549_format_double_escaping.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_549_other_orchestrators.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_553_circular_includes_non_recursive.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_557_codex_ndjson.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_566_code_fence_tags.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_579_bug_worktree_rerun.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_579_orchestrator_rerun.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_594_preamble_imports.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_604_handler_wiring.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_620_hallucinated_imports.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_626_nextjs_rendering_model.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_686_anthropic_cost_double_count.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_687_postprocess_model_name.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_737_step_completion_markers.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_745_initial_cost_tracking.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_773_hard_stop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_791_e2e_timeout_retry.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_793_test_packing.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_796_typescript_python_validation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_797_typescript_verification.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_817_step5_degenerate_cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_824_artifact_filtering.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_825_param_drop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_830_workflow_stall.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_894.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_902_provider_fallback.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_issue_903_convergence.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_openai_required_array.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_pattern_verification.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_selective_includes.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_selective_includes_integration.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_step11_cleanup_revert.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_story_workflow_1501.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_subprocess_issue_399_ssh_url_message.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_subprocess_issue_541_quiet_flag.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_e2e_subprocess_issue_593_bug_exit_code.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_embed_retrieve.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_estimate_generate_smoke.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_evidence_manifest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_example_error_detection.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_explicit_output_paths.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_extracts_prune.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_failure_classification.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_final_pr_gate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_find_prompt_file.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_find_section.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_firecrawl_cache.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_cli_agentic_fallback_events_contract.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_code_loop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_code_module_errors.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_error_loop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_error_loop_failure_aware.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_error_loop_prompt_contract.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_error_loop_sync_e2e.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_errors_from_unit_tests.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_focus.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_issue_1211_parent_dir_path.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_main_issue_232.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_verification_errors.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_verification_errors_loop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_fix_verification_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_force_local_issue_sync.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_gate_failed_sync.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_gate_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_generate_estimate_accuracy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_generate_model_catalog.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_generate_output_paths.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_generate_output_paths_regression.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_generate_test.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_generate_test_llm_preprocess.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_generation_completion.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_get_comment.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_get_extension.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_get_jwt_token.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_get_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_get_lint_commands.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_get_run_command.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_get_test_command.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_git_porcelain.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_git_update.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_grounding_generate_evidence.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_grounding_policy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_grounding_provenance.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_grounding_test_plan.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_home_isolation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_include_query_extractor.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_increase_tests.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_incremental_code_generator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_incremental_prd_architecture.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_incremental_prd_architecture_real.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_insert_includes.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_install_completion.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_interface_semantics.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1021_reproduction.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1049_reproduction.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1060_pollution.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1080_porcelain_scope_guards.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1203_breaker.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1212_reproduction.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1240_generate_prompt_meta_framing.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1272_cloud_timeout.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1558_semantic_contracts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1612_sibling_guards.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1677_canonical_module_resolution.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1714_no_progress_watchdog.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1714_sync_stall.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_1872_reproduction.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_225_paths_and_includes.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_237.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_417_regression_hardening.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_467_all_orchestrators.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_469_duplicate_unresolved.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_592_failing_case.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_600_agentic_weaknesses.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_633_reproduction.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_67.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_67_expansion.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_686_post_process_args_braces.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_737_step_completion_markers.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_791_reproduction.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_794_anti_tdd_and_test_discovery.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_794_repro.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_826_snapshot_touchpoint.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_830_contract_summary_touchpoint.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_830_remaining_fixes.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_865_reproduction.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_876_compress_wiring.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_876_compressed_few_shot.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_894_pytest_output_deadlock.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_902.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_902_prompt_sync.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_926_preserve_comments_directive.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_953_directory_scan_regression.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_jobs_sync_failure_detection.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_json_invocation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_language_extensions.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_list_drift_detection.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_llm_invoke.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_llm_invoke_csv_model_registration.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_llm_invoke_grounding.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_llm_invoke_integration.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_llm_invoke_nested_schema.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_llm_invoke_retry_cost.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_llm_invoke_task_routing.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_llm_invoke_vertex_retry.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_load_prompt_template.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_logo_animation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_metadata_sync.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_mid_run_steer_orchestrator_integration.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_mock_vs_production_fix.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_model_tester.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_nextjs_rendering_model.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_one_session_eval.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_one_session_sync.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_opencode_provider.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_operation_log.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_operation_logging_e2e.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_path_resolution.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_pattern_completeness_verification.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_pddrc_initializer.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_pddrc_true_e2e.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_pin_example_hack.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_post_step_comment_once_real.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_postprocess.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_postprocess_0.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_pre_checkup_gate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_preprocess.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_preprocess_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_preprocess_main_pdd_tags.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_process_csv_change.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_prompt_contract_validation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_prompt_gate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_prompt_gate_integration.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_prompt_lint.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_prompt_repair.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_provider_env_isolation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_provider_manager.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_pytest_output.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_pytest_slicer.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_quiet_flag.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_reasoning.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_release_video.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_release_video_discord_backfill.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_remote_command_completion.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_remote_session.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_render_mermaid.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_report.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_research_prompt_web_tools.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_resolved_sync_unit.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_routing_policy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_selector_parse.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_server_routes_prompts.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_server_spawn.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_setup_tool.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sops_release_env.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_source_set_model.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_space_path_support.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_split.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_split_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_split_seam_resolution.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_split_validation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_step11_api_mocking_guidance.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_story_backfill_cross_unit_flows.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_story_backfill_top_flows.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_story_backfill_unit_like_flows.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_story_coverage.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_story_regression.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_story_regression_gate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_story_summary_conftest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_story_test_generation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_story_test_generator.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_structural_test_guard.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_structural_test_guard_integration.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_summarize_directory.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_animation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_animation_0.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_animation_e2e.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_animation_phases.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_backward_compat.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_code_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_contract_matrix.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_certificate.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_certificate_verifier.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_classifier.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_cli.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_evidence_store.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_fingerprint_store.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_identity_path_policy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_includes.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_language.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_lifecycle_scenarios.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_manifest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_pdd_rollout_policy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_planner_capabilities.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_released_checker.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_reporting.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_runner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_snapshot.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_transaction.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_trust.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_verification_profiles.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_determine_operation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_graph_order_consistency.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_orchestration.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_order.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_phase_marker_contract.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_target_coverage_infinite_loop.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_template_prompt_discovery.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_tui.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_template_expander.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_template_registry.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_test_context_packer.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_thread_safe_redirector.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_time_reasoning_effort_env.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_trace.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_trace_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_track_cost.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_unfinished_prompt.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_update_command.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_update_main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_update_model_costs.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_update_prompt.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_user_story_tests.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_validate_behavioral_test.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_version.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_waiver_policy.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_which.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_xml_tagger.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_z3_prompt_test_correspondence.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/validate_behavioral_test.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/agentic_bug_orchestrator_agentic_common.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/agentic_checkup_orchestrator.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/agentic_common.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/agentic_sync_runner_code_generator_main.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/coverage_contracts_story_regression_user_story_tests.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_agentic_provider_fallback_status.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_architecture_dependency_order.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_bug.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_bug_fix_verification.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_change.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_checkup.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_checkup_coverage_evidence.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_ci_validation_fix_loop.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_cli_mode_guardrails.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_connect.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_context_compression_manifest.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_contracts_check_gate.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_estimate_side_effect_free.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_feature_change_pr.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_fix.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_generate.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_issue_routing_source_truth.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_prd_generate_sync.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_preprocess_snapshot_reproducibility.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_story_contract_hash_sync.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_story_gate_identity.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_story_test_coverage.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_sync.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_sync_conflict_safe_update.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_test.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_update.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/pdd_update_metadata_sync.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/story_coverage.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/contracts/template.contract.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__agentic_bug_orchestrator_agentic_common.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__agentic_checkup_orchestrator.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__agentic_common.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__agentic_sync_runner_code_generator_main.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__coverage_contracts_story_regression_user_story_tests.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_agentic_provider_fallback_status.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_architecture_dependency_order.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_bug.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_bug_fix_verification.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_change.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_checkup.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_checkup_coverage_evidence.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_ci_validation_fix_loop.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_cli_mode_guardrails.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_connect.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_context_compression_manifest.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_contracts_check_gate.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_estimate_side_effect_free.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_feature_change_pr.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_fix.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_generate.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_issue_routing_source_truth.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_prd_generate_sync.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_preprocess_snapshot_reproducibility.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_story_contract_hash_sync.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_story_gate_identity.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_story_test_coverage.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_sync.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_sync_conflict_safe_update.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_test.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_update.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__pdd_update_metadata_sync.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__story_coverage.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "user_stories/story__template.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/context/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/context/definitions_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/context/handlers_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/context/main_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/context/regenerate_test_files.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/context/runner_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/context/server_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/generate_prompt.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/generate_python.sh",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/pdd_mcp_server/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/pdd_mcp_server/main.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/pdd_mcp_server/server.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/pdd_mcp_server/tools/__init__.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/pdd_mcp_server/tools/api_key_check.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/pdd_mcp_server/tools/definitions.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/pdd_mcp_server/tools/handlers.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/pdd_mcp_server/tools/runner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/prompts/README_md.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/prompts/definitions_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/prompts/generate_prompt.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/prompts/handlers_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/prompts/io_dependencies.csv",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/prompts/io_dependencies_csv.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/prompts/main_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/prompts/mcp_architecture.csv",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/prompts/mcp_architecture_csv.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/prompts/requirements_txt.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/prompts/runner_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/prompts/server_python.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/requirements.txt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/mcp/tests/test_mcp_client.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/run_generated.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/.gitignore",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/.vscode/launch.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/.vscodeignore",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/AGENTS.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/CHANGELOG.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/LICENSE.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/Makefile",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/README.md",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/examples/pddInstaller_example.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/images/icon.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/images/icon.svg",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/images/video-thumb.png",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/language-configuration.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/out/extension.js",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/out/extension.js.map",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/out/pddInstaller.js",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/out/pddInstaller.js.map",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/package-lock.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/package.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/prompts/extension_typescript.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/prompts/pddInstaller_typescript.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/prompts/prompt.tmLanguage_json.prompt",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/scripts/generate-video-thumb.mjs",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/scripts/render-icon.mjs",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/src/extension.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/src/pddInstaller.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/syntaxes/prompt.tmLanguage.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/tests/test_extension.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/tests/test_pddInstaller.ts",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/tsconfig.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "utils/vscode_prompt/vsc-extension-quickstart.md",
+      "role": "human-maintained"
+    }
+  ]
+}

--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -5871,6 +5871,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/signer_process.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "pdd/sync_core/snapshot.py",
       "role": "human-maintained"
     },

--- a/pdd/sync_core/decommission.py
+++ b/pdd/sync_core/decommission.py
@@ -3,11 +3,19 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
 
 from .git_io import read_git_blob
 from .types import UnitId
+
+if TYPE_CHECKING:
+    from .manifest import OwnershipRule, UnitManifest
+
+
+_EXPECTED_MANAGED_PATH = PurePosixPath(".pdd/expected-managed.json")
+_OWNERSHIP_PATH = PurePosixPath(".pdd/sync-ownership.json")
 
 
 @dataclass(frozen=True)
@@ -100,3 +108,61 @@ def load_expected_registry(
             raise ValueError("expected-managed registry contains a duplicate unit")
         units.add(unit)
     return units
+
+
+def control_transition_invalid(
+    root: Path,
+    base_ref: str,
+    head_ref: str,
+    base_ownership: tuple[OwnershipRule, ...],
+    head_ownership: tuple[OwnershipRule, ...],
+) -> list[str]:
+    """Reject removal or weakening of protected denominator controls."""
+    invalid: list[str] = []
+    base_ownership_blob = read_git_blob(root, base_ref, _OWNERSHIP_PATH)
+    head_ownership_blob = read_git_blob(root, head_ref, _OWNERSHIP_PATH)
+    if base_ownership_blob is not None and head_ownership_blob is None:
+        invalid.append(f"{head_ref}: protected sync ownership policy is missing")
+    elif base_ownership_blob is not None:
+        removed = set(base_ownership) - set(head_ownership)
+        for rule in sorted(removed, key=lambda item: item.pattern):
+            invalid.append(
+                f"{head_ref}: protected sync ownership rule was removed or weakened: "
+                f"{rule.pattern}"
+            )
+
+    base_expected = read_git_blob(root, base_ref, _EXPECTED_MANAGED_PATH)
+    head_expected = read_git_blob(root, head_ref, _EXPECTED_MANAGED_PATH)
+    if base_expected is not None and head_expected is None:
+        invalid.append(f"{head_ref}: protected expected-managed registry is missing")
+    return invalid
+
+
+def enforce_head_fixed_point(
+    transition: UnitManifest,
+    stable_head: UnitManifest,
+    control_invalid: list[str],
+) -> UnitManifest:
+    """Require the candidate head to be a valid next protected base."""
+    invalid = list(transition.invalid_reasons)
+    invalid.extend(control_invalid)
+    invalid.extend(
+        f"{stable_head.head_ref}: fixed-point: {reason}"
+        for reason in stable_head.invalid_reasons
+    )
+    stable_managed = {unit.unit_id for unit in stable_head.managed_units}
+    if stable_managed != set(stable_head.expected_managed):
+        invalid.append(
+            f"{stable_head.head_ref}: fixed-point managed units do not match "
+            "the protected expected-managed registry"
+        )
+    return replace(
+        transition,
+        invalid_reasons=tuple(invalid),
+        unaccounted_tracked_paths=tuple(
+            sorted(
+                set(transition.unaccounted_tracked_paths)
+                | set(stable_head.unaccounted_tracked_paths)
+            )
+        ),
+    )

--- a/pdd/sync_core/finalize.py
+++ b/pdd/sync_core/finalize.py
@@ -275,6 +275,15 @@ def finalize_unit(
     manifest = build_unit_manifest(
         repository_root, base_ref=base_sha, head_ref=head_sha
     )
+    managed_ids = {unit.unit_id for unit in manifest.managed_units}
+    if (
+        manifest.invalid_reasons
+        or manifest.unaccounted_tracked_paths
+        or managed_ids != set(manifest.expected_managed)
+    ):
+        raise ValueError(
+            "canonical finalization requires a valid protected candidate manifest"
+        )
     matches = [
         unit
         for unit in manifest.managed_units

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -15,6 +15,8 @@ import yaml
 
 from .decommission import (
     DecommissionTombstone,
+    control_transition_invalid,
+    enforce_head_fixed_point,
     load_expected_registry,
     load_tombstones,
 )
@@ -958,29 +960,32 @@ def build_unit_manifest(
     base = _tree_manifest(
         repository_root, base_ref, repository_id, language_registry, ownership
     )
-    head = _tree_manifest(
-        repository_root,
-        head_ref,
-        repository_id,
-        language_registry,
-        ownership,
-        set(base.entries),
-    )
+    head = _tree_manifest(repository_root, head_ref, repository_id,
+                          language_registry, ownership, set(base.entries))
     try:
         tombstones = load_tombstones(repository_root, base_ref)
-        load_tombstones(repository_root, head_ref)
+        head_tombstones = load_tombstones(repository_root, head_ref)
         expected_registry = load_expected_registry(
             repository_root, base_ref, repository_id
         )
-        load_expected_registry(repository_root, head_ref, repository_id)
+        head_expected_registry = load_expected_registry(
+            repository_root, head_ref, repository_id
+        )
     except ValueError as exc:
         raise ManifestError(str(exc)) from exc
-    return _assemble_manifest(
-        repository_id,
-        language_registry.digest(),
-        base,
-        head,
-        tombstones,
-        expected_registry,
-        ownership,
+    transition = _assemble_manifest(repository_id, language_registry.digest(),
+                                    base, head, tombstones, expected_registry,
+                                    ownership)
+    if base_ref == head_ref:
+        return transition
+
+    head_ownership = _ownership_rules(repository_root, head_ref)
+    stable_base = _tree_manifest(repository_root, head_ref, repository_id,
+                                 language_registry, head_ownership)
+    stable = _assemble_manifest(repository_id, language_registry.digest(),
+                                stable_base, stable_base, head_tombstones,
+                                head_expected_registry, head_ownership)
+    control_invalid = control_transition_invalid(
+        repository_root, base_ref, head_ref, ownership, head_ownership
     )
+    return enforce_head_fixed_point(transition, stable, control_invalid)

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -16,6 +16,7 @@ REPOSITORY_ID = "3b4d7b1c-d6cc-4752-ba93-6b98d1a710e0"
 EXPECTED_MANAGED_UNITS = 466
 FOUNDATION_PROFILE_PATHS = {
     "pdd/sync_core/descriptor_store.py",
+    "pdd/sync_core/signer_process.py",
     "pdd/sync_core/supervisor.py",
     "tests/test_sync_core_descriptor_store.py",
 }

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -152,8 +152,9 @@ def test_profile_candidate_accounts_for_foundation_paths_from_protected_base(
         check=True,
         capture_output=True,
     )
-    (root / ".pdd" / "sync-ownership.json").write_bytes(OWNERSHIP_PATH.read_bytes())
-    base = _commit(root, "protected ownership baseline")
+    base = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
 
     (root / ".pdd" / "verification-profiles.json").write_text(
         '{"schema_version": 1, "profiles": []}\n', encoding="utf-8"

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -69,8 +69,8 @@ def test_pdd_protected_inventory_is_complete_and_exact() -> None:
     }
     assert managed_prompt_paths == {path for path, _language in identities}
     tracked = subprocess.check_output(
-        ["git", "ls-tree", "-r", "--name-only", "HEAD"], cwd=ROOT, text=True
-    ).splitlines()
+        ["git", "ls-tree", "-r", "-z", "--name-only", "HEAD"], cwd=ROOT
+    ).decode("utf-8").split("\0")[:-1]
     assert {item.candidate_id.artifact_relpath.as_posix() for item in manifest.candidates} == set(tracked)
 
 

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -14,6 +14,11 @@ EXPECTED_PATH = ROOT / ".pdd" / "expected-managed.json"
 OWNERSHIP_PATH = ROOT / ".pdd" / "sync-ownership.json"
 REPOSITORY_ID = "3b4d7b1c-d6cc-4752-ba93-6b98d1a710e0"
 EXPECTED_MANAGED_UNITS = 466
+FOUNDATION_PROFILE_PATHS = {
+    "pdd/sync_core/descriptor_store.py",
+    "pdd/sync_core/supervisor.py",
+    "tests/test_sync_core_descriptor_store.py",
+}
 
 
 def _git(root: Path, *args: str) -> None:
@@ -134,4 +139,44 @@ def test_pdd_registry_prevents_candidate_denominator_reduction(tmp_path: Path) -
     assert any(
         "removed managed unit lacks" in reason
         for reason in removal_manifest.invalid_reasons
+    )
+
+
+def test_profile_candidate_accounts_for_foundation_paths_from_protected_base(
+    tmp_path: Path,
+) -> None:
+    """A profile candidate cannot supply ownership missing from its protected base."""
+    root = tmp_path / "profile-candidate"
+    subprocess.run(
+        ["git", "clone", "-q", "--no-hardlinks", str(ROOT), str(root)],
+        check=True,
+        capture_output=True,
+    )
+    (root / ".pdd" / "sync-ownership.json").write_bytes(OWNERSHIP_PATH.read_bytes())
+    base = _commit(root, "protected ownership baseline")
+
+    (root / ".pdd" / "verification-profiles.json").write_text(
+        '{"schema_version": 1, "profiles": []}\n', encoding="utf-8"
+    )
+    _git(root, "add", "-f", ".pdd/verification-profiles.json")
+    candidate = _commit(root, "candidate profile rollout")
+
+    manifest = build_unit_manifest(root, base_ref=base, head_ref=candidate)
+    assert manifest.refs.base == base
+    assert manifest.refs.head == candidate
+    assert not FOUNDATION_PROFILE_PATHS.intersection(
+        path.as_posix() for path in manifest.unaccounted_tracked_paths
+    )
+    records = {
+        item.candidate_id.artifact_relpath.as_posix(): item
+        for item in manifest.candidates
+        if item.candidate_id.artifact_relpath.as_posix() in FOUNDATION_PROFILE_PATHS
+    }
+    assert set(records) == FOUNDATION_PROFILE_PATHS
+    assert all(
+        item.inventory.value == "HUMAN_OWNED"
+        and item.candidate_id.role == "human-maintained"
+        and item.ownership_provenance
+        == f"protected-ownership:pdd-maintainers:{path}"
+        for path, item in records.items()
     )

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -6,8 +6,6 @@ import json
 import subprocess
 from pathlib import Path
 
-import pytest
-
 from pdd.sync_core.manifest import build_unit_manifest
 
 
@@ -24,7 +22,16 @@ def _git(root: Path, *args: str) -> None:
 
 def _commit(root: Path, message: str) -> str:
     _git(root, "add", ".")
-    _git(root, "-c", "user.name=PDD test", "-c", "user.email=pdd@example.test", "commit", "-m", message)
+    _git(
+        root,
+        "-c",
+        "user.name=PDD test",
+        "-c",
+        "user.email=pdd@example.test",
+        "commit",
+        "-m",
+        message,
+    )
     return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
 
 
@@ -61,7 +68,10 @@ def test_pdd_protected_inventory_is_complete_and_exact() -> None:
     assert manifest.repository_id == REPOSITORY_ID
     assert not manifest.invalid_reasons
     assert not manifest.unaccounted_tracked_paths
-    assert {(unit.prompt_relpath.as_posix(), unit.language_id) for unit in manifest.expected_managed} == identities
+    assert {
+        (unit.prompt_relpath.as_posix(), unit.language_id)
+        for unit in manifest.expected_managed
+    } == identities
     assert len(manifest.expected_managed) == EXPECTED_MANAGED_UNITS
 
     managed_prompt_paths = {
@@ -71,7 +81,10 @@ def test_pdd_protected_inventory_is_complete_and_exact() -> None:
     tracked = subprocess.check_output(
         ["git", "ls-tree", "-r", "-z", "--name-only", "HEAD"], cwd=ROOT
     ).decode("utf-8").split("\0")[:-1]
-    assert {item.candidate_id.artifact_relpath.as_posix() for item in manifest.candidates} == set(tracked)
+    assert {
+        item.candidate_id.artifact_relpath.as_posix()
+        for item in manifest.candidates
+    } == set(tracked)
 
 
 def test_pdd_registry_prevents_candidate_denominator_reduction(tmp_path: Path) -> None:
@@ -118,4 +131,7 @@ def test_pdd_registry_prevents_candidate_denominator_reduction(tmp_path: Path) -
     removed = _commit(root, "candidate removal")
     removal_manifest = build_unit_manifest(root, base_ref=base, head_ref=removed)
     assert len(removal_manifest.expected_managed) == 2
-    assert any("removed managed unit lacks" in reason for reason in removal_manifest.invalid_reasons)
+    assert any(
+        "removed managed unit lacks" in reason
+        for reason in removal_manifest.invalid_reasons
+    )

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -94,7 +94,7 @@ def test_pdd_protected_inventory_is_complete_and_exact() -> None:
 
 
 def test_pdd_registry_prevents_candidate_denominator_reduction(tmp_path: Path) -> None:
-    """Candidate additions grow the union; removals remain protected debt."""
+    """Candidate additions must persist the denominator; removals remain debt."""
     root = tmp_path / "inventory"
     (root / ".pdd").mkdir(parents=True)
     (root / "prompts").mkdir()
@@ -132,6 +132,32 @@ def test_pdd_registry_prevents_candidate_denominator_reduction(tmp_path: Path) -
     added = _commit(root, "candidate addition")
     addition_manifest = build_unit_manifest(root, base_ref=base, head_ref=added)
     assert len(addition_manifest.expected_managed) == 2
+    assert any(
+        "fixed-point" in reason
+        and "protected expected-managed registry omits base unit" in reason
+        for reason in addition_manifest.invalid_reasons
+    )
+
+    expected = json.loads(
+        (root / ".pdd" / "expected-managed.json").read_text(encoding="utf-8")
+    )
+    expected["units"].append(
+        {"prompt_path": "prompts/added_python.prompt", "language_id": "python"}
+    )
+    (root / ".pdd" / "expected-managed.json").write_text(
+        json.dumps(expected), encoding="utf-8"
+    )
+    registered = _commit(root, "persist candidate denominator")
+    registered_manifest = build_unit_manifest(root, base_ref=base, head_ref=registered)
+    stable_manifest = build_unit_manifest(
+        root, base_ref=registered, head_ref=registered
+    )
+    assert not registered_manifest.invalid_reasons
+    assert not registered_manifest.unaccounted_tracked_paths
+    assert not stable_manifest.invalid_reasons
+    assert not stable_manifest.unaccounted_tracked_paths
+    assert len(registered_manifest.expected_managed) == 2
+    assert len(stable_manifest.expected_managed) == 2
 
     _git(root, "rm", "prompts/owned_python.prompt")
     removed = _commit(root, "candidate removal")
@@ -141,6 +167,74 @@ def test_pdd_registry_prevents_candidate_denominator_reduction(tmp_path: Path) -
         "removed managed unit lacks" in reason
         for reason in removal_manifest.invalid_reasons
     )
+
+
+def test_candidate_cannot_delete_protected_denominator_controls(
+    tmp_path: Path,
+) -> None:
+    """A head without either protected manifest cannot become the next base."""
+    root = tmp_path / "deleted-controls"
+    (root / ".pdd").mkdir(parents=True)
+    (root / "prompts").mkdir()
+    (root / ".pdd" / "repository-id").write_text(
+        f"{REPOSITORY_ID}\n", encoding="ascii"
+    )
+    (root / ".pdd" / "expected-managed.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "units": [
+                    {
+                        "prompt_path": "prompts/owned_python.prompt",
+                        "language_id": "python",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / ".pdd" / "sync-ownership.json").write_text(
+        json.dumps(
+            {
+                "rules": [
+                    {
+                        "pattern": "README.md",
+                        "inventory": "HUMAN_OWNED",
+                        "role": "human-maintained",
+                        "owner": "pdd-maintainers",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "prompts" / "owned_python.prompt").write_text(
+        "owned", encoding="utf-8"
+    )
+    (root / "README.md").write_text("human", encoding="utf-8")
+    _git(root, "init", "-q")
+    base = _commit(root, "protected baseline")
+
+    _git(
+        root,
+        "rm",
+        ".pdd/expected-managed.json",
+        ".pdd/sync-ownership.json",
+    )
+    deleted = _commit(root, "delete protected controls")
+    transition = build_unit_manifest(root, base_ref=base, head_ref=deleted)
+    stable = build_unit_manifest(root, base_ref=deleted, head_ref=deleted)
+
+    assert any(
+        "protected sync ownership policy is missing" in reason
+        for reason in transition.invalid_reasons
+    )
+    assert any(
+        "protected expected-managed registry is missing" in reason
+        for reason in transition.invalid_reasons
+    )
+    assert Path("README.md") in transition.unaccounted_tracked_paths
+    assert Path("README.md") in stable.unaccounted_tracked_paths
 
 
 def test_profile_candidate_accounts_for_foundation_paths_from_protected_base(

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -47,7 +47,7 @@ def test_pdd_protected_inventory_is_complete_and_exact() -> None:
     assert all(
         row.keys() == {"pattern", "inventory", "role", "owner"}
         and row["inventory"] == "HUMAN_OWNED"
-        and row["role"] == "human-maintained"
+        and row["role"] in {"human-maintained", "excluded-project"}
         and row["owner"] == "pdd-maintainers"
         and not any(token in row["pattern"] for token in ("*", "?", "["))
         for row in ownership["rules"]

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -1,0 +1,121 @@
+"""Protected PDD inventory rollout policy tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from pdd.sync_core.manifest import build_unit_manifest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_PATH = ROOT / ".pdd" / "expected-managed.json"
+OWNERSHIP_PATH = ROOT / ".pdd" / "sync-ownership.json"
+REPOSITORY_ID = "3b4d7b1c-d6cc-4752-ba93-6b98d1a710e0"
+EXPECTED_MANAGED_UNITS = 466
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=root, check=True, capture_output=True)
+
+
+def _commit(root: Path, message: str) -> str:
+    _git(root, "add", ".")
+    _git(root, "-c", "user.name=PDD test", "-c", "user.email=pdd@example.test", "commit", "-m", message)
+    return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+
+
+def test_pdd_protected_inventory_is_complete_and_exact() -> None:
+    """The committed PDD tree has a non-waived protected inventory partition."""
+    assert EXPECTED_PATH.is_file(), "missing protected expected-managed registry"
+    assert OWNERSHIP_PATH.is_file(), "missing protected sync ownership policy"
+
+    expected = json.loads(EXPECTED_PATH.read_text(encoding="utf-8"))
+    ownership = json.loads(OWNERSHIP_PATH.read_text(encoding="utf-8"))
+    assert expected.keys() == {"schema_version", "units"}
+    assert expected["schema_version"] == 1
+    assert isinstance(expected["units"], list) and expected["units"]
+    assert all(set(row) == {"prompt_path", "language_id"} for row in expected["units"])
+    identities = {(row["prompt_path"], row["language_id"]) for row in expected["units"]}
+    assert len(identities) == len(expected["units"]) == EXPECTED_MANAGED_UNITS
+
+    assert ownership.keys() == {"rules"}
+    assert isinstance(ownership["rules"], list) and ownership["rules"]
+    assert all(
+        row.keys() == {"pattern", "inventory", "role", "owner"}
+        and row["inventory"] == "HUMAN_OWNED"
+        and row["role"] == "human-maintained"
+        and row["owner"] == "pdd-maintainers"
+        and not any(token in row["pattern"] for token in ("*", "?", "["))
+        for row in ownership["rules"]
+    )
+
+    assert not (ROOT / ".pdd" / "sync-waivers.json").exists()
+    assert not (ROOT / ".pdd" / "verification-profiles.json").exists()
+    assert not (ROOT / ".pdd" / "attestation-trust.json").exists()
+
+    manifest = build_unit_manifest(ROOT, base_ref="HEAD", head_ref="HEAD")
+    assert manifest.repository_id == REPOSITORY_ID
+    assert not manifest.invalid_reasons
+    assert not manifest.unaccounted_tracked_paths
+    assert {(unit.prompt_relpath.as_posix(), unit.language_id) for unit in manifest.expected_managed} == identities
+    assert len(manifest.expected_managed) == EXPECTED_MANAGED_UNITS
+
+    managed_prompt_paths = {
+        unit.unit_id.prompt_relpath.as_posix() for unit in manifest.managed_units
+    }
+    assert managed_prompt_paths == {path for path, _language in identities}
+    tracked = subprocess.check_output(
+        ["git", "ls-tree", "-r", "--name-only", "HEAD"], cwd=ROOT, text=True
+    ).splitlines()
+    assert {item.candidate_id.artifact_relpath.as_posix() for item in manifest.candidates} == set(tracked)
+
+
+def test_pdd_registry_prevents_candidate_denominator_reduction(tmp_path: Path) -> None:
+    """Candidate additions grow the union; removals remain protected debt."""
+    root = tmp_path / "inventory"
+    (root / ".pdd").mkdir(parents=True)
+    (root / "prompts").mkdir()
+    (root / ".pdd" / "repository-id").write_text(f"{REPOSITORY_ID}\n", encoding="ascii")
+    (root / ".pdd" / "expected-managed.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "units": [{"prompt_path": "prompts/owned_python.prompt", "language_id": "python"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / ".pdd" / "sync-ownership.json").write_text(
+        json.dumps(
+            {
+                "rules": [
+                    {
+                        "pattern": "README.md",
+                        "inventory": "HUMAN_OWNED",
+                        "role": "human-maintained",
+                        "owner": "pdd-maintainers",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "prompts" / "owned_python.prompt").write_text("owned", encoding="utf-8")
+    (root / "README.md").write_text("human", encoding="utf-8")
+    _git(root, "init", "-q")
+    base = _commit(root, "protected baseline")
+
+    (root / "prompts" / "added_python.prompt").write_text("added", encoding="utf-8")
+    added = _commit(root, "candidate addition")
+    addition_manifest = build_unit_manifest(root, base_ref=base, head_ref=added)
+    assert len(addition_manifest.expected_managed) == 2
+
+    _git(root, "rm", "prompts/owned_python.prompt")
+    removed = _commit(root, "candidate removal")
+    removal_manifest = build_unit_manifest(root, base_ref=base, head_ref=removed)
+    assert len(removal_manifest.expected_managed) == 2
+    assert any("removed managed unit lacks" in reason for reason in removal_manifest.invalid_reasons)

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -563,6 +563,48 @@ def test_trusted_finalizer_commits_artifact_closure_evidence_and_fingerprint(
     assert report["counts"]["trusted_in_sync"] == 1
 
 
+def test_trusted_finalizer_rejects_invalid_next_protected_base(tmp_path) -> None:
+    """Per-unit finalization cannot bypass invalid protected controls."""
+    root, _commit = _repository(tmp_path)
+    (root / ".pdd/expected-managed.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "units": [
+                    {
+                        "prompt_path": "prompts/widget_python.prompt",
+                        "language_id": "python",
+                    }
+                ],
+            }
+        )
+    )
+    _git(root, "add", ".pdd/expected-managed.json")
+    _git(root, "commit", "-q", "-m", "protect managed denominator")
+    base = _git(root, "rev-parse", "HEAD")
+    _git(
+        root,
+        "rm",
+        ".pdd/expected-managed.json",
+        ".pdd/sync-ownership.json",
+    )
+    _git(root, "commit", "-q", "-m", "delete protected controls")
+    head = _git(root, "rev-parse", "HEAD")
+
+    with pytest.raises(
+        ValueError,
+        match="canonical finalization requires a valid protected candidate manifest",
+    ):
+        finalize_unit(
+            root,
+            PurePosixPath("prompts/widget_python.prompt"),
+            base_ref=base,
+            head_ref=head,
+            signer=SIGNER,
+            replay_ledger_path=tmp_path / "external-trust/invalid-base.json",
+        )
+
+
 def test_trusted_finalizer_second_run_is_zero_write_no_op(tmp_path) -> None:
     root, commit = _repository(tmp_path)
     replay = tmp_path / "external-trust/idempotency.json"


### PR DESCRIPTION
## Summary

Establishes the PDD protected inventory authority only. This is the first bootstrap tranche: no profiles, fingerprints, evidence, waivers, baselines, workflow activation, or verification claim are included.

## Investigation

- Read the canonical manifest/decommission/ownership schemas and the pdd_cloud precedent: `39b78e487` / `57cf48246` (expected registry) and `be6ea76d2`, `726e2ac35`, `385e27b8e` (ownership policy).
- Canonical exact-tree scan reconciles syntactic prompt files with architecture ownership: 631 syntactic prompt candidates become 466 PDD managed units under `pdd/prompts`; historical context, examples, fixtures, demos, and utilities are explicitly human-owned.
- Historical nested architecture fixtures are explicitly `excluded-project`; their prompt mappings are not silently treated as PDD product units.
- Ownership uses exact tracked paths only. There are no catch-all rules, so future paths are uncovered until reviewed.

## TDD

Red commit `763bed6a1`: `pytest -q tests/test_sync_core_pdd_rollout_policy.py` failed with `missing protected expected-managed registry` (1 failed, 1 passed).

Green after protected data: `pytest -q tests/test_sync_core_pdd_rollout_policy.py` passes (2 passed). The test validates registry/policy schemas, unique nonzero exact identities, complete tracked-path accounting, no waiver/profile/trust files, representative path coverage, and base/head candidate addition/removal denominator behavior.

## Exact Inventory

- 466 expected-managed and currently managed units
- 3,010 tracked paths
- 656 managed candidate paths
- 2,354 explicit human-owned candidate paths
- 0 unaccounted and 0 manifest-invalid paths
- Two read-only canonical manifest runs produced the same digest: `67c37a835fd6ddae4f4dac0776ef9e41024fca2872a3ec23aa903dd423ec84ee`

## Remaining Rollout Debt

The canonical report is intentionally not activatable in this PR. Complete verification profiles, fingerprints/baselines, trusted evidence, and protected enforcement remain follow-up work. A read-only `pdd sync certify --base-ref HEAD --head-ref HEAD` diagnostic remains red before profile evaluation on an existing prompt include glob rejected by Python 3.12 (`Invalid pattern: ** can only be an entire path component`); this PR does not alter that production behavior.

## Verification

- `pytest -q tests/test_sync_core_pdd_rollout_policy.py`
- Two read-only `build_unit_manifest(..., base_ref=HEAD, head_ref=HEAD)` diagnostics
- `git diff --check origin/codex/issue-1932-verifiable-goal...HEAD`

Rebased onto foundation head `8a8cf5137` and pushed with `--force-with-lease`.