### PR TITLE
fix(release-video): guide terminal PDS recovery

### DIFF
--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -49,6 +49,22 @@ TERMINAL_PDS_STATUSES = {
     "timed_out",
     "timeout",
 }
+FAILED_PDS_STATUSES = {
+    "canceled",
+    "cancelled",
+    "error",
+    "errored",
+    "failed",
+    "failure",
+    "timed_out",
+    "timeout",
+}
+PDS_PROVIDER_QUOTA_CODES = {
+    "provider_quota",
+    "spec_generation_provider_quota",
+    "component_generation_provider_quota",
+}
+PDS_AUDIT_GATE_CODES = {"audit_failed"}
 SENSITIVE_COMMAND_OPTIONS = {
     "--access-token",
     "--api-key",
@@ -633,6 +649,9 @@ def print_release_video_status(args: argparse.Namespace, repo: Path) -> int:
     status_note = release_video_status_note(metadata)
     if status_note:
         print(f"status-note: {status_note}")
+    terminal_failure_hint = pds_terminal_failure_hint_from_status(metadata)
+    if terminal_failure_hint:
+        print(f"status-note: {terminal_failure_hint}")
     return 0
 
 
@@ -701,9 +720,13 @@ def query_pds_release_video_status(
                 completed=completed,
                 pds_cli=args.pds_cli,
             )
-        raise ReleaseVideoError(
+        message = (
             f"PDS release-video status failed: {redacted_process_details(completed)}"
         )
+        hint = pds_failure_hint(completed)
+        if hint:
+            message += f" {hint}"
+        raise ReleaseVideoError(message)
     return persist_status_query_success(
         metadata=metadata,
         path=run_metadata_path,
@@ -2666,14 +2689,186 @@ def refresh_pds_recovery_commands(metadata: dict[str, Any], pds_cli: str) -> Non
 
 
 def pds_failure_hint(completed: subprocess.CompletedProcess[str]) -> str:
-    combined = f"{completed.stderr}\n{completed.stdout}".lower()
-    if "request_hash_mismatch" not in combined:
+    """Return fixed, redacted recovery guidance for a terminal PDS failure."""
+    combined = f"{completed.stderr}\n{completed.stdout}"
+    if "request_hash_mismatch" in combined.lower():
+        return (
+            "PDS reported request_hash_mismatch: the same idempotency key was "
+            "reused with a different request body. Retry with a distinct "
+            "RELEASE_VIDEO_ATTEMPT_ID, RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE, or "
+            "explicit RELEASE_VIDEO_IDEMPOTENCY_KEY."
+        )
+    return pds_terminal_failure_hint(completed.stderr, completed.stdout)
+
+
+def pds_terminal_failure_hint_from_status(metadata: dict[str, Any]) -> str:
+    """Classify a refreshed failed-run sidecar without trusting stale history."""
+    status = str(metadata.get("status") or "").strip().lower()
+    if status not in FAILED_PDS_STATUSES:
         return ""
-    return (
-        "PDS reported request_hash_mismatch: the same idempotency key was "
-        "reused with a different request body. Retry with a distinct "
-        "RELEASE_VIDEO_ATTEMPT_ID, RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE, or "
-        "explicit RELEASE_VIDEO_IDEMPOTENCY_KEY."
+    last_query = metadata.get("lastStatusQuery")
+    if not isinstance(last_query, dict) or last_query.get("ok") is not True:
+        return ""
+    response = last_query.get("response")
+    return pds_terminal_failure_hint(pds_current_status_failure_payload(response))
+
+
+def pds_current_status_failure_payload(value: Any) -> Any:
+    """Remove historical run collections before classifying current status."""
+    if isinstance(value, list):
+        return [pds_current_status_failure_payload(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    current: dict[str, Any] = {}
+    for key, nested in value.items():
+        normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
+        if normalized_key in {
+            "attempts",
+            "events",
+            "history",
+            "previous",
+            "previousruns",
+            "runs",
+        }:
+            continue
+        current[key] = pds_current_status_failure_payload(nested)
+    return current
+
+
+def pds_terminal_failure_hint(*values: Any) -> str:
+    """Classify stable PDS terminal signals and return payload-free guidance."""
+    failure_class = classify_pds_terminal_failure(*values)
+    if failure_class == "provider_quota":
+        return (
+            "PDS/GVS provider quota interrupted release-video generation. "
+            "No YouTube URL is expected from this run. Do not rerun "
+            "package/tag/PyPI release steps. Recover or switch the upstream "
+            "provider, then retry release-video with a new attempt id; if the "
+            "team intentionally abandons the historical video, use "
+            "make release-video-skip with an explicit reason."
+        )
+    if failure_class == "audit_gate":
+        return (
+            "The PDS/GVS distribution audit gate blocked safe video publish. "
+            "No YouTube URL is expected from this run. Do not rerun "
+            "package/tag/PyPI release steps or fabricate a video URL. Repair "
+            "the upstream audit failure, then retry release-video; if the team "
+            "intentionally abandons the historical video, use "
+            "make release-video-skip with an explicit reason."
+        )
+    return ""
+
+
+def classify_pds_terminal_failure(*values: Any) -> str | None:
+    """Return a stable terminal class from structured codes or bounded text."""
+    for value in values:
+        for structured in pds_structured_failure_values(value):
+            failure_class = classify_pds_failure_signal(structured, plain=False)
+            if failure_class:
+                return failure_class
+
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        for line in value.splitlines():
+            failure_class = classify_pds_failure_signal(line, plain=True)
+            if failure_class:
+                return failure_class
+    return None
+
+
+def classify_pds_failure_signal(signal: str, *, plain: bool) -> str | None:
+    """Classify one structured value or code-shaped diagnostic line."""
+    normalized = signal.strip().lower()
+    if not normalized or len(normalized) > 512:
+        return None
+    if normalized == "distribution audit gate failed" or (
+        plain and pds_plain_audit_gate_failure(normalized)
+    ):
+        return "audit_gate"
+    if normalized in PDS_AUDIT_GATE_CODES or (
+        plain and pds_plain_failure_code(normalized, PDS_AUDIT_GATE_CODES)
+    ):
+        return "audit_gate"
+    if normalized in PDS_PROVIDER_QUOTA_CODES or (
+        plain and pds_plain_failure_code(normalized, PDS_PROVIDER_QUOTA_CODES)
+    ):
+        return "provider_quota"
+    return "provider_quota" if pds_provider_429_line(normalized) else None
+
+
+def pds_structured_failure_values(value: Any) -> list[str]:
+    """Extract only authoritative failure fields from JSON-like PDS output."""
+    if isinstance(value, str):
+        parsed_values = list(iter_json_values(value))
+        extracted: list[str] = []
+        for parsed in parsed_values:
+            extracted.extend(pds_structured_failure_values(parsed))
+        return extracted
+    if isinstance(value, list):
+        extracted = []
+        for nested in value:
+            extracted.extend(pds_structured_failure_values(nested))
+        return extracted
+    if not isinstance(value, dict):
+        return []
+
+    extracted = []
+    for key, nested in value.items():
+        normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
+        if isinstance(nested, str) and normalized_key in {
+            "code",
+            "error",
+            "errorcode",
+            "failurecode",
+            "reason",
+            "type",
+            "message",
+        }:
+            extracted.append(nested)
+        if isinstance(nested, (dict, list)):
+            extracted.extend(pds_structured_failure_values(nested))
+    return extracted
+
+
+def pds_plain_failure_code(line: str, codes: set[str]) -> bool:
+    """Accept a code-shaped diagnostic line, not an arbitrary prose mention."""
+    if line in codes:
+        return True
+    if not any(code in line for code in codes):
+        return False
+    return bool(
+        re.match(r"^(?:\[pds\]\s*)?(?:error|code|reason|failure|failed)\b", line)
+        or (line.startswith("{") and line.endswith("}"))
+    )
+
+
+def pds_plain_audit_gate_failure(line: str) -> bool:
+    """Recognize the stable audit phrase with a compact diagnostic prefix."""
+    return bool(
+        re.fullmatch(
+            r"(?:\[pds\]\s*)?(?:error|failed|failure|reason):?\s*"
+            r"distribution audit gate failed[.!]?",
+            line,
+        )
+    )
+
+
+def pds_provider_429_line(line: str) -> bool:
+    """Recognize only compact provider-request HTTP 429 diagnostics."""
+    if len(line) > 240:
+        return False
+    return bool(
+        re.search(
+            r"\bprovider(?:\s+request)?\s+(?:failed|error(?:ed)?)\b.{0,32}"
+            r"\b(?:http\s*)?429\b",
+            line,
+        )
+        or re.search(
+            r"\bprovider\b.{0,16}\b(?:http\s*)?429\b.{0,48}"
+            r"\b(?:error|exhausted|failed|limit|quota)\b",
+            line,
+        )
     )
 
 

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -65,6 +65,7 @@ PDS_PROVIDER_QUOTA_CODES = {
     "component_generation_provider_quota",
 }
 PDS_AUDIT_GATE_CODES = {"audit_failed"}
+PDS_REQUEST_HASH_CODES = {"request_hash_mismatch"}
 SENSITIVE_COMMAND_OPTIONS = {
     "--access-token",
     "--api-key",
@@ -723,7 +724,11 @@ def query_pds_release_video_status(
         message = (
             f"PDS release-video status failed: {redacted_process_details(completed)}"
         )
-        hint = pds_failure_hint(completed)
+        hint = pds_failure_hint(
+            completed,
+            expected_run_id=run_id,
+            allow_unscoped=False,
+        )
         if hint:
             message += f" {hint}"
         raise ReleaseVideoError(message)
@@ -2187,7 +2192,15 @@ def create_release_video(
             f"{rendered_command} failed: "
             f"{process_details(completed)}"
         )
-        hint = pds_failure_hint(completed)
+        persisted_metadata = load_persisted_pds_run_metadata(
+            persisted_run_metadata_path
+        )
+        persisted_run_id = str(persisted_metadata.get("runId") or "").strip()
+        hint = pds_failure_hint(
+            completed,
+            expected_run_id=persisted_run_id or None,
+            allow_unscoped=not bool(persisted_run_id),
+        )
         if hint:
             message += f" {hint}"
         if persisted_run_metadata_path:
@@ -2688,17 +2701,20 @@ def refresh_pds_recovery_commands(metadata: dict[str, Any], pds_cli: str) -> Non
     metadata["watchCommand"] = watch_command
 
 
-def pds_failure_hint(completed: subprocess.CompletedProcess[str]) -> str:
+def pds_failure_hint(
+    completed: subprocess.CompletedProcess[str],
+    *,
+    expected_run_id: str | None = None,
+    allow_unscoped: bool = True,
+) -> str:
     """Return fixed, redacted recovery guidance for a terminal PDS failure."""
-    combined = f"{completed.stderr}\n{completed.stdout}"
-    if "request_hash_mismatch" in combined.lower():
-        return (
-            "PDS reported request_hash_mismatch: the same idempotency key was "
-            "reused with a different request body. Retry with a distinct "
-            "RELEASE_VIDEO_ATTEMPT_ID, RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE, or "
-            "explicit RELEASE_VIDEO_IDEMPOTENCY_KEY."
-        )
-    return pds_terminal_failure_hint(completed.stderr, completed.stdout)
+    payloads = pds_authoritative_failure_payloads(
+        completed.stderr,
+        completed.stdout,
+        expected_run_id=expected_run_id,
+        allow_unscoped=allow_unscoped,
+    )
+    return pds_terminal_failure_hint(*payloads)
 
 
 def pds_terminal_failure_hint_from_status(metadata: dict[str, Any]) -> str:
@@ -2709,8 +2725,104 @@ def pds_terminal_failure_hint_from_status(metadata: dict[str, Any]) -> str:
     last_query = metadata.get("lastStatusQuery")
     if not isinstance(last_query, dict) or last_query.get("ok") is not True:
         return ""
+    run_id = str(metadata.get("runId") or "").strip()
+    query_run_id = str(last_query.get("runId") or "").strip()
+    if not run_id or query_run_id != run_id:
+        return ""
     response = last_query.get("response")
-    return pds_terminal_failure_hint(pds_current_status_failure_payload(response))
+    payloads = pds_authoritative_failure_payloads(
+        response,
+        expected_run_id=run_id,
+        allow_unscoped=False,
+    )
+    return pds_terminal_failure_hint(*payloads)
+
+
+def pds_authoritative_failure_payloads(
+    *values: Any,
+    expected_run_id: str | None,
+    allow_unscoped: bool,
+) -> list[Any]:
+    """Select failure payloads owned by the current command or exact run."""
+    payloads: list[Any] = []
+    for value in values:
+        if isinstance(value, (dict, list)):
+            payloads.extend(
+                pds_authoritative_json_failure_payloads(
+                    value,
+                    expected_run_id=expected_run_id,
+                    allow_unscoped=allow_unscoped,
+                )
+            )
+            continue
+        if not isinstance(value, str):
+            continue
+        parsed_spans = list(iter_json_value_spans(value))
+        for parsed, _, _ in parsed_spans:
+            payloads.extend(
+                pds_authoritative_json_failure_payloads(
+                    parsed,
+                    expected_run_id=expected_run_id,
+                    allow_unscoped=allow_unscoped,
+                )
+            )
+        plain_text = text_without_json_spans(value, parsed_spans)
+        if expected_run_id:
+            payloads.extend(
+                pds_plain_failure_segments_for_run(plain_text, expected_run_id)
+            )
+        elif allow_unscoped and not PDS_RUN_HANDLE_LINE_RE.search(plain_text):
+            payloads.append(plain_text)
+    return payloads
+
+
+def pds_authoritative_json_failure_payloads(
+    value: Any,
+    *,
+    expected_run_id: str | None,
+    allow_unscoped: bool,
+) -> list[Any]:
+    """Select a history-pruned JSON payload under explicit authority rules."""
+    if not isinstance(value, dict):
+        return []
+    current = pds_current_status_failure_payload(value)
+    if not isinstance(current, dict):
+        return []
+    run_id = response_pds_run_id(current)
+    if expected_run_id:
+        return [current] if run_id == expected_run_id else []
+    if not allow_unscoped:
+        return []
+    return [current] if not run_id else []
+
+
+def text_without_json_spans(
+    text: str,
+    spans: list[tuple[Any, int, int]],
+) -> str:
+    """Remove parsed JSON while preserving line boundaries for plain parsing."""
+    characters = list(text)
+    for _, start, end in spans:
+        for index in range(start, end):
+            if characters[index] != "\n":
+                characters[index] = " "
+    return "".join(characters)
+
+
+def pds_plain_failure_segments_for_run(text: str, run_id: str) -> list[str]:
+    """Return only diagnostic segments introduced by a matching run handle."""
+    matches = list(PDS_RUN_HANDLE_LINE_RE.finditer(text))
+    segments: list[str] = []
+    for index, match in enumerate(matches):
+        fields = {
+            field.group("key"): field.group("value")
+            for field in PDS_RUN_HANDLE_FIELD_RE.finditer(match.group("fields"))
+        }
+        if fields.get("runId") != run_id:
+            continue
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        segments.append(text[match.start():end])
+    return segments
 
 
 def pds_current_status_failure_payload(value: Any) -> Any:
@@ -2738,6 +2850,13 @@ def pds_current_status_failure_payload(value: Any) -> Any:
 def pds_terminal_failure_hint(*values: Any) -> str:
     """Classify stable PDS terminal signals and return payload-free guidance."""
     failure_class = classify_pds_terminal_failure(*values)
+    if failure_class == "request_hash_mismatch":
+        return (
+            "PDS reported request_hash_mismatch: the same idempotency key was "
+            "reused with a different request body. Retry with a distinct "
+            "RELEASE_VIDEO_ATTEMPT_ID, RELEASE_VIDEO_IDEMPOTENCY_PROVENANCE, or "
+            "explicit RELEASE_VIDEO_IDEMPOTENCY_KEY."
+        )
     if failure_class == "provider_quota":
         return (
             "PDS/GVS provider quota interrupted release-video generation. "
@@ -2752,7 +2871,8 @@ def pds_terminal_failure_hint(*values: Any) -> str:
             "The PDS/GVS distribution audit gate blocked safe video publish. "
             "No YouTube URL is expected from this run. Do not rerun "
             "package/tag/PyPI release steps or fabricate a video URL. Repair "
-            "the upstream audit failure, then retry release-video; if the team "
+            "the upstream audit failure, then retry release-video with a fresh "
+            "RELEASE_VIDEO_ATTEMPT_ID; if the team "
             "intentionally abandons the historical video, use "
             "make release-video-skip with an explicit reason."
         )
@@ -2786,6 +2906,10 @@ def classify_pds_failure_signal(signal: str, *, plain: bool) -> str | None:
         plain and pds_plain_audit_gate_failure(normalized)
     ):
         return "audit_gate"
+    if normalized in PDS_REQUEST_HASH_CODES or (
+        plain and pds_plain_failure_code(normalized, PDS_REQUEST_HASH_CODES)
+    ):
+        return "request_hash_mismatch"
     if normalized in PDS_AUDIT_GATE_CODES or (
         plain and pds_plain_failure_code(normalized, PDS_AUDIT_GATE_CODES)
     ):

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -3420,6 +3420,204 @@ def test_pds_terminal_status_hint_ignores_prior_run_failure_codes():
     assert release_video.pds_terminal_failure_hint_from_status(metadata) == ""
 
 
+def test_pds_terminal_status_hint_rejects_mismatched_last_query_run():
+    release_video = load_release_video_module()
+    metadata = {
+        "runId": "agent_run_current",
+        "status": "failed",
+        "lastStatusQuery": {
+            "ok": True,
+            "runId": "agent_run_old",
+            "response": {
+                "runId": "agent_run_old",
+                "status": "failed",
+                "error": {"code": "provider_quota"},
+            },
+        },
+    }
+
+    assert release_video.pds_terminal_failure_hint_from_status(metadata) == ""
+
+
+def test_release_video_nonzero_status_ignores_mismatched_run_quota(
+    tmp_path: Path,
+):
+    repo = init_release_repo(tmp_path)
+    output_dir = tmp_path / "videos"
+    capture = tmp_path / "pds-status-capture.json"
+    sidecar = output_dir / "v1.1.0" / "pds_run.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "runId": "agent_run_current",
+                "projectId": "pdd-v1-1-0-release",
+                "status": "running",
+            }
+        ),
+        encoding="utf8",
+    )
+    response = {
+        "runId": "agent_run_old",
+        "status": "failed",
+        "error": {
+            "code": "provider_quota",
+            "token": "secret-old-run-token",
+        },
+    }
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--output-dir",
+            str(output_dir),
+            "--status",
+            "--status-query",
+            "--pds-cli",
+            str(
+                pds_output_stub(
+                    tmp_path,
+                    stdout=json.dumps(response) + "\n",
+                    exit_code=1,
+                )
+            ),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "provider quota interrupted" not in combined.lower()
+    assert "No YouTube URL is expected" not in combined
+    assert "secret-old-run-token" not in combined
+
+
+def test_release_video_nonzero_status_ignores_current_generic_failure_history(
+    tmp_path: Path,
+):
+    repo = init_release_repo(tmp_path)
+    output_dir = tmp_path / "videos"
+    capture = tmp_path / "pds-status-capture.json"
+    sidecar = output_dir / "v1.1.0" / "pds_run.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "runId": "agent_run_current",
+                "projectId": "pdd-v1-1-0-release",
+                "status": "running",
+            }
+        ),
+        encoding="utf8",
+    )
+    response = {
+        "run": {"runId": "agent_run_current", "status": "failed"},
+        "error": {"code": "render_failed"},
+        "history": [
+            {
+                "runId": "agent_run_old",
+                "status": "failed",
+                "error": {"code": "provider_quota"},
+            }
+        ],
+    }
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--output-dir",
+            str(output_dir),
+            "--status",
+            "--status-query",
+            "--pds-cli",
+            str(
+                pds_output_stub(
+                    tmp_path,
+                    stdout=json.dumps(response) + "\n",
+                    exit_code=1,
+                )
+            ),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "provider quota interrupted" not in combined.lower()
+    assert "No YouTube URL is expected" not in combined
+
+
+def test_release_video_create_ignores_historical_request_hash_failure(
+    tmp_path: Path,
+):
+    repo = init_release_repo(tmp_path)
+    capture = tmp_path / "pds-capture.json"
+    existing_script = tmp_path / "existing_release_video_script.md"
+    existing_script.write_text(reusable_script_text(), encoding="utf8")
+    response = {
+        "run": {"runId": "agent_run_current", "status": "failed"},
+        "error": {"code": "render_failed"},
+        "history": [
+            {
+                "runId": "agent_run_old",
+                "status": "failed",
+                "error": {"code": "request_hash_mismatch"},
+            }
+        ],
+    }
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--git-sha",
+            "abc123def456",
+            "--script-path",
+            str(existing_script),
+            "--pds-cli",
+            str(
+                pds_output_stub(
+                    tmp_path,
+                    stderr=json.dumps(response) + "\n",
+                    exit_code=1,
+                )
+            ),
+            "--output-dir",
+            str(tmp_path / "videos"),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "same idempotency key was reused" not in result.stderr
+
+
 def test_release_video_create_provider_quota_reports_recovery_without_retry(
     tmp_path: Path,
 ):
@@ -3573,6 +3771,8 @@ def test_release_video_nonzero_status_query_reports_audit_gate_recovery_hint(
                     stdout=json.dumps(
                         {
                             "ok": False,
+                            "runId": "agent_run_audit",
+                            "status": "failed",
                             "error": {
                                 "code": "audit_failed",
                                 "token": "secret-audit-token",
@@ -3596,7 +3796,69 @@ def test_release_video_nonzero_status_query_reports_audit_gate_recovery_hint(
     assert "audit gate" in combined.lower()
     assert "No YouTube URL is expected" in combined
     assert "make release-video-skip" in combined
+    assert "fresh RELEASE_VIDEO_ATTEMPT_ID" in combined
     assert "secret-audit-token" not in combined
+
+
+def test_release_video_plain_status_audit_hint_requires_matching_run_handle(
+    tmp_path: Path,
+):
+    repo = init_release_repo(tmp_path)
+    output_dir = tmp_path / "videos"
+    capture = tmp_path / "pds-status-capture.json"
+    sidecar = output_dir / "v1.1.0" / "pds_run.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "runId": "agent_run_plain_audit",
+                "projectId": "pdd-v1-1-0-release",
+                "status": "running",
+            }
+        ),
+        encoding="utf8",
+    )
+    diagnostic = (
+        "[pds] release-video run handle: "
+        "runId=agent_run_plain_audit status=failed\n"
+        "error: Distribution audit gate failed\n"
+        "Authorization: Bearer secret-plain-audit-token\n"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--output-dir",
+            str(output_dir),
+            "--status",
+            "--status-query",
+            "--pds-cli",
+            str(
+                pds_output_stub(
+                    tmp_path,
+                    stderr=diagnostic,
+                    exit_code=1,
+                )
+            ),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "audit gate blocked" in combined.lower()
+    assert "fresh RELEASE_VIDEO_ATTEMPT_ID" in combined
+    assert "Do not rerun package/tag/PyPI" in combined
+    assert "secret-plain-audit-token" not in combined
 
 
 def test_release_video_create_failure_redacts_pds_cli_command_secrets(tmp_path: Path):

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -3309,7 +3309,7 @@ def test_release_video_request_hash_mismatch_reports_idempotency_hint(tmp_path: 
     assert "same idempotency key was reused with a different request body" in result.stderr
 
 
-def test_pds_failure_hint_classifies_structured_provider_quota_without_leaking_details():
+def test_pds_failure_hint_classifies_structured_quota_without_leaking():
     release_video = load_release_video_module()
     completed = subprocess.CompletedProcess(
         ["pds", "release-video", "create"],
@@ -3340,7 +3340,7 @@ def test_pds_failure_hint_classifies_plain_audit_gate_failure_from_stderr():
         ["pds", "release-video", "create"],
         1,
         stdout="",
-        stderr="Distribution audit gate failed\n",
+        stderr="error: Distribution audit gate failed\n",
     )
 
     hint = release_video.pds_failure_hint(completed)
@@ -3362,6 +3362,24 @@ def test_pds_failure_hint_classifies_bounded_provider_429_plaintext():
     assert "provider quota" in release_video.pds_failure_hint(completed).lower()
 
 
+def test_pds_failure_hint_recognizes_all_stable_provider_quota_codes():
+    release_video = load_release_video_module()
+
+    for code in (
+        "provider_quota",
+        "PROVIDER_QUOTA",
+        "spec_generation_provider_quota",
+        "component_generation_provider_quota",
+    ):
+        completed = subprocess.CompletedProcess(
+            ["pds", "release-video", "create"],
+            1,
+            stdout=f"error: {code}\n",
+            stderr="",
+        )
+        assert "provider quota" in release_video.pds_failure_hint(completed).lower()
+
+
 def test_pds_failure_hint_ignores_misleading_or_unbounded_failure_prose():
     release_video = load_release_video_module()
     prose = (
@@ -3376,6 +3394,87 @@ def test_pds_failure_hint_ignores_misleading_or_unbounded_failure_prose():
     )
 
     assert release_video.pds_failure_hint(completed) == ""
+
+
+def test_pds_terminal_status_hint_ignores_prior_run_failure_codes():
+    release_video = load_release_video_module()
+    metadata = {
+        "runId": "agent_run_current",
+        "status": "failed",
+        "lastStatusQuery": {
+            "ok": True,
+            "response": {
+                "run": {"runId": "agent_run_current", "status": "failed"},
+                "error": {"code": "render_failed"},
+                "history": [
+                    {
+                        "runId": "agent_run_old",
+                        "status": "failed",
+                        "error": {"code": "provider_quota"},
+                    }
+                ],
+            },
+        },
+    }
+
+    assert release_video.pds_terminal_failure_hint_from_status(metadata) == ""
+
+
+def test_release_video_create_provider_quota_reports_recovery_without_retry(
+    tmp_path: Path,
+):
+    repo = init_release_repo(tmp_path)
+    capture = tmp_path / "pds-capture.json"
+    existing_script = tmp_path / "existing_release_video_script.md"
+    existing_script.write_text(reusable_script_text(), encoding="utf8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--git-sha",
+            "abc123def456",
+            "--script-path",
+            str(existing_script),
+            "--pds-cli",
+            str(
+                pds_output_stub(
+                    tmp_path,
+                    stderr=json.dumps(
+                        {
+                            "error": {
+                                "code": "provider_quota",
+                                "apiKey": "secret-provider-api-key",
+                            }
+                        }
+                    )
+                    + "\n",
+                    exit_code=1,
+                )
+            ),
+            "--output-dir",
+            str(tmp_path / "videos"),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "provider quota" in combined.lower()
+    assert "No YouTube URL is expected" in combined
+    assert "Do not rerun package/tag/PyPI" in combined
+    assert "make release-video-skip" in combined
+    assert "secret-provider-api-key" not in combined
+    assert "YouTube video:" not in combined
+    assert len(json.loads(capture.read_text(encoding="utf8"))) > 0
 
 
 def test_release_video_status_query_reports_delayed_terminal_provider_quota(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -3309,6 +3309,197 @@ def test_release_video_request_hash_mismatch_reports_idempotency_hint(tmp_path: 
     assert "same idempotency key was reused with a different request body" in result.stderr
 
 
+def test_pds_failure_hint_classifies_structured_provider_quota_without_leaking_details():
+    release_video = load_release_video_module()
+    completed = subprocess.CompletedProcess(
+        ["pds", "release-video", "create"],
+        1,
+        stdout=json.dumps(
+            {
+                "error": {
+                    "code": "component_generation_provider_quota",
+                    "token": "secret-provider-token",
+                }
+            }
+        ),
+        stderr="",
+    )
+
+    hint = release_video.pds_failure_hint(completed)
+
+    assert "provider quota" in hint.lower()
+    assert "No YouTube URL is expected" in hint
+    assert "Do not rerun package/tag/PyPI" in hint
+    assert "make release-video-skip" in hint
+    assert "secret-provider-token" not in hint
+
+
+def test_pds_failure_hint_classifies_plain_audit_gate_failure_from_stderr():
+    release_video = load_release_video_module()
+    completed = subprocess.CompletedProcess(
+        ["pds", "release-video", "create"],
+        1,
+        stdout="",
+        stderr="Distribution audit gate failed\n",
+    )
+
+    hint = release_video.pds_failure_hint(completed)
+
+    assert "audit gate" in hint.lower()
+    assert "No YouTube URL is expected" in hint
+    assert "make release-video-skip" in hint
+
+
+def test_pds_failure_hint_classifies_bounded_provider_429_plaintext():
+    release_video = load_release_video_module()
+    completed = subprocess.CompletedProcess(
+        ["pds", "release-video", "create"],
+        1,
+        stdout="provider request failed with HTTP 429 quota exhausted\n",
+        stderr="",
+    )
+
+    assert "provider quota" in release_video.pds_failure_hint(completed).lower()
+
+
+def test_pds_failure_hint_ignores_misleading_or_unbounded_failure_prose():
+    release_video = load_release_video_module()
+    prose = (
+        "The operator guide discusses provider quota and later mentions status 429, "
+        "but this command failed because the network is offline."
+    )
+    completed = subprocess.CompletedProcess(
+        ["pds", "release-video", "create"],
+        1,
+        stdout=prose,
+        stderr="",
+    )
+
+    assert release_video.pds_failure_hint(completed) == ""
+
+
+def test_release_video_status_query_reports_delayed_terminal_provider_quota(
+    tmp_path: Path,
+):
+    repo = init_release_repo(tmp_path)
+    output_dir = tmp_path / "videos"
+    capture = tmp_path / "pds-status-capture.json"
+    sidecar = output_dir / "v1.1.0" / "pds_run.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "runId": "agent_run_quota",
+                "projectId": "pdd-v1-1-0-release",
+                "status": "running",
+            }
+        ),
+        encoding="utf8",
+    )
+    status_response = {
+        "run": {"runId": "agent_run_quota", "status": "failed"},
+        "error": {
+            "code": "spec_generation_provider_quota",
+            "authorization": "secret-status-authorization",
+        },
+    }
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--output-dir",
+            str(output_dir),
+            "--status",
+            "--status-query",
+            "--pds-cli",
+            str(pds_output_stub(tmp_path, stdout=json.dumps(status_response) + "\n")),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0
+    assert "provider quota" in combined.lower()
+    assert "No YouTube URL is expected" in combined
+    assert "Do not rerun package/tag/PyPI" in combined
+    assert "make release-video-skip" in combined
+    assert "secret-status-authorization" not in combined
+    assert "YouTube video:" not in combined
+
+
+def test_release_video_nonzero_status_query_reports_audit_gate_recovery_hint(
+    tmp_path: Path,
+):
+    repo = init_release_repo(tmp_path)
+    output_dir = tmp_path / "videos"
+    capture = tmp_path / "pds-status-capture.json"
+    sidecar = output_dir / "v1.1.0" / "pds_run.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "runId": "agent_run_audit",
+                "projectId": "pdd-v1-1-0-release",
+                "status": "running",
+            }
+        ),
+        encoding="utf8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(repo),
+            "--tag",
+            "v1.1.0",
+            "--output-dir",
+            str(output_dir),
+            "--status",
+            "--status-query",
+            "--pds-cli",
+            str(
+                pds_output_stub(
+                    tmp_path,
+                    stdout=json.dumps(
+                        {
+                            "ok": False,
+                            "error": {
+                                "code": "audit_failed",
+                                "token": "secret-audit-token",
+                            },
+                        }
+                    )
+                    + "\n",
+                    exit_code=1,
+                )
+            ),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=release_video_env({"PDS_STUB_CAPTURE": str(capture)}),
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "audit gate" in combined.lower()
+    assert "No YouTube URL is expected" in combined
+    assert "make release-video-skip" in combined
+    assert "secret-audit-token" not in combined
+
+
 def test_release_video_create_failure_redacts_pds_cli_command_secrets(tmp_path: Path):
     repo = init_release_repo(tmp_path)
     capture = tmp_path / "pds-capture.json"


### PR DESCRIPTION
## Summary

- centralize classification of stable terminal PDS quota and distribution-audit failures
- surface fixed, redacted recovery guidance from immediate create errors, nonzero status queries, and successful status queries that refresh the current run to a failed terminal state
- preserve request-hash guidance, terminal exit behavior, audit enforcement, and package/tag/PyPI artifacts
- exclude prior-run history and arbitrary prose from authoritative classification

## Root cause

The recovery hint added in c80f833ef was only called by the immediate nonzero `release-video create` branch and only recognized `request_hash_mismatch`. Later status-recovery work correctly persisted delayed terminal state, but neither status-query exit path invoked a terminal-failure classifier. As a result, provider quota and audit-gate terminal states had no safe operator next step even when the current run was known to have failed.

## Test plan

- `python -m pytest -q tests/test_release_video.py` (226 passed)
- focused terminal-hint selection: 10 passed
- `python -m py_compile scripts/release_video.py tests/test_release_video.py`
- `git diff --check`
- real wrapper boundary is exercised via subprocess calls to `scripts/release_video.py` with deterministic PDS CLI stubs for create, failed status, and delayed terminal status

Closes #1925
