### PR TITLE
fix: resolve auto-heal reverse includes by path

### DIFF
--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -7,5 +7,16 @@
       "from_config_digest": "threshold-ed25519-v1",
       "policy_path": ".pdd/attestation-trust.json"
     }
+  ],
+  "requirement_rotations": [
+    {
+      "prompt_path": "pdd/prompts/ci_detect_changed_modules_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:ef30764861a3080d2fb093ca747f86a3f46bba733a0cdc6a5634efc1b36a73a2",
+      "to_requirement_id": "CONTRACT-SHA256:2d5d65f695fc6c8cd2f3e82f5c5d2a55ad3eb30fc4791b2a1d94ff8465ab6d10",
+      "policy_path": ".pdd/verification-profiles.json",
+      "from_policy_sha256": "ffd867088a7c9a92840130ffd9db9eb8f279e611a02afe501d02855ebb03930f",
+      "to_policy_sha256": "8a957dfa94fdc78ec9d1eb5ea6dfb0a08ff2452928a8b9f6a4dbd5368cb25f53"
+    }
   ]
 }

--- a/.pdd/verification-profiles.json
+++ b/.pdd/verification-profiles.json
@@ -3701,7 +3701,7 @@
       "prompt_path": "pdd/prompts/ci_detect_changed_modules_python.prompt",
       "language_id": "python",
       "required_requirement_ids": [
-        "CONTRACT-SHA256:ef30764861a3080d2fb093ca747f86a3f46bba733a0cdc6a5634efc1b36a73a2"
+        "CONTRACT-SHA256:2d5d65f695fc6c8cd2f3e82f5c5d2a55ad3eb30fc4791b2a1d94ff8465ab6d10"
       ],
       "obligations": [
         {
@@ -3710,7 +3710,7 @@
           "validator_id": "threshold-ed25519",
           "validator_config_digest": "threshold-ed25519-v1",
           "requirement_ids": [
-            "CONTRACT-SHA256:ef30764861a3080d2fb093ca747f86a3f46bba733a0cdc6a5634efc1b36a73a2"
+            "CONTRACT-SHA256:2d5d65f695fc6c8cd2f3e82f5c5d2a55ad3eb30fc4791b2a1d94ff8465ab6d10"
           ],
           "artifact_paths": [
             "pdd/prompts/ci_detect_changed_modules_python.prompt"

--- a/pdd/ci_detect_changed_modules.py
+++ b/pdd/ci_detect_changed_modules.py
@@ -23,6 +23,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 PDD_PATH_PREFIXES = ("pdd/", "prompts/", "context/", "tests/")
 # Package execution shims and CI helper scripts are not PDD dev units;
@@ -59,6 +60,7 @@ _INCLUDE_OPEN_TAG = re.compile(
     re.DOTALL,
 )
 _SELECT_ATTR = re.compile(r"""\bselect\s*=\s*(['"])(.*?)\1""", re.DOTALL)
+_PATH_ATTR = re.compile(r"""\bpath\s*=\s*(['"])(.*?)\1""", re.DOTALL)
 _PROMPT_DIRS = ("prompts/", "pdd/prompts/")
 _INCLUDE_PATH_SUFFIXES = (
     ".bash",
@@ -81,6 +83,15 @@ _INCLUDE_PATH_SUFFIXES = (
     ".yaml",
     ".yml",
 )
+
+
+class _ReverseDepContext(NamedTuple):
+    """Shared immutable inputs and mutable parse cache for closure traversal."""
+
+    repo_root: Path
+    changed_paths: set[str]
+    changed_defs_by_path: dict[str, set[str] | None]
+    refs_by_path: dict[str, list[tuple[str, set[str] | None]]]
 
 
 def _git_changed_files(diff_base: str) -> list[str]:
@@ -195,23 +206,34 @@ def _extract_include_refs(content: str) -> list[tuple[str, set[str] | None]]:
             pos = start + 1
             continue
 
-        close_tag = f"</{match.group('tag')}>"
+        attrs = match.group("attrs") or ""
+        tag = match.group("tag")
+        selected_defs = _selected_defs_from_attrs(attrs)
+        path_attr = _path_from_attrs(attrs) if tag == "include" else None
+        if attrs.rstrip().endswith("/"):
+            if path_attr is not None:
+                normalized = _normalize_repo_path(path_attr)
+                if _looks_like_include_target(normalized):
+                    refs.append((normalized, selected_defs))
+            pos = match.end()
+            continue
+
+        close_tag = f"</{tag}>"
         close_start = content.find(close_tag, match.end())
         if close_start == -1:
             pos = match.end()
             continue
 
-        attrs = match.group("attrs") or ""
         body = content[match.end() : close_start]
         # Prompt prose sometimes mentions literal <include> tags before a real
         # include block. If a candidate body contains another include opener,
         # this was prose, so advance one byte and let the real tag match next.
-        if "<include" in body:
+        if path_attr is None and "<include" in body:
             pos = start + 1
             continue
 
-        selected_defs = _selected_defs_from_attrs(attrs)
-        for part in re.split(r"[,\n]", body):
+        parts = [path_attr] if path_attr is not None else re.split(r"[,\n]", body)
+        for part in parts:
             normalized = _normalize_repo_path(part)
             if _looks_like_include_target(normalized):
                 refs.append((normalized, selected_defs))
@@ -246,6 +268,12 @@ def _selected_defs_from_attrs(attrs: str) -> set[str] | None:
             selected_defs.add(name)
 
     return selected_defs or None
+
+
+def _path_from_attrs(attrs: str) -> str | None:
+    """Return the declared include path, preserving path-over-body precedence."""
+    match = _PATH_ATTR.search(attrs)
+    return match.group(2).strip() if match else None
 
 
 def _diff_base_ref(diff_base: str) -> str:
@@ -322,7 +350,7 @@ def _resolved_include_targets(
         return set()
 
     candidates: list[str] = []
-    for root in (repo_root, prompt_path.resolve().parent):
+    for root in _include_resolution_roots(prompt_path, repo_root):
         try:
             resolved = (root / target).resolve()
             relative = resolved.relative_to(repo_root).as_posix()
@@ -335,6 +363,27 @@ def _resolved_include_targets(
         if resolved.exists():
             return {normalized}
     return set(candidates)
+
+
+def _include_resolution_roots(prompt_path: Path, repo_root: Path) -> tuple[Path, ...]:
+    """Return repository, prompt, and projected-source roots in precedence order."""
+    prompt_resolved = prompt_path.resolve()
+    roots = [repo_root, prompt_resolved.parent]
+    try:
+        relative = prompt_resolved.relative_to(repo_root)
+    except ValueError:
+        return tuple(roots)
+
+    prompt_indexes = [
+        index for index, part in enumerate(relative.parts) if part == "prompts"
+    ]
+    if prompt_indexes:
+        index = prompt_indexes[-1]
+        projected_file = repo_root.joinpath(
+            *relative.parts[:index], *relative.parts[index + 1 :]
+        )
+        roots.append(projected_file.parent)
+    return tuple(dict.fromkeys(roots))
 
 
 def _include_matches_changed(
@@ -370,28 +419,64 @@ def _matching_changed_path(
 
 def _reverse_dep_basename_for_prompt(
     prompt_file: Path,
-    repo_root: Path,
-    changed_paths: set[str],
-    changed_defs_by_path: dict[str, set[str] | None],
+    context: _ReverseDepContext,
 ) -> str | None:
-    """Return a prompt basename when it includes one changed target."""
-    try:
-        content = prompt_file.read_text(encoding="utf-8")
-    except OSError:
-        return None
-
+    """Return a prompt basename when its recursive closure reaches a change."""
     prompt_basename = _prompt_basename_from_path(prompt_file.as_posix())
     if not prompt_basename:
         return None
-    for include_path, selected_defs in _extract_include_refs(content):
-        changed_path = _matching_changed_path(
-            include_path, prompt_file, repo_root, changed_paths
-        )
-        if changed_path is not None and _include_matches_changed(
-            selected_defs, changed_path, changed_defs_by_path
-        ):
-            return prompt_basename
+    if _source_reaches_changed_path(
+        prompt_file,
+        context,
+    ):
+        return prompt_basename
     return None
+
+
+def _source_reaches_changed_path(
+    source_file: Path,
+    context: _ReverseDepContext,
+) -> bool:
+    """Walk one include closure iteratively with deterministic cycle protection."""
+    pending = [source_file]
+    visited: set[str] = set()
+    while pending:
+        current_file = pending.pop()
+        try:
+            source_path = (
+                current_file.resolve().relative_to(context.repo_root).as_posix()
+            )
+        except (OSError, ValueError):
+            continue
+        if source_path in visited:
+            continue
+        visited.add(source_path)
+
+        if source_path not in context.refs_by_path:
+            try:
+                content = current_file.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                context.refs_by_path[source_path] = []
+            else:
+                context.refs_by_path[source_path] = _extract_include_refs(content)
+
+        children: dict[str, Path] = {}
+        for include_path, selected_defs in context.refs_by_path[source_path]:
+            changed_path = _matching_changed_path(
+                include_path, current_file, context.repo_root, context.changed_paths
+            )
+            if changed_path is not None and _include_matches_changed(
+                selected_defs, changed_path, context.changed_defs_by_path
+            ):
+                return True
+            for target in _resolved_include_targets(
+                include_path, current_file, context.repo_root
+            ):
+                target_file = context.repo_root / target
+                if target_file.is_file() and target not in visited:
+                    children[target] = target_file
+        pending.extend(children[path] for path in reversed(sorted(children)))
+    return False
 
 
 def _reverse_dep_basenames(
@@ -414,16 +499,19 @@ def _reverse_dep_basenames(
         path: _changed_python_defs(path, diff_base) for path in changed_paths
     }
     repo_root = Path.cwd().resolve()
+    prompt_files: list[Path] = []
     for pdir in _PROMPT_DIRS:
         prompt_root = Path(pdir)
         if not prompt_root.exists():
             continue
-        for prompt_file in prompt_root.rglob("*.prompt"):
-            prompt_basename = _reverse_dep_basename_for_prompt(
-                prompt_file, repo_root, changed_paths, changed_defs_by_path
-            )
-            if not prompt_basename:
-                continue
+        prompt_files.extend(prompt_root.rglob("*.prompt"))
+
+    context = _ReverseDepContext(
+        repo_root, changed_paths, changed_defs_by_path, {}
+    )
+    for prompt_file in sorted(prompt_files, key=lambda path: path.as_posix()):
+        prompt_basename = _reverse_dep_basename_for_prompt(prompt_file, context)
+        if prompt_basename:
             found.add(prompt_basename)
     return found
 

--- a/pdd/ci_detect_changed_modules.py
+++ b/pdd/ci_detect_changed_modules.py
@@ -306,22 +306,43 @@ def _changed_python_defs(path: str, diff_base: str | None) -> set[str] | None:
     return changed_defs
 
 
+def _resolved_include_targets(
+    include_path: str, prompt_path: Path, repo_root: Path
+) -> set[str]:
+    """Return normalized, in-repository paths an include can resolve to.
+
+    Include processing resolves a repository-relative target before trying the
+    including prompt's directory. Preserve that precedence whenever a target
+    exists. For a deleted target, return the distinct valid candidates so the
+    caller can still detect a reverse dependency when exactly one changed path
+    matches; multiple changed candidates remain deliberately ambiguous.
+    """
+    target = Path(include_path)
+    if target.is_absolute():
+        return set()
+
+    candidates: list[str] = []
+    for root in (repo_root, prompt_path.resolve().parent):
+        try:
+            resolved = (root / target).resolve()
+            relative = resolved.relative_to(repo_root).as_posix()
+        except (OSError, ValueError):
+            continue
+        normalized = _normalize_repo_path(relative)
+        if not normalized or normalized in candidates:
+            continue
+        candidates.append(normalized)
+        if resolved.exists():
+            return {normalized}
+    return set(candidates)
+
+
 def _include_matches_changed(
-    include_path: str,
     selected_defs: set[str] | None,
     changed_path: str,
-    changed_basename: str,
     changed_defs_by_path: dict[str, set[str] | None],
 ) -> bool:
-    """Return True if a prompt include should react to a changed file."""
-    include_basename = os.path.basename(include_path)
-    path_matches = (
-        changed_path.endswith(include_path)
-        or include_path.endswith(changed_basename)
-        or include_basename == changed_basename
-    )
-    if not path_matches:
-        return False
+    """Return True when selectors permit a resolved include to react."""
 
     if selected_defs is None:
         return True
@@ -331,6 +352,46 @@ def _include_matches_changed(
         return True
 
     return bool(selected_defs & changed_defs)
+
+
+def _matching_changed_path(
+    include_path: str,
+    prompt_path: Path,
+    repo_root: Path,
+    changed_paths: set[str],
+) -> str | None:
+    """Return the sole changed file an include resolves to, if unambiguous."""
+    matched_paths = (
+        _resolved_include_targets(include_path, prompt_path, repo_root)
+        & changed_paths
+    )
+    return next(iter(matched_paths)) if len(matched_paths) == 1 else None
+
+
+def _reverse_dep_basename_for_prompt(
+    prompt_file: Path,
+    repo_root: Path,
+    changed_paths: set[str],
+    changed_defs_by_path: dict[str, set[str] | None],
+) -> str | None:
+    """Return a prompt basename when it includes one changed target."""
+    try:
+        content = prompt_file.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    prompt_basename = _prompt_basename_from_path(prompt_file.as_posix())
+    if not prompt_basename:
+        return None
+    for include_path, selected_defs in _extract_include_refs(content):
+        changed_path = _matching_changed_path(
+            include_path, prompt_file, repo_root, changed_paths
+        )
+        if changed_path is not None and _include_matches_changed(
+            selected_defs, changed_path, changed_defs_by_path
+        ):
+            return prompt_basename
+    return None
 
 
 def _reverse_dep_basenames(
@@ -344,39 +405,26 @@ def _reverse_dep_basenames(
     found: set[str] = set()
     if not changed_files:
         return found
-    changed_lookup = {}
+    changed_paths: set[str] = set()
     for path in changed_files:
         normalized = _normalize_repo_path(path)
         if normalized:
-            changed_lookup[normalized] = os.path.basename(normalized)
+            changed_paths.add(normalized)
     changed_defs_by_path = {
-        path: _changed_python_defs(path, diff_base) for path in changed_lookup
+        path: _changed_python_defs(path, diff_base) for path in changed_paths
     }
+    repo_root = Path.cwd().resolve()
     for pdir in _PROMPT_DIRS:
         prompt_root = Path(pdir)
         if not prompt_root.exists():
             continue
         for prompt_file in prompt_root.rglob("*.prompt"):
-            try:
-                content = prompt_file.read_text(encoding="utf-8")
-            except OSError:
-                continue
-            prompt_basename = _prompt_basename_from_path(prompt_file.as_posix())
+            prompt_basename = _reverse_dep_basename_for_prompt(
+                prompt_file, repo_root, changed_paths, changed_defs_by_path
+            )
             if not prompt_basename:
                 continue
-            for include_path, selected_defs in _extract_include_refs(content):
-                if any(
-                    _include_matches_changed(
-                        include_path,
-                        selected_defs,
-                        changed_path,
-                        changed_basename,
-                        changed_defs_by_path,
-                    )
-                    for changed_path, changed_basename in changed_lookup.items()
-                ):
-                    found.add(prompt_basename)
-                    break
+            found.add(prompt_basename)
     return found
 
 

--- a/pdd/prompts/ci_detect_changed_modules_python.prompt
+++ b/pdd/prompts/ci_detect_changed_modules_python.prompt
@@ -42,6 +42,7 @@ The script does not import the PDD package; it operates on repo file conventions
 3. **Basename Extraction**: Implement `_basename_from_path` that dispatches across prompt, context, logic, and test path patterns, applying `EXCLUDED_MODULE_BASENAMES` consistently to all four categories.
 4. **Include Extraction**:
     - `_extract_include_refs(content)` returns a list of `(normalized_path, selected_defs)` tuples.
+    - Parse canonical body-form `<include>path</include>`, body-form `<include path="declared">fallback</include>`, self-closing `<include path="declared" />`, and `<include-many>` syntax. `path=` overrides the include body whenever it is present, including when selectors are also present; never track the fallback body in that case.
     - `selected_defs` is `None` when there is no `select=` attribute OR when the selector is not of the supported `def:<name>` form (conservative fallback).
     - Multiple selectors are comma-separated inside the attribute value; whitespace is stripped.
 5. **AST Function Diffing**:
@@ -50,7 +51,10 @@ The script does not import the PDD package; it operates on repo file conventions
 6. **Reverse Dependency Resolution**:
     - Walk both `prompts/` and `pdd/prompts/` if they exist.
     - For each prompt file, derive its own basename via `_prompt_basename_from_path` and skip prompts whose basename can't be derived.
-    - For each `(include_path, selected_defs)` ref, match against every changed file using three path strategies: full path match, suffix match, or basename match. Selector filtering only applies when the path matched and `selected_defs` is non-None.
+    - Resolve each normalized include to exact in-repository candidates with deterministic precedence: repository-relative, including-prompt-relative, then the canonical source projection formed by removing the `prompts` path component (for example, `pdd/prompts/frontend/components/PromptSelector_typescriptreact.prompt` plus `./CreatePromptModal.tsx` projects to `pdd/frontend/components/CreatePromptModal.tsx`). Prefer the first existing candidate. For a deleted target with no existing candidate, match only when exactly one valid candidate is in the changed-path set; multiple matches are genuinely ambiguous and must fail closed.
+    - Never use suffix or bare-basename matching for reverse dependencies; directory identity is mandatory so same-named files cannot collide across modules.
+    - Compute the complete transitive reverse-dependency closure from changed leaves through included prompts or text artifacts to every outer consumer. Use deterministic traversal with a per-closure visited set so cycles terminate and each source is inspected at most once per consumer.
+    - Selector filtering only applies after an exact resolved path matched and `selected_defs` is non-None. Unknown AST diffs remain conservative as described above.
 7. **Execution Flow**:
     - Fetch changed files via `git diff --name-only <diff-base> -- pdd/ prompts/ context/ tests/`.
     - Direct basename extraction across the changed file list (skipping excluded basenames).

--- a/scripts/ci_detect_changed_modules.py
+++ b/scripts/ci_detect_changed_modules.py
@@ -303,22 +303,43 @@ def _changed_python_defs(path: str, diff_base: str | None) -> set[str] | None:
     return changed_defs
 
 
+def _resolved_include_targets(
+    include_path: str, prompt_path: Path, repo_root: Path
+) -> set[str]:
+    """Return normalized, in-repository paths an include can resolve to.
+
+    Include processing resolves a repository-relative target before trying the
+    including prompt's directory. Preserve that precedence whenever a target
+    exists. For a deleted target, return the distinct valid candidates so the
+    caller can still detect a reverse dependency when exactly one changed path
+    matches; multiple changed candidates remain deliberately ambiguous.
+    """
+    target = Path(include_path)
+    if target.is_absolute():
+        return set()
+
+    candidates: list[str] = []
+    for root in (repo_root, prompt_path.resolve().parent):
+        try:
+            resolved = (root / target).resolve()
+            relative = resolved.relative_to(repo_root).as_posix()
+        except (OSError, ValueError):
+            continue
+        normalized = _normalize_repo_path(relative)
+        if not normalized or normalized in candidates:
+            continue
+        candidates.append(normalized)
+        if resolved.exists():
+            return {normalized}
+    return set(candidates)
+
+
 def _include_matches_changed(
-    include_path: str,
     selected_defs: set[str] | None,
     changed_path: str,
-    changed_basename: str,
     changed_defs_by_path: dict[str, set[str] | None],
 ) -> bool:
-    """Return True if a prompt include should react to a changed file."""
-    include_basename = os.path.basename(include_path)
-    path_matches = (
-        changed_path.endswith(include_path)
-        or include_path.endswith(changed_basename)
-        or include_basename == changed_basename
-    )
-    if not path_matches:
-        return False
+    """Return True when selectors permit a resolved include to react."""
 
     if selected_defs is None:
         return True
@@ -328,6 +349,46 @@ def _include_matches_changed(
         return True
 
     return bool(selected_defs & changed_defs)
+
+
+def _matching_changed_path(
+    include_path: str,
+    prompt_path: Path,
+    repo_root: Path,
+    changed_paths: set[str],
+) -> str | None:
+    """Return the sole changed file an include resolves to, if unambiguous."""
+    matched_paths = (
+        _resolved_include_targets(include_path, prompt_path, repo_root)
+        & changed_paths
+    )
+    return next(iter(matched_paths)) if len(matched_paths) == 1 else None
+
+
+def _reverse_dep_basename_for_prompt(
+    prompt_file: Path,
+    repo_root: Path,
+    changed_paths: set[str],
+    changed_defs_by_path: dict[str, set[str] | None],
+) -> str | None:
+    """Return a prompt basename when it includes one changed target."""
+    try:
+        content = prompt_file.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    prompt_basename = _prompt_basename_from_path(prompt_file.as_posix())
+    if not prompt_basename:
+        return None
+    for include_path, selected_defs in _extract_include_refs(content):
+        changed_path = _matching_changed_path(
+            include_path, prompt_file, repo_root, changed_paths
+        )
+        if changed_path is not None and _include_matches_changed(
+            selected_defs, changed_path, changed_defs_by_path
+        ):
+            return prompt_basename
+    return None
 
 
 def _reverse_dep_basenames(
@@ -341,39 +402,26 @@ def _reverse_dep_basenames(
     found: set[str] = set()
     if not changed_files:
         return found
-    changed_lookup = {}
+    changed_paths: set[str] = set()
     for path in changed_files:
         normalized = _normalize_repo_path(path)
         if normalized:
-            changed_lookup[normalized] = os.path.basename(normalized)
+            changed_paths.add(normalized)
     changed_defs_by_path = {
-        path: _changed_python_defs(path, diff_base) for path in changed_lookup
+        path: _changed_python_defs(path, diff_base) for path in changed_paths
     }
+    repo_root = Path.cwd().resolve()
     for pdir in _PROMPT_DIRS:
         prompt_root = Path(pdir)
         if not prompt_root.exists():
             continue
         for prompt_file in prompt_root.rglob("*.prompt"):
-            try:
-                content = prompt_file.read_text(encoding="utf-8")
-            except OSError:
-                continue
-            prompt_basename = _prompt_basename_from_path(prompt_file.as_posix())
+            prompt_basename = _reverse_dep_basename_for_prompt(
+                prompt_file, repo_root, changed_paths, changed_defs_by_path
+            )
             if not prompt_basename:
                 continue
-            for include_path, selected_defs in _extract_include_refs(content):
-                if any(
-                    _include_matches_changed(
-                        include_path,
-                        selected_defs,
-                        changed_path,
-                        changed_basename,
-                        changed_defs_by_path,
-                    )
-                    for changed_path, changed_basename in changed_lookup.items()
-                ):
-                    found.add(prompt_basename)
-                    break
+            found.add(prompt_basename)
     return found
 
 

--- a/scripts/ci_detect_changed_modules.py
+++ b/scripts/ci_detect_changed_modules.py
@@ -20,6 +20,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 PDD_PATH_PREFIXES = ("pdd/", "prompts/", "context/", "tests/")
 # Package execution shims and CI helper scripts are not PDD dev units;
@@ -56,6 +57,7 @@ _INCLUDE_OPEN_TAG = re.compile(
     re.DOTALL,
 )
 _SELECT_ATTR = re.compile(r"""\bselect\s*=\s*(['"])(.*?)\1""", re.DOTALL)
+_PATH_ATTR = re.compile(r"""\bpath\s*=\s*(['"])(.*?)\1""", re.DOTALL)
 _PROMPT_DIRS = ("prompts/", "pdd/prompts/")
 _INCLUDE_PATH_SUFFIXES = (
     ".bash",
@@ -78,6 +80,15 @@ _INCLUDE_PATH_SUFFIXES = (
     ".yaml",
     ".yml",
 )
+
+
+class _ReverseDepContext(NamedTuple):
+    """Shared immutable inputs and mutable parse cache for closure traversal."""
+
+    repo_root: Path
+    changed_paths: set[str]
+    changed_defs_by_path: dict[str, set[str] | None]
+    refs_by_path: dict[str, list[tuple[str, set[str] | None]]]
 
 
 def _git_changed_files(diff_base: str) -> list[str]:
@@ -192,23 +203,34 @@ def _extract_include_refs(content: str) -> list[tuple[str, set[str] | None]]:
             pos = start + 1
             continue
 
-        close_tag = f"</{match.group('tag')}>"
+        attrs = match.group("attrs") or ""
+        tag = match.group("tag")
+        selected_defs = _selected_defs_from_attrs(attrs)
+        path_attr = _path_from_attrs(attrs) if tag == "include" else None
+        if attrs.rstrip().endswith("/"):
+            if path_attr is not None:
+                normalized = _normalize_repo_path(path_attr)
+                if _looks_like_include_target(normalized):
+                    refs.append((normalized, selected_defs))
+            pos = match.end()
+            continue
+
+        close_tag = f"</{tag}>"
         close_start = content.find(close_tag, match.end())
         if close_start == -1:
             pos = match.end()
             continue
 
-        attrs = match.group("attrs") or ""
         body = content[match.end() : close_start]
         # Prompt prose sometimes mentions literal <include> tags before a real
         # include block. If a candidate body contains another include opener,
         # this was prose, so advance one byte and let the real tag match next.
-        if "<include" in body:
+        if path_attr is None and "<include" in body:
             pos = start + 1
             continue
 
-        selected_defs = _selected_defs_from_attrs(attrs)
-        for part in re.split(r"[,\n]", body):
+        parts = [path_attr] if path_attr is not None else re.split(r"[,\n]", body)
+        for part in parts:
             normalized = _normalize_repo_path(part)
             if _looks_like_include_target(normalized):
                 refs.append((normalized, selected_defs))
@@ -243,6 +265,12 @@ def _selected_defs_from_attrs(attrs: str) -> set[str] | None:
             selected_defs.add(name)
 
     return selected_defs or None
+
+
+def _path_from_attrs(attrs: str) -> str | None:
+    """Return the declared include path, preserving path-over-body precedence."""
+    match = _PATH_ATTR.search(attrs)
+    return match.group(2).strip() if match else None
 
 
 def _diff_base_ref(diff_base: str) -> str:
@@ -319,7 +347,7 @@ def _resolved_include_targets(
         return set()
 
     candidates: list[str] = []
-    for root in (repo_root, prompt_path.resolve().parent):
+    for root in _include_resolution_roots(prompt_path, repo_root):
         try:
             resolved = (root / target).resolve()
             relative = resolved.relative_to(repo_root).as_posix()
@@ -332,6 +360,27 @@ def _resolved_include_targets(
         if resolved.exists():
             return {normalized}
     return set(candidates)
+
+
+def _include_resolution_roots(prompt_path: Path, repo_root: Path) -> tuple[Path, ...]:
+    """Return repository, prompt, and projected-source roots in precedence order."""
+    prompt_resolved = prompt_path.resolve()
+    roots = [repo_root, prompt_resolved.parent]
+    try:
+        relative = prompt_resolved.relative_to(repo_root)
+    except ValueError:
+        return tuple(roots)
+
+    prompt_indexes = [
+        index for index, part in enumerate(relative.parts) if part == "prompts"
+    ]
+    if prompt_indexes:
+        index = prompt_indexes[-1]
+        projected_file = repo_root.joinpath(
+            *relative.parts[:index], *relative.parts[index + 1 :]
+        )
+        roots.append(projected_file.parent)
+    return tuple(dict.fromkeys(roots))
 
 
 def _include_matches_changed(
@@ -367,28 +416,64 @@ def _matching_changed_path(
 
 def _reverse_dep_basename_for_prompt(
     prompt_file: Path,
-    repo_root: Path,
-    changed_paths: set[str],
-    changed_defs_by_path: dict[str, set[str] | None],
+    context: _ReverseDepContext,
 ) -> str | None:
-    """Return a prompt basename when it includes one changed target."""
-    try:
-        content = prompt_file.read_text(encoding="utf-8")
-    except OSError:
-        return None
-
+    """Return a prompt basename when its recursive closure reaches a change."""
     prompt_basename = _prompt_basename_from_path(prompt_file.as_posix())
     if not prompt_basename:
         return None
-    for include_path, selected_defs in _extract_include_refs(content):
-        changed_path = _matching_changed_path(
-            include_path, prompt_file, repo_root, changed_paths
-        )
-        if changed_path is not None and _include_matches_changed(
-            selected_defs, changed_path, changed_defs_by_path
-        ):
-            return prompt_basename
+    if _source_reaches_changed_path(
+        prompt_file,
+        context,
+    ):
+        return prompt_basename
     return None
+
+
+def _source_reaches_changed_path(
+    source_file: Path,
+    context: _ReverseDepContext,
+) -> bool:
+    """Walk one include closure iteratively with deterministic cycle protection."""
+    pending = [source_file]
+    visited: set[str] = set()
+    while pending:
+        current_file = pending.pop()
+        try:
+            source_path = (
+                current_file.resolve().relative_to(context.repo_root).as_posix()
+            )
+        except (OSError, ValueError):
+            continue
+        if source_path in visited:
+            continue
+        visited.add(source_path)
+
+        if source_path not in context.refs_by_path:
+            try:
+                content = current_file.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                context.refs_by_path[source_path] = []
+            else:
+                context.refs_by_path[source_path] = _extract_include_refs(content)
+
+        children: dict[str, Path] = {}
+        for include_path, selected_defs in context.refs_by_path[source_path]:
+            changed_path = _matching_changed_path(
+                include_path, current_file, context.repo_root, context.changed_paths
+            )
+            if changed_path is not None and _include_matches_changed(
+                selected_defs, changed_path, context.changed_defs_by_path
+            ):
+                return True
+            for target in _resolved_include_targets(
+                include_path, current_file, context.repo_root
+            ):
+                target_file = context.repo_root / target
+                if target_file.is_file() and target not in visited:
+                    children[target] = target_file
+        pending.extend(children[path] for path in reversed(sorted(children)))
+    return False
 
 
 def _reverse_dep_basenames(
@@ -411,16 +496,19 @@ def _reverse_dep_basenames(
         path: _changed_python_defs(path, diff_base) for path in changed_paths
     }
     repo_root = Path.cwd().resolve()
+    prompt_files: list[Path] = []
     for pdir in _PROMPT_DIRS:
         prompt_root = Path(pdir)
         if not prompt_root.exists():
             continue
-        for prompt_file in prompt_root.rglob("*.prompt"):
-            prompt_basename = _reverse_dep_basename_for_prompt(
-                prompt_file, repo_root, changed_paths, changed_defs_by_path
-            )
-            if not prompt_basename:
-                continue
+        prompt_files.extend(prompt_root.rglob("*.prompt"))
+
+    context = _ReverseDepContext(
+        repo_root, changed_paths, changed_defs_by_path, {}
+    )
+    for prompt_file in sorted(prompt_files, key=lambda path: path.as_posix()):
+        prompt_basename = _reverse_dep_basename_for_prompt(prompt_file, context)
+        if prompt_basename:
             found.add(prompt_basename)
     return found
 

--- a/tests/test_ci_detect_changed_modules.py
+++ b/tests/test_ci_detect_changed_modules.py
@@ -321,6 +321,27 @@ def test_reverse_dep_traverses_complete_include_closure(tmp_path, monkeypatch):
     assert result >= {"nested/inner", "nested/outer"}
 
 
+def test_reverse_dep_closure_traverses_included_artifacts(tmp_path, monkeypatch):
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+
+    prompt_dir = tmp_path / "prompts"
+    docs_dir = tmp_path / "docs"
+    source_dir = tmp_path / "pdd"
+    prompt_dir.mkdir()
+    docs_dir.mkdir()
+    source_dir.mkdir()
+    (source_dir / "leaf.py").write_text("leaf = True\n", encoding="utf-8")
+    (docs_dir / "inner.md").write_text(
+        "<include>pdd/leaf.py</include>", encoding="utf-8"
+    )
+    (prompt_dir / "outer_python.prompt").write_text(
+        "<include>docs/inner.md</include>", encoding="utf-8"
+    )
+
+    assert "outer" in module._reverse_dep_basenames(["pdd/leaf.py"])
+
+
 @pytest.mark.timeout(1)
 def test_reverse_dep_include_cycle_terminates_deterministically(tmp_path, monkeypatch):
     module = _load_module()

--- a/tests/test_ci_detect_changed_modules.py
+++ b/tests/test_ci_detect_changed_modules.py
@@ -186,6 +186,77 @@ def test_reverse_dep_respects_selected_function_changes(tmp_path, monkeypatch):
     assert "old_consumer" not in result
 
 
+def test_reverse_dep_matches_exact_repo_and_prompt_relative_paths(tmp_path, monkeypatch):
+    """Repository and prompt-relative includes must resolve without basename matching."""
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+
+    prompt_dir = tmp_path / "pdd" / "prompts" / "nested"
+    prompt_dir.mkdir(parents=True)
+    (tmp_path / "pdd" / "shared.py").write_text(
+        "def root_change():\n    return 'root'\n", encoding="utf-8"
+    )
+    relative_target = prompt_dir / "parts" / "shared.py"
+    relative_target.parent.mkdir()
+    relative_target.write_text(
+        "def relative_change():\n    return 'relative'\n", encoding="utf-8"
+    )
+    (prompt_dir / "repo_consumer_python.prompt").write_text(
+        "<include>pdd/shared.py</include>", encoding="utf-8"
+    )
+    (prompt_dir / "relative_consumer_python.prompt").write_text(
+        '<include select="def:relative_change">./parts/shared.py</include>',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        module,
+        "_changed_python_defs",
+        lambda path, diff_base: {"relative_change"}
+        if path == "pdd/prompts/nested/parts/shared.py"
+        else None,
+    )
+
+    result = module._reverse_dep_basenames(
+        ["pdd/shared.py", "pdd/prompts/nested/parts/shared.py"],
+        diff_base="origin/main...HEAD",
+    )
+
+    assert "nested/repo_consumer" in result
+    assert "nested/relative_consumer" in result
+
+
+def test_reverse_dep_ignores_cross_directory_basename_collisions(
+    tmp_path, monkeypatch
+):
+    """An include must not pull in a similarly named module from another directory."""
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    (tmp_path / "pdd").mkdir()
+    (tmp_path / "pdd" / "evidence_store.py").write_text(
+        "def target():\n    return 'target'\n", encoding="utf-8"
+    )
+    (tmp_path / "pdd" / "agentic_sync_runner.py").write_text(
+        "def target():\n    return 'target'\n", encoding="utf-8"
+    )
+    (prompt_dir / "evidence_consumer_python.prompt").write_text(
+        "<include>pdd/evidence_store.py</include>", encoding="utf-8"
+    )
+    (prompt_dir / "runner_consumer_python.prompt").write_text(
+        "<include>pdd/agentic_sync_runner.py</include>", encoding="utf-8"
+    )
+
+    result = module._reverse_dep_basenames(
+        ["pdd/sync_core/evidence_store.py", "pdd/sync_core/runner.py"]
+    )
+
+    assert "evidence_consumer" not in result
+    assert "runner_consumer" not in result
+
+
 def test_reverse_dep_without_diff_base_keeps_conservative_matching(
     tmp_path, monkeypatch
 ):

--- a/tests/test_ci_detect_changed_modules.py
+++ b/tests/test_ci_detect_changed_modules.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 
 def _load_module():
     script_path = (
@@ -226,6 +228,18 @@ def test_reverse_dep_matches_exact_repo_and_prompt_relative_paths(tmp_path, monk
     assert "nested/relative_consumer" in result
 
 
+def test_reverse_dep_projects_packaged_prompt_to_source_tree(monkeypatch):
+    """Packaged prompt-relative includes resolve against the canonical source tree."""
+    monkeypatch.chdir(_repo_root())
+
+    for module in (_load_module(), _load_packaged_module()):
+        result = module._reverse_dep_basenames(
+            ["pdd/frontend/components/CreatePromptModal.tsx"]
+        )
+
+        assert "frontend/components/PromptSelector" in result
+
+
 def test_reverse_dep_ignores_cross_directory_basename_collisions(
     tmp_path, monkeypatch
 ):
@@ -255,6 +269,79 @@ def test_reverse_dep_ignores_cross_directory_basename_collisions(
 
     assert "evidence_consumer" not in result
     assert "runner_consumer" not in result
+
+
+def test_extract_include_refs_honors_path_attribute_precedence():
+    module = _load_module()
+
+    refs = module._extract_include_refs(
+        '<include path="pdd/right.py">pdd/wrong.py</include>\n'
+        '<include select="def:chosen" path="pdd/right.py" />'
+    )
+
+    assert refs == [("pdd/right.py", None), ("pdd/right.py", {"chosen"})]
+
+
+def test_reverse_dep_path_attribute_tracks_target_not_body(tmp_path, monkeypatch):
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+
+    prompt_dir = tmp_path / "prompts"
+    source_dir = tmp_path / "pdd"
+    prompt_dir.mkdir()
+    source_dir.mkdir()
+    (source_dir / "right.py").write_text("right = True\n", encoding="utf-8")
+    (source_dir / "wrong.py").write_text("wrong = True\n", encoding="utf-8")
+    (prompt_dir / "consumer_python.prompt").write_text(
+        '<include path="pdd/right.py">pdd/wrong.py</include>', encoding="utf-8"
+    )
+
+    assert "consumer" in module._reverse_dep_basenames(["pdd/right.py"])
+    assert "consumer" not in module._reverse_dep_basenames(["pdd/wrong.py"])
+
+
+def test_reverse_dep_traverses_complete_include_closure(tmp_path, monkeypatch):
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+
+    prompt_dir = tmp_path / "prompts" / "nested"
+    source_dir = tmp_path / "pdd"
+    prompt_dir.mkdir(parents=True)
+    source_dir.mkdir()
+    (source_dir / "leaf.py").write_text("leaf = True\n", encoding="utf-8")
+    (prompt_dir / "inner_python.prompt").write_text(
+        "<include>pdd/leaf.py</include>", encoding="utf-8"
+    )
+    (prompt_dir / "outer_python.prompt").write_text(
+        "<include>./inner_python.prompt</include>", encoding="utf-8"
+    )
+
+    result = module._reverse_dep_basenames(["pdd/leaf.py"])
+
+    assert result >= {"nested/inner", "nested/outer"}
+
+
+@pytest.mark.timeout(1)
+def test_reverse_dep_include_cycle_terminates_deterministically(tmp_path, monkeypatch):
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+
+    prompt_dir = tmp_path / "prompts"
+    source_dir = tmp_path / "pdd"
+    prompt_dir.mkdir()
+    source_dir.mkdir()
+    (source_dir / "leaf.py").write_text("leaf = True\n", encoding="utf-8")
+    (prompt_dir / "a_python.prompt").write_text(
+        "<include>pdd/leaf.py</include><include>./b_python.prompt</include>",
+        encoding="utf-8",
+    )
+    (prompt_dir / "b_python.prompt").write_text(
+        "<include>./a_python.prompt</include>", encoding="utf-8"
+    )
+
+    result = module._reverse_dep_basenames(["pdd/leaf.py"])
+
+    assert result == {"a", "b"}
 
 
 def test_reverse_dep_without_diff_base_keeps_conservative_matching(
@@ -370,3 +457,13 @@ def test_detect_excludes_package_main_shim(monkeypatch):
     )
 
     assert module.detect("origin/main...HEAD") == []
+
+
+def test_prompt_contract_requires_exact_transitive_include_matching():
+    prompt = (
+        _repo_root() / "pdd" / "prompts" / "ci_detect_changed_modules_python.prompt"
+    ).read_text(encoding="utf-8")
+
+    assert "Never use suffix or bare-basename matching" in prompt
+    assert "complete transitive reverse-dependency closure" in prompt
+    assert "`path=` overrides the include body" in prompt


### PR DESCRIPTION
## Summary
- resolve reverse dependencies against repository and prompt-relative paths instead of basenames
- preserve selector filtering, nested relative includes, and packaged helper parity
- prevent cross-directory evidence_store.py and runner.py collisions

## Test plan
- pytest -q tests/test_ci_detect_changed_modules.py
- pylint with existing baseline diagnostics suppressed for touched files
- python scripts/ci_detect_changed_modules.py --diff-base origin/main...HEAD
- git diff --check