### PR TITLE
fix(sync): eliminate runtime digest test barrier race

### DIFF
--- a/tests/test_sync_core_runner.py
+++ b/tests/test_sync_core_runner.py
@@ -7,6 +7,7 @@ import sys
 import threading
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
+from typing import Callable
 
 import pytest
 import pdd.sync_core.runner as runner_module
@@ -91,6 +92,26 @@ def _run(
         ),
         config=RunnerConfig(timeout_seconds=20),
     )
+
+
+def _observe_runtime_digest_hash_workers(
+    original: Callable[[tuple[str, Path]], tuple[str, bytes] | None],
+    barrier: threading.Barrier,
+    thread_ids: set[int],
+    *,
+    interleaving_hook: Callable[[], None] | None = None,
+) -> Callable[[tuple[str, Path]], tuple[str, bytes] | None]:
+    """Observe runtime-digest hashing workers while selecting two barrier peers."""
+
+    def observed(entry: tuple[str, Path]) -> tuple[str, bytes] | None:
+        thread_ids.add(threading.get_ident())
+        if interleaving_hook is not None:
+            interleaving_hook()
+        if len(thread_ids) <= 2:
+            barrier.wait(timeout=2)
+        return original(entry)
+
+    return observed
 
 
 def test_passing_collected_test_is_pass(tmp_path) -> None:
@@ -1253,6 +1274,58 @@ def test_released_runtime_digest_hashes_entries_concurrently(
     runner_module._released_runtime_closure_digest()
 
     assert len(thread_ids) > 1
+
+
+def test_runtime_digest_hash_observer_selects_two_workers_atomically() -> None:
+    barrier = threading.Barrier(2)
+    first_selected = threading.Event()
+    third_finished = threading.Event()
+    thread_ids: set[int] = set()
+    worker_errors: list[BaseException] = []
+    third: threading.Thread | None = None
+
+    def run_observer(worker: str) -> None:
+        try:
+            observed((worker, Path(worker)))
+        except threading.BrokenBarrierError as error:
+            worker_errors.append(error)
+        finally:
+            if worker == "third":
+                third_finished.set()
+
+    def interleave_after_second_registration() -> None:
+        nonlocal third
+        worker = threading.current_thread().name
+        if worker == "first":
+            first_selected.set()
+        elif worker == "second":
+            third = threading.Thread(target=run_observer, args=("third",), name="third")
+            third.start()
+            assert third_finished.wait(timeout=2)
+
+    observed = _observe_runtime_digest_hash_workers(
+        lambda _entry: None,
+        barrier,
+        thread_ids,
+        interleaving_hook=interleave_after_second_registration,
+    )
+    first = threading.Thread(target=run_observer, args=("first",), name="first")
+    second = threading.Thread(target=run_observer, args=("second",), name="second")
+
+    first.start()
+    assert first_selected.wait(timeout=2)
+    second.start()
+    second.join(timeout=2)
+    assert not second.is_alive()
+    assert third is not None
+    third.join(timeout=2)
+    assert not third.is_alive()
+    barrier.abort()
+    first.join(timeout=2)
+
+    assert not first.is_alive()
+    assert len(thread_ids) == 3
+    assert worker_errors == []
 
 
 def test_released_runtime_digest_binds_runtime_and_sandbox_bytes_prefix_portably(

--- a/tests/test_sync_core_runner.py
+++ b/tests/test_sync_core_runner.py
@@ -94,6 +94,28 @@ def _run(
     )
 
 
+class _BarrierWithArrivalSignal:
+    """Expose when a worker has entered a two-party test barrier."""
+
+    def __init__(self) -> None:
+        self._barrier = threading.Barrier(2)
+        self.first_waiting = threading.Event()
+
+    @property
+    def n_waiting(self) -> int:
+        """Return the current number of barrier waiters."""
+        return self._barrier.n_waiting
+
+    def wait(self, timeout: float | None = None) -> int:
+        """Signal arrival, then wait for the second selected worker."""
+        self.first_waiting.set()
+        return self._barrier.wait(timeout)
+
+    def abort(self) -> None:
+        """Release a deliberately stranded worker during test cleanup."""
+        self._barrier.abort()
+
+
 def _observe_runtime_digest_hash_workers(
     original: Callable[[tuple[str, Path]], tuple[str, bytes] | None],
     barrier: threading.Barrier,
@@ -102,12 +124,18 @@ def _observe_runtime_digest_hash_workers(
     interleaving_hook: Callable[[], None] | None = None,
 ) -> Callable[[tuple[str, Path]], tuple[str, bytes] | None]:
     """Observe runtime-digest hashing workers while selecting two barrier peers."""
+    participant_lock = threading.Lock()
 
     def observed(entry: tuple[str, Path]) -> tuple[str, bytes] | None:
-        thread_ids.add(threading.get_ident())
+        with participant_lock:
+            worker_id = threading.get_ident()
+            selected_for_barrier = (
+                worker_id not in thread_ids and len(thread_ids) < 2
+            )
+            thread_ids.add(worker_id)
         if interleaving_hook is not None:
             interleaving_hook()
-        if len(thread_ids) <= 2:
+        if selected_for_barrier:
             barrier.wait(timeout=2)
         return original(entry)
 
@@ -1260,13 +1288,16 @@ def test_released_runtime_digest_hashes_entries_concurrently(
         entries.append((path.name, path))
     barrier = threading.Barrier(2)
     thread_ids = set()
+    hashed_entries = set()
+    hashed_entries_lock = threading.Lock()
     original = runner_module._hash_runtime_entry
+    observer = _observe_runtime_digest_hash_workers(original, barrier, thread_ids)
 
     def observed(entry):
-        thread_ids.add(threading.get_ident())
-        if len(thread_ids) <= 2:
-            barrier.wait(timeout=2)
-        return original(entry)
+        result = observer(entry)
+        with hashed_entries_lock:
+            hashed_entries.add(entry[0])
+        return result
 
     monkeypatch.setattr(runner_module, "_released_runtime_closure_paths", lambda: tuple(entries))
     monkeypatch.setattr(runner_module, "_hash_runtime_entry", observed)
@@ -1274,10 +1305,11 @@ def test_released_runtime_digest_hashes_entries_concurrently(
     runner_module._released_runtime_closure_digest()
 
     assert len(thread_ids) > 1
+    assert hashed_entries == {name for name, _path in entries}
 
 
 def test_runtime_digest_hash_observer_selects_two_workers_atomically() -> None:
-    barrier = threading.Barrier(2)
+    barrier = _BarrierWithArrivalSignal()
     first_selected = threading.Event()
     third_finished = threading.Event()
     thread_ids: set[int] = set()
@@ -1314,13 +1346,15 @@ def test_runtime_digest_hash_observer_selects_two_workers_atomically() -> None:
 
     first.start()
     assert first_selected.wait(timeout=2)
+    assert barrier.first_waiting.wait(timeout=2)
     second.start()
     second.join(timeout=2)
     assert not second.is_alive()
     assert third is not None
     third.join(timeout=2)
     assert not third.is_alive()
-    barrier.abort()
+    if barrier.n_waiting:
+        barrier.abort()
     first.join(timeout=2)
 
     assert not first.is_alive()


### PR DESCRIPTION
## Summary
- Atomically select exactly two distinct runtime-digest hash workers in the test observer.
- Add a deterministic interleaving harness that reproduces the former stranded-barrier failure.
- Confirm every runtime entry still reaches the real hash function and retain the multi-worker assertion.

Closes #2015.

## Test plan
- [x] Red test commit: deterministic observer harness fails with one BrokenBarrierError before the fix.
- [x] Deterministic observer harness: 2,000/2,000 direct iterations passed after the fix.
- [x] Focused pytest pair passed.
- [x] tests/test_sync_core_runner.py: 37 passed, 46 skipped.
- [x] pylint errors-only, Python compile, and diff checks passed.
- [!] Protected subset ran: 134 passed, 70 skipped, 4 existing trusted-finalizer reporting failures (pytest=COLLECTION_ERROR); no production code or reporting tests are changed here.
