### PR TITLE
fix(release): harden CLI gate prompt and auth

### DIFF
--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -217,7 +217,8 @@ elif [ "${TASK_INDEX}" -ge "${PYTEST_START}" ] && [ "${TASK_INDEX}" -le "${PYTES
 fi
 
 if [ "${NEEDS_PDD_JWT}" = "1" ] && [ -n "${PDD_REFRESH_TOKEN:-}" ] && [ -n "${FIREBASE_API_KEY:-}" ]; then
-    JWT_MAX_ATTEMPTS=4
+    JWT_MAX_ATTEMPTS=6
+    JWT_QUOTA_BACKOFF_SECONDS=30
     JWT_ATTEMPT=0
     JWT_LAST_ERROR=""
     JWT_INITIAL_DELAY=$(( (TASK_INDEX * 7) % 30 + RANDOM % 5 ))
@@ -299,9 +300,15 @@ else:
 
         JWT_LAST_ERROR="${JWT_ERROR}"
         if [ "${JWT_ATTEMPT}" -lt "${JWT_MAX_ATTEMPTS}" ]; then
-            # Backoff 2/4/8s base + 0-2s jitter to scatter concurrent retries
-            # across sibling Cloud Batch tasks (avoids re-creating the herd).
-            JWT_BACKOFF=$((2 ** JWT_ATTEMPT + RANDOM % 3))
+            # Firebase quota exhaustion needs a longer cooldown than ordinary
+            # transport/parser transients. Keep jitter so overlapping release
+            # gates do not retry on the same boundary.
+            if [ "${JWT_ERROR}" = "QUOTA_EXCEEDED" ]; then
+                JWT_BACKOFF=$((JWT_QUOTA_BACKOFF_SECONDS + RANDOM % 6))
+            else
+                # Generic backoff: 2/4/8/16/32s base + 0-2s jitter.
+                JWT_BACKOFF=$((2 ** JWT_ATTEMPT + RANDOM % 3))
+            fi
             echo "WARNING: JWT exchange attempt ${JWT_ATTEMPT}/${JWT_MAX_ATTEMPTS} failed (${JWT_ERROR}); retrying in ${JWT_BACKOFF}s"
             sleep "${JWT_BACKOFF}"
         fi

--- a/pdd/prompts/change_LLM.prompt
+++ b/pdd/prompts/change_LLM.prompt
@@ -34,6 +34,7 @@
     Step 2. Explain in detail step by step what changes need to be made to the input_prompt to generate the modified_prompt based on Step 1. This step describes how to modify the input_prompt to generate the modified_prompt.
         - When introducing retry, reset, or loop-back logic, always specify a maximum retry count and define fallback behavior when retries are exhausted.
     Step 3. Generate the modified_prompt based on Step 2. Except for the change, the rest of the existing functionality of the input_prompt should remain. Structure the prompt similar to the example prompts, especially including the descriptions of the inputs and outputs.
+        - If Step 1 found call sites affected by a behavior or return-value change, the final modified_prompt itself must name every affected call site and state how each caller must adapt to the changed behavior, including how it must unpack, check, or use changed return values. Do not leave caller-handling requirements only in your Step 1 or Step 2 explanation.
         - If Step 2 introduced retry, reset, or loop-back logic, the final modified_prompt itself must include a concrete numeric retry limit and exhausted-retry fallback behavior. Do not leave those safety constraints only in your Step 2 explanation. If the change_prompt does not specify a number, choose a conservative default such as "maximum of 3 attempts" and state what to do after all attempts fail.
 
     IMPORTANT: Output the modified prompt between these exact delimiters:

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -254,6 +254,13 @@ pipeline.
 class TestDeterministicChangeJudges:
     """Unit coverage for release-gate judges used by the real LLM tests."""
 
+    def test_change_prompt_requires_call_site_safety_in_final_prompt(self) -> None:
+        template = Path("pdd/prompts/change_LLM.prompt").read_text(encoding="utf-8")
+
+        assert "final modified_prompt itself" in template
+        assert "name every affected call site" in template
+        assert "how each caller must adapt" in template
+
     def test_change_prompt_requires_retry_safety_in_final_prompt(self) -> None:
         template = Path("pdd/prompts/change_LLM.prompt").read_text(encoding="utf-8")
 

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -255,6 +255,7 @@ class TestDeterministicChangeJudges:
     """Unit coverage for release-gate judges used by the real LLM tests."""
 
     def test_change_prompt_requires_call_site_safety_in_final_prompt(self) -> None:
+        """The final prompt contract must carry call-site adaptations forward."""
         template = Path("pdd/prompts/change_LLM.prompt").read_text(encoding="utf-8")
 
         assert "final modified_prompt itself" in template
@@ -356,7 +357,8 @@ class TestCallSiteEnumeration:
         judgment = _judge_call_site_names(modified_prompt)
         assert judgment.passed, (
             f"LLM did not enumerate all 4 call sites. "
-            f"Judge: {judgment.reasoning} | Model: {model}, cost: ${cost:.4f}"
+            f"Judge: {judgment.reasoning} | Model: {model}, cost: ${cost:.4f} | "
+            f"Output excerpt: {modified_prompt[:1000]}"
         )
 
 

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -157,6 +157,17 @@ def test_cloud_batch_entrypoint_scopes_jwt_exchange_to_cloud_regression():
     assert "Skipping PDD JWT exchange" in entrypoint_text
 
 
+def test_cloud_batch_entrypoint_extends_quota_retry_horizon():
+    """Quota exhaustion must cool down longer than generic transient errors."""
+    entrypoint_text = (
+        REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "JWT_MAX_ATTEMPTS=6" in entrypoint_text
+    assert "JWT_QUOTA_BACKOFF_SECONDS=30" in entrypoint_text
+    assert '"${JWT_ERROR}" = "QUOTA_EXCEEDED"' in entrypoint_text
+
+
 def test_cloud_batch_entrypoint_forces_pytest_shards_local_by_default():
     entrypoint_text = (
         REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"


### PR DESCRIPTION
## Summary

- require changed return-value call sites to be named and adapted in the final `change` prompt
- extend Firebase Secure Token retries to six attempts
- use a 30-second quota-specific cooldown with jitter
- improve real-LLM failure evidence with the generated prompt excerpt

## Release-gate evidence

The 2026-07-11 gate run `run-20260711-214913-49504fc9a` failed one real-LLM assertion because caller adaptation was omitted and one Firebase exchange with `QUOTA_EXCEEDED`. The clean rerun reproduced quota exhaustion in multiple serialized cloud shards, proving the existing retry window is too short.

## Tests

- red: call-site final-prompt contract
- red: quota cooldown retry contract
- green: 17 targeted deterministic/template tests
- `bash -n ci/cloud-batch/entrypoint.sh`
- full cloud release gate pending this PR review/merge

Follow-up to #939 and the release-gate auth work in #1956 and #1963.