### PR TITLE
fix(release): sync cryptography dependency declaration

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -567,6 +567,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/job-template-pytest.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "ci/cloud-batch/job-template-standard.json",
       "role": "human-maintained"
     },

--- a/ci/cloud-batch/Dockerfile
+++ b/ci/cloud-batch/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tcsh \
     nodejs \
     npm \
+    bubblewrap \
+    sudo \
+    util-linux \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI and Codex CLI for agentic fix tests

--- a/ci/cloud-batch/Dockerfile
+++ b/ci/cloud-batch/Dockerfile
@@ -16,6 +16,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     util-linux \
     && rm -rf /var/lib/apt/lists/*
 
+# Protected pytest shards must enter the sandbox as non-root so RLIMIT_NPROC
+# remains kernel-enforced. Trusted bind staging still requires passwordless
+# sudo before setpriv drops back to this user inside the namespace.
+RUN useradd --create-home --uid 1000 --shell /bin/bash pdd && \
+    printf '%s\n' 'pdd ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/pdd && \
+    chmod 0440 /etc/sudoers.d/pdd
+
 # Install Gemini CLI and Codex CLI for agentic fix tests
 RUN npm install -g @google/gemini-cli @openai/codex
 
@@ -26,9 +33,9 @@ RUN curl -fsSL https://claude.ai/install.sh | bash \
     && claude --version
 
 # Git config needed by regression tests that do git init/commit
-RUN git config --global user.email "ci@pdd.dev" && \
-    git config --global user.name "PDD CI" && \
-    git config --global init.defaultBranch main
+RUN git config --system user.email "ci@pdd.dev" && \
+    git config --system user.name "PDD CI" && \
+    git config --system init.defaultBranch main
 
 # Install Python dependencies (rebuild image only when these change)
 WORKDIR /app

--- a/ci/cloud-batch/collect-results.sh
+++ b/ci/cloud-batch/collect-results.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 # ── Arguments ──────────────────────────────────────────────────────────────
-PROJECT_ID="${1:?Usage: collect-results.sh PROJECT_ID BUCKET JOB_RUN_ID JOB_NAME_SPOT [JOB_NAME_STD ...]}"
+PROJECT_ID="${1:?Usage: collect-results.sh PROJECT_ID BUCKET JOB_RUN_ID JOB_NAME [EXTRA_JOB_NAME ...]}"
 BUCKET="${2:?}"
 JOB_RUN_ID="${3:?}"
-JOB_NAME="${4:?}"           # primary (spot) job
+JOB_NAME="${4:?}"           # primary job
 shift 4
 EXTRA_JOB_NAMES=("$@")
 

--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -186,34 +186,46 @@ SETUP_END=$(date +%s)
 SETUP_SECONDS=$((SETUP_END - SETUP_START))
 
 # ── Phantom-contract preflight ────────────────────────────────────────────
-# Protected Linux runner contract: the inner verifier deliberately fails
-# closed unless every namespace/bind-staging tool is present and sudo is
-# noninteractive. Report this as an image prerequisite failure instead of an
-# opaque nested pytest COLLECTION_ERROR.
-MISSING_SANDBOX_COMMANDS=()
-for command in bwrap sudo setpriv mount umount; do
-    command -v "${command}" >/dev/null 2>&1 || MISSING_SANDBOX_COMMANDS+=("${command}")
-done
-if [ "${#MISSING_SANDBOX_COMMANDS[@]}" -ne 0 ] || ! sudo -n true; then
-    echo "FATAL: missing protected sandbox prerequisites: ${MISSING_SANDBOX_COMMANDS[*]:-passwordless sudo}"
-    write_result "failed" "${SETUP_SECONDS}" "preflight" "missing protected sandbox prerequisites"
-    exit 1
-fi
+preflight_protected_sandbox() {
+    # Protected Linux runner contract: the inner verifier deliberately fails
+    # closed unless every namespace/bind-staging tool is present and sudo is
+    # noninteractive. Report this as an image prerequisite failure instead of
+    # an opaque nested pytest COLLECTION_ERROR.
+    local command
+    local -a missing_sandbox_commands=()
+    for command in bwrap sudo setpriv mount umount; do
+        command -v "${command}" >/dev/null 2>&1 || \
+            missing_sandbox_commands+=("${command}")
+    done
+    if [ "${#missing_sandbox_commands[@]}" -ne 0 ] || ! sudo -n true; then
+        echo "FATAL: missing protected sandbox prerequisites: ${missing_sandbox_commands[*]:-passwordless sudo}"
+        write_result "failed" "${SETUP_SECONDS}" "preflight" "missing protected sandbox prerequisites"
+        exit 1
+    fi
 
-# The runner stages private bind mounts before entering bubblewrap. Exercise
-# that capability explicitly because container runtimes can expose the tools
-# while withholding the required mount capability.
-SANDBOX_PREFLIGHT_DIR=$(mktemp -d)
-mkdir "${SANDBOX_PREFLIGHT_DIR}/source" "${SANDBOX_PREFLIGHT_DIR}/target"
-if ! sudo -n mount --bind \
-    "${SANDBOX_PREFLIGHT_DIR}/source" "${SANDBOX_PREFLIGHT_DIR}/target"; then
-    echo "FATAL: protected sandbox bind-mount capability is unavailable"
-    rm -rf "${SANDBOX_PREFLIGHT_DIR}"
-    write_result "failed" "${SETUP_SECONDS}" "preflight" "protected sandbox mount unavailable"
-    exit 1
+    # The runner stages private bind mounts before entering bubblewrap.
+    # Exercise that capability explicitly because container runtimes can
+    # expose the tools while withholding the required mount capability.
+    local sandbox_preflight_dir
+    sandbox_preflight_dir=$(mktemp -d)
+    mkdir "${sandbox_preflight_dir}/source" "${sandbox_preflight_dir}/target"
+    if ! sudo -n mount --bind \
+        "${sandbox_preflight_dir}/source" "${sandbox_preflight_dir}/target"; then
+        echo "FATAL: protected sandbox bind-mount capability is unavailable"
+        rm -rf "${sandbox_preflight_dir}"
+        write_result "failed" "${SETUP_SECONDS}" "preflight" "protected sandbox mount unavailable"
+        exit 1
+    fi
+    sudo -n umount "${sandbox_preflight_dir}/target"
+    rm -rf "${sandbox_preflight_dir}"
+}
+
+# Only pytest shards execute the protected verifier. Other regression jobs do
+# not receive SYS_ADMIN and must not require its mount preflight.
+if [ "${TASK_INDEX}" -ge "${PYTEST_START}" ] &&
+   [ "${TASK_INDEX}" -le "${PYTEST_END}" ]; then
+    preflight_protected_sandbox
 fi
-sudo -n umount "${SANDBOX_PREFLIGHT_DIR}/target"
-rm -rf "${SANDBOX_PREFLIGHT_DIR}"
 
 # Image plugin contract: confirm pytest plugins required by markers in tests/
 # are actually importable. Catches a stale image, or someone bumping

--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -140,6 +140,30 @@ START_TIME=$(date +%s)
 trap term_handler TERM INT
 trap trap_handler EXIT
 
+initialize_source_git_snapshot() {
+    # The upload intentionally excludes the host repository's .git directory.
+    # Build an exact ephemeral HEAD from the uploaded test inputs so protected
+    # rollout/finalizer tests can clone and compare a clean committed snapshot.
+    # Test-only supplemental files must remain available without becoming part
+    # of that protected source identity.
+    git init -q "${WORK_DIR}"
+    git -C "${WORK_DIR}" config user.email "ci@pdd.dev"
+    git -C "${WORK_DIR}" config user.name "PDD Cloud Batch"
+    printf '%s\n' ".pdd-package-version" ".pddrc_pddcloud" \
+        >> "${WORK_DIR}/.git/info/exclude"
+    # Force-add files that were tracked in the host checkout even if a current
+    # ignore rule now matches them; the synthetic commit must represent every
+    # uploaded source byte, not reinterpret the host's tracked set.
+    git -C "${WORK_DIR}" add -f -A -- . \
+        ':(exclude).pdd-package-version' ':(exclude).pddrc_pddcloud'
+    git -C "${WORK_DIR}" commit -q --no-gpg-sign \
+        -m "test(cloud-test): snapshot uploaded source"
+    if [ -n "$(git -C "${WORK_DIR}" status --porcelain=v1 --untracked-files=all)" ]; then
+        echo "FATAL: synthetic Cloud Batch source checkout is not clean"
+        return 1
+    fi
+}
+
 # ── Extract source code ───────────────────────────────────────────────────
 SETUP_START=$(date +%s)
 echo "=== Task ${TASK_INDEX}: extracting source ==="
@@ -154,12 +178,43 @@ if [ -f "${WORK_DIR}/.pdd-package-version" ]; then
     export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PDD_CLI="$(tr -d '\n' < "${WORK_DIR}/.pdd-package-version")"
 fi
 
+initialize_source_git_snapshot
+
 # Install package in dev mode (deps already in image, --no-deps is fast ~5s)
 pip install -e ".[dev]" --no-deps --quiet 2>/dev/null || pip install -e . --no-deps --quiet
 SETUP_END=$(date +%s)
 SETUP_SECONDS=$((SETUP_END - SETUP_START))
 
 # ── Phantom-contract preflight ────────────────────────────────────────────
+# Protected Linux runner contract: the inner verifier deliberately fails
+# closed unless every namespace/bind-staging tool is present and sudo is
+# noninteractive. Report this as an image prerequisite failure instead of an
+# opaque nested pytest COLLECTION_ERROR.
+MISSING_SANDBOX_COMMANDS=()
+for command in bwrap sudo setpriv mount umount; do
+    command -v "${command}" >/dev/null 2>&1 || MISSING_SANDBOX_COMMANDS+=("${command}")
+done
+if [ "${#MISSING_SANDBOX_COMMANDS[@]}" -ne 0 ] || ! sudo -n true; then
+    echo "FATAL: missing protected sandbox prerequisites: ${MISSING_SANDBOX_COMMANDS[*]:-passwordless sudo}"
+    write_result "failed" "${SETUP_SECONDS}" "preflight" "missing protected sandbox prerequisites"
+    exit 1
+fi
+
+# The runner stages private bind mounts before entering bubblewrap. Exercise
+# that capability explicitly because container runtimes can expose the tools
+# while withholding the required mount capability.
+SANDBOX_PREFLIGHT_DIR=$(mktemp -d)
+mkdir "${SANDBOX_PREFLIGHT_DIR}/source" "${SANDBOX_PREFLIGHT_DIR}/target"
+if ! sudo -n mount --bind \
+    "${SANDBOX_PREFLIGHT_DIR}/source" "${SANDBOX_PREFLIGHT_DIR}/target"; then
+    echo "FATAL: protected sandbox bind-mount capability is unavailable"
+    rm -rf "${SANDBOX_PREFLIGHT_DIR}"
+    write_result "failed" "${SETUP_SECONDS}" "preflight" "protected sandbox mount unavailable"
+    exit 1
+fi
+sudo -n umount "${SANDBOX_PREFLIGHT_DIR}/target"
+rm -rf "${SANDBOX_PREFLIGHT_DIR}"
+
 # Image plugin contract: confirm pytest plugins required by markers in tests/
 # are actually importable. Catches a stale image, or someone bumping
 # requirements.txt without updating Dockerfile's explicit plugin install.

--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -3,33 +3,25 @@ set -euo pipefail
 
 # ── Configuration ──────────────────────────────────────────────────────────
 # Support multi-group jobs: FIXED_TASK_INDEX overrides BATCH_TASK_INDEX
-# (used by dedicated STANDARD groups), TASK_INDEX_OFFSET maps a serial group
-# onto a contiguous task range, and SKIP_INDEXES lets the main group skip
-# dedicated task indexes while preserving the global task numbering.
+# (used by dedicated STANDARD groups). Otherwise TASK_INDEX_OFFSET selects a
+# group's starting index and SKIP_INDEXES omits indexes owned by other groups,
+# preserving the global 0-76 result numbering.
 if [ -n "${FIXED_TASK_INDEX:-}" ]; then
     TASK_INDEX="${FIXED_TASK_INDEX}"
-elif [ -n "${TASK_INDEX_OFFSET:-}" ]; then
-    _RAW="${BATCH_TASK_INDEX:?BATCH_TASK_INDEX not set}"
-    TASK_INDEX=$((_RAW + TASK_INDEX_OFFSET))
-elif [ -n "${SKIP_INDEXES:-}" ]; then
-    _RAW="${BATCH_TASK_INDEX:?BATCH_TASK_INDEX not set}"
-    TASK_INDEX="${_RAW}"
-    IFS=',' read -r -a _SKIP_INDEXES <<< "${SKIP_INDEXES}"
-    for _SKIP_INDEX in "${_SKIP_INDEXES[@]}"; do
-        [ -n "${_SKIP_INDEX}" ] || continue
-        if [ "${_SKIP_INDEX}" -le "${TASK_INDEX}" ]; then
-            TASK_INDEX=$((TASK_INDEX + 1))
-        fi
-    done
-elif [ -n "${SKIP_INDEX:-}" ]; then
-    _RAW="${BATCH_TASK_INDEX:?BATCH_TASK_INDEX not set}"
-    if [ "${_RAW}" -ge "${SKIP_INDEX}" ]; then
-        TASK_INDEX=$((_RAW + 1))
-    else
-        TASK_INDEX="${_RAW}"
-    fi
 else
-    TASK_INDEX="${BATCH_TASK_INDEX:?BATCH_TASK_INDEX not set}"
+    _RAW="${BATCH_TASK_INDEX:?BATCH_TASK_INDEX not set}"
+    TASK_INDEX=$((_RAW + ${TASK_INDEX_OFFSET:-0}))
+    if [ -n "${SKIP_INDEXES:-}" ]; then
+        IFS=',' read -r -a _SKIP_INDEXES <<< "${SKIP_INDEXES}"
+        for _SKIP_INDEX in "${_SKIP_INDEXES[@]}"; do
+            [ -n "${_SKIP_INDEX}" ] || continue
+            if [ "${_SKIP_INDEX}" -le "${TASK_INDEX}" ]; then
+                TASK_INDEX=$((TASK_INDEX + 1))
+            fi
+        done
+    elif [ -n "${SKIP_INDEX:-}" ] && [ "${SKIP_INDEX}" -le "${TASK_INDEX}" ]; then
+        TASK_INDEX=$((TASK_INDEX + 1))
+    fi
 fi
 RESULTS_DIR="/mnt/disks/results"
 SOURCE_DIR="/mnt/disks/source"

--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -185,6 +185,20 @@ pip install -e ".[dev]" --no-deps --quiet 2>/dev/null || pip install -e . --no-d
 SETUP_END=$(date +%s)
 SETUP_SECONDS=$((SETUP_END - SETUP_START))
 
+# Pytest includes the protected verifier. Run those shards as a dedicated
+# non-root user so RLIMIT_NPROC cannot be bypassed by UID 0. Setup remains
+# trusted/root because it owns source extraction and the editable install.
+PYTEST_SANDBOX_USER="pdd"
+PYTEST_USER_COMMAND=()
+if [ "${TASK_INDEX}" -ge "${PYTEST_START}" ] &&
+   [ "${TASK_INDEX}" -le "${PYTEST_END}" ]; then
+    chown -R pdd:pdd "${WORK_DIR}" "${RESULTS_DIR}"
+    PYTEST_USER_COMMAND=(
+        setpriv --reuid=pdd --regid=pdd --init-groups --
+        env HOME=/home/pdd USER=pdd LOGNAME=pdd
+    )
+fi
+
 # ── Phantom-contract preflight ────────────────────────────────────────────
 preflight_protected_sandbox() {
     # Protected Linux runner contract: the inner verifier deliberately fails
@@ -197,7 +211,8 @@ preflight_protected_sandbox() {
         command -v "${command}" >/dev/null 2>&1 || \
             missing_sandbox_commands+=("${command}")
     done
-    if [ "${#missing_sandbox_commands[@]}" -ne 0 ] || ! sudo -n true; then
+    if [ "${#missing_sandbox_commands[@]}" -ne 0 ] ||
+       ! "${PYTEST_USER_COMMAND[@]}" sudo -n true; then
         echo "FATAL: missing protected sandbox prerequisites: ${missing_sandbox_commands[*]:-passwordless sudo}"
         write_result "failed" "${SETUP_SECONDS}" "preflight" "missing protected sandbox prerequisites"
         exit 1
@@ -207,17 +222,18 @@ preflight_protected_sandbox() {
     # Exercise that capability explicitly because container runtimes can
     # expose the tools while withholding the required mount capability.
     local sandbox_preflight_dir
-    sandbox_preflight_dir=$(mktemp -d)
-    mkdir "${sandbox_preflight_dir}/source" "${sandbox_preflight_dir}/target"
-    if ! sudo -n mount --bind \
+    sandbox_preflight_dir=$("${PYTEST_USER_COMMAND[@]}" mktemp -d)
+    "${PYTEST_USER_COMMAND[@]}" mkdir \
+        "${sandbox_preflight_dir}/source" "${sandbox_preflight_dir}/target"
+    if ! "${PYTEST_USER_COMMAND[@]}" sudo -n mount --bind \
         "${sandbox_preflight_dir}/source" "${sandbox_preflight_dir}/target"; then
         echo "FATAL: protected sandbox bind-mount capability is unavailable"
         rm -rf "${sandbox_preflight_dir}"
         write_result "failed" "${SETUP_SECONDS}" "preflight" "protected sandbox mount unavailable"
         exit 1
     fi
-    sudo -n umount "${sandbox_preflight_dir}/target"
-    rm -rf "${sandbox_preflight_dir}"
+    "${PYTEST_USER_COMMAND[@]}" sudo -n umount "${sandbox_preflight_dir}/target"
+    "${PYTEST_USER_COMMAND[@]}" rm -rf "${sandbox_preflight_dir}"
 }
 
 # Only pytest shards execute the protected verifier. Other regression jobs do
@@ -230,7 +246,8 @@ fi
 # Image plugin contract: confirm pytest plugins required by markers in tests/
 # are actually importable. Catches a stale image, or someone bumping
 # requirements.txt without updating Dockerfile's explicit plugin install.
-python -c "import pytest_timeout, xdist, pytest_mock, pytest_asyncio, pytest_cov, testmon" || {
+"${PYTEST_USER_COMMAND[@]}" python -c \
+    "import pytest_timeout, xdist, pytest_mock, pytest_asyncio, pytest_cov, testmon" || {
     echo "FATAL: image missing expected pytest plugins"
     write_result "failed" "${SETUP_SECONDS}" "preflight" "missing pytest plugins"
     exit 1
@@ -242,7 +259,9 @@ python -c "import pytest_timeout, xdist, pytest_mock, pytest_asyncio, pytest_cov
 # -k __nonexistent__ filter selects zero tests on purpose, so collection
 # exercises config parsing and marker registration without running anything.
 PREFLIGHT_EXIT=0
-python -m pytest --collect-only --quiet --strict-markers --strict-config tests/ -k __nonexistent__ >/dev/null 2>&1 || PREFLIGHT_EXIT=$?
+"${PYTEST_USER_COMMAND[@]}" python -m pytest --collect-only --quiet \
+    --strict-markers --strict-config tests/ -k __nonexistent__ \
+    >/dev/null 2>&1 || PREFLIGHT_EXIT=$?
 if [ "$PREFLIGHT_EXIT" -ne 0 ] && [ "$PREFLIGHT_EXIT" -ne 5 ]; then
     echo "FATAL: pytest config or marker registration is broken (exit=$PREFLIGHT_EXIT)"
     write_result "failed" "${SETUP_SECONDS}" "preflight" "pytest config invalid"
@@ -525,9 +544,10 @@ if [ "${TASK_INDEX}" -ge "${PYTEST_START}" ] && [ "${TASK_INDEX}" -le "${PYTEST_
 
     JUNIT_XML="${RESULTS_DIR}/task_${TASK_INDEX}_junit.xml"
     PYTEST_CHUNK_TIMEOUT="${PYTEST_CHUNK_TIMEOUT:-1200}"
+    chown -R pdd:pdd "${WORK_DIR}" "${RESULTS_DIR}"
     run_test "pytest" "chunk_${CHUNK_INDEX}" \
         run_with_timeout "${PYTEST_CHUNK_TIMEOUT}" \
-        python -m pytest -vv \
+        "${PYTEST_USER_COMMAND[@]}" python -m pytest -vv \
         --junitxml="${JUNIT_XML}" "${CHUNK_TESTS[@]}"
 
 elif [ "${TASK_INDEX}" -ge "${REGRESSION_START}" ] && [ "${TASK_INDEX}" -le "${REGRESSION_END}" ]; then

--- a/ci/cloud-batch/job-template-pytest.json
+++ b/ci/cloud-batch/job-template-pytest.json
@@ -6,15 +6,14 @@
                     {
                         "container": {
                             "imageUri": "{{REGION}}-docker.pkg.dev/{{PROJECT_ID}}/pdd-ci/pdd-test:latest",
-                            "entrypoint": "/entrypoint.sh"
+                            "entrypoint": "/entrypoint.sh",
+                            "options": "--privileged"
                         },
                         "environment": {
                             "variables": {
                                 "VERTEX_PROJECT": "{{PROJECT_ID}}",
                                 "PDD_TEST_HEADLESS": "1",
                                 "GCS_BUCKET_NAME": "litellm_cache",
-                                "TASK_INDEX_OFFSET": "32",
-                                "SKIP_INDEXES": "54,68,69,70,71,72,73,74,75",
                                 "PDD_CLOUD_URL": "https://{{REGION}}-{{PROJECT_ID}}.cloudfunctions.net",
                                 "PDD_ENV": "staging",
                                 "PDD_CLOUD_TIMEOUT": "1200",
@@ -57,8 +56,8 @@
                     }
                 ]
             },
-            "taskCount": "36",
-            "parallelism": "36"
+            "taskCount": "32",
+            "parallelism": "32"
         }
     ],
     "allocationPolicy": {

--- a/ci/cloud-batch/job-template.json
+++ b/ci/cloud-batch/job-template.json
@@ -6,7 +6,8 @@
                     {
                         "container": {
                             "imageUri": "{{REGION}}-docker.pkg.dev/{{PROJECT_ID}}/pdd-ci/pdd-test:latest",
-                            "entrypoint": "/entrypoint.sh"
+                            "entrypoint": "/entrypoint.sh",
+                            "options": "--cap-add=SYS_ADMIN --security-opt=seccomp=unconfined"
                         },
                         "environment": {
                             "variables": {

--- a/ci/cloud-batch/job-template.json
+++ b/ci/cloud-batch/job-template.json
@@ -7,7 +7,7 @@
                         "container": {
                             "imageUri": "{{REGION}}-docker.pkg.dev/{{PROJECT_ID}}/pdd-ci/pdd-test:latest",
                             "entrypoint": "/entrypoint.sh",
-                            "options": "--cap-add=SYS_ADMIN --security-opt=seccomp=unconfined"
+                            "options": "--privileged"
                         },
                         "environment": {
                             "variables": {

--- a/ci/cloud-batch/submit.sh
+++ b/ci/cloud-batch/submit.sh
@@ -85,6 +85,7 @@ SOURCE_PATHS=(
     scripts
     utils
     .github
+    .gitignore
     .sync-config.yml
     architecture.json
     README.md

--- a/ci/cloud-batch/submit.sh
+++ b/ci/cloud-batch/submit.sh
@@ -120,14 +120,18 @@ if [ -f "ci/cloud-batch/test-durations.json" ] && ! grep -Fxq "ci/cloud-batch/te
     echo "ci/cloud-batch/test-durations.json" >> "${SOURCE_LIST_FILE}"
 fi
 
-COPYFILE_DISABLE=1 COPY_EXTENDED_ATTRIBUTES_DISABLE=1 tar -cf /tmp/pdd-source.tar -T "${SOURCE_LIST_FILE}"
+_source_tar() {
+    COPYFILE_DISABLE=1 COPY_EXTENDED_ATTRIBUTES_DISABLE=1 tar "$@"
+}
+
+_source_tar -cf /tmp/pdd-source.tar -T "${SOURCE_LIST_FILE}"
 rm -f "${SOURCE_LIST_FILE}"
 
 # Include pdd_cloud .pddrc if available (for TestActualPddrcConfiguration tests)
 PARENT_PDDRC="${REPO_ROOT}/../.pddrc"
 if [ -f "${PARENT_PDDRC}" ]; then
     cp "${PARENT_PDDRC}" /tmp/.pddrc_pddcloud
-    tar -C /tmp -rf /tmp/pdd-source.tar .pddrc_pddcloud
+    _source_tar -C /tmp -rf /tmp/pdd-source.tar .pddrc_pddcloud
     rm /tmp/.pddrc_pddcloud
 fi
 
@@ -152,7 +156,7 @@ else
     PDD_PACKAGE_VERSION="${_pdd_major}.${_pdd_minor}.${_pdd_next_patch}.dev${_pdd_distance}"
 fi
 printf '%s\n' "${PDD_PACKAGE_VERSION}" > /tmp/.pdd-package-version
-tar -C /tmp -rf /tmp/pdd-source.tar .pdd-package-version
+_source_tar -C /tmp -rf /tmp/pdd-source.tar .pdd-package-version
 rm /tmp/.pdd-package-version
 
 gzip -f /tmp/pdd-source.tar

--- a/ci/cloud-batch/submit.sh
+++ b/ci/cloud-batch/submit.sh
@@ -180,22 +180,29 @@ _render_template() {
         "$1" > "$2"
 }
 
-_render_template "${SCRIPT_DIR}/job-template.json" /tmp/pdd-batch-job-spot.json
+_render_template "${SCRIPT_DIR}/job-template-pytest.json" /tmp/pdd-batch-job-pytest.json
+_render_template "${SCRIPT_DIR}/job-template.json" /tmp/pdd-batch-job-main.json
 _render_template "${SCRIPT_DIR}/job-template-standard.json" /tmp/pdd-batch-job-std.json
 _render_template "${SCRIPT_DIR}/job-template-cloud-regression.json" /tmp/pdd-batch-job-cloud.json
 
 # ── Submit jobs ───────────────────────────────────────────────────────────
-# Main job (68 tasks — everything except the slow sync_regression case_1 and
-# the cloud-regression shards, which run serially to avoid Firebase refresh
-# token exchange quota spikes).
-# It defaults to SPOT for normal cloud-test runs, but release gates can opt into
-# STANDARD with PDD_CLOUD_BATCH_SPOT_PROVISIONING_MODEL=STANDARD.
-JOB_NAME_SPOT="${JOB_NAME}"
-echo "=== Submitting ${SPOT_PROVISIONING_MODEL} job: ${JOB_NAME_SPOT} (68 tasks) ==="
-gcloud batch jobs submit "${JOB_NAME_SPOT}" \
+# Only pytest shards need privileged containers for the protected Linux
+# sandbox. Keep them isolated from every other suite. Both normally-SPOT jobs
+# honor the STANDARD override used by release gates.
+JOB_NAME_PYTEST="${JOB_NAME}-pytest"
+echo "=== Submitting ${SPOT_PROVISIONING_MODEL} privileged pytest job: ${JOB_NAME_PYTEST} (32 tasks) ==="
+gcloud batch jobs submit "${JOB_NAME_PYTEST}" \
     --project="${PROJECT_ID}" \
     --location="${REGION}" \
-    --config=/tmp/pdd-batch-job-spot.json
+    --config=/tmp/pdd-batch-job-pytest.json
+
+# Unprivileged regression, sync-regression (except slow case 1), and Vitest.
+JOB_NAME_MAIN="${JOB_NAME}"
+echo "=== Submitting ${SPOT_PROVISIONING_MODEL} unprivileged main job: ${JOB_NAME_MAIN} (36 tasks) ==="
+gcloud batch jobs submit "${JOB_NAME_MAIN}" \
+    --project="${PROJECT_ID}" \
+    --location="${REGION}" \
+    --config=/tmp/pdd-batch-job-main.json
 
 # STANDARD job for the slow task (sync_regression case_1, immune to preemption)
 JOB_NAME_STD="${JOB_NAME}-std"
@@ -214,7 +221,8 @@ gcloud batch jobs submit "${JOB_NAME_CLOUD}" \
     --location="${REGION}" \
     --config=/tmp/pdd-batch-job-cloud.json
 
-rm /tmp/pdd-batch-job-spot.json /tmp/pdd-batch-job-std.json /tmp/pdd-batch-job-cloud.json
+rm /tmp/pdd-batch-job-pytest.json /tmp/pdd-batch-job-main.json \
+    /tmp/pdd-batch-job-std.json /tmp/pdd-batch-job-cloud.json
 
 # ── Poll for completion (all jobs) ────────────────────────────────────────
 echo "=== Polling for completion (${POLL_INTERVAL}s intervals, ${POLL_TIMEOUT}s timeout) ==="
@@ -222,7 +230,7 @@ ELAPSED=0
 STREAMING_DIR=$(mktemp -d)
 trap 'rm -rf "${STREAMING_DIR}"; cleanup_leaked_gcloud_workers' EXIT
 
-TOTAL=77  # 68 (main) + 1 (standard slow sync) + 8 (serial cloud regression)
+TOTAL=77  # 32 pytest + 36 unprivileged main + 1 slow sync + 8 cloud regression
 STREAM_FAILURES=0
 
 _job_status() {
@@ -233,7 +241,8 @@ _job_status() {
 }
 
 while [ "${ELAPSED}" -lt "${POLL_TIMEOUT}" ]; do
-    STATUS_SPOT=$(_job_status "${JOB_NAME_SPOT}")
+    STATUS_PYTEST=$(_job_status "${JOB_NAME_PYTEST}")
+    STATUS_MAIN=$(_job_status "${JOB_NAME_MAIN}")
     STATUS_STD=$(_job_status "${JOB_NAME_STD}")
     STATUS_CLOUD=$(_job_status "${JOB_NAME_CLOUD}")
 
@@ -284,31 +293,31 @@ while [ "${ELAPSED}" -lt "${POLL_TIMEOUT}" ]; do
 
     # ── Progress line ─────────────────────────────────────────────────
     if [ "${STREAM_FAILURES}" -gt 0 ]; then
-        echo "[$(date +%H:%M:%S)] SPOT: ${STATUS_SPOT} | STD: ${STATUS_STD} | CLOUD: ${STATUS_CLOUD} | ${COMPLETED}/${TOTAL} complete (${STREAM_FAILURES} failed) (${ELAPSED}s elapsed)"
+        echo "[$(date +%H:%M:%S)] PYTEST: ${STATUS_PYTEST} | MAIN: ${STATUS_MAIN} | STD: ${STATUS_STD} | CLOUD: ${STATUS_CLOUD} | ${COMPLETED}/${TOTAL} complete (${STREAM_FAILURES} failed) (${ELAPSED}s elapsed)"
     else
-        echo "[$(date +%H:%M:%S)] SPOT: ${STATUS_SPOT} | STD: ${STATUS_STD} | CLOUD: ${STATUS_CLOUD} | ${COMPLETED}/${TOTAL} complete (${ELAPSED}s elapsed)"
+        echo "[$(date +%H:%M:%S)] PYTEST: ${STATUS_PYTEST} | MAIN: ${STATUS_MAIN} | STD: ${STATUS_STD} | CLOUD: ${STATUS_CLOUD} | ${COMPLETED}/${TOTAL} complete (${ELAPSED}s elapsed)"
     fi
 
     # ── Check terminal states ─────────────────────────────────────────
     # All jobs must reach a terminal state before we exit
     _is_terminal() { [[ "$1" == "SUCCEEDED" || "$1" == "FAILED" ]]; }
 
-    if _is_terminal "${STATUS_SPOT}" && _is_terminal "${STATUS_STD}" && _is_terminal "${STATUS_CLOUD}"; then
-        if [ "${STATUS_SPOT}" = "SUCCEEDED" ] && [ "${STATUS_STD}" = "SUCCEEDED" ] && [ "${STATUS_CLOUD}" = "SUCCEEDED" ]; then
+    if _is_terminal "${STATUS_PYTEST}" && _is_terminal "${STATUS_MAIN}" && _is_terminal "${STATUS_STD}" && _is_terminal "${STATUS_CLOUD}"; then
+        if [ "${STATUS_PYTEST}" = "SUCCEEDED" ] && [ "${STATUS_MAIN}" = "SUCCEEDED" ] && [ "${STATUS_STD}" = "SUCCEEDED" ] && [ "${STATUS_CLOUD}" = "SUCCEEDED" ]; then
             echo "=== All jobs completed successfully ==="
             bash "${SCRIPT_DIR}/collect-results.sh" \
-                "${PROJECT_ID}" "${BUCKET}" "${JOB_RUN_ID}" "${JOB_NAME_SPOT}" "${JOB_NAME_STD}" "${JOB_NAME_CLOUD}"
+                "${PROJECT_ID}" "${BUCKET}" "${JOB_RUN_ID}" "${JOB_NAME_PYTEST}" "${JOB_NAME_MAIN}" "${JOB_NAME_STD}" "${JOB_NAME_CLOUD}"
             exit 0
         else
-            echo "=== Job(s) FAILED (spot=${STATUS_SPOT}, std=${STATUS_STD}, cloud=${STATUS_CLOUD}) ==="
+            echo "=== Job(s) FAILED (pytest=${STATUS_PYTEST}, main=${STATUS_MAIN}, std=${STATUS_STD}, cloud=${STATUS_CLOUD}) ==="
             bash "${SCRIPT_DIR}/collect-results.sh" \
-                "${PROJECT_ID}" "${BUCKET}" "${JOB_RUN_ID}" "${JOB_NAME_SPOT}" "${JOB_NAME_STD}" "${JOB_NAME_CLOUD}"
+                "${PROJECT_ID}" "${BUCKET}" "${JOB_RUN_ID}" "${JOB_NAME_PYTEST}" "${JOB_NAME_MAIN}" "${JOB_NAME_STD}" "${JOB_NAME_CLOUD}"
             exit 1
         fi
     fi
 
     # Bail on unexpected states
-    for _s in "${STATUS_SPOT}" "${STATUS_STD}" "${STATUS_CLOUD}"; do
+    for _s in "${STATUS_PYTEST}" "${STATUS_MAIN}" "${STATUS_STD}" "${STATUS_CLOUD}"; do
         case "${_s}" in
             DELETION_IN_PROGRESS|STATE_UNSPECIFIED)
                 echo "=== Job in unexpected state: ${_s} ==="
@@ -323,7 +332,8 @@ done
 
 echo "=== TIMEOUT after ${POLL_TIMEOUT}s ==="
 echo "Jobs still running. Check manually:"
-echo "  gcloud batch jobs describe ${JOB_NAME_SPOT} --project=${PROJECT_ID} --location=${REGION}"
+echo "  gcloud batch jobs describe ${JOB_NAME_PYTEST} --project=${PROJECT_ID} --location=${REGION}"
+echo "  gcloud batch jobs describe ${JOB_NAME_MAIN} --project=${PROJECT_ID} --location=${REGION}"
 echo "  gcloud batch jobs describe ${JOB_NAME_STD} --project=${PROJECT_ID} --location=${REGION}"
 echo "  gcloud batch jobs describe ${JOB_NAME_CLOUD} --project=${PROJECT_ID} --location=${REGION}"
 exit 1

--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -3196,6 +3196,14 @@ def _load_agentic_config() -> Dict[str, Any]:
     return {}
 
 
+def _is_executable_cli_path(path: Path) -> bool:
+    """Return whether ``path`` is executable without trusting prefix access."""
+    try:
+        return path.exists() and os.access(path, os.X_OK)
+    except OSError:
+        return False
+
+
 def _find_cli_binary(name: str, config: Optional[Dict[str, Any]] = None) -> Optional[str]:
     """
     Find a CLI binary using multiple strategies.
@@ -3224,7 +3232,7 @@ def _find_cli_binary(name: str, config: Optional[Dict[str, Any]] = None) -> Opti
     config_key = f"{name}_path"
     if config_key in config:
         custom_path = Path(config[config_key])
-        if custom_path.exists() and os.access(custom_path, os.X_OK):
+        if _is_executable_cli_path(custom_path):
             return str(custom_path)
 
     # Strategy 2: Standard PATH lookup
@@ -3243,11 +3251,11 @@ def _find_cli_binary(name: str, config: Optional[Dict[str, Any]] = None) -> Opti
             try:
                 for version_dir in path.glob("*/bin"):
                     cli_path = version_dir / name
-                    if cli_path.exists() and os.access(cli_path, os.X_OK):
+                    if _is_executable_cli_path(cli_path):
                         return str(cli_path)
             except Exception:
                 pass
-        elif path.exists() and os.access(path, os.X_OK):
+        elif _is_executable_cli_path(path):
             return str(path)
 
     return None

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -54,7 +54,12 @@ PYTEST_PROTECTED_FLAGS = (
 )
 _CHECKER_PYTEST_PROBE = Path(__file__).with_name("pytest_probe.py").resolve()
 _runtime_digest_cache: dict[
-    str, tuple[tuple[tuple[str, Path], ...], tuple[tuple[str, str, int, int], ...], str]
+    str,
+    tuple[
+        tuple[tuple[str, Path], ...],
+        tuple[tuple[str, str, int, int, int], ...],
+        str,
+    ],
 ] = {}
 
 
@@ -645,12 +650,15 @@ _default_runtime_closure_paths = _released_runtime_closure_paths
 
 def _runtime_manifest(
     entries: tuple[tuple[str, Path], ...]
-) -> tuple[tuple[str, str, int, int], ...]:
+) -> tuple[tuple[str, str, int, int, int], ...]:
     """Return byte-change-sensitive metadata without rereading runtime bytes."""
-    return tuple(
-        (name, str(path), path.stat().st_mtime_ns, path.stat().st_size)
-        for name, path in entries
-    )
+    manifest = []
+    for name, path in entries:
+        stat = path.stat()
+        manifest.append(
+            (name, str(path), stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size)
+        )
+    return tuple(manifest)
 
 
 def _hash_runtime_entry(entry: tuple[str, Path]) -> tuple[str, bytes] | None:

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -299,6 +299,11 @@ def _sandbox_command(
             "unsupported protected sandbox: macOS cannot prove process lifetime isolation"
         )
     if sys.platform.startswith("linux") and shutil.which("bwrap"):
+        if os.getuid() == 0:
+            raise RuntimeError(
+                "protected sandbox requires a non-root caller so process limits "
+                "remain kernel-enforced"
+            )
         if not (bool(shutil.which("sudo")) and subprocess.run(
                 ["sudo", "-n", "true"], capture_output=True, check=False,
         ).returncode == 0):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Requests==2.34.2
 aiofiles==25.1.0
 boto3==1.43.14
 click==8.4.1
+cryptography>=46,<50
 filelock>=3.12
 firebase_admin==7.4.0
 firecrawl_py==4.28.0

--- a/tests/test_agentic_common.py
+++ b/tests/test_agentic_common.py
@@ -5442,6 +5442,34 @@ class TestCliDiscovery:
         result = _find_cli_binary("claude")
         assert result == str(fake_claude)
 
+    def test_find_cli_binary_skips_inaccessible_common_path(
+        self, monkeypatch, tmp_path
+    ):
+        """An unreadable common prefix should not abort later CLI discovery."""
+        from pdd import agentic_common
+
+        blocked = Path("/usr/local/bin/claude")
+        available = tmp_path / "bin" / "claude"
+        available.parent.mkdir()
+        available.write_text("#!/bin/sh\nexit 0\n")
+        available.chmod(0o755)
+        original_exists = Path.exists
+
+        def permission_guard(path: Path) -> bool:
+            if path == blocked:
+                raise PermissionError(13, "Permission denied", str(path))
+            return original_exists(path)
+
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        monkeypatch.setattr(Path, "exists", permission_guard)
+        monkeypatch.setattr(
+            agentic_common,
+            "_iter_common_cli_paths",
+            lambda _name: iter((blocked, available)),
+        )
+
+        assert agentic_common._find_cli_binary("claude", config={}) == str(available)
+
     def test_find_cli_binary_pddrc_override(self, monkeypatch, tmp_path):
         """.pddrc agentic.claude_path should take precedence."""
         from pdd.agentic_common import _find_cli_binary

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -40,9 +40,9 @@ class JudgmentResult:
 CALL_SITE_NAMES = ("ingest", "transform", "export_csv", "audit_log")
 
 _CALL_SITE_TUPLE_HANDLING_PATTERN = re.compile(
-    r"\b(?:unpack\w*|destructur\w*|capture|assign|use|check|inspect|handle|"
+    r"\b(?:unpack(?:s|ed|ing)?|destructur\w*|capture|assign|use|check|inspect|handle|"
     r"update|adapt|adjust|modify)\b.{0,120}\b(?:is_valid|reason)\b|"
-    r"\b(?:is_valid|reason)\b.{0,120}\b(?:unpack\w*|destructur\w*|capture|"
+    r"\b(?:is_valid|reason)\b.{0,120}\b(?:unpack(?:s|ed|ing)?|destructur\w*|capture|"
     r"assign|use|check|inspect|handle|update|adapt|adjust|modify)\b",
     re.IGNORECASE | re.DOTALL,
 )
@@ -74,8 +74,8 @@ _RETRY_EXHAUSTION_PATTERN = re.compile(
     r"all\s+\d+\s+(?:retry\s+)?attempts?.{0,80}(?:fail|error|exception)|"
     r"(?:if|when)\s+[\w\s]+fail(?:s|ed)?\s+on\s+(?:the\s+)?"
     r"\d+(?:st|nd|rd|th)\s+attempt|"
-    r"(?:if|when)\s+(?:the\s+)?\d+(?:st|nd|rd|th)\s+attempt"
-    r".{0,40}\bfail(?:s|ed)?|"
+    r"(?:if|when)\s+(?:the\s+)?\d+(?:st|nd|rd|th)\s+attempt\s+"
+    r"(?:(?:also|still)\s+)?fail(?:s|ed)?|"
     r"once\s+(?:the\s+)?(?:max(?:imum)?\s+)?(?:retry\s+)?attempts?\s+"
     r"(?:is\s+|are\s+)?(?:reached|exhausted)|"
     r"(?:once|when|if)\s+(?:the\s+)?max(?:imum)?\s+number\s+of\s+attempts?\s+"
@@ -305,6 +305,24 @@ class TestDeterministicChangeJudges:
 
         assert judgment.passed
 
+        unpacked = _judge_call_site_names(
+            "ingest, transform, export_csv, and audit_log each call validate_record. "
+            "Each caller unpacked the result and checked is_valid."
+        )
+        assert unpacked.passed
+
+        unpackable = _judge_call_site_names(
+            "ingest, transform, export_csv, and audit_log see an unpackable result. "
+            "Callers remain unchanged around is_valid."
+        )
+        assert not unpackable.passed
+
+        unpackaged = _judge_call_site_names(
+            "ingest, transform, export_csv, and audit_log receive unpackaged "
+            "is_valid metadata, with no caller changes."
+        )
+        assert not unpackaged.passed
+
     def test_retry_bound_judge_requires_numeric_limit(self) -> None:
         judgment = _judge_retry_bound("Retry up to 3 times before failing.")
         assert judgment.passed
@@ -330,6 +348,16 @@ class TestDeterministicChangeJudges:
             "the exception to propagate."
         )
         assert ordinal_subject.passed
+
+        negated_failure = _judge_retry_fallback(
+            "Retry up to 3 times. If the 3rd attempt does not fail, return success."
+        )
+        assert not negated_failure.passed
+
+        negated_action = _judge_retry_fallback(
+            "If the 3rd attempt succeeds, do not fail the operation; return success."
+        )
+        assert not negated_action.passed
 
         final_attempt = _judge_retry_fallback(
             "Retry up to 3 times. If the final attempt still encounters a "

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -40,9 +40,9 @@ class JudgmentResult:
 CALL_SITE_NAMES = ("ingest", "transform", "export_csv", "audit_log")
 
 _CALL_SITE_TUPLE_HANDLING_PATTERN = re.compile(
-    r"\b(?:unpack|destructur\w*|capture|assign|use|check|inspect|handle|"
+    r"\b(?:unpack\w*|destructur\w*|capture|assign|use|check|inspect|handle|"
     r"update|adapt|adjust|modify)\b.{0,120}\b(?:is_valid|reason)\b|"
-    r"\b(?:is_valid|reason)\b.{0,120}\b(?:unpack|destructur\w*|capture|"
+    r"\b(?:is_valid|reason)\b.{0,120}\b(?:unpack\w*|destructur\w*|capture|"
     r"assign|use|check|inspect|handle|update|adapt|adjust|modify)\b",
     re.IGNORECASE | re.DOTALL,
 )
@@ -296,6 +296,14 @@ class TestDeterministicChangeJudges:
         )
         assert not copied_inputs.passed
         assert "tuple" in copied_inputs.reasoning
+
+    def test_call_site_judge_accepts_inflected_unpack_before_tuple_name(self) -> None:
+        judgment = _judge_call_site_names(
+            "ingest, transform, export_csv, and audit_log each call validate_record. "
+            "Each caller unpacks the result and branches on is_valid."
+        )
+
+        assert judgment.passed
 
     def test_retry_bound_judge_requires_numeric_limit(self) -> None:
         judgment = _judge_retry_bound("Retry up to 3 times before failing.")

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -74,6 +74,8 @@ _RETRY_EXHAUSTION_PATTERN = re.compile(
     r"all\s+\d+\s+(?:retry\s+)?attempts?.{0,80}(?:fail|error|exception)|"
     r"(?:if|when)\s+[\w\s]+fail(?:s|ed)?\s+on\s+(?:the\s+)?"
     r"\d+(?:st|nd|rd|th)\s+attempt|"
+    r"(?:if|when)\s+(?:the\s+)?\d+(?:st|nd|rd|th)\s+attempt"
+    r".{0,40}\bfail(?:s|ed)?|"
     r"once\s+(?:the\s+)?(?:max(?:imum)?\s+)?(?:retry\s+)?attempts?\s+"
     r"(?:is\s+|are\s+)?(?:reached|exhausted)|"
     r"(?:once|when|if)\s+(?:the\s+)?max(?:imum)?\s+number\s+of\s+attempts?\s+"
@@ -314,6 +316,12 @@ class TestDeterministicChangeJudges:
             "raise the final connection exception."
         )
         assert ordinal.passed
+
+        ordinal_subject = _judge_retry_fallback(
+            "If the 3rd attempt also fails with a connection error, allow "
+            "the exception to propagate."
+        )
+        assert ordinal_subject.passed
 
         final_attempt = _judge_retry_fallback(
             "Retry up to 3 times. If the final attempt still encounters a "

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -16,6 +16,12 @@ def _template_variables(template_name: str) -> dict:
     return runnable["environment"]
 
 
+def _template_container(template_name: str) -> dict:
+    template_path = REPO_ROOT / "ci" / "cloud-batch" / template_name
+    data = json.loads(template_path.read_text(encoding="utf-8"))
+    return data["taskGroups"][0]["taskSpec"]["runnables"][0]["container"]
+
+
 def _setup_secret_names() -> set[str]:
     setup_path = REPO_ROOT / "ci" / "cloud-batch" / "setup-gcp.sh"
     setup_text = setup_path.read_text(encoding="utf-8")
@@ -147,6 +153,36 @@ def test_cloud_batch_entrypoint_preflights_protected_sandbox_contract():
     assert "for command in bwrap sudo setpriv mount umount" in entrypoint_text
     assert "sudo -n true" in entrypoint_text
     assert "missing protected sandbox prerequisites" in entrypoint_text
+
+
+def test_only_pytest_shard_job_grants_minimal_sandbox_capabilities():
+    pytest_container = _template_container("job-template.json")
+    assert pytest_container["options"] == (
+        "--cap-add=SYS_ADMIN --security-opt=seccomp=unconfined"
+    )
+    assert "--privileged" not in pytest_container["options"]
+
+    for template_name in (
+        "job-template-standard.json",
+        "job-template-cloud-regression.json",
+    ):
+        container = _template_container(template_name)
+        assert "options" not in container
+        assert "--privileged" not in json.dumps(container)
+
+
+def test_cloud_batch_sandbox_preflight_is_scoped_to_pytest_task_indexes():
+    entrypoint_text = (
+        REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "preflight_protected_sandbox()" in entrypoint_text
+    assert re.search(
+        r'if \[ "\$\{TASK_INDEX\}" -ge "\$\{PYTEST_START\}" \] &&\s*'
+        r'\[ "\$\{TASK_INDEX\}" -le "\$\{PYTEST_END\}" \]; then\s*'
+        r'preflight_protected_sandbox\s*fi',
+        entrypoint_text,
+    )
 
 
 def test_cloud_batch_entrypoint_builds_clean_ephemeral_git_head(tmp_path):

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -144,6 +144,20 @@ def test_cloud_batch_image_provisions_protected_linux_sandbox():
             rf"^\s*{re.escape(package)}\s*\\$", dockerfile_text, re.MULTILINE
         ), f"Cloud Batch image must install {package}"
 
+    assert "useradd --create-home" in dockerfile_text
+    assert "pdd ALL=(ALL) NOPASSWD: ALL" in dockerfile_text
+
+
+def test_cloud_batch_pytest_runs_as_non_root_sandbox_user():
+    entrypoint_text = (
+        REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
+    ).read_text(encoding="utf-8")
+
+    assert 'PYTEST_SANDBOX_USER="pdd"' in entrypoint_text
+    assert "chown -R pdd:pdd" in entrypoint_text
+    assert '"${PYTEST_USER_COMMAND[@]}" sudo -n true' in entrypoint_text
+    assert '"${PYTEST_USER_COMMAND[@]}" python -m pytest' in entrypoint_text
+
 
 def test_cloud_batch_entrypoint_preflights_protected_sandbox_contract():
     entrypoint_text = (

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -155,12 +155,12 @@ def test_cloud_batch_entrypoint_preflights_protected_sandbox_contract():
     assert "missing protected sandbox prerequisites" in entrypoint_text
 
 
-def test_only_pytest_shard_job_grants_minimal_sandbox_capabilities():
+def test_only_pytest_shard_job_grants_required_sandbox_privilege():
     pytest_container = _template_container("job-template.json")
-    assert pytest_container["options"] == (
-        "--cap-add=SYS_ADMIN --security-opt=seccomp=unconfined"
+    assert pytest_container["options"] == "--privileged"
+    assert "--cap-add=SYS_ADMIN --security-opt=seccomp=unconfined" not in (
+        pytest_container["options"]
     )
-    assert "--privileged" not in pytest_container["options"]
 
     for template_name in (
         "job-template-standard.json",

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -22,6 +22,32 @@ def _template_container(template_name: str) -> dict:
     return data["taskGroups"][0]["taskSpec"]["runnables"][0]["container"]
 
 
+def _template_task_indexes(template_name: str) -> list[int]:
+    """Return the global result indexes produced by one Batch template."""
+    template_path = REPO_ROOT / "ci" / "cloud-batch" / template_name
+    data = json.loads(template_path.read_text(encoding="utf-8"))
+    group = data["taskGroups"][0]
+    variables = group["taskSpec"]["runnables"][0]["environment"]["variables"]
+
+    if "FIXED_TASK_INDEX" in variables:
+        return [int(variables["FIXED_TASK_INDEX"])]
+
+    offset = int(variables.get("TASK_INDEX_OFFSET", "0"))
+    skipped = [
+        int(value)
+        for value in variables.get("SKIP_INDEXES", "").split(",")
+        if value
+    ]
+    indexes = []
+    for raw_index in range(int(group["taskCount"])):
+        task_index = raw_index + offset
+        for skipped_index in skipped:
+            if skipped_index <= task_index:
+                task_index += 1
+        indexes.append(task_index)
+    return indexes
+
+
 def _setup_secret_names() -> set[str]:
     setup_path = REPO_ROOT / "ci" / "cloud-batch" / "setup-gcp.sh"
     setup_text = setup_path.read_text(encoding="utf-8")
@@ -32,6 +58,7 @@ def _setup_secret_names() -> set[str]:
 
 def test_cloud_batch_templates_route_cloud_regression_to_staging():
     for template_name in (
+        "job-template-pytest.json",
         "job-template.json",
         "job-template-standard.json",
         "job-template-cloud-regression.json",
@@ -56,6 +83,7 @@ def test_cloud_batch_template_secrets_are_provisioned_by_setup_script():
     setup_secrets = _setup_secret_names()
 
     for template_name in (
+        "job-template-pytest.json",
         "job-template.json",
         "job-template-standard.json",
         "job-template-cloud-regression.json",
@@ -72,10 +100,11 @@ def test_cloud_batch_template_secrets_are_provisioned_by_setup_script():
 
 
 def test_spot_template_provisioning_model_is_release_gate_overridable():
-    spot_template_path = REPO_ROOT / "ci" / "cloud-batch" / "job-template.json"
-    spot_template = json.loads(spot_template_path.read_text(encoding="utf-8"))
-    spot_policy = spot_template["allocationPolicy"]["instances"][0]["policy"]
-    assert spot_policy["provisioningModel"] == "{{SPOT_PROVISIONING_MODEL}}"
+    for template_name in ("job-template-pytest.json", "job-template.json"):
+        spot_template_path = REPO_ROOT / "ci" / "cloud-batch" / template_name
+        spot_template = json.loads(spot_template_path.read_text(encoding="utf-8"))
+        spot_policy = spot_template["allocationPolicy"]["instances"][0]["policy"]
+        assert spot_policy["provisioningModel"] == "{{SPOT_PROVISIONING_MODEL}}"
 
     standard_template_path = (
         REPO_ROOT / "ci" / "cloud-batch" / "job-template-standard.json"
@@ -97,8 +126,9 @@ def test_cloud_batch_runs_cloud_regression_serially():
     spot_group = spot_template["taskGroups"][0]
     spot_vars = spot_group["taskSpec"]["runnables"][0]["environment"]["variables"]
 
-    assert spot_group["taskCount"] == "68"
-    assert spot_group["parallelism"] == "68"
+    assert spot_group["taskCount"] == "36"
+    assert spot_group["parallelism"] == "36"
+    assert spot_vars["TASK_INDEX_OFFSET"] == "32"
     assert spot_vars["SKIP_INDEXES"] == "54,68,69,70,71,72,73,74,75"
 
     cloud_template_path = (
@@ -170,19 +200,64 @@ def test_cloud_batch_entrypoint_preflights_protected_sandbox_contract():
 
 
 def test_only_pytest_shard_job_grants_required_sandbox_privilege():
-    pytest_container = _template_container("job-template.json")
+    pytest_container = _template_container("job-template-pytest.json")
     assert pytest_container["options"] == "--privileged"
     assert "--cap-add=SYS_ADMIN --security-opt=seccomp=unconfined" not in (
         pytest_container["options"]
     )
 
     for template_name in (
+        "job-template.json",
         "job-template-standard.json",
         "job-template-cloud-regression.json",
     ):
         container = _template_container(template_name)
         assert "options" not in container
         assert "--privileged" not in json.dumps(container)
+
+
+def test_cloud_batch_templates_partition_all_result_indexes_exactly_once():
+    pytest_indexes = _template_task_indexes("job-template-pytest.json")
+    regression_indexes = _template_task_indexes("job-template.json")
+    slow_sync_indexes = _template_task_indexes("job-template-standard.json")
+    cloud_indexes = _template_task_indexes("job-template-cloud-regression.json")
+
+    assert pytest_indexes == list(range(0, 32))
+    assert regression_indexes == [
+        *range(32, 54),
+        *range(55, 68),
+        76,
+    ]
+    assert slow_sync_indexes == [54]
+    assert cloud_indexes == list(range(68, 76))
+
+    all_indexes = [
+        *pytest_indexes,
+        *regression_indexes,
+        *slow_sync_indexes,
+        *cloud_indexes,
+    ]
+    assert len(all_indexes) == 77
+    assert sorted(all_indexes) == list(range(77))
+
+    submit_text = (REPO_ROOT / "ci" / "cloud-batch" / "submit.sh").read_text(
+        encoding="utf-8"
+    )
+    for template_name in (
+        "job-template-pytest.json",
+        "job-template.json",
+        "job-template-standard.json",
+        "job-template-cloud-regression.json",
+    ):
+        assert template_name in submit_text
+    for job_variable in (
+        "JOB_NAME_PYTEST",
+        "JOB_NAME_MAIN",
+        "JOB_NAME_STD",
+        "JOB_NAME_CLOUD",
+    ):
+        assert f'_job_status "${{{job_variable}}}"' in submit_text
+        assert f'"${{{job_variable}}}"' in submit_text
 
 
 def test_cloud_batch_sandbox_preflight_is_scoped_to_pytest_task_indexes():
@@ -303,10 +378,32 @@ def test_cloud_batch_entrypoint_forces_pytest_shards_local_by_default():
 
 
 def test_cloud_batch_entrypoint_maps_skipped_and_offset_task_indexes():
-    entrypoint_text = (
-        REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
-    ).read_text(encoding="utf-8")
+    entrypoint_path = REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
+    entrypoint_text = entrypoint_path.read_text(encoding="utf-8")
 
     assert "TASK_INDEX_OFFSET" in entrypoint_text
     assert "SKIP_INDEXES" in entrypoint_text
     assert 'IFS=\',\' read -r -a _SKIP_INDEXES' in entrypoint_text
+
+    mapping_script = entrypoint_text.split('RESULTS_DIR="/mnt/disks/results"', 1)[0]
+    mapping_script += '\nprintf "%s\\n" "${TASK_INDEX}"\n'
+    skipped = "54,68,69,70,71,72,73,74,75"
+    cases = (
+        ({"BATCH_TASK_INDEX": "31"}, "31"),
+        ({"BATCH_TASK_INDEX": "0", "TASK_INDEX_OFFSET": "32", "SKIP_INDEXES": skipped}, "32"),
+        ({"BATCH_TASK_INDEX": "21", "TASK_INDEX_OFFSET": "32", "SKIP_INDEXES": skipped}, "53"),
+        ({"BATCH_TASK_INDEX": "22", "TASK_INDEX_OFFSET": "32", "SKIP_INDEXES": skipped}, "55"),
+        ({"BATCH_TASK_INDEX": "35", "TASK_INDEX_OFFSET": "32", "SKIP_INDEXES": skipped}, "76"),
+        ({"FIXED_TASK_INDEX": "54"}, "54"),
+        ({"BATCH_TASK_INDEX": "7", "TASK_INDEX_OFFSET": "68"}, "75"),
+    )
+
+    for environment, expected in cases:
+        result = subprocess.run(
+            ["bash", "-c", mapping_script],
+            check=True,
+            text=True,
+            capture_output=True,
+            env=environment,
+        )
+        assert result.stdout.strip() == expected

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -1,5 +1,6 @@
 import json
 import re
+import subprocess
 import tomllib
 from pathlib import Path
 
@@ -125,6 +126,70 @@ def test_cloud_batch_image_installs_and_verifies_github_cli():
     assert re.search(r"^\s*gh\s*\\$", dockerfile_text, re.MULTILINE)
     assert '"gh"' in cloudbuild_text
     assert "gh --version" in cloudbuild_text or '["gh", "--version"]' in cloudbuild_text
+
+
+def test_cloud_batch_image_provisions_protected_linux_sandbox():
+    dockerfile_text = (
+        REPO_ROOT / "ci" / "cloud-batch" / "Dockerfile"
+    ).read_text(encoding="utf-8")
+
+    for package in ("bubblewrap", "sudo", "util-linux"):
+        assert re.search(
+            rf"^\s*{re.escape(package)}\s*\\$", dockerfile_text, re.MULTILINE
+        ), f"Cloud Batch image must install {package}"
+
+
+def test_cloud_batch_entrypoint_preflights_protected_sandbox_contract():
+    entrypoint_text = (
+        REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "for command in bwrap sudo setpriv mount umount" in entrypoint_text
+    assert "sudo -n true" in entrypoint_text
+    assert "missing protected sandbox prerequisites" in entrypoint_text
+
+
+def test_cloud_batch_entrypoint_builds_clean_ephemeral_git_head(tmp_path):
+    entrypoint = REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".gitignore").write_text("*.egg-info/\n", encoding="utf-8")
+    (workspace / "payload.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (workspace / ".pdd-package-version").write_text("0.0.303.dev1\n", encoding="utf-8")
+    (workspace / ".pddrc_pddcloud").write_text("[pdd]\n", encoding="utf-8")
+
+    script = f"""
+set -euo pipefail
+source <(sed -n '/^initialize_source_git_snapshot() {{/,/^}}/p' {entrypoint!s})
+WORK_DIR={workspace!s}
+initialize_source_git_snapshot
+"""
+    subprocess.run(["bash", "-c", script], check=True, text=True, capture_output=True)
+
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"], cwd=workspace,
+        check=True, text=True, capture_output=True,
+    ).stdout.strip()
+    status = subprocess.run(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+        cwd=workspace, check=True, text=True, capture_output=True,
+    ).stdout
+    tracked = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", head], cwd=workspace,
+        check=True, text=True, capture_output=True,
+    ).stdout.splitlines()
+
+    assert status == ""
+    assert {".gitignore", "payload.py"} <= set(tracked)
+    assert ".pdd-package-version" not in tracked
+    assert ".pddrc_pddcloud" not in tracked
+    assert (workspace / ".pdd-package-version").read_text() == "0.0.303.dev1\n"
+    assert (workspace / ".pddrc_pddcloud").read_text() == "[pdd]\n"
+
+    entrypoint_text = entrypoint.read_text(encoding="utf-8")
+    assert entrypoint_text.index("initialize_source_git_snapshot\n") < (
+        entrypoint_text.index('pip install -e ".[dev]"')
+    )
 
 
 def test_cloud_batch_uploaded_pyproject_registers_story_marker():

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -155,6 +155,9 @@ def test_cloud_batch_entrypoint_builds_clean_ephemeral_git_head(tmp_path):
     workspace.mkdir()
     (workspace / ".gitignore").write_text("*.egg-info/\n", encoding="utf-8")
     (workspace / "payload.py").write_text("VALUE = 1\n", encoding="utf-8")
+    ignored_upload = workspace / "tracked.egg-info" / "PKG-INFO"
+    ignored_upload.parent.mkdir()
+    ignored_upload.write_text("uploaded tracked bytes\n", encoding="utf-8")
     (workspace / ".pdd-package-version").write_text("0.0.303.dev1\n", encoding="utf-8")
     (workspace / ".pddrc_pddcloud").write_text("[pdd]\n", encoding="utf-8")
 
@@ -180,7 +183,7 @@ initialize_source_git_snapshot
     ).stdout.splitlines()
 
     assert status == ""
-    assert {".gitignore", "payload.py"} <= set(tracked)
+    assert {".gitignore", "payload.py", "tracked.egg-info/PKG-INFO"} <= set(tracked)
     assert ".pdd-package-version" not in tracked
     assert ".pddrc_pddcloud" not in tracked
     assert (workspace / ".pdd-package-version").read_text() == "0.0.303.dev1\n"

--- a/tests/test_cloud_batch_source_upload.py
+++ b/tests/test_cloud_batch_source_upload.py
@@ -65,3 +65,8 @@ def test_cloud_batch_source_upload_includes_checkup_interactive_demo() -> None:
         "cloud-batch source upload must include checkup interactive "
         f"demo fixtures; missing: {missing}"
     )
+
+
+def test_cloud_batch_source_upload_includes_repository_ignore_contract() -> None:
+    """The synthetic worker checkout must retain generated-file exclusions."""
+    assert ".gitignore" in _cloud_batch_source_paths()

--- a/tests/test_cloud_batch_source_upload.py
+++ b/tests/test_cloud_batch_source_upload.py
@@ -70,3 +70,19 @@ def test_cloud_batch_source_upload_includes_checkup_interactive_demo() -> None:
 def test_cloud_batch_source_upload_includes_repository_ignore_contract() -> None:
     """The synthetic worker checkout must retain generated-file exclusions."""
     assert ".gitignore" in _cloud_batch_source_paths()
+
+
+def test_cloud_batch_source_archive_disables_macos_metadata_for_every_write() -> None:
+    """Every tar write must suppress AppleDouble metadata on macOS."""
+    submit_text = SUBMIT_SCRIPT.read_text(encoding="utf-8")
+
+    assert "_source_tar()" in submit_text
+    assert "COPYFILE_DISABLE=1 COPY_EXTENDED_ATTRIBUTES_DISABLE=1 tar \"$@\"" in (
+        submit_text
+    )
+    assert submit_text.count("_source_tar ") == 3
+    assert not any(
+        line.strip().startswith("tar ")
+        and (" -cf " in f" {line} " or " -rf " in f" {line} ")
+        for line in submit_text.splitlines()
+    )

--- a/tests/test_sync_core_includes.py
+++ b/tests/test_sync_core_includes.py
@@ -61,14 +61,14 @@ def test_literal_include_tag_in_prose_does_not_consume_later_markup() -> None:
     assert [item.path for item in references] == ["docs/actual.md"]
 
 
-@pytest.mark.timeout(1)
+@pytest.mark.timeout(1, func_only=True)
 def test_malformed_include_text_is_bounded() -> None:
     """Unterminated include markup cannot trigger superlinear parser backtracking."""
     text = "<include " + ('path="docs/a.md" ' * 20_000)
     assert parse_include_references(text) == ()
 
 
-@pytest.mark.timeout(1)
+@pytest.mark.timeout(1, func_only=True)
 def test_attribute_parser_is_bounded_for_repeated_word_characters() -> None:
     """Unquoted attribute-like input must not cause quadratic regex retries."""
     text = "<include " + ("0" * 15_000) + ">docs/a.md</include>"

--- a/tests/test_sync_core_runner.py
+++ b/tests/test_sync_core_runner.py
@@ -1220,7 +1220,12 @@ def test_default_runtime_digest_cache_invalidates_changed_native_bytes(
     monkeypatch.setattr(runner_module, "_default_runtime_closure_paths", provider)
     monkeypatch.setattr(runner_module, "_runtime_digest_cache", {})
     first = runner_module._released_runtime_closure_digest()
+    original_stat = native.stat()
     native.write_bytes(b"native-v2")
+    os.utime(
+        native,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+    )
     assert runner_module._released_runtime_closure_digest() != first
 
 

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -51,6 +51,8 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(os, "getuid", lambda: 1234)
+    monkeypatch.setattr(os, "getgid", lambda: 2345)
     monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(
         "pdd.sync_core.supervisor.subprocess.run",
@@ -67,9 +69,27 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     assert "--unshare-user" not in bwrap
     separator = bwrap.index("--")
     assert bwrap.index("--bind") < separator < bwrap.index("--reuid")
-    assert bwrap[bwrap.index("--reuid") + 1] == str(os.getuid())
+    assert bwrap[bwrap.index("--reuid") + 1] == "1234"
+    assert bwrap[bwrap.index("--regid") + 1] == "2345"
     assert bwrap.index("--proc") < separator
     assert bwrap[bwrap.index("--ro-bind") + 1].startswith("@FD:")
+
+
+def test_linux_sandbox_fails_closed_for_root_caller(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(os, "getuid", lambda: 0)
+    monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    result, surviving = run_supervised(
+        ["/bin/true"], cwd=tmp_path, timeout=1, env={},
+        writable_roots=(tmp_path,),
+    )
+
+    assert result.returncode == 125
+    assert "non-root caller" in result.stderr
+    assert surviving is False
 
 
 def test_sandbox_directory_bind_provides_parent_for_nested_file(


### PR DESCRIPTION
## Summary

- add the `cryptography>=46,<50` requirement that PR #1985 declared in `pyproject.toml`
- restore the release `check-deps` invariant before v0.0.303

## Investigation

- The release preflight failed with `In pyproject.toml but not requirements.txt: ['cryptography']`.
- `git blame` and `git show 5ab254a09` trace the mismatch to #1985.
- Sibling dependency-sync history uses the same declaration in both files; no other mismatches were found.

## Tests

- `conda run -n pdd --no-capture-output python scripts/check_deps.py` — pass (45 production, 8 dev, 52 requirements)
- `git diff --check` — pass
- Full Cloud Batch release gate — running; final evidence will be posted before merge
