### PR TITLE
fix(release): default blank GitHub CLI override

### DIFF
--- a/scripts/backfill_release_video_discord.py
+++ b/scripts/backfill_release_video_discord.py
@@ -501,6 +501,22 @@ def validate_skip_inputs(tag: str, reason: str, repo: str) -> None:
         raise BackfillError("Skip reason is required when recording a release-video skip.")
 
 
+def env_default(name: str, default: str) -> str:
+    """Return a trimmed environment override or its default when blank."""
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return default
+    return value.strip()
+
+
+def validate_gh_cli(gh_cli: str) -> str:
+    """Normalize an explicit GitHub CLI executable before any release access."""
+    normalized = str(gh_cli or "").strip()
+    if not normalized:
+        raise BackfillError("--gh-cli must be a non-empty executable path.")
+    return normalized
+
+
 def record_release_video_skip(
     *,
     tag: str,
@@ -644,7 +660,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--gh-cli",
-        default=os.environ.get("GH_CLI", "gh"),
+        default=env_default("GH_CLI", "gh"),
         help="gh executable path. Defaults to gh.",
     )
     return parser.parse_args(argv)
@@ -652,8 +668,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    github = GitHubReleaseClient(gh_cli=args.gh_cli, repo=args.repo)
     try:
+        github = GitHubReleaseClient(
+            gh_cli=validate_gh_cli(args.gh_cli),
+            repo=args.repo,
+        )
         if args.skip_reason is not None:
             result = record_release_video_skip(
                 tag=args.tag,

--- a/tests/test_release_video_discord_backfill.py
+++ b/tests/test_release_video_discord_backfill.py
@@ -1,5 +1,6 @@
 import importlib.util
 import io
+import os
 from pathlib import Path
 import urllib.error
 
@@ -699,3 +700,109 @@ def test_github_client_uses_gh_release_view_and_edit_without_network():
             "Updated notes\n",
         ),
     ]
+
+
+@pytest.mark.parametrize("env_value", [None, "", "   "])
+def test_gh_cli_env_defaults_to_gh_when_unset_or_blank(monkeypatch, env_value):
+    module = load_backfill_module()
+    if env_value is None:
+        monkeypatch.delenv("GH_CLI", raising=False)
+    else:
+        monkeypatch.setenv("GH_CLI", env_value)
+
+    args = module.parse_args(
+        ["--tag", "v0.0.297", "--skip-reason", "No safe video was produced."]
+    )
+
+    assert args.gh_cli == "gh"
+
+
+def test_gh_cli_env_preserves_non_empty_executable_path(monkeypatch):
+    module = load_backfill_module()
+    gh_path = os.fspath(Path("/opt/tools/gh"))
+    monkeypatch.setenv("GH_CLI", gh_path)
+
+    args = module.parse_args(
+        ["--tag", "v0.0.297", "--skip-reason", "No safe video was produced."]
+    )
+
+    assert args.gh_cli == gh_path
+
+
+@pytest.mark.parametrize(
+    "mode_args",
+    [
+        ["--youtube-url", "https://youtu.be/RIkxCaylRAQ"],
+        ["--skip-reason", "No safe video was produced."],
+    ],
+)
+@pytest.mark.parametrize("blank_cli", ["", "   "])
+def test_blank_explicit_gh_cli_fails_before_github_mutation(
+    monkeypatch,
+    capsys,
+    mode_args,
+    blank_cli,
+):
+    module = load_backfill_module()
+    constructed = []
+
+    def fail_if_constructed(**kwargs):
+        constructed.append(kwargs)
+        raise AssertionError("GitHub client must not be constructed")
+
+    monkeypatch.setattr(module, "GitHubReleaseClient", fail_if_constructed)
+
+    result = module.main(
+        ["--tag", "v0.0.297", *mode_args, "--gh-cli", blank_cli]
+    )
+
+    assert result == 1
+    assert constructed == []
+    assert "--gh-cli must be a non-empty executable path" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("mode_args", "operation_name"),
+    [
+        (
+            ["--youtube-url", "https://youtu.be/RIkxCaylRAQ"],
+            "backfill_release_video_discord",
+        ),
+        (["--skip-reason", "No safe video was produced."], "record_release_video_skip"),
+    ],
+)
+def test_both_modes_use_shared_github_client_with_explicit_override(
+    monkeypatch,
+    mode_args,
+    operation_name,
+):
+    module = load_backfill_module()
+    captured = {}
+    fake_github = object()
+
+    def fake_client(**kwargs):
+        captured["client_kwargs"] = kwargs
+        return fake_github
+
+    def fake_operation(**kwargs):
+        captured["operation_kwargs"] = kwargs
+        return module.BackfillResult(
+            posted=False,
+            release_body_updated=False,
+            marker_added=False,
+            skipped_reason="release-video-skip-already-marked",
+        )
+
+    monkeypatch.setattr(module, "GitHubReleaseClient", fake_client)
+    monkeypatch.setattr(module, operation_name, fake_operation)
+
+    result = module.main(
+        ["--tag", "v0.0.297", *mode_args, "--gh-cli", "/opt/tools/gh"]
+    )
+
+    assert result == 0
+    assert captured["client_kwargs"] == {
+        "gh_cli": "/opt/tools/gh",
+        "repo": "promptdriven/pdd",
+    }
+    assert captured["operation_kwargs"]["github"] is fake_github


### PR DESCRIPTION
## Summary

- treat unset, empty, and whitespace-only `GH_CLI` as the default `gh` executable
- preserve explicit non-empty executable path overrides
- reject explicit blank `--gh-cli` values before constructing the shared GitHub release client in either success/backfill or skip mode

## Root cause and prior work

The release-video Discord backfill introduced in #1694 / `3915eca15` used `os.environ.get("GH_CLI", "gh")`. A present-but-empty environment variable bypasses that default. This is the same empty-environment defaulting class fixed for release-video commands in #1919 / `f4c759830`; this PR follows that established trimmed environment-default helper and early validation shape.

PR #1922 added skip-reason mode, which shares the same `GitHubReleaseClient`, so the validation is deliberately placed before the shared client is constructed and covers both modes.

A repository-wide search found no other `GH_CLI` environment override sites. Multi-token shell command parsing is intentionally out of scope; a non-empty override remains one executable path.

## TDD evidence

Red commit: `5b2df9bea`

```text
6 failed, 4 passed, 23 deselected
- empty and whitespace GH_CLI values remained unchanged
- explicit blank --gh-cli values constructed the GitHub client
```

Green commit: `f4b87434e`

```text
pytest -q tests/test_release_video_discord_backfill.py
33 passed, 1 warning

pylint ... scripts/backfill_release_video_discord.py tests/test_release_video_discord_backfill.py
10.00/10

python -m py_compile scripts/backfill_release_video_discord.py tests/test_release_video_discord_backfill.py
git diff --check
# clean
```

Safe real-entrypoint checks ran both modes with explicit blank values. Both exited 1 with `--gh-cli must be a non-empty executable path.` before GitHub or Discord mutation.

Closes #1920
