### PR TITLE
fix(release-video): reject brittle visual cues

### DIFF
--- a/.pdd/verification-profiles.json
+++ b/.pdd/verification-profiles.json
@@ -8791,7 +8791,7 @@
       "prompt_path": "pdd/prompts/release_video_script_LLM.prompt",
       "language_id": "llm",
       "required_requirement_ids": [
-        "CONTRACT-SHA256:5bdc61011a619d3252b97c6f14c418b12a2c779400450c814c3d3220b8ef6d3a"
+        "CONTRACT-SHA256:a135251ea9eb6562758424ce1d7438cafdfb898d28e7a8eb577d3df6eb1b8e7b"
       ],
       "obligations": [
         {
@@ -8800,7 +8800,7 @@
           "validator_id": "threshold-ed25519",
           "validator_config_digest": "threshold-ed25519-v1",
           "requirement_ids": [
-            "CONTRACT-SHA256:5bdc61011a619d3252b97c6f14c418b12a2c779400450c814c3d3220b8ef6d3a"
+            "CONTRACT-SHA256:a135251ea9eb6562758424ce1d7438cafdfb898d28e7a8eb577d3df6eb1b8e7b"
           ],
           "artifact_paths": [
             "pdd/prompts/release_video_script_LLM.prompt"

--- a/pdd/prompts/release_video_script_LLM.prompt
+++ b/pdd/prompts/release_video_script_LLM.prompt
@@ -38,12 +38,12 @@ Visual requirements:
   - Every spoken narration block starts with `NARRATOR:` on its own line.
   - Every non-spoken visual cue is written on one line as `VISUAL: <cue text>`.
 - Do not put `VISUAL:` by itself with the cue text on the next line.
-- Visual cues must be detailed enough for an automated video generator to create relevant scenes.
-- For every `VISUAL:` cue, include specific screen/UI/content direction, not generic phrases.
-- Prefer visuals that reveal the product and workflow: terminal commands, before/after output, GitHub release page, changelog snippets, failing/passing checks, audit files, config snippets, PR/issue references, diagrams of the workflow, and short code/doc excerpts.
-- When showing text on screen, specify the exact or representative text to display.
-- Include motion/composition direction when useful: split-screen before/after, highlighted lines, zoom into terminal output, progress ticks, callout labels, timeline arrows, or overlay badges.
-- Do not use purely atmospheric visuals. Avoid vague cues like "show developers coding" unless tied to a concrete PDD workflow on screen.
+- Default to transform-safe, text-free abstract visuals that communicate the idea without asking the video model to reproduce product artifacts. Good building blocks include soft color fields, matte orbs, translucent shields, rounded package cubes, diffuse light pulses, and simple environmental lighting.
+- Do not request monitors, screens, terminals, consoles, source code, UI panels, dashboards, documents, changelogs, release notes, GitHub pages, JSON/config files, readable text, labels, words, or logos. Explain concrete product details in narration instead of displaying them.
+- Do not require exact geometry or layout. Avoid parallel or precisely aligned elements, split screens, side-by-side panels, grids, crossings/non-crossings, symmetry, exact positions, or exact color transitions.
+- Do not require frame-exact or semantic motion such as one object crossing, aligning with, merging into, or transforming into another at a specified moment.
+- Camera direction must be optional and transform-safe. For example: `an optional gentle camera drift may be used`. Do not mandate a zoom, pan, orbit, push-in, or timed camera beat.
+- Keep each visual cue forgiving: describe a small set of abstract subjects, a broad mood or color family, and an optional camera treatment. The intended meaning must still work if the generated clip is static or the composition varies.
 
 Structure requirements:
 - Use plain Markdown.

--- a/pdd/prompts/release_video_script_LLM.prompt
+++ b/pdd/prompts/release_video_script_LLM.prompt
@@ -39,10 +39,10 @@ Visual requirements:
   - Every non-spoken visual cue is written on one line as `VISUAL: <cue text>`.
 - Do not put `VISUAL:` by itself with the cue text on the next line.
 - Default to transform-safe, text-free abstract visuals that communicate the idea without asking the video model to reproduce product artifacts. Good building blocks include soft color fields, matte orbs, translucent shields, rounded package cubes, diffuse light pulses, and simple environmental lighting.
-- Do not request monitors, screens, terminals, consoles, source code, UI panels, dashboards, documents, changelogs, release notes, GitHub pages, JSON/config files, readable text, labels, words, or logos. Explain concrete product details in narration instead of displaying them.
+- Do not request monitors, screens, terminals, consoles, source code, IDE/editor windows, browsers, application UI, spreadsheets, tables, data grids, charts, graphs, captions, subtitles, forms, menus, dashboards, documents, changelogs, release notes, GitHub pages, JSON/config files, readable text, labels, words, or logos. Explain concrete product details in narration instead of displaying them.
 - Do not require exact geometry or layout. Avoid parallel or precisely aligned elements, split screens, side-by-side panels, grids, crossings/non-crossings, symmetry, exact positions, or exact color transitions.
 - Do not require frame-exact or semantic motion such as one object crossing, aligning with, merging into, or transforming into another at a specified moment.
-- Camera direction must be optional and transform-safe. For example: `an optional gentle camera drift may be used`. Do not mandate a zoom, pan, orbit, push-in, or timed camera beat.
+- Camera direction must be optional and transform-safe. For example: `an optional gentle camera drift may be used`. Put the optional wording in the same clause as each camera action; optionality elsewhere in the cue does not apply. Do not mandate a zoom, pan, tilt, orbit, roll, crane, rack focus, push-in, transition, or timed camera beat.
 - Keep each visual cue forgiving: describe a small set of abstract subjects, a broad mood or color family, and an optional camera treatment. The intended meaning must still work if the generated clip is static or the composition varies.
 
 Structure requirements:

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -92,7 +92,13 @@ READABLE_VISUAL_RE = re.compile(
     r"source\s+code|code(?:\s+snippet)?|commands?|makefile|browsers?|web\s+pages?|"
     r"user\s+interface|ui|dashboard|documents?|docs?|changelog|release\s+notes?|"
     r"github(?:\s+page)?|pull\s+requests?|issues?|json|ya?ml|configuration|config|"
-    r"readable|text|words?|labels?|logos?)\b",
+    r"readable|text|words?|labels?|logos?|ides?|editors?|spreadsheets?|charts?|"
+    r"graphs?|captions?|subtitles?|menus?|toolbars?|web\s+apps?|"
+    r"(?:application|app|browser|editor)\s+windows?|data\s+tables?|"
+    r"(?:data|comparison|status)\s+tables?|table\s+(?:of|with)\s+"
+    r"(?:data|rows?|columns?|cells?|values?|text)|column\s+headers?|"
+    r"ui\s+controls?|(?:input|web|application)\s+forms?|"
+    r"(?:graphical|software|application|app)\s+(?:user\s+)?interfaces?)\b",
     flags=re.IGNORECASE,
 )
 EXACT_GEOMETRY_VISUAL_RE = re.compile(
@@ -103,24 +109,61 @@ EXACT_GEOMETRY_VISUAL_RE = re.compile(
     flags=re.IGNORECASE,
 )
 CAMERA_MOTION_VISUAL_RE = re.compile(
-    r"\b(?:push(?:es|ed|ing)?[- ]?in|zoom(?:s|ed|ing)?|pan(?:s|ned|ning)?|"
-    r"orbit(?:s|ed|ing)?|track(?:s|ed|ing)?|dolly|camera\s+(?:moves?|drifts?|"
-    r"pushes?|zooms?|pans?|orbits?))\b",
+    r"\b(?:push(?:es|ed|ing)?[- ]in|zoom(?!ed[- ]out)(?:s|ing|ed(?:[- ]in)?)?|"
+    r"pan(?:s|ned|ning)?|orbit(?:s|ed|ing)?|track(?:s|ed|ing)?|"
+    r"doll(?:y|ies|ied|ying)|tilt(?:s|ed|ing)?|crane(?:s|d|ing)?|"
+    r"roll(?:s|ed|ing)?|rack[- ]focus(?:es|ed|ing)?|drift(?:s|ed|ing)?|"
+    r"transition(?:s|ed|ing)?|moves?)\b",
+    flags=re.IGNORECASE,
+)
+IMPLICIT_CAMERA_ACTION_RE = re.compile(
+    r"\b(?:push(?:es|ed|ing)?[- ]in|zoom(?!ed[- ]out)|pan|orbit|track|doll|"
+    r"tilt|crane|rack[- ]focus)",
     flags=re.IGNORECASE,
 )
 SEMANTIC_MOTION_VISUAL_RE = re.compile(
     r"\b(?:cross(?:es|ed|ing)?|align(?:s|ed|ing)?|merge(?:s|d|ing)?|"
     r"morph(?:s|ed|ing)?|transform(?:s|ed|ing)?|"
-    r"transition(?:s|ed|ing)?|rotat(?:e|es|ed|ing)|spin(?:s|ning)?)\b",
+    r"mov(?:e|es|ed|ing)\s+into|rotat(?:e|es|ed|ing)|spin(?:s|ning)?)\b",
     flags=re.IGNORECASE,
 )
 FRAME_EXACT_MOTION_RE = re.compile(
-    r"(?:\b(?:at|by)\s+(?:exactly\s+)?\d+(?:\.\d+)?\s*(?:seconds?|s)\b|"
-    r"\bframe[- ]by[- ]frame\b|\bframe\s+\d+\b)",
+    r"(?:\b(?:at|after|by|on)\s+(?:the\s+)?(?:exactly\s+)?"
+    r"(?:(?:\d+(?:\.\d+)?|one|two|three|four|five|six|seven|eight|nine|ten)"
+    r"[- ]?(?:seconds?|secs?|s)(?:\s+mark)?|(?:frame|second)\s+"
+    r"(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten))\b|"
+    r"\b(?:frame|second)\s+(?:\d+|one|two|three|four|five|six|seven|eight|"
+    r"nine|ten)\b|\b\d+(?:st|nd|rd|th)\s+(?:frame|second)\b|"
+    r"\b(?:at|after|by)\s+\d{1,2}:\d{2}\b|\bframe[- ]by[- ]frame\b)",
     flags=re.IGNORECASE,
 )
-OPTIONAL_MOTION_RE = re.compile(
-    r"\b(?:optional(?:ly)?|may|can|if\s+(?:available|supported|desired))\b",
+VISUAL_CLAUSE_SPLIT_RE = re.compile(
+    r"[;,.!?]+|\b(?:while|whereas|but|and\s+then|then)\b|"
+    r"\b(?:as|with)(?=\s+(?:the\s+)?camera\b)|"
+    r"\band(?=\s+(?:the\s+)?camera\b)",
+    flags=re.IGNORECASE,
+)
+MOTION_OPTIONAL_PREFIX_RE = re.compile(
+    r"\boptional(?:ly)?(?:\s+(?:gentle|slow|subtle|soft|smooth|slight|"
+    r"transform[- ]safe|camera)){0,5}\s*$",
+    flags=re.IGNORECASE,
+)
+CAMERA_MODAL_PREFIX_RE = re.compile(
+    r"\bcamera\s+(?:may|can|could)(?:\s+\w+){0,3}\s*$",
+    flags=re.IGNORECASE,
+)
+IMPLICIT_CAMERA_MODAL_PREFIX_RE = re.compile(
+    r"^(?:the\s+)?(?:view\s+)?(?:may|can|could)(?:\s+\w+){0,3}\s*$",
+    flags=re.IGNORECASE,
+)
+MOTION_OPTIONAL_SUFFIX_RE = re.compile(
+    r"^(?:\s+\w+){0,4}\s+(?:(?:may|can|could)\s+be\s+used|"
+    r"if\s+(?:available|supported|desired))\b",
+    flags=re.IGNORECASE,
+)
+MOTION_REQUIRED_PREFIX_RE = re.compile(
+    r"\b(?:must|required\s+to|has\s+to|needs\s+to|should|will)"
+    r"(?:\s+\w+){0,3}\s*$",
     flags=re.IGNORECASE,
 )
 SAFE_TEXT_QUALIFIER_RE = re.compile(
@@ -3043,14 +3086,43 @@ def visual_safety_categories(cue: str) -> list[str]:
         categories.append("risky_readable_surface")
     if EXACT_GEOMETRY_VISUAL_RE.search(cue):
         categories.append("brittle_exact_geometry")
-    has_frame_exact_motion = bool(FRAME_EXACT_MOTION_RE.search(cue))
-    has_required_motion = bool(SEMANTIC_MOTION_VISUAL_RE.search(cue)) or (
-        bool(CAMERA_MOTION_VISUAL_RE.search(cue))
-        and not bool(OPTIONAL_MOTION_RE.search(cue))
-    )
-    if has_frame_exact_motion or has_required_motion:
+    if has_unsafe_visual_motion(cue):
         categories.append("brittle_mandatory_motion")
     return categories
+
+
+def has_unsafe_visual_motion(cue: str) -> bool:
+    """Return whether a cue requires timed, semantic, or mandatory motion."""
+    if FRAME_EXACT_MOTION_RE.search(cue) or SEMANTIC_MOTION_VISUAL_RE.search(cue):
+        return True
+    for clause in visual_motion_clauses(cue):
+        for match in CAMERA_MOTION_VISUAL_RE.finditer(clause):
+            if not camera_motion_is_locally_optional(clause, match):
+                return True
+    return False
+
+
+def visual_motion_clauses(cue: str) -> list[str]:
+    """Split a cue at boundaries that separate independently required actions."""
+    return [part.strip() for part in VISUAL_CLAUSE_SPLIT_RE.split(cue) if part.strip()]
+
+
+def camera_motion_is_locally_optional(clause: str, match: re.Match[str]) -> bool:
+    """Return whether the matched camera action has local optional grammar."""
+    before = clause[: match.start()]
+    after = clause[match.end() :]
+    if MOTION_REQUIRED_PREFIX_RE.search(before):
+        return False
+    camera_context = bool(re.search(r"\bcamera\b", clause, flags=re.IGNORECASE))
+    camera_context = camera_context or bool(IMPLICIT_CAMERA_ACTION_RE.match(match.group(0)))
+    if not camera_context:
+        return False
+    return bool(
+        MOTION_OPTIONAL_PREFIX_RE.search(before)
+        or CAMERA_MODAL_PREFIX_RE.search(before)
+        or IMPLICIT_CAMERA_MODAL_PREFIX_RE.search(before)
+        or MOTION_OPTIONAL_SUFFIX_RE.search(after)
+    )
 
 
 def validate_release_video_script(

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -82,6 +82,52 @@ MIN_PDS_CLI_VERSION_TEXT = ".".join(str(part) for part in MIN_PDS_CLI_VERSION)
 PDS_VERSION_RE = re.compile(r"(?<!\d)(?P<version>\d+\.\d+\.\d+)(?!\d)")
 PDS_VERSION_PROBE_TIMEOUT_SECONDS = 10.0
 DEFAULT_PDS_CREATE_TIMEOUT_SECONDS = 1800.0
+VISUAL_SAFETY_CHECKS = {
+    "risky_readable_surface": "hasNoReadableSurfaceVisuals",
+    "brittle_exact_geometry": "hasNoExactGeometryVisuals",
+    "brittle_mandatory_motion": "hasNoMandatoryMotionVisuals",
+}
+READABLE_VISUAL_RE = re.compile(
+    r"\b(?:workstation|laptops?|phones?|monitors?|screens?|terminal|console|shell|"
+    r"source\s+code|code(?:\s+snippet)?|commands?|makefile|browsers?|web\s+pages?|"
+    r"user\s+interface|ui|dashboard|documents?|docs?|changelog|release\s+notes?|"
+    r"github(?:\s+page)?|pull\s+requests?|issues?|json|ya?ml|configuration|config|"
+    r"readable|text|words?|labels?|logos?)\b",
+    flags=re.IGNORECASE,
+)
+EXACT_GEOMETRY_VISUAL_RE = re.compile(
+    r"\b(?:exact(?:ly)?|precise(?:ly)?|perfect(?:ly)?|parallel|"
+    r"align(?:ed|ment|s|ing)?|symmetr(?:y|ic|ical|ically)|split[- ]screen|"
+    r"side[- ]by[- ]side|grid|x[- ]shap(?:e|ed)|cross(?:es|ed|ing)?|"
+    r"non[- ]crossing|(?:left|right|top|bottom)\s+(?:side|panel|orb|strand))\b",
+    flags=re.IGNORECASE,
+)
+CAMERA_MOTION_VISUAL_RE = re.compile(
+    r"\b(?:push(?:es|ed|ing)?[- ]?in|zoom(?:s|ed|ing)?|pan(?:s|ned|ning)?|"
+    r"orbit(?:s|ed|ing)?|track(?:s|ed|ing)?|dolly|camera\s+(?:moves?|drifts?|"
+    r"pushes?|zooms?|pans?|orbits?))\b",
+    flags=re.IGNORECASE,
+)
+SEMANTIC_MOTION_VISUAL_RE = re.compile(
+    r"\b(?:cross(?:es|ed|ing)?|align(?:s|ed|ing)?|merge(?:s|d|ing)?|"
+    r"morph(?:s|ed|ing)?|transform(?:s|ed|ing)?|"
+    r"transition(?:s|ed|ing)?|rotat(?:e|es|ed|ing)|spin(?:s|ning)?)\b",
+    flags=re.IGNORECASE,
+)
+FRAME_EXACT_MOTION_RE = re.compile(
+    r"(?:\b(?:at|by)\s+(?:exactly\s+)?\d+(?:\.\d+)?\s*(?:seconds?|s)\b|"
+    r"\bframe[- ]by[- ]frame\b|\bframe\s+\d+\b)",
+    flags=re.IGNORECASE,
+)
+OPTIONAL_MOTION_RE = re.compile(
+    r"\b(?:optional(?:ly)?|may|can|if\s+(?:available|supported|desired))\b",
+    flags=re.IGNORECASE,
+)
+SAFE_TEXT_QUALIFIER_RE = re.compile(
+    r"\b(?:text[- ]free|non[- ]textual|unlabeled|without\s+(?:readable\s+)?"
+    r"(?:text|words?|labels?|logos?)|no\s+(?:readable\s+)?(?:text|words?|labels?|logos?))\b",
+    flags=re.IGNORECASE,
+)
 RELEASE_VIDEO_AUDIT_FIX_POLICY_ARGS = (
     "--audit-fix-max-passes",
     "2",
@@ -2967,6 +3013,46 @@ def is_collapsible_visual_cue_line(line: str) -> bool:
     )
 
 
+def visual_safety_findings(script: str) -> list[dict[str, Any]]:
+    """Return deterministic safety findings for release-video visual cues."""
+    findings: list[dict[str, Any]] = []
+    cue_index = 0
+    for line_number, line in enumerate(script.splitlines(), start=1):
+        cue = visual_cue_text(line)
+        if not cue:
+            continue
+        cue_index += 1
+        categories = visual_safety_categories(cue)
+        findings.extend(
+            {
+                "category": category,
+                "check": VISUAL_SAFETY_CHECKS[category],
+                "cueIndex": cue_index,
+                "line": line_number,
+            }
+            for category in categories
+        )
+    return findings
+
+
+def visual_safety_categories(cue: str) -> list[str]:
+    """Classify one visual cue using stable, machine-readable categories."""
+    categories: list[str] = []
+    readable_candidate = SAFE_TEXT_QUALIFIER_RE.sub("", cue)
+    if READABLE_VISUAL_RE.search(readable_candidate):
+        categories.append("risky_readable_surface")
+    if EXACT_GEOMETRY_VISUAL_RE.search(cue):
+        categories.append("brittle_exact_geometry")
+    has_frame_exact_motion = bool(FRAME_EXACT_MOTION_RE.search(cue))
+    has_required_motion = bool(SEMANTIC_MOTION_VISUAL_RE.search(cue)) or (
+        bool(CAMERA_MOTION_VISUAL_RE.search(cue))
+        and not bool(OPTIONAL_MOTION_RE.search(cue))
+    )
+    if has_frame_exact_motion or has_required_motion:
+        categories.append("brittle_mandatory_motion")
+    return categories
+
+
 def validate_release_video_script(
     *,
     script: str,
@@ -2974,6 +3060,11 @@ def validate_release_video_script(
     source: str,
     changes: list[str],
 ) -> dict[str, Any]:
+    safety_findings = visual_safety_findings(script)
+    safety_categories = {
+        str(finding["category"])
+        for finding in safety_findings
+    }
     checks = {
         "minLength": len(script.strip()) >= 200,
         "hasSection": bool(re.search(r"(?m)^##\s+\S", script)),
@@ -2983,6 +3074,10 @@ def validate_release_video_script(
         "hasNoDuplicateNarratorLabels": not has_duplicate_narrator_labels(script),
         "hasNoLabelOnlyVisualCues": not has_label_only_visual_cues(script),
         "hasNoMarkdownFences": not has_markdown_fence_line(script),
+        **{
+            check: category not in safety_categories
+            for category, check in VISUAL_SAFETY_CHECKS.items()
+        },
     }
     errors = [name for name, passed in checks.items() if not passed]
     return {
@@ -2992,6 +3087,7 @@ def validate_release_video_script(
         "changes": changes,
         "checks": checks,
         "errors": errors,
+        "visualSafetyFindings": safety_findings,
     }
 
 

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -199,6 +199,26 @@ VISUAL: show the PDS response with the YouTube URL ready for release notes.
 """
 
 
+def visual_safety_script(*visual_cues: str) -> str:
+    cues = "\n\n".join(f"VISUAL: {cue}" for cue in visual_cues)
+    return f"""# PDD v1.1.0 Release Video
+
+## Opening
+
+NARRATOR:
+PDD v1.1.0 makes release-video creation fail fast before paid generation when
+visual direction would predictably conflict with the downstream video audit.
+
+{cues}
+
+## Close
+
+NARRATOR:
+The local validation artifact gives maintainers a stable reason code and keeps
+the rejected script available for a safe, inexpensive rewrite and retry.
+"""
+
+
 def load_release_video_module():
     spec = importlib.util.spec_from_file_location("release_video", SCRIPT)
     assert spec is not None
@@ -206,6 +226,122 @@ def load_release_video_module():
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+@pytest.mark.parametrize(
+    ("cue", "category", "check"),
+    [
+        (
+            "Over-the-shoulder developer workstation with two monitors showing readable source code and terminal output.",
+            "risky_readable_surface",
+            "hasNoReadableSurfaceVisuals",
+        ),
+        (
+            "Two soft strands align in perfectly parallel rows, never crossing, with an exact split-screen layout.",
+            "brittle_exact_geometry",
+            "hasNoExactGeometryVisuals",
+        ),
+        (
+            "At exactly 2 seconds the left orb must cross the right orb, then the camera slowly pushes in.",
+            "brittle_mandatory_motion",
+            "hasNoMandatoryMotionVisuals",
+        ),
+    ],
+)
+def test_release_video_visual_safety_reports_stable_categories(
+    cue: str,
+    category: str,
+    check: str,
+):
+    release_video = load_release_video_module()
+
+    artifacts = release_video.prepare_release_video_script(
+        visual_safety_script(cue),
+        source="test",
+    )
+
+    validation = artifacts["validation"]
+    assert validation["checks"][check] is False
+    assert check in validation["errors"]
+    assert category in {
+        finding["category"] for finding in validation["visualSafetyFindings"]
+    }
+
+
+def test_release_video_visual_safety_allows_abstract_text_free_cues_and_optional_camera():
+    release_video = load_release_video_module()
+    script = visual_safety_script(
+        "A text-free field of soft blue and violet light surrounds a simple matte orb.",
+        "A translucent shield and rounded package cube rest in a diffuse color field; an optional gentle camera drift may be used.",
+    )
+
+    artifacts = release_video.prepare_release_video_script(script, source="test")
+
+    assert artifacts["validation"]["visualSafetyFindings"] == []
+    assert artifacts["validation"]["checks"]["hasNoReadableSurfaceVisuals"] is True
+    assert artifacts["validation"]["checks"]["hasNoExactGeometryVisuals"] is True
+    assert artifacts["validation"]["checks"]["hasNoMandatoryMotionVisuals"] is True
+    assert artifacts["validation"]["errors"] == []
+
+
+@pytest.mark.parametrize("script_source", ["generated", "script-path"])
+def test_release_video_rejects_unsafe_visual_before_pds_for_all_script_sources(
+    tmp_path: Path,
+    script_source: str,
+):
+    repo = init_release_repo(tmp_path)
+    capture = tmp_path / "pds-capture.json"
+    unsafe_script = visual_safety_script(
+        "Show a terminal screen with exact readable command text and highlighted source code."
+    )
+    script_path = tmp_path / "unsafe-release-video.md"
+    script_path.write_text(unsafe_script, encoding="utf8")
+    source_args = (
+        ["--script-path", str(script_path)]
+        if script_source == "script-path"
+        else ["--claude-cli", str(claude_output_stub(tmp_path, unsafe_script))]
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--git-sha",
+            "abc123def456",
+            *source_args,
+            "--pds-cli",
+            str(
+                pds_stub(
+                    tmp_path,
+                    {"ok": True, "summary": {"youtubeUrl": "https://youtu.be/unsafe"}},
+                )
+            ),
+            "--output-dir",
+            str(tmp_path / "videos"),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    validation = json.loads(
+        (
+            tmp_path
+            / "videos"
+            / "v1.1.0"
+            / "release_video_script_validation.json"
+        ).read_text(encoding="utf8")
+    )
+    assert result.returncode == 1
+    assert "PDS was not invoked" in result.stderr
+    assert "hasNoReadableSurfaceVisuals" in validation["errors"]
+    assert not capture.exists()
 
 
 def pds_stub(tmp_path: Path, response: dict) -> Path:

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -150,9 +150,9 @@ pathlib.Path("claude_argv.json").write_text(json.dumps(sys.argv[1:], indent=2), 
 print("# PDD v1.1.0 Release Video\\n\\n"
       "Hook: This release turns the PDD release process into a publishable video story.\\n\\n"
       "Narration: PDD v1.1.0 adds release video automation, using release context to create a concise update for developers. "
-      "The video shows the changed files, the release tag, and the path from script to YouTube upload. "
+      "The narration explains the changed files, release tag, and path from script to YouTube upload. "
       "It closes with a reminder that the release artifact and the release story now ship together.\\n\\n"
-      "Visual direction: show the changelog, a terminal running make release, and the uploaded YouTube receipt.")
+      "Visual direction: a text-free matte package cube rests in a soft blue and violet light field.")
 """,
     )
 
@@ -188,14 +188,14 @@ def reusable_script_text() -> str:
 NARRATOR:
 PDD v1.1.0 ships release video automation so maintainers can publish a clear story for every CLI release without changing the package publishing path.
 
-VISUAL: show the release tag, changelog excerpt, and terminal command side by side.
+VISUAL: A text-free matte package cube rests in a soft blue and violet light field.
 
 ## Details
 
 NARRATOR:
 The script highlights what changed, why it matters for developers, and how the generated release artifact flows into the PDS publish step for an unlisted YouTube video.
 
-VISUAL: show the PDS response with the YouTube URL ready for release notes.
+VISUAL: A translucent shield surrounds a rounded orb in a diffuse color field.
 """
 
 
@@ -232,17 +232,20 @@ def load_release_video_module():
     ("cue", "category", "check"),
     [
         (
-            "Over-the-shoulder developer workstation with two monitors showing readable source code and terminal output.",
+            "Over-the-shoulder developer workstation with two monitors showing "
+            "readable source code and terminal output.",
             "risky_readable_surface",
             "hasNoReadableSurfaceVisuals",
         ),
         (
-            "Two soft strands align in perfectly parallel rows, never crossing, with an exact split-screen layout.",
+            "Two soft strands align in perfectly parallel rows, never crossing, "
+            "with an exact split-screen layout.",
             "brittle_exact_geometry",
             "hasNoExactGeometryVisuals",
         ),
         (
-            "At exactly 2 seconds the left orb must cross the right orb, then the camera slowly pushes in.",
+            "At exactly 2 seconds the left orb must cross the right orb, then the "
+            "camera slowly pushes in.",
             "brittle_mandatory_motion",
             "hasNoMandatoryMotionVisuals",
         ),
@@ -268,11 +271,12 @@ def test_release_video_visual_safety_reports_stable_categories(
     }
 
 
-def test_release_video_visual_safety_allows_abstract_text_free_cues_and_optional_camera():
+def test_release_video_visual_safety_allows_safe_abstract_cues():
     release_video = load_release_video_module()
     script = visual_safety_script(
         "A text-free field of soft blue and violet light surrounds a simple matte orb.",
-        "A translucent shield and rounded package cube rest in a diffuse color field; an optional gentle camera drift may be used.",
+        "A translucent shield and rounded package cube rest in a diffuse color "
+        "field; an optional gentle camera drift may be used.",
     )
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -542,7 +546,7 @@ def test_release_video_generates_script_and_invokes_pds_publish(tmp_path: Path):
     assert script_text.startswith("# PDD v1.1.0 Release Video")
     assert "\n## Release Overview (0:00 - 1:00)" in script_text
     assert "\nNARRATOR:\n" in script_text
-    assert "\nVISUAL: show the changelog" in script_text
+    assert "\nvisual: a text-free matte package cube" in script_text.lower()
     claude_prompt = (repo / "claude_prompt.txt").read_text(encoding="utf8")
     assert "Research requirement:" in claude_prompt
     assert "Business-value requirements:" in claude_prompt
@@ -554,6 +558,10 @@ def test_release_video_generates_script_and_invokes_pds_publish(tmp_path: Path):
         "Every non-spoken visual cue is written on one line as `VISUAL: <cue text>`."
         in claude_prompt
     )
+    assert "Default to transform-safe, text-free abstract visuals" in claude_prompt
+    assert "Do not request monitors, screens, terminals" in claude_prompt
+    assert "Do not require exact geometry or layout" in claude_prompt
+    assert "Camera direction must be optional and transform-safe" in claude_prompt
     assert "release video automation" in claude_prompt
     claude_argv = json.loads((repo / "claude_argv.json").read_text(encoding="utf8"))
     assert claude_argv[claude_argv.index("--model") + 1] == "claude-opus-4-8"
@@ -628,13 +636,13 @@ NARRATOR:
 NARRATOR:
 PDD v1.1.0 turns the release notes into a short operator-ready video story that tells maintainers what shipped, why it matters, and how the release path changed.
 
-VISUAL: show the release tag, changelog excerpt, and terminal command side by side.
+VISUAL: a text-free matte package cube rests in a soft blue and violet light field.
 
 ## Reliability
 
 NARRATOR: NARRATOR: The release path now keeps generated assets, PDS run state, and publishing evidence together so recovery work can continue without guessing which artifact was sent downstream.
 
-VISUAL: show the PDS status JSON, the persisted run metadata, and the final YouTube receipt.
+VISUAL: a translucent shield surrounds a rounded orb in a diffuse color field.
 
 Let me know if you want a punchier version.
 """
@@ -704,7 +712,7 @@ the PDS create step receives anything.
 
 VISUAL:
 
-show the release context, normalized script, and pds_run.json side by side with callout labels for raw output, final script, and validation state.
+a text-free matte cube and translucent shield rest in a diffuse violet field with a soft ambient light pulse.
 
 ## Recovery
 
@@ -714,17 +722,17 @@ see which sanitation steps ran, which reduces guesswork during release
 recovery and keeps publishing diagnostics reproducible.
 
 VISUAL:
-zoom into release_video_script_validation.json highlighting checks.hasVisual true and the collapsed visual-label change entry.
+a rounded orb rests in a soft blue field; an optional gentle camera drift may be used.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
 
     assert "\nVISUAL:\n" not in artifacts["script"]
     assert (
-        "\nVISUAL: show the release context, normalized script, and pds_run.json"
+        "\nVISUAL: a text-free matte cube and translucent shield"
         in artifacts["script"]
     )
-    assert "\nVISUAL: zoom into release_video_script_validation.json" in artifacts["script"]
+    assert "\nVISUAL: a rounded orb rests in a soft blue field" in artifacts["script"]
     assert artifacts["validation"]["checks"]["hasVisual"] is True
     assert "collapsed_label_only_visual_cues" in artifacts["validation"]["changes"]
     assert artifacts["validation"]["errors"] == []
@@ -742,9 +750,9 @@ output, normalized script, validation JSON, and PDS run state before the
 publish command can hand the script to downstream video generation.
 
 VISUAL:
-show a split screen with release_video_script.raw.md on the left and the final
-release_video_script.md on the right, with callouts for raw output, collapsed
-visual cue paragraph, validation changes, and the PDS create command.
+a matte package cube rests beneath a translucent shield in a soft blue field;
+an optional gentle camera drift may be used while a diffuse light pulse
+brightens the background.
 
 ## Recovery
 
@@ -753,20 +761,19 @@ The normalized script must keep the entire visual direction together so the
 video generator receives one complete storyboard cue instead of dropping the
 wrapped continuation text.
 
-VISUAL: show release_video_script_validation.json with checks.hasVisual true.
+VISUAL: a rounded orb rests in a text-free violet field.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
 
     assert (
-        "\nVISUAL: show a split screen with release_video_script.raw.md on the left "
-        "and the final release_video_script.md on the right, with callouts for raw "
-        "output, collapsed visual cue paragraph, validation changes, and the PDS "
-        "create command."
+        "\nVISUAL: a matte package cube rests beneath a translucent shield in a "
+        "soft blue field; an optional gentle camera drift may be used while a "
+        "diffuse light pulse brightens the background."
         in artifacts["script"]
     )
-    assert "\nrelease_video_script.md on the right" not in artifacts["script"]
-    assert "\nvisual cue paragraph, validation changes" not in artifacts["script"]
+    assert "\nan optional gentle camera drift" not in artifacts["script"]
+    assert "\nbrightens the background" not in artifacts["script"]
     assert artifacts["validation"]["checks"]["hasVisual"] is True
     assert artifacts["validation"]["errors"] == []
 
@@ -782,18 +789,18 @@ the publish request reaches PDS. Maintainers can reattach to the same run, see
 whether a running sidecar is stale, and retry with a stable idempotency key
 without regenerating the release story or losing the incident trail.
 
-Visual direction: show the changelog, generated script, pds_run.json, status
-query output, and final YouTube receipt side by side.
+Visual direction: a text-free matte cube rests beneath a translucent shield
+in a soft blue field with a diffuse ambient light pulse.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
 
     assert (
-        "\nVISUAL: show the changelog, generated script, pds_run.json, status "
-        "query output, and final YouTube receipt side by side."
+        "\nVISUAL: a text-free matte cube rests beneath a translucent shield "
+        "in a soft blue field with a diffuse ambient light pulse."
         in artifacts["script"]
     )
-    assert "\nNARRATOR:\nquery output" not in artifacts["script"]
+    assert "\nNARRATOR:\nin a soft blue field" not in artifacts["script"]
     assert "collapsed_wrapped_visual_cues" in artifacts["validation"]["changes"]
     assert artifacts["validation"]["checks"]["hasVisual"] is True
     assert artifacts["validation"]["errors"] == []
@@ -820,7 +827,7 @@ The recovery workflow still includes enough narration and a concrete valid
 visual later in the script to satisfy all other validation checks, isolating
 the failure to the leftover label-only visual cue.
 
-VISUAL: show the validation JSON with hasNoLabelOnlyVisualCues highlighted false.
+VISUAL: a text-free matte cube rests in a soft amber field.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -857,8 +864,8 @@ Here is the release video script you asked for:
 
 VISUAL:
 
-show the validation JSON beside the final PDS create command with a highlighted
-hasVisual check and a callout for the normalized script artifact.
+a translucent shield surrounds a matte package cube in a diffuse blue field
+with a soft ambient light pulse.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -867,7 +874,7 @@ hasVisual check and a callout for the normalized script artifact.
     assert "\nVISUAL: NARRATOR:" not in artifacts["script"]
     assert "\nVISUAL: Here is the release video script" not in artifacts["script"]
     assert (
-        "\nVISUAL: show the validation JSON beside the final PDS create command"
+        "\nVISUAL: a translucent shield surrounds a matte package cube"
         in artifacts["script"]
     )
     assert artifacts["validation"]["checks"]["hasVisual"] is True
@@ -887,7 +894,7 @@ PDD v1.1.0 keeps exact raw script diagnostics while sending a normalized script
 to PDS, so release recovery can compare the generated content with the content
 that downstream systems received.
 
-VISUAL: show raw and normalized script artifacts side by side.
+VISUAL: a text-free matte cube and translucent shield rest in a soft blue field.
 
 ## Recovery
 
@@ -895,7 +902,7 @@ NARRATOR:
 Operators can inspect the raw Claude output, the final script, and validation
 metadata without guessing which transformation happened before PDS create.
 
-VISUAL: show the validation JSON and PDS create command.
+VISUAL: a rounded orb rests in a diffuse violet field.
 ```
 """
 
@@ -949,7 +956,7 @@ PDD v1.1.0 keeps release-video recovery visible with durable scripts, status
 metadata, and validation evidence that helps maintainers recover failed
 publishes without guessing.
 
-VISUAL: show the release artifacts and PDS status side by side.
+VISUAL: a text-free matte cube rests in a soft blue field.
 
 ## Close
 
@@ -957,7 +964,7 @@ NARRATOR:
 Operators can query the persisted PDS run, inspect the final script sent
 downstream, and connect the YouTube receipt back to the release notes.
 
-VISUAL: show the terminal status and YouTube URL.
+VISUAL: a translucent shield surrounds a rounded orb in a diffuse violet field.
 ```
 
 Let me know if you want a shorter version.
@@ -983,7 +990,7 @@ PDD v1.1.0 keeps release-video recovery visible with durable scripts, status
 metadata, and validation evidence that helps maintainers recover failed
 publishes without guessing.
 
-VISUAL: show the release artifacts and PDS status side by side.
+VISUAL: a text-free matte cube rests in a soft blue field.
 
 Sure, here is the next section of the release-video script:
 
@@ -993,7 +1000,7 @@ NARRATOR:
 Operators can query the persisted PDS run, inspect the final script sent
 downstream, and connect the YouTube receipt back to the release notes.
 
-VISUAL: show the terminal status and YouTube URL.
+VISUAL: a translucent shield surrounds a rounded orb in a diffuse violet field.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1015,7 +1022,7 @@ PDD v1.1.0 keeps release-video recovery visible with durable scripts, status
 metadata, and validation evidence that helps maintainers recover failed
 publishes without guessing.
 
-VISUAL: show the release artifacts and PDS status side by side.
+VISUAL: a text-free matte cube rests in a soft blue field.
 
 ## Close
 
@@ -1023,7 +1030,7 @@ NARRATOR:
 Operators can query the persisted PDS run, inspect the final script sent
 downstream, and connect the YouTube receipt back to the release notes.
 
-VISUAL: show the terminal status and YouTube URL.
+VISUAL: a translucent shield surrounds a rounded orb in a diffuse violet field.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1058,7 +1065,7 @@ PDD v1.1.0 keeps release-video recovery visible with durable scripts, status
 metadata, and validation evidence that helps maintainers recover failed
 publishes without guessing.
 
-VISUAL: show the release artifacts and PDS status side by side.
+VISUAL: a text-free matte cube rests in a soft blue field.
 
 ## Close
 
@@ -1066,7 +1073,7 @@ NARRATOR:
 Operators can query the persisted PDS run, inspect the final script sent
 downstream, and connect the YouTube receipt back to the release notes.
 
-VISUAL: show the terminal status and YouTube URL.
+VISUAL: a translucent shield surrounds a rounded orb in a diffuse violet field.
 """
 
         artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1087,7 +1094,7 @@ PDD v1.1.0 keeps release-video recovery visible with durable scripts, status
 metadata, and validation evidence that helps maintainers recover failed
 publishes without guessing.
 
-VISUAL: show the release artifacts and PDS status side by side.
+VISUAL: a text-free matte cube rests in a soft blue field.
 
 ## Close
 
@@ -1096,7 +1103,7 @@ Sure, here is the next section of the release-video script:
 Operators can query the persisted PDS run, inspect the final script sent
 downstream, and connect the YouTube receipt back to the release notes.
 
-VISUAL: show the terminal status and YouTube URL.
+VISUAL: a translucent shield surrounds a rounded orb in a diffuse violet field.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1116,7 +1123,7 @@ Here is the command maintainers run after tagging a release, and the reason it
 matters for recovery: the release-video wrapper keeps PDS status, scripts, and
 validation evidence together.
 
-VISUAL: show make release-video-status output beside pds_run.json.
+VISUAL: a text-free package cube rests beneath a soft ambient light pulse.
 
 ## Close
 
@@ -1124,7 +1131,7 @@ NARRATOR:
 The recovery artifacts stay readable and complete, so operators can reattach to
 the release run without depending on stale local profile state.
 
-VISUAL: show the refreshed terminal status and YouTube URL.
+VISUAL: a translucent shield rests in a diffuse blue field.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1145,7 +1152,7 @@ def test_release_video_preserves_trailing_here_is_narration_line():
             "PDD v1.1.0 keeps release recovery visible with durable scripts and",
             "status evidence for maintainers who need to debug failed video publishes.",
             "",
-            "VISUAL: show the release context, normalized script, and pds_run.json.",
+            "VISUAL: a text-free matte cube rests in a soft blue field.",
             "",
             "## Close",
             "",
@@ -1175,7 +1182,7 @@ def test_release_video_preserves_blank_after_label_trailing_here_is_narration():
             "PDD v1.1.0 keeps release recovery visible with durable scripts and",
             "status evidence for maintainers who need to debug failed video publishes.",
             "",
-            "VISUAL: show the release context, normalized script, and pds_run.json.",
+            "VISUAL: a text-free matte cube rests in a soft blue field.",
             "",
             "## Close",
             "",
@@ -1207,7 +1214,7 @@ def test_release_video_preserves_multiparagraph_trailing_here_is_narration():
             "PDD v1.1.0 keeps release recovery visible with durable scripts and",
             "status evidence for maintainers who need to debug failed video publishes.",
             "",
-            "VISUAL: show the release context, normalized script, and pds_run.json.",
+            "VISUAL: a text-free matte cube rests in a soft blue field.",
             "",
             "## Close",
             "",
@@ -1241,8 +1248,8 @@ the publish request reaches PDS. Maintainers can reattach to the same run, see
 whether a running sidecar is stale, and retry with a stable idempotency key
 without regenerating the release story or losing the incident trail.
 
-Visual direction: show the changelog, generated script, pds_run.json, status
-query output, and final YouTube receipt side by side.
+Visual direction: a text-free matte package cube rests beneath a translucent
+shield in a diffuse blue field with a soft ambient light pulse.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1263,7 +1270,7 @@ recover a failed publish without guessing. Generated scripts, validation
 evidence, PDS run handles, and status query diagnostics stay attached to the
 release attempt so maintainers can continue recovery with a stable audit trail.
 
-VISUAL: show release artifacts, pds_run.json, and a terminal status query.
+VISUAL: a text-free matte cube and shield rest in a diffuse blue field.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1282,7 +1289,7 @@ NARRATOR:
 PDD v1.1.0 keeps release recovery visible with durable scripts and status
 evidence for maintainers who need to debug failed video publishes.
 
-VISUAL: show the release context, normalized script, and pds_run.json.
+VISUAL: a text-free rounded orb rests in a soft violet field.
 
 ## Close
 
@@ -1312,7 +1319,7 @@ The wrapper should collapse duplicate speaker labels even when the duplicated
 label line has no narration body, because the final script is what PDS receives
 for section specification and rendering.
 
-VISUAL: show a cleaned narrator block in the script artifact.
+VISUAL: a matte package cube rests in a diffuse blue field.
 
 ## Recovery
 
@@ -1320,7 +1327,7 @@ NARRATOR:
 The validation artifact records the normalization and the script stays free of
 duplicated speaker labels before the create command runs.
 
-VISUAL: show release_video_script_validation.json with no errors.
+VISUAL: a translucent shield surrounds a rounded orb.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1343,7 +1350,7 @@ The wrapper should collapse a long repeated speaker-label run without relying
 on a backtracking-heavy regular expression, because generated scripts can echo
 speaker labels many times after a model formatting failure.
 
-VISUAL: show the duplicate labels collapsed into one narrator block.
+VISUAL: a matte cube rests beneath a soft ambient light pulse.
 
 ## Recovery
 
@@ -1351,7 +1358,7 @@ NARRATOR:
 The final script remains readable, validation stays clean, and PDS receives one
 stable narrator block instead of repeated labels.
 
-VISUAL: show the validation JSON with no duplicate-label errors.
+VISUAL: a translucent shield rests in a diffuse violet field.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1373,7 +1380,7 @@ Opening narration should follow the narrator label without an extra markdown
 marker in the spoken body, because generated scripts sometimes bold speaker
 labels while keeping them on their own line.
 
-VISUAL: show the release artifacts beside the PDS status JSON.
+VISUAL: a text-free package cube rests in a soft blue field.
 
 ## Close
 
@@ -1381,7 +1388,7 @@ VISUAL: show the release artifacts beside the PDS status JSON.
 The workflow stores raw output, normalized narration, and validation evidence
 before publish, keeping the release story auditable through recovery.
 
-VISUAL: show the final YouTube receipt and validation file.
+VISUAL: a translucent shield surrounds a matte orb.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1402,7 +1409,7 @@ Opening narration should follow the narrator label without a literal markdown
 marker in the spoken body, even when generated scripts put whitespace before
 the closing bold marker.
 
-VISUAL: show the release artifacts beside the PDS status JSON.
+VISUAL: a text-free package cube rests in a soft blue field.
 
 ## Close
 
@@ -1410,7 +1417,7 @@ VISUAL: show the release artifacts beside the PDS status JSON.
 The workflow stores raw output, normalized narration, and validation evidence
 before publish, keeping the release story auditable through recovery.
 
-VISUAL: show the final YouTube receipt and validation file.
+VISUAL: a translucent shield surrounds a matte orb.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1429,13 +1436,13 @@ def test_release_video_preserves_wrapped_script_with_bold_narrator_labels():
 Opening narration should be preserved because it explains the release value and
 recovery path for maintainers before the first visual direction appears.
 
-VISUAL: show the release artifacts beside the PDS status JSON.
+VISUAL: a text-free package cube rests in a soft blue field.
 
 **NARRATOR:**
 The workflow stores raw output, normalized narration, and validation evidence
 before publish, keeping the release story auditable through recovery.
 
-VISUAL: show the final YouTube receipt and validation file.
+VISUAL: a translucent shield surrounds a matte orb.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1456,7 +1463,7 @@ def test_release_video_normalizes_spaced_inline_bold_narrator_labels():
 path, with generated scripts, validation artifacts, and PDS run metadata
 preserved before the publish step is allowed to continue.
 
-VISUAL: show the normalized script beside the raw Claude output artifact.
+VISUAL: a text-free matte cube rests in a diffuse violet field.
 
 ## Recovery
 
@@ -1464,7 +1471,7 @@ VISUAL: show the normalized script beside the raw Claude output artifact.
 still providing the standalone narrator blocks PDS expects for scene generation
 and video rendering.
 
-VISUAL: show clean narrator blocks in the final script.
+VISUAL: a translucent shield surrounds a rounded orb in soft light.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")
@@ -1485,7 +1492,7 @@ NARRATOR: PDD v1.1.0 turns release-video recovery into a visible operator path,
 with generated scripts, validation artifacts, and PDS run metadata preserved
 before the publish step is allowed to continue.
 
-VISUAL: show the normalized script beside the raw Claude output artifact.
+VISUAL: a text-free matte cube rests in a diffuse violet field.
 
 ## Recovery
 
@@ -1493,7 +1500,7 @@ NARRATOR: The wrapper keeps narration labels out of the spoken body while still
 providing the standalone narrator blocks PDS expects for scene generation and
 video rendering.
 
-VISUAL: show clean narrator blocks in the final script.
+VISUAL: a translucent shield surrounds a rounded orb in soft light.
 """
 
     artifacts = release_video.prepare_release_video_script(script, source="test")

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -288,6 +288,86 @@ def test_release_video_visual_safety_allows_safe_abstract_cues():
     assert artifacts["validation"]["errors"] == []
 
 
+@pytest.mark.parametrize(
+    "cue",
+    [
+        "Optional particles may appear; the camera must push in toward the orb.",
+        "The orb can be blue while the camera pushes in toward it.",
+        "An optional camera drift may be used; the camera must tilt down afterward.",
+    ],
+)
+def test_release_video_visual_safety_scopes_camera_optionality_to_local_action(
+    cue: str,
+):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "brittle_mandatory_motion" in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
+        "An IDE editor window with syntax-highlighted functions and a toolbar.",
+        "A spreadsheet table with cells, column headers, and a data grid.",
+        "A chart and graph with readable axes, captions, and subtitles.",
+        "A generic application window with menus, a form, and UI controls.",
+        "A browser window displays a readable web app screen.",
+    ],
+)
+def test_release_video_visual_safety_rejects_readable_interface_equivalents(
+    cue: str,
+):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "risky_readable_surface" in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
+        "A slow camera tilt reveals the matte orb.",
+        "The camera cranes upward and then rolls around the shield.",
+        "Rack focus from the package cube to the orb.",
+        "At the 2-second mark, one orb moves into the other.",
+        "After 2 sec, the shield rotates around the package cube.",
+        "At the two-second mark, one orb moves into the other.",
+        "On frame 24, the package cube transforms into an orb.",
+        "At second 3, the camera must pan toward the shield.",
+    ],
+)
+def test_release_video_visual_safety_rejects_common_mandatory_or_timed_motion(
+    cue: str,
+):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "brittle_mandatory_motion" in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
+        "A static zoomed-out view of a matte orb in a soft blue field.",
+        "An optional gentle camera transition may be used around the shield.",
+        "A soft violet field surrounds a package cube; the camera may tilt gently.",
+        "A text-free abstract composition of matte cubes in diffuse blue light.",
+    ],
+)
+def test_release_video_visual_safety_allows_static_or_optional_camera_wording(
+    cue: str,
+):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert categories == []
+
+
 @pytest.mark.parametrize("script_source", ["generated", "script-path"])
 def test_release_video_rejects_unsafe_visual_before_pds_for_all_script_sources(
     tmp_path: Path,

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -294,6 +294,9 @@ def test_release_video_visual_safety_allows_safe_abstract_cues():
         "Optional particles may appear; the camera must push in toward the orb.",
         "The orb can be blue while the camera pushes in toward it.",
         "An optional camera drift may be used; the camera must tilt down afterward.",
+        "An optional camera must slowly pan toward the package cube.",
+        "The orb can be blue as the camera pushes in toward it.",
+        "Optional particles may appear near the orb before the camera pushes in.",
     ],
 )
 def test_release_video_visual_safety_scopes_camera_optionality_to_local_action(
@@ -314,6 +317,7 @@ def test_release_video_visual_safety_scopes_camera_optionality_to_local_action(
         "A chart and graph with readable axes, captions, and subtitles.",
         "A generic application window with menus, a form, and UI controls.",
         "A browser window displays a readable web app screen.",
+        "A graphical interface presents a table of status values and controls.",
     ],
 )
 def test_release_video_visual_safety_rejects_readable_interface_equivalents(
@@ -337,6 +341,7 @@ def test_release_video_visual_safety_rejects_readable_interface_equivalents(
         "At the two-second mark, one orb moves into the other.",
         "On frame 24, the package cube transforms into an orb.",
         "At second 3, the camera must pan toward the shield.",
+        "At 0:02, the package cube moves into the shield.",
     ],
 )
 def test_release_video_visual_safety_rejects_common_mandatory_or_timed_motion(
@@ -355,6 +360,9 @@ def test_release_video_visual_safety_rejects_common_mandatory_or_timed_motion(
         "A static zoomed-out view of a matte orb in a soft blue field.",
         "An optional gentle camera transition may be used around the shield.",
         "A soft violet field surrounds a package cube; the camera may tilt gently.",
+        "The view may gently pan across a soft blue field.",
+        "An optional slow smooth push-in may be used around the matte orb.",
+        "Soft ambient light forms a halo around a matte orb.",
         "A text-free abstract composition of matte cubes in diffuse blue light.",
     ],
 )


### PR DESCRIPTION
Closes #1749.

## Summary

- replace the contradictory release-video visual prompt with transform-safe, text-free abstract guidance
- add deterministic cue-level preflight categories for readable surfaces, exact geometry, and mandatory motion
- run the same preflight for generated and `--script-path` inputs before PDS can be invoked
- keep existing normalization behavior while making test scripts conform to the new visual contract

## Root cause

PR #1459 (`7a3f92cd4`) intentionally optimized visual directions for concrete demos—terminals, code/docs, exact text, split layouts, and zooms—while local validation only checked script structure. PR #1784 centralized cue normalization but did not classify cue semantics, and PR #2012 added downstream repair policy only after paid generation. The generator therefore authored prompts that downstream video validation was likely to reject.

## Test plan

- `direnv exec . pytest -q tests/test_release_video.py` (186 passed)
- `direnv exec . pytest -q tests/test_release_video.py -k 'visual_safety or unsafe_visual_before_pds or generates_script_and_invokes_pds_publish'` (7 passed)
- `direnv exec . pylint --errors-only scripts/release_video.py tests/test_release_video.py`
- `python -m py_compile scripts/release_video.py`
- `git diff --check`

The subprocess CLI tests exercise both generated and prewritten-script entrypoints and prove the PDS capture stub is never invoked when visual safety validation fails.
