### PR TITLE
fix(sync): preauthorize protected child ownership

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -5787,6 +5787,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/human_attestation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "pdd/sync_core/identity.py",
       "role": "human-maintained"
     },
@@ -11175,6 +11181,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "tests/test_cloud_global_dry_run.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "tests/test_cloud_noninteractive_auth.py",
       "role": "human-maintained"
     },
@@ -11350,6 +11362,12 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_continue_generation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_continuous_sync_path_policy.py",
       "role": "human-maintained"
     },
     {
@@ -13101,6 +13119,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_human_attestation.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "tests/test_sync_core_identity_path_policy.py",
       "role": "human-maintained"
     },
@@ -13156,6 +13180,24 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_sync_core_runner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_runner_jest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_runner_playwright.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_sync_core_runner_vitest.py",
       "role": "human-maintained"
     },
     {

--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -5788,6 +5788,7 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "pdd/sync_core/human_attestation.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
@@ -11182,6 +11183,7 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_cloud_global_dry_run.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
@@ -11368,6 +11370,7 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_continuous_sync_path_policy.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
@@ -13120,6 +13123,7 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_sync_core_human_attestation.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
@@ -13186,18 +13190,21 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_sync_core_runner_jest.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_sync_core_runner_playwright.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_sync_core_runner_vitest.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -646,11 +646,15 @@ def _candidate_records(
     invalid: list[str] = []
     for path in sorted(set(sources.base_entries) | set(sources.head_entries)):
         unit_id = sources.prompt_owner.get(path) or sources.output_owner.get(path)
-        rule, rule_error = (
-            _ownership_for(path, sources.ownership_rules)
-            if path in sources.base_entries
-            else (None, None)
-        )
+        if path in sources.base_entries:
+            rule, rule_error = _ownership_for(path, sources.ownership_rules)
+        else:
+            exact_rules = tuple(
+                item
+                for item in sources.ownership_rules
+                if item.pattern == path.as_posix()
+            )
+            rule, rule_error = _ownership_for(path, exact_rules)
         if path in sources.prompt_owner:
             role = "prompt"
             inventory = InventoryStatus.MANAGED

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -775,12 +775,8 @@ def _ownership_rules(root: Path, protected_base_ref: str) -> tuple[OwnershipRule
             owner = str(item["owner"])
         except (KeyError, ValueError) as exc:
             raise ManifestError("protected ownership rule is malformed") from exc
-        preauthorize_absent = item.get("preauthorize_absent", False)
-        if not isinstance(preauthorize_absent, bool):
-            raise ManifestError("protected ownership rule is malformed")
-        rule = OwnershipRule(
-            pattern, inventory, role, owner, preauthorize_absent
-        )
+        rule = OwnershipRule(pattern, inventory, role, owner,
+                             item.get("preauthorize_absent", False))
         if not _valid_ownership_rule(rule):
             raise ManifestError("protected ownership rule is overly broad or invalid")
         if pattern in patterns:
@@ -792,26 +788,16 @@ def _ownership_rules(root: Path, protected_base_ref: str) -> tuple[OwnershipRule
 
 def _valid_ownership_rule(rule: OwnershipRule) -> bool:
     """Reject catch-all or escaping rules that could hide future managed debt."""
-    path = PurePosixPath(rule.pattern)
-    pattern_valid = (
-        rule.pattern not in {"*", "**", "**/*"}
-        and not rule.pattern.startswith("/")
-        and ".." not in path.parts
-    )
+    pattern_valid = rule.pattern not in {"*", "**", "**/*"} and not rule.pattern.startswith("/")
+    pattern_valid = pattern_valid and ".." not in PurePosixPath(rule.pattern).parts
     identity_valid = bool(rule.role and rule.owner)
-    inventory_valid = rule.inventory in {
-        InventoryStatus.MANAGED,
-        InventoryStatus.HUMAN_OWNED,
-    }
-    absent_authorization_valid = not rule.preauthorize_absent or not any(
-        token in rule.pattern for token in ("*", "?", "[")
-    )
+    inventory_valid = rule.inventory in {InventoryStatus.MANAGED, InventoryStatus.HUMAN_OWNED}
     return (
-        pattern_valid
-        and identity_valid
-        and inventory_valid
-        and absent_authorization_valid
-    )
+        pattern_valid and identity_valid and inventory_valid
+        and isinstance(rule.preauthorize_absent, bool)
+        and (not rule.preauthorize_absent or not any(
+            token in rule.pattern for token in ("*", "?", "[")
+        )))
 
 
 def _tree_manifest(

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -83,6 +83,7 @@ class OwnershipRule:
     inventory: InventoryStatus
     role: str
     owner: str
+    preauthorize_absent: bool = False
 
 
 @dataclass(frozen=True)
@@ -652,7 +653,7 @@ def _candidate_records(
             exact_rules = tuple(
                 item
                 for item in sources.ownership_rules
-                if item.pattern == path.as_posix()
+                if item.preauthorize_absent and item.pattern == path.as_posix()
             )
             rule, rule_error = _ownership_for(path, exact_rules)
         if path in sources.prompt_owner:
@@ -774,7 +775,12 @@ def _ownership_rules(root: Path, protected_base_ref: str) -> tuple[OwnershipRule
             owner = str(item["owner"])
         except (KeyError, ValueError) as exc:
             raise ManifestError("protected ownership rule is malformed") from exc
-        rule = OwnershipRule(pattern, inventory, role, owner)
+        preauthorize_absent = item.get("preauthorize_absent", False)
+        if not isinstance(preauthorize_absent, bool):
+            raise ManifestError("protected ownership rule is malformed")
+        rule = OwnershipRule(
+            pattern, inventory, role, owner, preauthorize_absent
+        )
         if not _valid_ownership_rule(rule):
             raise ManifestError("protected ownership rule is overly broad or invalid")
         if pattern in patterns:
@@ -797,7 +803,15 @@ def _valid_ownership_rule(rule: OwnershipRule) -> bool:
         InventoryStatus.MANAGED,
         InventoryStatus.HUMAN_OWNED,
     }
-    return pattern_valid and identity_valid and inventory_valid
+    absent_authorization_valid = not rule.preauthorize_absent or not any(
+        token in rule.pattern for token in ("*", "?", "[")
+    )
+    return (
+        pattern_valid
+        and identity_valid
+        and inventory_valid
+        and absent_authorization_valid
+    )
 
 
 def _tree_manifest(

--- a/tests/test_sync_core_manifest.py
+++ b/tests/test_sync_core_manifest.py
@@ -522,3 +522,40 @@ def test_absent_preauthorization_rejects_wildcard_pattern(tmp_path) -> None:
 
     with pytest.raises(ManifestError, match="overly broad or invalid"):
         build_unit_manifest(root, base_ref=commit, head_ref=commit)
+
+
+def test_unmarked_absent_exact_rule_does_not_classify_new_head_path(tmp_path) -> None:
+    """Dormant historical rules remain inert without explicit authorization."""
+    root = _repository(tmp_path)
+    policy_path = root / ".pdd/sync-ownership.json"
+    policy = json.loads(policy_path.read_text())
+    policy["rules"].append(
+        {
+            "pattern": "docs/unmarked-future.md",
+            "inventory": "HUMAN_OWNED",
+            "role": "documentation",
+            "owner": "docs@example.com",
+        }
+    )
+    policy_path.write_text(json.dumps(policy))
+    base = _commit(root, "unmarked absent ownership rule")
+
+    docs_path = root / "docs/unmarked-future.md"
+    docs_path.parent.mkdir()
+    docs_path.write_text("candidate addition\n")
+    head = _commit(root, "introduce unmarked path")
+
+    manifest = build_unit_manifest(root, base_ref=base, head_ref=head)
+    candidate = next(
+        item
+        for item in manifest.candidates
+        if item.candidate_id.artifact_relpath
+        == PurePosixPath("docs/unmarked-future.md")
+    )
+    assert candidate.inventory is InventoryStatus.INVALID
+    assert candidate.candidate_id.role == "unaccounted"
+    assert not candidate.in_base and candidate.in_head
+    assert candidate.ownership_provenance == "none"
+    assert PurePosixPath("docs/unmarked-future.md") in (
+        manifest.unaccounted_tracked_paths
+    )

--- a/tests/test_sync_core_manifest.py
+++ b/tests/test_sync_core_manifest.py
@@ -501,3 +501,24 @@ def test_protected_human_pattern_does_not_auto_classify_new_head_path(tmp_path) 
     head = _commit(root, "new file")
     manifest = build_unit_manifest(root, base_ref=base, head_ref=head)
     assert PurePosixPath("docs/new.md") in manifest.unaccounted_tracked_paths
+
+
+def test_absent_preauthorization_rejects_wildcard_pattern(tmp_path) -> None:
+    """Future-path authorization is restricted to one exact protected path."""
+    root = _repository(tmp_path)
+    policy_path = root / ".pdd/sync-ownership.json"
+    policy = json.loads(policy_path.read_text())
+    policy["rules"].append(
+        {
+            "pattern": "docs/**",
+            "inventory": "HUMAN_OWNED",
+            "role": "documentation",
+            "owner": "docs@example.com",
+            "preauthorize_absent": True,
+        }
+    )
+    policy_path.write_text(json.dumps(policy))
+    commit = _commit(root, "wildcard absent preauthorization")
+
+    with pytest.raises(ManifestError, match="overly broad or invalid"):
+        build_unit_manifest(root, base_ref=commit, head_ref=commit)

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -68,7 +68,11 @@ PREAUTHORIZED_CHILD_OWNERSHIP = {
     "inventory": "HUMAN_OWNED",
     "role": "human-maintained",
     "owner": "pdd-maintainers",
+    "preauthorize_absent": True,
 }
+UNMARKED_ABSENT_HISTORICAL_PATH = (
+    "docs/Software Development Costs and Maintenance_ 2022–2025 Trends and AI Impact.md"
+)
 
 
 def _git(root: Path, *args: str) -> None:
@@ -123,10 +127,15 @@ def test_pdd_protected_inventory_is_complete_and_exact() -> None:
     assert ownership.keys() == {"rules"}
     assert isinstance(ownership["rules"], list) and ownership["rules"]
     assert all(
-        row.keys() == {"pattern", "inventory", "role", "owner"}
+        set(row) in (
+            {"pattern", "inventory", "role", "owner"},
+            {"pattern", "inventory", "role", "owner", "preauthorize_absent"},
+        )
         and row["inventory"] == "HUMAN_OWNED"
         and row["role"] in {"human-maintained", "excluded-project"}
         and row["owner"] == "pdd-maintainers"
+        and row.get("preauthorize_absent", False)
+        == (row["pattern"] in PREAUTHORIZED_CHILD_PATHS)
         and not any(token in row["pattern"] for token in ("*", "?", "["))
         for row in ownership["rules"]
     )
@@ -500,6 +509,12 @@ def test_protected_base_pre_authorizes_absent_exact_child_paths(
         }
         for path in PREAUTHORIZED_CHILD_PATHS
     }
+    assert rules[UNMARKED_ABSENT_HISTORICAL_PATH] == {
+        "pattern": UNMARKED_ABSENT_HISTORICAL_PATH,
+        "inventory": "HUMAN_OWNED",
+        "role": "human-maintained",
+        "owner": "pdd-maintainers",
+    }
 
     baseline = build_unit_manifest(ROOT, base_ref="HEAD", head_ref="HEAD")
     baseline_paths = {
@@ -519,7 +534,8 @@ def test_protected_base_pre_authorizes_absent_exact_child_paths(
         ["git", "rev-parse", "HEAD"], cwd=root, text=True
     ).strip()
 
-    for path in PREAUTHORIZED_CHILD_PATHS:
+    simulated_paths = PREAUTHORIZED_CHILD_PATHS | {UNMARKED_ABSENT_HISTORICAL_PATH}
+    for path in simulated_paths:
         child_path = root / path
         child_path.parent.mkdir(parents=True, exist_ok=True)
         child_path.write_text("# preauthorized child path\n", encoding="utf-8")
@@ -540,5 +556,17 @@ def test_protected_base_pre_authorizes_absent_exact_child_paths(
         assert record.ownership_provenance == (
             f"protected-ownership:pdd-maintainers:{path}"
         )
-    assert not manifest.unaccounted_tracked_paths
+    historical = next(
+        item
+        for item in manifest.candidates
+        if item.candidate_id.artifact_relpath.as_posix()
+        == UNMARKED_ABSENT_HISTORICAL_PATH
+    )
+    assert historical.inventory.value == "INVALID"
+    assert historical.candidate_id.role == "unaccounted"
+    assert not historical.in_base and historical.in_head
+    assert historical.ownership_provenance == "none"
+    assert manifest.unaccounted_tracked_paths == (
+        PurePosixPath(UNMARKED_ABSENT_HISTORICAL_PATH),
+    )
     assert len(manifest.expected_managed) == baseline_denominator

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -55,6 +55,20 @@ FOUNDATION_OBLIGATIONS = {
         "code": ("pdd/sync_core/signer_process.py",),
     },
 }
+PREAUTHORIZED_CHILD_PATHS = {
+    "tests/test_sync_core_runner_jest.py",
+    "tests/test_sync_core_runner_vitest.py",
+    "tests/test_sync_core_runner_playwright.py",
+    "tests/test_cloud_global_dry_run.py",
+    "tests/test_continuous_sync_path_policy.py",
+    "pdd/sync_core/human_attestation.py",
+    "tests/test_sync_core_human_attestation.py",
+}
+PREAUTHORIZED_CHILD_OWNERSHIP = {
+    "inventory": "HUMAN_OWNED",
+    "role": "human-maintained",
+    "owner": "pdd-maintainers",
+}
 
 
 def _git(root: Path, *args: str) -> None:
@@ -116,6 +130,8 @@ def test_pdd_protected_inventory_is_complete_and_exact() -> None:
         and not any(token in row["pattern"] for token in ("*", "?", "["))
         for row in ownership["rules"]
     )
+    patterns = [row["pattern"] for row in ownership["rules"]]
+    assert len(patterns) == len(set(patterns))
 
     assert not (ROOT / ".pdd" / "sync-waivers.json").exists()
     assert PROFILE_FILE.is_file()
@@ -466,3 +482,61 @@ def test_profile_candidate_accounts_for_foundation_paths_from_protected_base(
         == f"protected-ownership:pdd-maintainers:{path}"
         for path, item in records.items()
     )
+
+
+def test_protected_base_pre_authorizes_absent_exact_child_paths(
+    tmp_path: Path,
+) -> None:
+    """Known exact base rules safely classify later child-path additions."""
+    ownership = json.loads(OWNERSHIP_PATH.read_text(encoding="utf-8"))
+    rules = {row["pattern"]: row for row in ownership["rules"]}
+    assert {
+        path: rules.get(path)
+        for path in PREAUTHORIZED_CHILD_PATHS
+    } == {
+        path: {
+            "pattern": path,
+            **PREAUTHORIZED_CHILD_OWNERSHIP,
+        }
+        for path in PREAUTHORIZED_CHILD_PATHS
+    }
+
+    baseline = build_unit_manifest(ROOT, base_ref="HEAD", head_ref="HEAD")
+    baseline_paths = {
+        item.candidate_id.artifact_relpath.as_posix()
+        for item in baseline.candidates
+    }
+    assert not PREAUTHORIZED_CHILD_PATHS.intersection(baseline_paths)
+    baseline_denominator = len(baseline.expected_managed)
+
+    root = tmp_path / "preauthorized-child-paths"
+    subprocess.run(
+        ["git", "clone", "-q", "--no-hardlinks", str(ROOT), str(root)],
+        check=True,
+        capture_output=True,
+    )
+    base = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+
+    for path in sorted(PREAUTHORIZED_CHILD_PATHS):
+        child_path = root / path
+        child_path.parent.mkdir(parents=True, exist_ok=True)
+        child_path.write_text("# preauthorized child path\n", encoding="utf-8")
+        _git(root, "add", path)
+        candidate = _commit(root, f"add {path}")
+
+        manifest = build_unit_manifest(root, base_ref=base, head_ref=candidate)
+        record = next(
+            item
+            for item in manifest.candidates
+            if item.candidate_id.artifact_relpath.as_posix() == path
+        )
+        assert record.inventory.value == "HUMAN_OWNED"
+        assert record.candidate_id.role == "human-maintained"
+        assert not record.in_base and record.in_head
+        assert record.ownership_provenance == (
+            f"protected-ownership:pdd-maintainers:{path}"
+        )
+        assert not manifest.unaccounted_tracked_paths
+        assert len(manifest.expected_managed) == baseline_denominator

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -519,24 +519,26 @@ def test_protected_base_pre_authorizes_absent_exact_child_paths(
         ["git", "rev-parse", "HEAD"], cwd=root, text=True
     ).strip()
 
-    for path in sorted(PREAUTHORIZED_CHILD_PATHS):
+    for path in PREAUTHORIZED_CHILD_PATHS:
         child_path = root / path
         child_path.parent.mkdir(parents=True, exist_ok=True)
         child_path.write_text("# preauthorized child path\n", encoding="utf-8")
         _git(root, "add", path)
-        candidate = _commit(root, f"add {path}")
+    candidate = _commit(root, "add preauthorized child paths")
 
-        manifest = build_unit_manifest(root, base_ref=base, head_ref=candidate)
-        record = next(
-            item
-            for item in manifest.candidates
-            if item.candidate_id.artifact_relpath.as_posix() == path
-        )
+    manifest = build_unit_manifest(root, base_ref=base, head_ref=candidate)
+    records = {
+        item.candidate_id.artifact_relpath.as_posix(): item
+        for item in manifest.candidates
+        if item.candidate_id.artifact_relpath.as_posix() in PREAUTHORIZED_CHILD_PATHS
+    }
+    assert set(records) == PREAUTHORIZED_CHILD_PATHS
+    for path, record in records.items():
         assert record.inventory.value == "HUMAN_OWNED"
         assert record.candidate_id.role == "human-maintained"
         assert not record.in_base and record.in_head
         assert record.ownership_provenance == (
             f"protected-ownership:pdd-maintainers:{path}"
         )
-        assert not manifest.unaccounted_tracked_paths
-        assert len(manifest.expected_managed) == baseline_denominator
+    assert not manifest.unaccounted_tracked_paths
+    assert len(manifest.expected_managed) == baseline_denominator

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -70,9 +70,6 @@ PREAUTHORIZED_CHILD_OWNERSHIP = {
     "owner": "pdd-maintainers",
     "preauthorize_absent": True,
 }
-UNMARKED_ABSENT_HISTORICAL_PATH = (
-    "docs/Software Development Costs and Maintenance_ 2022–2025 Trends and AI Impact.md"
-)
 
 
 def _git(root: Path, *args: str) -> None:
@@ -509,13 +506,6 @@ def test_protected_base_pre_authorizes_absent_exact_child_paths(
         }
         for path in PREAUTHORIZED_CHILD_PATHS
     }
-    assert rules[UNMARKED_ABSENT_HISTORICAL_PATH] == {
-        "pattern": UNMARKED_ABSENT_HISTORICAL_PATH,
-        "inventory": "HUMAN_OWNED",
-        "role": "human-maintained",
-        "owner": "pdd-maintainers",
-    }
-
     baseline = build_unit_manifest(ROOT, base_ref="HEAD", head_ref="HEAD")
     baseline_paths = {
         item.candidate_id.artifact_relpath.as_posix()
@@ -534,8 +524,7 @@ def test_protected_base_pre_authorizes_absent_exact_child_paths(
         ["git", "rev-parse", "HEAD"], cwd=root, text=True
     ).strip()
 
-    simulated_paths = PREAUTHORIZED_CHILD_PATHS | {UNMARKED_ABSENT_HISTORICAL_PATH}
-    for path in simulated_paths:
+    for path in PREAUTHORIZED_CHILD_PATHS:
         child_path = root / path
         child_path.parent.mkdir(parents=True, exist_ok=True)
         child_path.write_text("# preauthorized child path\n", encoding="utf-8")
@@ -556,17 +545,5 @@ def test_protected_base_pre_authorizes_absent_exact_child_paths(
         assert record.ownership_provenance == (
             f"protected-ownership:pdd-maintainers:{path}"
         )
-    historical = next(
-        item
-        for item in manifest.candidates
-        if item.candidate_id.artifact_relpath.as_posix()
-        == UNMARKED_ABSENT_HISTORICAL_PATH
-    )
-    assert historical.inventory.value == "INVALID"
-    assert historical.candidate_id.role == "unaccounted"
-    assert not historical.in_base and historical.in_head
-    assert historical.ownership_provenance == "none"
-    assert manifest.unaccounted_tracked_paths == (
-        PurePosixPath(UNMARKED_ABSENT_HISTORICAL_PATH),
-    )
+    assert not manifest.unaccounted_tracked_paths
     assert len(manifest.expected_managed) == baseline_denominator


### PR DESCRIPTION
Summary

Pre-authorizes the seven exact #1932 stack paths in the protected base ownership policy. Newly introduced candidate paths may use only an exact protected-base rule; existing base paths retain established matching behavior.

This keeps the current managed denominator unchanged while allowing each known child path to classify as protected human-owned when introduced.

Closes #1932.

Test plan

- focused protected-base child ownership simulation
- focused sync-core manifest and rollout tests
- pylint for the changed production module and rollout tests
- diff whitespace check

No external CLI workflow applies: this changes protected Git manifest policy consumed by sync validation, and the base/head manifest simulations exercise that integration boundary directly.