### PR TITLE
Preauthorize generated metadata for PR #2017

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -174,6 +174,20 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_langtest_python.json",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/agentic_langtest_python_run.json",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/agentic_sync_python.json",
       "role": "human-maintained"
     },
@@ -278,6 +292,13 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/code_generator_main_python_run.json",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/commands_checkup_python.json",
       "role": "human-maintained"
     },
@@ -369,7 +390,21 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/fix_code_loop_python_run.json",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/fix_error_loop_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/fix_error_loop_python_run.json",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
@@ -389,6 +424,13 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/get_test_command_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/get_test_command_python_run.json",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {

--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -261,6 +261,28 @@
       "head_policy_sha256": "56ea5d189034c9d85e91c86348689eb18c4c34fa67406258f78f0ae3330eaeb6",
       "base_prompt_sha256": "88ba7a932f444bb1b91e17429ca8c211742fadc8457b96d71b648b2529785d4f",
       "head_prompt_sha256": "fbd4c2c6592bcb6950868a6b57691a66c2c3cd16d0ffd4a39abf3081ba613931"
+    },
+    {
+      "prompt_path": "pdd/prompts/get_test_command_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:ef559f5558fb627aa53f078cba0eaae221a7af9a2c6bdadf580a4cb12bf217b7",
+      "to_requirement_id": "CONTRACT-SHA256:023045865bfe0d5920b5008986106a16e7014b35f09fc80faa43b1f0d42bcd44",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "56ea5d189034c9d85e91c86348689eb18c4c34fa67406258f78f0ae3330eaeb6",
+      "head_policy_sha256": "85fbc4f5957e9872b7d368a1b6f9e8c3bad852142ed4c0ec49589eaf63bd8fb3",
+      "base_prompt_sha256": "ef559f5558fb627aa53f078cba0eaae221a7af9a2c6bdadf580a4cb12bf217b7",
+      "head_prompt_sha256": "023045865bfe0d5920b5008986106a16e7014b35f09fc80faa43b1f0d42bcd44"
+    },
+    {
+      "prompt_path": "pdd/prompts/fix_error_loop_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:afffd825b4495819b853fec9a86b0be7644f6fe0468d40548d8b9b2803d183ce",
+      "to_requirement_id": "CONTRACT-SHA256:8f4ef46cf85f9ed8e4ff28732dba2614005a1d50d6793ceb25e15608d5ffb751",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "56ea5d189034c9d85e91c86348689eb18c4c34fa67406258f78f0ae3330eaeb6",
+      "head_policy_sha256": "85fbc4f5957e9872b7d368a1b6f9e8c3bad852142ed4c0ec49589eaf63bd8fb3",
+      "base_prompt_sha256": "afffd825b4495819b853fec9a86b0be7644f6fe0468d40548d8b9b2803d183ce",
+      "head_prompt_sha256": "8f4ef46cf85f9ed8e4ff28732dba2614005a1d50d6793ceb25e15608d5ffb751"
     }
   ]
 }

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -377,6 +377,22 @@ _PDD_1989_COMPOSED_ESTIMATE_REQUIREMENT_TRANSITIONS = (
         "71b12a08e5be55b958a737decde889c189f7ca00ceaddccd7b587f9c8b2a4b64",
         "1b4641d57921012a4aa7c507bb38b31c29dcc8ad23b370f0c4b979d8ff0a5d18",
     ),
+    _exact_bootstrap_requirement_transition(
+        "pdd/prompts/get_test_command_python.prompt",
+        "python",
+        "ef559f5558fb627aa53f078cba0eaae221a7af9a2c6bdadf580a4cb12bf217b7",
+        "023045865bfe0d5920b5008986106a16e7014b35f09fc80faa43b1f0d42bcd44",
+        "56ea5d189034c9d85e91c86348689eb18c4c34fa67406258f78f0ae3330eaeb6",
+        "85fbc4f5957e9872b7d368a1b6f9e8c3bad852142ed4c0ec49589eaf63bd8fb3",
+    ),
+    _exact_bootstrap_requirement_transition(
+        "pdd/prompts/fix_error_loop_python.prompt",
+        "python",
+        "afffd825b4495819b853fec9a86b0be7644f6fe0468d40548d8b9b2803d183ce",
+        "8f4ef46cf85f9ed8e4ff28732dba2614005a1d50d6793ceb25e15608d5ffb751",
+        "56ea5d189034c9d85e91c86348689eb18c4c34fa67406258f78f0ae3330eaeb6",
+        "85fbc4f5957e9872b7d368a1b6f9e8c3bad852142ed4c0ec49589eaf63bd8fb3",
+    ),
 )
 _BOOTSTRAP_REQUIREMENT_TRANSITIONS += (
     _PDD_1989_COMPOSED_ESTIMATE_REQUIREMENT_TRANSITIONS
@@ -633,6 +649,7 @@ class _DuplicateJsonMember(ValueError):
 
 def _strict_policy_json(raw: bytes, source: str) -> dict[str, Any]:
     """Decode policy JSON while rejecting duplicate object members at every level."""
+
     def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
         payload: dict[str, Any] = {}
         for key, value in pairs:
@@ -816,9 +833,7 @@ def _parse_requirement_transition_authorizations(
         if type(schema_version) is not int:
             raise TypeError
         if schema_version == 1:
-            _parse_dormant_policy_envelope(
-                raw, source, allow_legacy_protected=True
-            )
+            _parse_dormant_policy_envelope(raw, source, allow_legacy_protected=True)
             return ()
         rows = payload["requirement_rotations"]
         if (
@@ -1415,8 +1430,7 @@ def _validate_retirement_managed_prompt_bytes(
     changed = _managed_prompt_byte_changes(root, manifest, approved_aliases)
     if changed:
         raise VerificationProfileError(
-            "candidate retirement changes managed prompt bytes: "
-            f"{sorted(changed)[0]}"
+            f"candidate retirement changes managed prompt bytes: {sorted(changed)[0]}"
         )
 
 
@@ -2124,10 +2138,8 @@ def load_verification_profiles(root: Path, manifest: UnitManifest) -> ProfileSet
         requirement_authorizations,
         requirement_prompts,
         new_requirement_authorizations,
-    ) = (
-        _load_requirement_transition_authorizations(
-            root, manifest, base, head, approved_aliases
-        )
+    ) = _load_requirement_transition_authorizations(
+        root, manifest, base, head, approved_aliases
     )
     profile_additions = _authorized_profile_additions(root, manifest, base, head)
     if new_requirement_authorizations:

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -35,7 +35,7 @@ EXPECTED_MANAGED_UNITS = 468
 PDD_1989_ACTUAL_BASE = "39a60ec06dc065a70ad63077b6f873aca95cbf45"
 PDD_1989_ACTUAL_HEAD = "131f86d83e7f2058af861b8ee7bde432bbbf5027"
 CANDIDATE_ONLY_SOURCE_MODE = "candidate-tree-v1"
-PR_2017_PHASE_A_BASE = "39776aa9bb027c638812a01b8dabbe03cab92f64"
+PR_2017_PHASE_A_BASE = "c887daba0d171585658f8205e79316e5f36f82c6"
 FOUNDATION_PROFILE_PATHS = {
     "pdd/sync_core/descriptor_store.py",
     "pdd/sync_core/signer_process.py",
@@ -87,19 +87,22 @@ ISSUE_2083_VITEST_COORDINATOR_PREAUTHORIZED_PATHS = {
     "scripts/build_vitest_fd_cloexec_addon.py",
     "setup.py",
 }
+PR_2017_ABSENT_METADATA_PATHS = {
+    ".pdd/meta/agentic_langtest_python.json",
+    ".pdd/meta/agentic_langtest_python_run.json",
+    ".pdd/meta/code_generator_main_python_run.json",
+    ".pdd/meta/fix_code_loop_python_run.json",
+    ".pdd/meta/fix_error_loop_python_run.json",
+    ".pdd/meta/get_test_command_python_run.json",
+}
 PREAUTHORIZED_CHILD_PATHS = (
     LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS
     | ISSUE_2083_VITEST_COORDINATOR_PREAUTHORIZED_PATHS
+    | PR_2017_ABSENT_METADATA_PATHS
     | {
         ".github/toolchains/playwright_manifest.py",
         ".pdd/meta/agentic_checkup_orchestrator_python_run.json",
-        ".pdd/meta/agentic_langtest_python.json",
-        ".pdd/meta/agentic_langtest_python_run.json",
         ".pdd/meta/checkup_agentic_artifact_python.json",
-        ".pdd/meta/code_generator_main_python_run.json",
-        ".pdd/meta/fix_code_loop_python_run.json",
-        ".pdd/meta/fix_error_loop_python_run.json",
-        ".pdd/meta/get_test_command_python_run.json",
         ".pdd/meta/story_regression_python.json",
         "ci/cloud-batch/cloud-regression-runner.py",
         "context/checkup_agentic_artifact_example.py",
@@ -1477,6 +1480,37 @@ def test_protected_base_pre_authorizes_absent_exact_child_paths(
         )
     assert not manifest.unaccounted_tracked_paths
     assert len(manifest.expected_managed) == baseline_denominator
+
+
+def test_pr2017_absent_metadata_authorization_is_exact_six_path_set() -> None:
+    """PR #2017 adds only the six still-absent reviewed metadata paths."""
+    base_ownership = json.loads(
+        subprocess.check_output(
+            [
+                "git",
+                "show",
+                f"{PR_2017_PHASE_A_BASE}:{OWNERSHIP_PATH.relative_to(ROOT)}",
+            ],
+            text=True,
+        )
+    )
+    head_ownership = json.loads(OWNERSHIP_PATH.read_text(encoding="utf-8"))
+    base_rules = base_ownership["rules"]
+    head_rules = head_ownership["rules"]
+    added_rules = [row for row in head_rules if row not in base_rules]
+
+    assert not [row for row in base_rules if row not in head_rules]
+    assert len(PR_2017_ABSENT_METADATA_PATHS) == len(added_rules) == 6
+    assert {row["pattern"] for row in added_rules} == PR_2017_ABSENT_METADATA_PATHS
+    assert added_rules == sorted(added_rules, key=lambda row: row["pattern"])
+    assert all(
+        row
+        == {
+            "pattern": row["pattern"],
+            **PREAUTHORIZED_CHILD_OWNERSHIP,
+        }
+        for row in added_rules
+    )
 
 
 def test_issue_2083_vitest_coordinator_paths_are_exactly_preauthorized() -> None:

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -92,7 +92,13 @@ PREAUTHORIZED_CHILD_PATHS = (
     | {
     ".github/toolchains/playwright_manifest.py",
     ".pdd/meta/agentic_checkup_orchestrator_python_run.json",
+    ".pdd/meta/agentic_langtest_python.json",
+    ".pdd/meta/agentic_langtest_python_run.json",
     ".pdd/meta/checkup_agentic_artifact_python.json",
+    ".pdd/meta/code_generator_main_python_run.json",
+    ".pdd/meta/fix_code_loop_python_run.json",
+    ".pdd/meta/fix_error_loop_python_run.json",
+    ".pdd/meta/get_test_command_python_run.json",
     ".pdd/meta/story_regression_python.json",
     "ci/cloud-batch/cloud-regression-runner.py",
     "context/checkup_agentic_artifact_example.py",
@@ -1550,3 +1556,43 @@ def test_story_bootstrap_is_repository_bound(monkeypatch) -> None:
     )
 
     assert result == ()
+
+
+def test_candidate_cannot_self_authorize_absent_path(tmp_path: Path) -> None:
+    """A candidate cannot add its own absent-path authorization and file."""
+    root = tmp_path / "self-authorized-child-path"
+    subprocess.run(
+        ["git", "clone", "-q", "--no-hardlinks", str(ROOT), str(root)],
+        check=True,
+        capture_output=True,
+    )
+    base = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+    path = ".pdd/meta/candidate_self_authorized_python_run.json"
+    ownership_path = root / ".pdd" / "sync-ownership.json"
+    ownership = json.loads(ownership_path.read_text(encoding="utf-8"))
+    ownership["rules"].append(
+        {
+            "pattern": path,
+            **PREAUTHORIZED_CHILD_OWNERSHIP,
+        }
+    )
+    ownership["rules"].sort(key=lambda row: row["pattern"])
+    ownership_path.write_text(
+        json.dumps(ownership, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    candidate_path = root / path
+    candidate_path.parent.mkdir(parents=True, exist_ok=True)
+    candidate_path.write_text("{}\n", encoding="utf-8")
+    _git(root, "add", "-f", path, ".pdd/sync-ownership.json")
+    candidate = _commit(root, "attempt same-PR self-authorization")
+
+    manifest = build_unit_manifest(root, base_ref=base, head_ref=candidate)
+
+    assert Path(path) in manifest.unaccounted_tracked_paths
+    assert any(
+        reason == f"{path}: tracked path has no ownership rule"
+        for reason in manifest.invalid_reasons
+    )

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -35,6 +35,7 @@ EXPECTED_MANAGED_UNITS = 468
 PDD_1989_ACTUAL_BASE = "39a60ec06dc065a70ad63077b6f873aca95cbf45"
 PDD_1989_ACTUAL_HEAD = "131f86d83e7f2058af861b8ee7bde432bbbf5027"
 CANDIDATE_ONLY_SOURCE_MODE = "candidate-tree-v1"
+PR_2017_PHASE_A_BASE = "39776aa9bb027c638812a01b8dabbe03cab92f64"
 FOUNDATION_PROFILE_PATHS = {
     "pdd/sync_core/descriptor_store.py",
     "pdd/sync_core/signer_process.py",
@@ -90,35 +91,35 @@ PREAUTHORIZED_CHILD_PATHS = (
     LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS
     | ISSUE_2083_VITEST_COORDINATOR_PREAUTHORIZED_PATHS
     | {
-    ".github/toolchains/playwright_manifest.py",
-    ".pdd/meta/agentic_checkup_orchestrator_python_run.json",
-    ".pdd/meta/agentic_langtest_python.json",
-    ".pdd/meta/agentic_langtest_python_run.json",
-    ".pdd/meta/checkup_agentic_artifact_python.json",
-    ".pdd/meta/code_generator_main_python_run.json",
-    ".pdd/meta/fix_code_loop_python_run.json",
-    ".pdd/meta/fix_error_loop_python_run.json",
-    ".pdd/meta/get_test_command_python_run.json",
-    ".pdd/meta/story_regression_python.json",
-    "ci/cloud-batch/cloud-regression-runner.py",
-    "context/checkup_agentic_artifact_example.py",
-    "tests/test_checkup_agentic_artifact.py",
-    "tests/test_cloud_batch_cloud_regression_runner.py",
-    "tests/test_unit_tests_workflow.py",
-    "tests/test_ci_drift_heal_example_contract.py",
-    "tests/test_sync_core_runner_jest.py",
-    "tests/test_sync_core_runner_vitest.py",
-    "tests/test_sync_core_runner_playwright.py",
-    "tests/test_cloud_global_dry_run.py",
-    "tests/test_continuous_sync_path_policy.py",
-    "pdd/sync_core/human_attestation.py",
-    "tests/test_sync_core_human_attestation.py",
-    ".pdd/meta/ci_detect_changed_modules_python.json",
-    ".pdd/meta/evidence_manifest_python.json",
-    ".pdd/meta/story_detection_result_python.json",
-    "pdd/schemas/story_detection_result.schema.json",
-    "pdd/schemas/story_detection_scope.schema.json",
-    "tests/test_story_detection_result.py",
+        ".github/toolchains/playwright_manifest.py",
+        ".pdd/meta/agentic_checkup_orchestrator_python_run.json",
+        ".pdd/meta/agentic_langtest_python.json",
+        ".pdd/meta/agentic_langtest_python_run.json",
+        ".pdd/meta/checkup_agentic_artifact_python.json",
+        ".pdd/meta/code_generator_main_python_run.json",
+        ".pdd/meta/fix_code_loop_python_run.json",
+        ".pdd/meta/fix_error_loop_python_run.json",
+        ".pdd/meta/get_test_command_python_run.json",
+        ".pdd/meta/story_regression_python.json",
+        "ci/cloud-batch/cloud-regression-runner.py",
+        "context/checkup_agentic_artifact_example.py",
+        "tests/test_checkup_agentic_artifact.py",
+        "tests/test_cloud_batch_cloud_regression_runner.py",
+        "tests/test_unit_tests_workflow.py",
+        "tests/test_ci_drift_heal_example_contract.py",
+        "tests/test_sync_core_runner_jest.py",
+        "tests/test_sync_core_runner_vitest.py",
+        "tests/test_sync_core_runner_playwright.py",
+        "tests/test_cloud_global_dry_run.py",
+        "tests/test_continuous_sync_path_policy.py",
+        "pdd/sync_core/human_attestation.py",
+        "tests/test_sync_core_human_attestation.py",
+        ".pdd/meta/ci_detect_changed_modules_python.json",
+        ".pdd/meta/evidence_manifest_python.json",
+        ".pdd/meta/story_detection_result_python.json",
+        "pdd/schemas/story_detection_result.schema.json",
+        "pdd/schemas/story_detection_scope.schema.json",
+        "tests/test_story_detection_result.py",
     }
 )
 PREAUTHORIZED_CHILD_OWNERSHIP = {
@@ -422,7 +423,7 @@ def test_committed_rotations_equal_exact_protected_authority() -> None:
         )
     }
     policy_rows = {(row["prompt_path"], row["language_id"]): row for row in rows}
-    assert len(rows) == len(policy_rows) == len(bootstrap_rows) == 23
+    assert len(rows) == len(policy_rows) == len(bootstrap_rows) == 25
     story_identity = (STORY_REGRESSION_DORMANT_ROTATION["prompt_path"], "python")
     assert bootstrap_rows[story_identity] != STORY_REGRESSION_DORMANT_ROTATION
     bootstrap_rows[story_identity] = STORY_REGRESSION_DORMANT_ROTATION
@@ -430,6 +431,24 @@ def test_committed_rotations_equal_exact_protected_authority() -> None:
 
     profile_digest = hashlib.sha256(PROFILE_FILE.read_bytes()).hexdigest()
     assert profile_digest == STORY_REGRESSION_DORMANT_ROTATION["head_policy_sha256"]
+    future_pr2017_rows = [
+        row
+        for row in rows
+        if row["head_policy_sha256"]
+        == "85fbc4f5957e9872b7d368a1b6f9e8c3bad852142ed4c0ec49589eaf63bd8fb3"
+    ]
+    assert {row["prompt_path"] for row in future_pr2017_rows} == {
+        "pdd/prompts/fix_error_loop_python.prompt",
+        "pdd/prompts/get_test_command_python.prompt",
+    }
+    assert all(
+        row["base_policy_sha256"] == profile_digest for row in future_pr2017_rows
+    )
+    assert all(
+        hashlib.sha256((ROOT / row["prompt_path"]).read_bytes()).hexdigest()
+        == row["base_prompt_sha256"]
+        for row in future_pr2017_rows
+    )
     pdd1989_rows = [
         row
         for row in rows
@@ -437,9 +456,7 @@ def test_committed_rotations_equal_exact_protected_authority() -> None:
         == STORY_REGRESSION_DORMANT_ROTATION["base_policy_sha256"]
     ]
     assert len(pdd1989_rows) == 7
-    assert {
-        row["prompt_path"] for row in pdd1989_rows
-    } == {
+    assert {row["prompt_path"] for row in pdd1989_rows} == {
         "pdd/prompts/agentic_common_python.prompt",
         "pdd/prompts/commands/checkup_python.prompt",
         "pdd/prompts/generate_model_catalog_python.prompt",
@@ -453,8 +470,9 @@ def test_committed_rotations_equal_exact_protected_authority() -> None:
             "f0f1d36e337541ba4425f081e236c42847f8132cb61f9f8fe06334a805fc5c7b"
         )
         prompt = ROOT / row["prompt_path"]
-        assert hashlib.sha256(prompt.read_bytes()).hexdigest() == (
-            row["head_prompt_sha256"]
+        assert (
+            hashlib.sha256(prompt.read_bytes()).hexdigest()
+            == (row["head_prompt_sha256"])
         )
         assert row["base_prompt_sha256"] != row["head_prompt_sha256"]
 
@@ -478,8 +496,7 @@ def test_committed_rotations_equal_exact_protected_authority() -> None:
         assert row["head_policy_sha256"] == head_policy_digest
         prompt = ROOT / row["prompt_path"]
         assert (
-            hashlib.sha256(prompt.read_bytes()).hexdigest()
-            == row["head_prompt_sha256"]
+            hashlib.sha256(prompt.read_bytes()).hexdigest() == row["head_prompt_sha256"]
         )
         assert row["base_prompt_sha256"] != row["head_prompt_sha256"]
         assert row["base_policy_sha256"] != row["head_policy_sha256"]
@@ -491,9 +508,7 @@ def test_exact_bootstrap_row_installs_from_legacy_protected_source(
 ) -> None:
     """The exact in-code trust root can perform the first schema-2 install."""
     policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
-    authorization = verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS[
-        0
-    ]  # pylint: disable=protected-access
+    authorization = verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS[0]  # pylint: disable=protected-access
     rotations = policy["rotations"] if protected_source != "absent" else []
     protected_payload = {"schema_version": 1, "rotations": rotations}
     if protected_source == "schema-1-old-row":
@@ -536,9 +551,7 @@ def test_exact_bootstrap_row_rejects_profile_byte_mutation(
     monkeypatch, profile_source: str
 ) -> None:
     """A legacy bootstrap cannot install while profile bytes drift."""
-    authorization = verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS[
-        0
-    ]  # pylint: disable=protected-access
+    authorization = verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS[0]  # pylint: disable=protected-access
     candidate = json.dumps(
         {
             "schema_version": 2,
@@ -547,9 +560,7 @@ def test_exact_bootstrap_row_rejects_profile_byte_mutation(
         }
     ).encode()
     protected_profile = (
-        None
-        if profile_source == "absent"
-        else b'{"schema_version":1,"profiles":[]}\n'
+        None if profile_source == "absent" else b'{"schema_version":1,"profiles":[]}\n'
     )
     candidate_profile = b'{\n  "schema_version": 1, "profiles": []\n}\n'
 
@@ -584,9 +595,7 @@ def test_legacy_schema_1_bootstrap_rejects_malformed_envelope(
 ) -> None:
     """Historical rows are ignored as authority only after strict parsing."""
     policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
-    authorization = verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS[
-        0
-    ]  # pylint: disable=protected-access
+    authorization = verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS[0]  # pylint: disable=protected-access
     protected_payload = {
         "schema_version": 1,
         "rotations": policy["rotations"],
@@ -708,9 +717,7 @@ def test_bootstrap_install_cannot_change_active_rotation_authority(
 ) -> None:
     """Legacy bootstrap changes only the envelope, never active authority."""
     policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
-    authorization = verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS[
-        0
-    ]  # pylint: disable=protected-access
+    authorization = verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS[0]  # pylint: disable=protected-access
     rotations = policy["rotations"]
     protected = (
         None
@@ -762,6 +769,21 @@ def test_pdd1989_transitions_cover_the_actual_merged_base() -> None:
 
     assert len(manifest.expected_managed) == EXPECTED_MANAGED_UNITS
     assert not manifest.invalid_reasons
+    assert len(profiles.profiles) == EXPECTED_MANAGED_UNITS
+    assert not profiles.invalid_reasons
+    assert profiles.coverage == 1.0
+
+
+def test_pr2017_phase_a_is_dormant_on_current_protected_base() -> None:
+    """The prerequisite installs authority without consuming protected bytes."""
+    manifest = build_unit_manifest(
+        ROOT, base_ref=PR_2017_PHASE_A_BASE, head_ref="HEAD"
+    )
+    profiles = load_verification_profiles(ROOT, manifest)
+
+    assert len(manifest.expected_managed) == EXPECTED_MANAGED_UNITS
+    assert not manifest.invalid_reasons
+    assert not manifest.unaccounted_tracked_paths
     assert len(profiles.profiles) == EXPECTED_MANAGED_UNITS
     assert not profiles.invalid_reasons
     assert profiles.coverage == 1.0
@@ -889,9 +911,10 @@ def test_current_profile_rotation_matches_current_prompt_and_profile_rows() -> N
     for rotation in current_rows:
         prompt_path = ROOT / rotation["prompt_path"]
         expected_requirement = rotation["to_requirement_id"]
-        assert hashlib.sha256(prompt_path.read_bytes()).hexdigest() == rotation[
-            "head_prompt_sha256"
-        ]
+        assert (
+            hashlib.sha256(prompt_path.read_bytes()).hexdigest()
+            == rotation["head_prompt_sha256"]
+        )
         assert expected_requirement == (
             f"CONTRACT-SHA256:{rotation['head_prompt_sha256']}"
         )
@@ -903,6 +926,8 @@ def test_current_profile_rotation_matches_current_prompt_and_profile_rows() -> N
             if item["validator_id"] == "threshold-ed25519"
         )
         assert human["requirement_ids"] == [expected_requirement]
+
+
 @pytest.mark.parametrize(
     "field,replacement",
     (


### PR DESCRIPTION
## Summary

- Preauthorize exactly six absent generated metadata paths needed by replacement PR #2017.
- Keep ownership authority on protected main so a candidate cannot authorize its own new files.
- Add two bounded production verifier trust-root entries that authorize only the exact #2017 `get_test_command` and `fix_error_loop` requirement/profile transitions.
- Add regression coverage for the complete six-path authorization set and same-transition self-authorization rejection.

## Authoritative path set: six, not seven

The former seven-path wording was a requirements/body error. The protected base and current #2017 head already track and preauthorize `.pdd/meta/agentic_checkup_orchestrator_python_run.json`; it is therefore not an absent path requiring this prerequisite.

The six exact absent paths are:

- `.pdd/meta/agentic_langtest_python.json`
- `.pdd/meta/agentic_langtest_python_run.json`
- `.pdd/meta/code_generator_main_python_run.json`
- `.pdd/meta/fix_code_loop_python_run.json`
- `.pdd/meta/fix_error_loop_python_run.json`
- `.pdd/meta/get_test_command_python_run.json`

Evidence: historical commit `c2dba25d65d611397a3c7456451a68ee2672c822` removed seven metadata files, but its seventh file is the already-tracked/preauthorized `agentic_checkup_orchestrator_python_run.json`. Current protected main (`c887daba0d171585658f8205e79316e5f36f82c6`) and current #2017 head retain that file; the six listed above remain absent. The dedicated regression compares the ownership-policy delta from that protected base to exactly these six rows.

## Why this PR is needed

PR #2017 adds generated metadata. The PDD ownership validator intentionally reads authorization from the protected base, not from candidate changes. This narrow prerequisite must land first; then #2017 can rebase and pass the protected ownership gate without weakening it.

## PDD doctrine and scope

- Exact paths only; no wildcard or broad ownership rule.
- HUMAN_OWNED, pdd-maintainers, human-maintained, preauthorize_absent true.
- Narrow runtime authorization change only: `pdd/sync_core/verification.py` adds two fixed `_exact_bootstrap_requirement_transition(...)` trust-root entries. They bind only the reviewed #2017 `get_test_command` and `fix_error_loop` prompt/profile byte transitions; they add no general candidate authority.
- No prompt-generated runtime behavior, prompt source, fingerprint, architecture metadata, generated metadata artifact, public interface, or unrelated behavior changed.
- The prompting guide's Honest Task-Fit Boundary supports this narrow conventional trust-policy implementation/test change; prompt architecture metadata applies to prompt files and is not applicable here.
- #2017 must remain a separate candidate transition.

## Validation

- 67 focused rollout-policy tests passed.
- Base-to-head manifest: 468/468 managed profiles, coverage 1.0, zero invalid, zero unaccounted.
- Dedicated #2017 regression asserts the exact six-path/count policy delta; the general protected-base test proves all authorized paths are accepted, an arbitrary additional path is rejected, and same-PR rule-plus-file self-authorization is rejected.
- Strict JSON duplicate-key parsing, ownership/rotation uniqueness, exact transition composition, and `git diff --check` passed.
- Pylint is 9.97/10 with two pre-existing diagnostics in this already-large test module; no new Pylint finding was introduced.

## Landing order

1. Merge this prerequisite.
2. Rebase replacement PR #2017 onto the resulting main.
3. Preserve the protected-base preauthorize_absent fields and rerun the exact manifest, profile, test, CI, and independent review gates.