### PR TITLE
docs(release): define canonical end-to-end runbook

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -12864,6 +12864,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "tests/test_release_process_runbook.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "tests/test_release_video.py",
       "role": "human-maintained"
     },

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -727,7 +727,12 @@ Release-video diagnostics and recovery:
 - For PDS project metadata mismatch recovery, reuse the generated script and original release notes, then run `make release-video RELEASE_TAG=<tag> RELEASE_VIDEO_PROJECT_ID=<project-id> RELEASE_VIDEO_SCRIPT_PATH=.pdd/release-videos/<tag>/release_video_script.md RELEASE_VIDEO_RELEASE_NOTES_PATH=.pdd/release-videos/<tag>/release_notes.md RELEASE_VIDEO_METADATA_CONFLICT=replace RELEASE_VIDEO_FORCE_REGENERATE=1 RELEASE_VIDEO_ATTEMPT_ID=<timestamp-or-label>`. Use `RELEASE_VIDEO_METADATA_CONFLICT=use-existing` when PDS says to preserve existing metadata.
 - For PDS publish retries, inspect the previous run first. Exact retries should reuse the original idempotency key; start a new attempt only after confirming the old run should not be reused, with `make release-video RELEASE_TAG=<tag> RELEASE_VIDEO_ATTEMPT_ID=<timestamp-or-label>` or a full `RELEASE_VIDEO_IDEMPOTENCY_KEY=<key>`.
 - If a release video is recovered after the release workflow already posted to Discord, run the **Backfill release video Discord post** workflow with the release tag and YouTube URL. Local equivalent: `DISCORD_WEBHOOK_URL=<webhook> make release-video-discord-backfill RELEASE_TAG=<tag> RELEASE_VIDEO_YOUTUBE_URL=<youtube-url>`.
-- Set `PDS_CLI` if `pds` is not on `PATH`. Use `RELEASE_VIDEO=0` only for an emergency release that must skip paid video generation/upload.
+- Set `PDS_CLI` if `pds` is not on `PATH`. `RELEASE_VIDEO=0` is mandatory for
+  normal local tag creation: it disables the local create and leaves the
+  tag-triggered Actions video path enabled as the sole authority. Omit it only
+  after the canonical runbook proves no Actions attempt started and records an
+  exceptional manual authority transfer; an emergency no-video outcome uses
+  the explicit skip/recovery path instead.
 
 ### 9. Troubleshooting Development Setup
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -703,12 +703,19 @@ a quick entrypoint reference and do not replace its safety and closeout checks.
 The version is derived from git tags via setuptools-scm. To release, on `main`:
 
 ```bash
-make release-local             # patch bump with local SOPS release secrets
-make release-local BUMP=minor  # minor bump
-make release-local BUMP=major  # major bump
+RELEASE_VIDEO=0 make release-local             # patch bump; CI owns video creation
+RELEASE_VIDEO=0 make release-local BUMP=minor  # minor bump
+RELEASE_VIDEO=0 make release-local BUMP=major  # major bump
 ```
 
-`make release-local` injects release secrets from SOPS, tags `HEAD` with the next `vX.Y.Z`, pushes the tag, then runs `make release-video`. By default it looks for `../secrets/pdd_cloud/shared.prod.sops.env`; set `SOPS_RELEASE_ENV_FILE` if your `pdd_cloud` checkout is elsewhere. The local wrapper maps `CLAUDE_CODE_OAUTH_TOKEN` from `shared.staging.sops.env`, `shared.staging2.sops.env`, and `shared.prod.sops.env` into Claude Code rotation slots `_1`, `_2`, and `_3` at process runtime. The release-video step asks Claude Code to turn the release diff/notes into a short video script and calls the Prompt Driven Studio CLI (`pds release-video create --target publish --platform youtube --privacy unlisted --wait`) to create and upload an unlisted YouTube video. GitHub Actions then builds the wheel, waits for the `gltanaka` approval on the `pypi-publish` environment, publishes to PyPI via OIDC, and creates a GitHub Release with auto-generated notes.
+`RELEASE_VIDEO=0 make release-local` injects release secrets from SOPS, tags
+`HEAD` with the derived next `vX.Y.Z`, and pushes the tag while disabling the
+local video-create path. The tag-triggered GitHub Actions job is the sole normal
+release-video authority after its protected `pypi-publish` approval and package
+publication. By default the local wrapper looks for
+`../secrets/pdd_cloud/shared.prod.sops.env`; set `SOPS_RELEASE_ENV_FILE` if your
+`pdd_cloud` checkout is elsewhere. See the canonical runbook for approval
+ordering, recovery, and final evidence.
 
 Release-video diagnostics and recovery:
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -695,6 +695,11 @@ git commit -m "docs: update documentation"
 
 **Cut a release (maintainers only):**
 
+Use the [canonical release runbook](contributors/pdd-cli-release-process.md)
+for cloud testing, PR/review gates, production publication, release-video
+verification/recovery, Discord, and final evidence. The commands below are only
+a quick entrypoint reference and do not replace its safety and closeout checks.
+
 The version is derived from git tags via setuptools-scm. To release, on `main`:
 
 ```bash

--- a/docs/contributors/pdd-cli-release-process.md
+++ b/docs/contributors/pdd-cli-release-process.md
@@ -428,9 +428,11 @@ make release-video-skip \
 ```
 
 This writes `pdd-release-video-skipped` to the GitHub Release and sends no
-Discord message. Mark Discord follow-up explicitly unnecessary. The backfill
-command now refuses to backfill while a matching skip record remains, so a
-later verified video cannot create contradictory durable states.
+Discord message. It fails before editing the release when a video URL or exact,
+pending, stale, or mismatched backfill marker already exists. Mark Discord
+follow-up explicitly unnecessary. Reciprocally, the backfill command refuses to
+backfill while a matching skip record remains, so either direction stays
+monotonic while the full state machine in #2044 is pending.
 
 To supersede a skip, first state the release-body target, saved-body rollback,
 and ambiguous Discord risk. Save the current body, remove only the exact

--- a/docs/contributors/pdd-cli-release-process.md
+++ b/docs/contributors/pdd-cli-release-process.md
@@ -53,8 +53,9 @@ PY
 )
 RELEASE_TAG="v${NEXT_VERSION}"
 RELEASE_GIT_SHA=$(git rev-parse origin/main)
-printf 'candidate=%s sha=%s previous=%s\n' \
-  "$RELEASE_TAG" "$RELEASE_GIT_SHA" "$LATEST_TAG"
+PYPI_PROJECT="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["name"])')"
+printf 'candidate=%s sha=%s previous=%s distribution=%s\n' \
+  "$RELEASE_TAG" "$RELEASE_GIT_SHA" "$LATEST_TAG" "$PYPI_PROJECT"
 ```
 
 Confirm the candidate tag does not exist locally, on origin, on PyPI, or as a
@@ -127,7 +128,7 @@ make check-release-video-config-local
 Re-derive `RELEASE_TAG` and `RELEASE_GIT_SHA` after the pull and confirm they
 match the tested candidate. Before the release mutation, record:
 
-- Target: `promptdriven/pdd`, the derived tag, PyPI project `pdd`, the
+- Target: `promptdriven/pdd`, the derived tag, PyPI project `pdd-cli`, the
   `pypi-publish` GitHub environment, the production PDS endpoint, and the
   configured YouTube account.
 - Rollback: do not reuse/delete a published tag or PyPI version; correct defects
@@ -139,24 +140,35 @@ match the tested candidate. Before the release mutation, record:
 Only then run the maintainer entrypoint:
 
 ```bash
-make release-local BUMP="$BUMP"
+RELEASE_VIDEO=0 make release-local BUMP="$BUMP"
 ```
 
-The target derives the next tag, pushes it, and invokes local release-video.
-The tag push also starts `.github/workflows/release.yml`; its best-effort video
-path can overlap the local attempt. Treat the persisted request provenance,
-idempotency key, and run handle as authority. Do not start an unlabelled second
-attempt because one surface is still running.
+The target derives and pushes the next tag. `RELEASE_VIDEO=0` disables the
+Makefile's local create path, including its recursive `release-video` call. The
+tag-triggered `.github/workflows/release.yml` job is the sole normal creation
+authority: it uses `github-actions` provenance after package publication. This
+prevents local and CI from creating distinct requests for the same release.
+General automation to make this authority/state machine explicit is tracked in
+#2044; until it ships, the environment override is mandatory.
 
-If `HEAD` already has the intended tag at the same SHA, `make release-local`
-uses the recovery path. If it differs, stop. Never move a release tag.
+Do not use `make release-local` as a same-tag recovery command. Once the tag is
+on origin, use the state-specific recovery below.
 
 ## 5. Approve and verify package publication
 
-The tag workflow builds and checks the artifacts, then waits at the protected
-`pypi-publish` production environment. Before approving, re-check the target
-tag/SHA, cloud-test evidence, artifact attestations, and safety record. Approval
-is the production publication gate. Reject it if any identity differs.
+The protected `pypi-publish` environment is attached to the entire
+`publish-pypi` job. Its approval therefore occurs before checkout, build, Twine
+verification, and publication. Approval authorizes those steps from the exact
+tag SHA; it does not approve a prebuilt wheel.
+
+**Before approval**, verify the remote tag/SHA, final cloud-test evidence,
+workflow file and event identity, reviewed source, intended distribution name,
+and safety record. Wheel hashes and attestations do not exist yet. Reject the
+job if any available identity differs.
+
+**After publication**, verify the built artifact hashes, PyPI attestations,
+public version, workflow result, and GitHub Release. Approval alone is not
+publication evidence.
 
 After approval, require all of the following before package closeout:
 
@@ -165,16 +177,91 @@ gh run list --repo promptdriven/pdd --workflow release.yml \
   --limit 20 --json databaseId,headSha,status,conclusion,url
 gh release view "$RELEASE_TAG" --repo promptdriven/pdd \
   --json tagName,targetCommitish,publishedAt,url,body
-python -m pip index versions pdd
+python -m pip index versions "$PYPI_PROJECT"
+PYPI_VERSION_URL="https://pypi.org/project/${PYPI_PROJECT}/${NEXT_VERSION}/"
+PYPI_JSON_URL="https://pypi.org/pypi/${PYPI_PROJECT}/${NEXT_VERSION}/json"
+printf '%s\n' "$PYPI_VERSION_URL"
+curl -fsS "$PYPI_JSON_URL" | python -c '
+import json, sys
+payload = json.load(sys.stdin)
+assert payload["info"]["name"] == "pdd-cli"
+assert payload["info"]["version"] == sys.argv[1]
+assert payload["urls"] and all(item["digests"]["sha256"] for item in payload["urls"])
+' "$NEXT_VERSION"
+
+TAG_REFS=$(git ls-remote origin \
+  "refs/tags/$RELEASE_TAG" "refs/tags/$RELEASE_TAG^{}")
+DIRECT_TAG_SHA=$(printf '%s\n' "$TAG_REFS" \
+  | awk '$2 !~ /\^\{\}$/ {print $1; exit}')
+PEELED_TAG_SHA=$(printf '%s\n' "$TAG_REFS" \
+  | awk '$2 ~ /\^\{\}$/ {print $1; exit}')
+if [ -n "$PEELED_TAG_SHA" ]; then
+  REMOTE_TAG_SHA="$PEELED_TAG_SHA"
+else
+  REMOTE_TAG_SHA="$DIRECT_TAG_SHA"
+fi
+test -n "$REMOTE_TAG_SHA"
+test "$REMOTE_TAG_SHA" = "$RELEASE_GIT_SHA"
 ```
 
 - The workflow run is successful and its `headSha` is `RELEASE_GIT_SHA`.
 - PyPI shows the exact derived version and its artifacts/attestations.
 - The GitHub Release exists at the same tag and contains real release notes,
   not an authentication, quota, or tool diagnostic.
+- The exact version page at `$PYPI_VERSION_URL` identifies distribution
+  `pdd-cli` and the recorded files/hashes/attestations.
+- The remote tag's peeled commit equals `RELEASE_GIT_SHA`; do not use
+  `targetCommitish` (often `main`) as tag-object proof.
 
 Record URLs and immutable identifiers. Do not rerun package publication merely
 because release notes or video work remains.
+
+### Same-tag package workflow recovery
+
+First verify PyPI and the GitHub Release to distinguish an unpublished failure
+from an ambiguous response after publication. `skip-existing` limits duplicate
+file upload after an ambiguous PyPI response; it is not proof that a rerun is
+safe or that publication did not occur.
+
+Locate the existing production tag-push run and prove its SHA:
+
+```bash
+RUN_ID=$(gh run list --repo promptdriven/pdd --workflow release.yml \
+  --event push --branch "$RELEASE_TAG" --limit 20 \
+  --json databaseId,headSha,event,headBranch,status,conclusion \
+  --jq ".[] | select(.headSha == \"$RELEASE_GIT_SHA\" and .event == \"push\") | .databaseId" \
+  | head -1)
+test -n "$RUN_ID" || {
+  echo "no matching production tag-push run exists; open an automation incident" >&2
+  exit 1
+}
+gh run view "$RUN_ID" --repo promptdriven/pdd --json jobs,status,conclusion,url
+```
+
+Rerun only when the job/step evidence proves package publication did not
+complete **and the video step did not start**. The unchanged tag/SHA then keeps
+the tag-triggered workflow as the first and sole video authority:
+
+```bash
+gh run rerun "$RUN_ID" --repo promptdriven/pdd
+```
+
+The protected environment requires approval again. If the prior video step
+started, do not rerun the whole workflow: use PDS status/recovery and the
+release/Discord reconciliation paths. If no matching production tag-push run
+exists, stop and open an automation incident; `workflow_dispatch` targets
+TestPyPI and is not production recovery.
+
+If PyPI is proven complete but the GitHub Release is missing, state a new
+target/rollback/risk record, verify PyPI first, then create the release once:
+
+```bash
+gh release view "$RELEASE_TAG" --repo promptdriven/pdd >/dev/null 2>&1 \
+  || gh release create "$RELEASE_TAG" --repo promptdriven/pdd \
+       --generate-notes --verify-tag --target "$RELEASE_GIT_SHA"
+```
+
+This reconciliation is not permission to rerun PyPI or video work.
 
 ## 6. Create, audit, and distribute the release video
 
@@ -183,16 +270,13 @@ script generation uses `RELEASE_VIDEO_CLAUDE_MODEL` (default
 `claude-opus-4-8`); `RELEASE_VIDEO_PDS_CLAUDE_MODEL` controls non-vision PDS
 stages. Empty local model values are treated as unset.
 
-Normal release-video publication is production-affecting. State the PDS
-project/endpoint, request provenance, YouTube account/privacy, rollback, and
-paid-generation/publication risk before invoking it. When resuming an existing
-release, use the already-derived identifiers:
-
-```bash
-make release-video \
-  RELEASE_TAG="$RELEASE_TAG" \
-  RELEASE_GIT_SHA="$RELEASE_GIT_SHA"
-```
+Normal release-video publication is production-affecting. The sole normal
+creation authority is the tag-triggered `.github/workflows/release.yml` job;
+section 4 disables local creation. Its retained safety record must name the PDS
+project/endpoint, `github-actions` provenance, YouTube account/privacy,
+rollback, and paid-generation/publication risk. Monitor that exact workflow and
+download its `release-video-<tag>` recovery artifact. Do not invoke a second
+create from the operator shell.
 
 PDS must retain one attributable chain from request through distribution:
 
@@ -264,7 +348,10 @@ make release-video \
 
 Exact retries reuse the original idempotency key and provenance. Set
 `RELEASE_VIDEO_ATTEMPT_ID=<timestamp-or-label>` only after proving the previous
-run cannot be resumed. Never use both an attempt ID and a full idempotency key.
+run cannot be resumed. A manual create is exceptional and permitted only when
+authoritative status proves that no attempt was started by the normal authority
+and the safety record explicitly transfers creation authority to the operator.
+Never use both an attempt ID and a full idempotency key.
 
 ## Warnings versus blockers
 
@@ -341,8 +428,68 @@ make release-video-skip \
 ```
 
 This writes `pdd-release-video-skipped` to the GitHub Release and sends no
-Discord message. Mark Discord follow-up explicitly unnecessary. A later real
-video may supersede the skip through the normal verified backfill path.
+Discord message. Mark Discord follow-up explicitly unnecessary. The backfill
+command now refuses to backfill while a matching skip record remains, so a
+later verified video cannot create contradictory durable states.
+
+To supersede a skip, first state the release-body target, saved-body rollback,
+and ambiguous Discord risk. Save the current body, remove only the exact
+tag-bound skip text/marker with the shared parser, inspect the diff, and edit the
+release once:
+
+```bash
+BEFORE=$(mktemp)
+AFTER=$(mktemp)
+gh release view "$RELEASE_TAG" --repo promptdriven/pdd --json body --jq .body \
+  >"$BEFORE"
+python - "$RELEASE_TAG" "$BEFORE" "$AFTER" <<'PY'
+import pathlib
+import sys
+from scripts.backfill_release_video_discord import remove_release_video_skip_records
+
+tag, before, after = sys.argv[1:]
+body = pathlib.Path(before).read_text(encoding="utf8")
+reconciled = remove_release_video_skip_records(body, tag)
+if reconciled == body:
+    raise SystemExit("matching skip record not found; refusing broad edit")
+pathlib.Path(after).write_text(reconciled, encoding="utf8")
+PY
+diff -u "$BEFORE" "$AFTER"
+gh release edit "$RELEASE_TAG" --repo promptdriven/pdd --notes-file "$AFTER"
+```
+
+Read the body back and verify the edited release body contains neither the skip
+text nor marker for the tag. Only then run the verified
+`release-video-discord-backfill` command. If delivery becomes ambiguous, follow
+the pending-marker rules; do not restore a skip that could contradict a sent
+Discord post. Atomic skip supersession automation remains follow-up work.
+The broader duplicate-create, same-tag, and skip-reconciliation state machine is
+tracked in #2044; this runbook's current path stays fail-closed and manual.
+
+This controlled supersession is allowed only before `final-evidence.json`
+exists. An immutable skipped final cannot be replaced by a second final under
+the current one-final contract; keep that release skipped and track any future
+publication design in #2044. Before final issuance, verify reconciliation and
+then backfill:
+
+```bash
+READBACK=$(mktemp)
+gh release view "$RELEASE_TAG" --repo promptdriven/pdd --json body --jq .body \
+  >"$READBACK"
+python - "$RELEASE_TAG" "$READBACK" <<'PY'
+import pathlib
+import sys
+from scripts.backfill_release_video_discord import remove_release_video_skip_records
+
+tag, readback = sys.argv[1:]
+body = pathlib.Path(readback).read_text(encoding="utf8")
+if remove_release_video_skip_records(body, tag) != body:
+    raise SystemExit("skip reconciliation did not persist; refusing backfill")
+PY
+DISCORD_WEBHOOK_URL=<webhook> make release-video-discord-backfill \
+  RELEASE_TAG="$RELEASE_TAG" \
+  RELEASE_VIDEO_YOUTUBE_URL="https://youtu.be/<verified-video-id>"
+```
 
 ## Terminal decision tree
 
@@ -361,8 +508,10 @@ video may supersede the skip through the normal verified backfill path.
 7. Publish receipt and YouTube URL exist: perform all live-resource checks.
 8. Live checks pass: update the GitHub Release, send Discord only if the main
    announcement lacked the URL, and finalize evidence.
-9. Safe video recovery is abandoned: record `pdd-release-video-skipped`, or
-   leave an active release-level recovery issue; never imply full completion.
+9. Safe video recovery is abandoned: record `pdd-release-video-skipped` and
+   produce terminal evidence.
+10. Recovery remains active: write a recovery checkpoint and keep the release
+    issue open; active recovery is not final closeout.
 
 Recovery must never create or push another package tag for the same release,
 must never republish to PyPI, and must never weaken, bypass, or relabel a failed audit.
@@ -370,14 +519,23 @@ Do not delete/re-push a published tag to retrigger automation.
 
 ## Authoritative final evidence
 
-Maintain exactly one authoritative `final-evidence.json` for the release.
-Automation is tracked in #2041; until then, construct it from authoritative
-receipts, validate it, attach it to the release-level closure issue, and store
-its SHA-256. Never include secrets. Earlier snapshots must be labelled
-`historical/intermediate` and must not use "final" in their path.
+Maintain exactly one authoritative `final-evidence.json` only after the video is
+terminally published or skipped. Automation is tracked in #2041; until then,
+construct it from authoritative receipts, validate it, attach it to the
+release-level closure issue, and store its SHA-256. Never include secrets.
+Earlier snapshots must be labelled `historical/intermediate` and must not use
+"final" in their path.
 
-The manifest must bind these fields (use `null` plus a reason only for the skip
-or active-recovery terminal branch):
+Active recovery uses `recovery-checkpoint-<sequence>.json`, never a final
+manifest. Each immutable checkpoint includes `schemaVersion`, `sequence`,
+`previousCheckpointSha256` (null only for the first), observed state, present
+receipts, and explicit per-field absence reasons. A later checkpoint links to
+the previous hash; success or skip then produces the sole final manifest.
+
+The manifest must bind these fields. A published manifest has no missing
+evidence. A skipped manifest uses `null` only for unavailable video fields and
+adds a `missingEvidenceReasons` entry for every null field; one aggregate reason
+cannot stand in for field-level provenance.
 
 Core contract fields are `releaseTag`, `releaseGitSha`, `pypiUrl`,
 `githubReleaseUrl`, `cloudTest`, `pdsProjectId`, `requestHash`, `attemptId`,
@@ -391,10 +549,11 @@ retains the supporting provenance and receipt fields needed to validate them.
 
 ```json
 {
+  "schemaVersion": 1,
   "releaseTag": "<derived tag>",
   "releaseGitSha": "<40-char SHA>",
   "previousReleaseTag": "<derived previous tag>",
-  "pypiUrl": "<exact version URL>",
+  "pypiUrl": "https://pypi.org/project/pdd-cli/<version>/",
   "pypiArtifactSha256": ["<hash>"],
   "githubReleaseUrl": "<URL>",
   "releaseWorkflowRunUrl": "<URL>",
@@ -432,20 +591,25 @@ retains the supporting provenance and receipt fields needed to validate them.
   "captionReceipt": "<receipt or approved state>",
   "thumbnailReceipt": "<receipt or approved state>",
   "liveVerifiedAt": "<RFC3339 timestamp>",
-  "discordMarker": "<completed marker, unnecessary, skipped, or pending>",
+  "discordMarker": "<completed marker, unnecessary, or skipped>",
   "discordWorkflowRunUrl": "<URL or null with reason>",
   "closureIssueUrl": "<URL>",
-  "terminalState": "<video-published | video-skipped | recovery-active>",
-  "videoTerminalReason": "<null or issue-bound skip/recovery reason>"
+  "terminalState": "video-published | video-skipped",
+  "missingEvidenceReasons": {
+    "<null field>": "<issue-bound reason; allowed only for video-skipped>"
+  },
+  "videoTerminalReason": "<null for published; issue-bound reason for skipped>"
 }
 ```
 
-Final closeout is one of exactly three honest branches:
+Final closeout is one of exactly two terminal branches:
 
 - verified video, GitHub Release updated, and Discord posted or proven already
   covered by the main announcement;
-- explicit skip recorded and Discord marked unnecessary; or
-- package released with a release-level recovery issue still open.
+- explicit skip recorded and Discord marked unnecessary.
+
+A package release with an open release-video recovery issue is an operational
+checkpoint, not final closeout and not `final-evidence.json`.
 
 Post a concise closure comment containing the manifest hash/location, test and
 workflow URLs, live verification result, terminal branch, unresolved risks, and

--- a/docs/contributors/pdd-cli-release-process.md
+++ b/docs/contributors/pdd-cli-release-process.md
@@ -1,100 +1,467 @@
 # PDD CLI Release Process
 
-## Release-Video PDS CLI
+This is the canonical maintainer runbook for a PDD CLI release, including
+post-publication release-video recovery. Use
+[`pr-loop-process.md`](../runbooks/pr-loop-process.md) for every code fix found
+during the release. Keep operational recovery separate from a fix PR: recovery
+must not bypass its review, test, merge, or deployment gates.
 
-Local release-video targets default to:
+The package release and release video have different terminal states. A video
+failure after package publication does not make the PyPI release unpublished,
+and it must not be "fixed" by publishing the package again.
 
-```bash
-npx -y @promptdriven/pds@0.1.7 --timeout 120s
+## Safety record before mutations
+
+Before any command that creates cloud work, pushes a tag, approves publication,
+edits a GitHub Release, publishes a video, or posts to Discord, write this in the
+operator session and retain it with the release evidence:
+
+```text
+Target: <repository/project/service/account/resource and environment>
+Rollback path: <exact prior state or compensating action>
+Risk: <cost, irreversible publication, duplicate-post, or user impact>
 ```
 
-That avoids silently picking up an older globally installed `pds` binary and
-keeps the PDS wait path bounded before recovery/status metadata is needed. Run
-the local preflight before a release to print the redacted PDS command and the
-resolved CLI version:
+In other words, state the **target, rollback path, and risk** before the
+mutation. Stop if the target identity cannot be proven. Package versions and a
+published tag are immutable; their "rollback" is a follow-up release, not tag
+reuse or deletion. A YouTube or Discord publication may be externally visible
+and may require manual removal. Never print tokens or webhook URLs in the
+record.
+
+## 1. Derive the candidate
+
+Work from a clean dedicated release worktree while fixes remain on their own PR
+branches. Fetch tags and derive the candidate; never copy a version number from
+an issue or hard-code the next version in this runbook:
 
 ```bash
-make check-release-video-config
+git fetch origin main --tags --prune
+LATEST_TAG=$(git tag --list --merged origin/main --sort=-v:refname 'v*' \
+  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+BUMP=${BUMP:-patch}
+NEXT_VERSION=$(python - "$LATEST_TAG" "$BUMP" <<'PY'
+import sys
+
+version = [int(part) for part in sys.argv[1].removeprefix("v").split(".")]
+index = {"major": 0, "minor": 1, "patch": 2}[sys.argv[2]]
+version[index] += 1
+for position in range(index + 1, 3):
+    version[position] = 0
+print(".".join(map(str, version)))
+PY
+)
+RELEASE_TAG="v${NEXT_VERSION}"
+RELEASE_GIT_SHA=$(git rev-parse origin/main)
+printf 'candidate=%s sha=%s previous=%s\n' \
+  "$RELEASE_TAG" "$RELEASE_GIT_SHA" "$LATEST_TAG"
 ```
 
-Release-video creation uses `RELEASE_VIDEO_CLAUDE_MODEL=claude-opus-4-8` by
-default for local Claude Code script generation. Override that release-scoped
-setting only when intentionally changing the local script model; direct
-`scripts/release_video.py` invocations also accept non-empty `CLAUDE_MODEL` as
-a fallback. Empty or whitespace-only local model values are treated as unset.
+Confirm the candidate tag does not exist locally, on origin, on PyPI, or as a
+GitHub Release. Record the intended bump and the source SHA. Inspect commits,
+merged PRs, open release blockers, and the latest release before proceeding.
 
-The wrapper sends `--claude-model glm-5.2` to PDS by default for non-vision
-pipeline stages such as specs and compositions. Override with
-`RELEASE_VIDEO_PDS_CLAUDE_MODEL=<model>` only when intentionally changing the
-downstream PDS model; setting it to an empty string intentionally omits the PDS
-model flag and uses the server default.
-
-The release workflow also installs `@promptdriven/pds@0.1.7` by default when
-`PDS_CLI_PACKAGE` is unset and runs the same preflight before creating the
-video. If the GitHub repo variable is pinned below `0.1.7`, update it outside
-the PR:
+Release-video uses PDS `0.1.11`. Local targets default to:
 
 ```bash
-gh variable set PDS_CLI_PACKAGE --repo promptdriven/pdd --body '@promptdriven/pds@0.1.7'
+npx -y @promptdriven/pds@0.1.11 --timeout 120s
 ```
 
-## Release-Video Metadata Recovery
-
-When PDS create times out but prints an active run handle, or when PDS reports
-an existing-project conflict with an active run, the wrapper exits successfully
-with a pending `pds_response.json`. It prints the project/run/status plus the
-exact status and Discord backfill commands. Do not rerun package publishing,
-tag creation, or PyPI upload for this recovery path; wait for the PDS run and
-backfill the release-video announcement after YouTube is available.
-
-If a historical release video is intentionally abandoned because upstream PDS
-or GVS blockers prevent safe publication, record that decision on the GitHub
-release instead of leaving the backfill state ambiguous:
+The release workflow defaults `PDS_CLI_PACKAGE` to the same version. If the
+repository variable overrides it, verify that it is not older:
 
 ```bash
-make release-video-skip \
-  RELEASE_TAG=<tag> \
-  RELEASE_VIDEO_SKIP_REASON="Provider quota and audit gate failures blocked safe publication."
+gh variable get PDS_CLI_PACKAGE --repo promptdriven/pdd || true
+make check-release-video-config-local
 ```
 
-This updates the release body with an idempotent skip marker and does not send a
-Discord follow-up.
+An empty variable means the workflow default applies. Changing a repository
+variable is a production-affecting mutation and needs its own safety record.
 
-Keep `RELEASE_VIDEO_METADATA_CONFLICT` unset for ordinary retries so the PDS
-idempotency key still matches the original create request. Set
-`RELEASE_VIDEO_METADATA_CONFLICT=use-existing` only when PDS explicitly reports
-that preserving existing project metadata is the recovery mode. Use
-`RELEASE_VIDEO_METADATA_CONFLICT=replace` only with
-`RELEASE_VIDEO_FORCE_REGENERATE=1`, because replacement is destructive.
+## 2. Cloud test
 
-When PDS reports a recoverable project metadata mismatch such as
-`release_video_existing_project_metadata_mismatch`, inspect the existing run
-state first:
+Record the staging Cloud Batch target, how to cancel the job or restore the
+prior image, and the compute/image risk. Then run the candidate source through
+the real cloud boundary:
 
 ```bash
-make release-video-status RELEASE_TAG=<tag> RELEASE_VIDEO_STATUS_QUERY=1
+make cloud-test
 ```
 
-PDS may recommend a direct command shaped like:
+Use `make cloud-test-quick` only when the dependency-image hash proves a rebuild
+is unnecessary. Save the Batch job/build identifiers, source SHA, image digest,
+test counts, result artifact URI, and final status. A failed or incomplete job
+is a release blocker. Fix failures via the PR loop; do not patch only the
+release worktree or silently exclude a test.
+
+## 3. PR, review, and merge
+
+For every release-blocking change:
+
+1. Inspect the issue, sibling bugs, and prior related commits/PRs.
+2. Add and push a failing test commit before the fix when practical.
+3. Implement in a dedicated worktree, run focused and broader relevant tests,
+   lint/static checks, an end-to-end boundary check, and `git diff --check`.
+4. Open a non-draft PR, post TDD and investigation evidence, obtain independent
+   adversarial review, and resolve findings.
+5. Merge only the reviewed exact head with required hosted checks green.
+
+Follow [`pr-loop-process.md`](../runbooks/pr-loop-process.md) for the complete
+commands and evidence format. After all release PRs merge, rerun cloud test on
+the final candidate SHA if any merged change could affect its result.
+
+## 4. Release from clean `main`
+
+Create a fresh or cleaned `main` worktree; do not release from a PR branch:
 
 ```bash
-pds release-video create --metadata-conflict replace --force-regenerate
+git fetch origin main --tags --prune
+git switch main
+git pull --ff-only origin main
+make check-release-remote
+make check-release-branch
+make check-release-clean
+make check-release-video-config-local
 ```
 
-Use the PDD wrapper for release recovery so the generated script, release notes,
-idempotency key, and PDS run metadata stay under `.pdd/release-videos/<tag>/`:
+Re-derive `RELEASE_TAG` and `RELEASE_GIT_SHA` after the pull and confirm they
+match the tested candidate. Before the release mutation, record:
+
+- Target: `promptdriven/pdd`, the derived tag, PyPI project `pdd`, the
+  `pypi-publish` GitHub environment, the production PDS endpoint, and the
+  configured YouTube account.
+- Rollback: do not reuse/delete a published tag or PyPI version; correct defects
+  with a new version. Before publication, retain the same tag/SHA and resume the
+  idempotent workflow. A video can be recovered or explicitly skipped later.
+- Risk: irreversible public package publication, supply-chain identity,
+  production PDS cost, unlisted YouTube publication, and duplicate messaging.
+
+Only then run the maintainer entrypoint:
+
+```bash
+make release-local BUMP="$BUMP"
+```
+
+The target derives the next tag, pushes it, and invokes local release-video.
+The tag push also starts `.github/workflows/release.yml`; its best-effort video
+path can overlap the local attempt. Treat the persisted request provenance,
+idempotency key, and run handle as authority. Do not start an unlabelled second
+attempt because one surface is still running.
+
+If `HEAD` already has the intended tag at the same SHA, `make release-local`
+uses the recovery path. If it differs, stop. Never move a release tag.
+
+## 5. Approve and verify package publication
+
+The tag workflow builds and checks the artifacts, then waits at the protected
+`pypi-publish` production environment. Before approving, re-check the target
+tag/SHA, cloud-test evidence, artifact attestations, and safety record. Approval
+is the production publication gate. Reject it if any identity differs.
+
+After approval, require all of the following before package closeout:
+
+```bash
+gh run list --repo promptdriven/pdd --workflow release.yml \
+  --limit 20 --json databaseId,headSha,status,conclusion,url
+gh release view "$RELEASE_TAG" --repo promptdriven/pdd \
+  --json tagName,targetCommitish,publishedAt,url,body
+python -m pip index versions pdd
+```
+
+- The workflow run is successful and its `headSha` is `RELEASE_GIT_SHA`.
+- PyPI shows the exact derived version and its artifacts/attestations.
+- The GitHub Release exists at the same tag and contains real release notes,
+  not an authentication, quota, or tool diagnostic.
+
+Record URLs and immutable identifiers. Do not rerun package publication merely
+because release notes or video work remains.
+
+## 6. Create, audit, and distribute the release video
+
+The configured PDS CLI must report at least `0.1.11` in preflight. Local Claude
+script generation uses `RELEASE_VIDEO_CLAUDE_MODEL` (default
+`claude-opus-4-8`); `RELEASE_VIDEO_PDS_CLAUDE_MODEL` controls non-vision PDS
+stages. Empty local model values are treated as unset.
+
+Normal release-video publication is production-affecting. State the PDS
+project/endpoint, request provenance, YouTube account/privacy, rollback, and
+paid-generation/publication risk before invoking it. When resuming an existing
+release, use the already-derived identifiers:
 
 ```bash
 make release-video \
-  RELEASE_TAG=<tag> \
-  RELEASE_GIT_SHA=<release-sha> \
-  RELEASE_VIDEO_PROJECT_ID=<project-id> \
-  RELEASE_VIDEO_SCRIPT_PATH=.pdd/release-videos/<tag>/release_video_script.md \
-  RELEASE_VIDEO_RELEASE_NOTES_PATH=.pdd/release-videos/<tag>/release_notes.md \
-  RELEASE_VIDEO_METADATA_CONFLICT=replace \
-  RELEASE_VIDEO_FORCE_REGENERATE=1 \
-  RELEASE_VIDEO_ATTEMPT_ID=<timestamp-or-label>
+  RELEASE_TAG="$RELEASE_TAG" \
+  RELEASE_GIT_SHA="$RELEASE_GIT_SHA"
 ```
 
-Use `RELEASE_VIDEO_METADATA_CONFLICT=use-existing` when the PDS remediation
-requires preserving the existing project metadata.
+PDS must retain one attributable chain from request through distribution:
+
+1. Script and release notes pass local validation before paid work.
+2. The persisted PDS project, request hash, provenance, attempt, parent
+   `agent_run_*`, and child jobs describe the current attempt.
+3. The stitched video generation/hash is immutable.
+4. The promoted audit generation/hash is immutable and its aggregate counts
+   pass the distribution gate. Never substitute a later mutable audit path.
+5. Distribution package and dry-run receipts bind the same video and audit.
+6. The publish receipt binds the YouTube video ID and requested privacy.
+
+Preserve `.pdd/release-videos/<tag>/` and the workflow recovery artifact. Do not
+rename a failed aggregate to `final-audit`; store attempts as
+`historical/intermediate-<attempt>` and reserve authoritative final status for
+the manifest described below.
+
+### Status and safe recovery
+
+Inspect the persisted sidecar first, then refresh its authoritative status:
+
+```bash
+make release-video-status RELEASE_TAG="$RELEASE_TAG"
+make release-video-status \
+  RELEASE_TAG="$RELEASE_TAG" \
+  RELEASE_VIDEO_STATUS_QUERY=1
+```
+
+Read parent `agent_run_*` state together with child job IDs, `failedStage`,
+terminal state, retryability, request hash, and distribution gate. Old rows and
+prior-attempt prose are historical; they cannot override the current run.
+
+- **Active/timeout:** wait and query the saved run. A timeout with an active run
+  handle is pending, not permission to create another run.
+- **Local Claude failure before PDS:** fix the local model/auth environment and
+  reuse a valid generated script if present. This is not a PDS publish failure.
+- **Metadata conflict:** inspect status first. Use
+  `RELEASE_VIDEO_METADATA_CONFLICT=use-existing` only when PDS says existing
+  metadata is authoritative. `replace` is destructive and is allowed only with
+  `RELEASE_VIDEO_FORCE_REGENERATE=1`, a new labelled attempt, and a safety
+  record.
+- **Provider quota/capacity:** do not loop paid calls. Follow the current-run
+  terminal hint: wait, choose an approved provider/model, or open/update the GVS
+  provider issue before a labelled retry.
+- **Audit failure:** keep the package release, block video distribution, and
+  open/update the GVS audit issue with immutable evidence. Never weaken the
+  audit to obtain a URL.
+- **Incomplete/slow status planning:** retain the run handle and retry status;
+  update the GVS status issue if the bounded status path fails. Do not infer
+  success from a partial artifact list.
+
+Keep `RELEASE_VIDEO_METADATA_CONFLICT` unset for ordinary exact retries. If PDS
+explicitly recommends the raw recovery shape
+`--metadata-conflict replace --force-regenerate`, use the wrapper equivalent
+`RELEASE_VIDEO_METADATA_CONFLICT=replace` with
+`RELEASE_VIDEO_FORCE_REGENERATE=1` so the original artifacts and run metadata
+remain in the release directory.
+
+For an authorized recovery that must reuse exact inputs:
+
+```bash
+make release-video \
+  RELEASE_TAG="$RELEASE_TAG" \
+  RELEASE_GIT_SHA="$RELEASE_GIT_SHA" \
+  RELEASE_VIDEO_PROJECT_ID=<project-id> \
+  RELEASE_VIDEO_SCRIPT_PATH=".pdd/release-videos/$RELEASE_TAG/release_video_script.md" \
+  RELEASE_VIDEO_RELEASE_NOTES_PATH=".pdd/release-videos/$RELEASE_TAG/release_notes.md"
+```
+
+Exact retries reuse the original idempotency key and provenance. Set
+`RELEASE_VIDEO_ATTEMPT_ID=<timestamp-or-label>` only after proving the previous
+run cannot be resumed. Never use both an attempt ID and a full idempotency key.
+
+## Warnings versus blockers
+
+A warning label is not authority to publish. Use the current immutable audit
+and distribution decision:
+
+- Informational transport/status warnings with a successful authoritative gate,
+  complete receipts, and unchanged hashes can be recorded as non-blocking.
+- Any failed audit gate (including a policy that promotes a `content_warn` to a
+  blocker), provider limit that prevents required work, missing/mismatched
+  generation or receipt, unknown terminal state, failed distribution dry-run,
+  or unverifiable live resource is blocking.
+- Video blockers do not invalidate an already successful package release. They
+  do block video backfill and final video-success closeout.
+
+Do not downgrade a blocker based only on an error string or the existence of a
+rendered file.
+
+## 7. Verify the live YouTube resource
+
+A returned URL is not sufficient. Open the canonical live resource using the
+authenticated YouTube account or supported API and bind the observation to the
+publish receipt. Verify:
+
+- **title** exactly names the derived release tag and has no diagnostic text;
+- **channel** is the approved PDD release channel;
+- **privacy** is the requested value (normally `unlisted`);
+- **captions** are present/processed as required, or their receipt records an
+  explicit approved state;
+- **thumbnail** is present and bound to the intended uploaded asset/receipt;
+- the video is playable and its ID matches the distribution publish receipt.
+
+Record the observation timestamp and receipt IDs. If any check fails, the video
+success path remains blocked even when the URL resolves.
+
+## 8. Complete Discord and release closeout
+
+First inspect the GitHub Release body and the normal release workflow. If its
+Discord announcement already included the verified YouTube URL, record Discord
+as complete and **do not** send a follow-up.
+
+If the verified video arrived after the main announcement, state the target
+release/webhook, rollback (release-body edit plus manual Discord deletion when
+available), and duplicate/ambiguous-delivery risk. Then use the protected
+**Backfill release video Discord post** workflow, or its local equivalent:
+
+```bash
+DISCORD_WEBHOOK_URL=<webhook> make release-video-discord-backfill \
+  RELEASE_TAG="$RELEASE_TAG" \
+  RELEASE_VIDEO_YOUTUBE_URL="https://youtu.be/<video-id>"
+```
+
+Discord marker semantics are:
+
+- `pdd-release-video-discord-backfill-pending`: delivery may have happened but
+  completion is not proven. Inspect Discord; do not rerun blindly.
+- `pdd-release-video-discord-backfill`: the matching follow-up and release-body
+  update completed. Repeating the same backfill is a no-op.
+- A definite 4xx delivery rejection removes the pending marker; correct the
+  cause before retrying. A timeout/5xx is ambiguous and keeps it.
+- For stale pre-marker releases, inspect Discord manually before removing any
+  stale marker or doing a single controlled backfill.
+
+### Explicit no-video skip
+
+After repeated terminal blockers, an operator may choose a documented no-video
+terminal state. State the GitHub Release target, release-body rollback, and
+public-record risk, then run:
+
+```bash
+make release-video-skip \
+  RELEASE_TAG="$RELEASE_TAG" \
+  RELEASE_VIDEO_SKIP_REASON="<specific upstream blocker and issue URL>"
+```
+
+This writes `pdd-release-video-skipped` to the GitHub Release and sends no
+Discord message. Mark Discord follow-up explicitly unnecessary. A later real
+video may supersede the skip through the normal verified backfill path.
+
+## Terminal decision tree
+
+1. Package workflow not published: stay at the protected approval/build gate.
+   Resume the same tag only for the unchanged SHA/artifacts; if a code fix is
+   required, ship it under a newly derived version without moving the old tag.
+2. Package published, video local preflight failed: preserve the package and
+   fix/reuse the script without invoking package release.
+3. PDS run active or timed out with a handle: query that run and wait.
+4. Metadata conflict: select `use-existing`, or an explicitly destructive new
+   attempt, only from authoritative PDS guidance.
+5. Provider quota/capacity: wait/switch under policy or track upstream; do not
+   retry in a paid loop.
+6. Audit/distribution gate failed: block publish and update the GVS issue with
+   immutable evidence.
+7. Publish receipt and YouTube URL exist: perform all live-resource checks.
+8. Live checks pass: update the GitHub Release, send Discord only if the main
+   announcement lacked the URL, and finalize evidence.
+9. Safe video recovery is abandoned: record `pdd-release-video-skipped`, or
+   leave an active release-level recovery issue; never imply full completion.
+
+Recovery must never create or push another package tag for the same release,
+must never republish to PyPI, and must never weaken, bypass, or relabel a failed audit.
+Do not delete/re-push a published tag to retrigger automation.
+
+## Authoritative final evidence
+
+Maintain exactly one authoritative `final-evidence.json` for the release.
+Automation is tracked in #2041; until then, construct it from authoritative
+receipts, validate it, attach it to the release-level closure issue, and store
+its SHA-256. Never include secrets. Earlier snapshots must be labelled
+`historical/intermediate` and must not use "final" in their path.
+
+The manifest must bind these fields (use `null` plus a reason only for the skip
+or active-recovery terminal branch):
+
+Core contract fields are `releaseTag`, `releaseGitSha`, `pypiUrl`,
+`githubReleaseUrl`, `cloudTest`, `pdsProjectId`, `requestHash`, `attemptId`,
+`agentRunId`, `stitchedGeneration`, `stitchedSha256`,
+`promotedAuditGeneration`, `promotedAuditSha256`,
+`distributionPackageReceipt`, `distributionDryRunReceipt`,
+`distributionPublishReceipt`, `youtubeVideoId`, `youtubeTitle`,
+`youtubeChannel`, `youtubePrivacy`, `captionReceipt`, `thumbnailReceipt`,
+`discordMarker`, `discordWorkflowRunUrl`, and `closureIssueUrl`. The schema also
+retains the supporting provenance and receipt fields needed to validate them.
+
+```json
+{
+  "releaseTag": "<derived tag>",
+  "releaseGitSha": "<40-char SHA>",
+  "previousReleaseTag": "<derived previous tag>",
+  "pypiUrl": "<exact version URL>",
+  "pypiArtifactSha256": ["<hash>"],
+  "githubReleaseUrl": "<URL>",
+  "releaseWorkflowRunUrl": "<URL>",
+  "cloudTest": {
+    "sourceSha": "<SHA>",
+    "buildId": "<ID>",
+    "batchJobId": "<ID>",
+    "imageDigest": "<digest>",
+    "resultUri": "<URI>",
+    "passed": 0,
+    "failed": 0
+  },
+  "pdsProjectId": "<ID>",
+  "requestHash": "<hash>",
+  "requestProvenance": "<local or github-actions>",
+  "attemptId": "<label>",
+  "agentRunId": "agent_run_<ID>",
+  "childJobIds": ["<ID>"],
+  "stitchedGeneration": "<generation>",
+  "stitchedSha256": "<hash>",
+  "auditJobId": "<ID>",
+  "promotionAttemptId": "<ID>",
+  "promotionFingerprint": "<hash>",
+  "promotedAuditGeneration": "<generation>",
+  "promotedAuditSha256": "<hash>",
+  "promotedAuditCounts": {"total": 0, "passed": 0, "warned": 0, "failed": 0},
+  "distributionPackageReceipt": "<immutable ID/hash>",
+  "distributionDryRunReceipt": "<immutable ID/hash>",
+  "distributionPublishReceipt": "<immutable ID/hash>",
+  "youtubeVideoId": "<ID>",
+  "youtubeUrl": "<canonical URL>",
+  "youtubeTitle": "<observed title>",
+  "youtubeChannel": "<observed channel ID/name>",
+  "youtubePrivacy": "<observed privacy>",
+  "captionReceipt": "<receipt or approved state>",
+  "thumbnailReceipt": "<receipt or approved state>",
+  "liveVerifiedAt": "<RFC3339 timestamp>",
+  "discordMarker": "<completed marker, unnecessary, skipped, or pending>",
+  "discordWorkflowRunUrl": "<URL or null with reason>",
+  "closureIssueUrl": "<URL>",
+  "terminalState": "<video-published | video-skipped | recovery-active>",
+  "videoTerminalReason": "<null or issue-bound skip/recovery reason>"
+}
+```
+
+Final closeout is one of exactly three honest branches:
+
+- verified video, GitHub Release updated, and Discord posted or proven already
+  covered by the main announcement;
+- explicit skip recorded and Discord marked unnecessary; or
+- package released with a release-level recovery issue still open.
+
+Post a concise closure comment containing the manifest hash/location, test and
+workflow URLs, live verification result, terminal branch, unresolved risks, and
+follow-up issue links.
+
+## Issue routing
+
+- File in **PDD**: local environment/script validation, Make targets,
+  idempotency/provenance wrapper behavior, release workflow, PyPI/GitHub
+  Release, Discord marker/backfill behavior, or runbook/manifest automation.
+- File in **Generative-Video-Studio (GVS)**: PDS run planning/status, provider
+  quota/capacity, paid-generation replay, render/stitch closure, immutable audit
+  promotion, storage receipts, distribution package/publish, or YouTube receipt
+  integrity.
+
+Search first. Augment an existing issue with release tag, current run IDs,
+immutable hashes/receipts, redacted signatures, and workflow URLs; otherwise
+create a narrowly scoped issue. Code changes in either repository follow that
+repository's PR-loop runbook.

--- a/scripts/backfill_release_video_discord.py
+++ b/scripts/backfill_release_video_discord.py
@@ -246,6 +246,23 @@ def remove_release_video_skip_records(body: str, tag: str) -> str:
     )
 
 
+def ensure_no_release_video_skip_record(body: str, tag: str) -> None:
+    """Fail closed before backfill when this release is durably marked skipped."""
+    if remove_release_video_skip_records(body, tag) != body:
+        raise BackfillError(
+            "Release has a release-video skip record. Reconcile and remove the exact "
+            "skip text and marker under the release runbook before backfilling."
+        )
+    if re.search(rf"(?m)^<!-- {re.escape(SKIP_MARKER_NAME)}:", body) or re.search(
+        r"(?m)^Release video: skipped for ",
+        body,
+    ):
+        raise BackfillError(
+            "Release has a stale or mismatched release-video skip record. "
+            "Inspect it manually; refusing to mutate the release or post Discord."
+        )
+
+
 def remove_release_body_pending_marker(body: str, tag: str, youtube_url: str) -> tuple[str, bool]:
     pending_marker = discord_backfill_pending_marker(tag, youtube_url)
     if pending_marker not in body:
@@ -564,6 +581,7 @@ def backfill_release_video_discord(
     validate_inputs(tag, youtube_url, repo)
 
     body = github.get_release_body(tag)
+    ensure_no_release_video_skip_record(body, tag)
     marker = discord_backfill_marker(tag, youtube_url)
 
     if marker in body:
@@ -587,6 +605,7 @@ def backfill_release_video_discord(
         raise BackfillError("DISCORD_WEBHOOK_URL is required when a follow-up has not been marked.")
 
     latest_body = github.get_release_body(tag)
+    ensure_no_release_video_skip_record(latest_body, tag)
     if marker in latest_body:
         latest_body_with_link, link_added = ensure_release_body_has_video_link(
             latest_body,

--- a/scripts/backfill_release_video_discord.py
+++ b/scripts/backfill_release_video_discord.py
@@ -263,6 +263,35 @@ def ensure_no_release_video_skip_record(body: str, tag: str) -> None:
         )
 
 
+def ensure_no_release_video_publication_state(body: str, tag: str) -> None:
+    """Fail closed before skip when video delivery is complete or ambiguous."""
+    marker_names = (MARKER_NAME, PENDING_MARKER_NAME)
+    exact_marker = re.compile(
+        rf"(?m)^<!-- (?:{'|'.join(map(re.escape, marker_names))}): "
+        rf"tag={re.escape(tag)} video_sha256=[0-9a-f]{{64}} -->$"
+    )
+    if exact_marker.search(body):
+        raise BackfillError(
+            "Release has tag-bound video backfill state. Refusing to mark it skipped."
+        )
+
+    any_marker = re.compile(
+        rf"(?m)^<!-- (?:{'|'.join(map(re.escape, marker_names))}):"
+    )
+    if any_marker.search(body):
+        raise BackfillError(
+            "Release has stale or mismatched video backfill state. "
+            "Inspect it manually; refusing to mark the release skipped."
+        )
+
+    for line in body.splitlines():
+        if "release video" in line.lower() and YOUTUBE_URL_IN_TEXT_RE.search(line):
+            raise BackfillError(
+                "Release already contains an attributable release-video URL. "
+                "Refusing to mark it skipped."
+            )
+
+
 def remove_release_body_pending_marker(body: str, tag: str, youtube_url: str) -> tuple[str, bool]:
     pending_marker = discord_backfill_pending_marker(tag, youtube_url)
     if pending_marker not in body:
@@ -548,6 +577,7 @@ def record_release_video_skip(
     validate_skip_inputs(tag, normalized_reason, repo)
 
     body = github.get_release_body(tag)
+    ensure_no_release_video_publication_state(body, tag)
     marked_body, updated, marker_added = ensure_release_body_has_skip_record(
         body,
         tag,

--- a/tests/test_release_process_runbook.py
+++ b/tests/test_release_process_runbook.py
@@ -1,0 +1,95 @@
+"""Contract tests for the canonical PDD CLI release runbook."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNBOOK = ROOT / "docs" / "contributors" / "pdd-cli-release-process.md"
+ONBOARDING = ROOT / "docs" / "ONBOARDING.md"
+
+
+def runbook_text() -> str:
+    """Return the canonical release runbook as checked-in text."""
+    return RUNBOOK.read_text(encoding="utf8")
+
+
+def test_release_runbook_is_current_and_covers_the_ordered_lifecycle():
+    text = runbook_text()
+
+    assert "@promptdriven/pds@0.1.11" in text
+    assert "0.1.7" not in text
+    assert "v0.0.305" not in text
+
+    ordered_contracts = [
+        "## 1. Derive the candidate",
+        "## 2. Cloud test",
+        "## 3. PR, review, and merge",
+        "## 4. Release from clean `main`",
+        "## 5. Approve and verify package publication",
+        "## 6. Create, audit, and distribute the release video",
+        "## 7. Verify the live YouTube resource",
+        "## 8. Complete Discord and release closeout",
+    ]
+    positions = [text.index(contract) for contract in ordered_contracts]
+    assert positions == sorted(positions)
+
+
+def test_release_runbook_requires_mutation_disclosure_and_final_evidence():
+    text = runbook_text()
+
+    assert "target, rollback path, and risk" in text
+    assert "authoritative `final-evidence.json`" in text
+    for field in (
+        "releaseTag",
+        "releaseGitSha",
+        "pypiUrl",
+        "githubReleaseUrl",
+        "cloudTest",
+        "pdsProjectId",
+        "requestHash",
+        "attemptId",
+        "agentRunId",
+        "stitchedGeneration",
+        "stitchedSha256",
+        "promotedAuditGeneration",
+        "promotedAuditSha256",
+        "distributionPackageReceipt",
+        "distributionDryRunReceipt",
+        "distributionPublishReceipt",
+        "youtubeVideoId",
+        "youtubeTitle",
+        "youtubeChannel",
+        "youtubePrivacy",
+        "captionReceipt",
+        "thumbnailReceipt",
+        "discordMarker",
+        "discordWorkflowRunUrl",
+        "closureIssueUrl",
+    ):
+        assert f"`{field}`" in text
+    assert "historical/intermediate" in text
+
+
+def test_release_runbook_recovery_is_non_duplicating_and_fail_closed():
+    text = runbook_text()
+
+    assert "## Terminal decision tree" in text
+    assert "## Warnings versus blockers" in text
+    assert "must never create or push another package tag" in text
+    assert "must never republish to PyPI" in text
+    assert "must never weaken, bypass, or relabel a failed audit" in text
+    for marker in (
+        "pdd-release-video-discord-backfill-pending",
+        "pdd-release-video-discord-backfill",
+        "pdd-release-video-skipped",
+    ):
+        assert marker in text
+    for live_check in ("title", "channel", "privacy", "captions", "thumbnail"):
+        assert f"**{live_check}**" in text
+
+
+def test_onboarding_points_maintainers_to_the_canonical_runbook():
+    text = ONBOARDING.read_text(encoding="utf8")
+
+    assert "contributors/pdd-cli-release-process.md" in text
+    assert "canonical release runbook" in text.lower()

--- a/tests/test_release_process_runbook.py
+++ b/tests/test_release_process_runbook.py
@@ -201,9 +201,10 @@ def test_release_runbook_recovery_is_non_duplicating_and_fail_closed():
 
 def test_onboarding_points_maintainers_to_the_canonical_runbook():
     text = ONBOARDING.read_text(encoding="utf8")
+    compact = " ".join(text.split())
 
     assert "contributors/pdd-cli-release-process.md" in text
     assert "canonical release runbook" in text.lower()
     assert "RELEASE_VIDEO=0 make release-local" in text
     assert "Use `RELEASE_VIDEO=0` only for an emergency release" not in text
-    assert "leaves the tag-triggered Actions video path enabled" in text
+    assert "leaves the tag-triggered Actions video path enabled" in compact

--- a/tests/test_release_process_runbook.py
+++ b/tests/test_release_process_runbook.py
@@ -205,3 +205,5 @@ def test_onboarding_points_maintainers_to_the_canonical_runbook():
     assert "contributors/pdd-cli-release-process.md" in text
     assert "canonical release runbook" in text.lower()
     assert "RELEASE_VIDEO=0 make release-local" in text
+    assert "Use `RELEASE_VIDEO=0` only for an emergency release" not in text
+    assert "leaves the tag-triggered Actions video path enabled" in text

--- a/tests/test_release_process_runbook.py
+++ b/tests/test_release_process_runbook.py
@@ -1,16 +1,38 @@
-"""Contract tests for the canonical PDD CLI release runbook."""
+"""Semantic contract tests for the canonical PDD CLI release runbook."""
 
+import json
 from pathlib import Path
+import re
+import tomllib
 
 
 ROOT = Path(__file__).resolve().parents[1]
 RUNBOOK = ROOT / "docs" / "contributors" / "pdd-cli-release-process.md"
 ONBOARDING = ROOT / "docs" / "ONBOARDING.md"
+MAKEFILE = ROOT / "Makefile"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+PYPROJECT = ROOT / "pyproject.toml"
 
 
 def runbook_text() -> str:
     """Return the canonical release runbook as checked-in text."""
     return RUNBOOK.read_text(encoding="utf8")
+
+
+def runbook_section(start: str, end: str | None = None) -> str:
+    """Extract a runbook section for command and ordering assertions."""
+    text = runbook_text()
+    start_offset = text.index(start)
+    end_offset = text.index(end, start_offset) if end else len(text)
+    return text[start_offset:end_offset]
+
+
+def final_evidence_example() -> dict:
+    """Parse the final evidence JSON example as executable documentation."""
+    section = runbook_section("## Authoritative final evidence", "## Issue routing")
+    match = re.search(r"```json\n(?P<json>.*?)\n```", section, re.DOTALL)
+    assert match is not None
+    return json.loads(match.group("json"))
 
 
 def test_release_runbook_is_current_and_covers_the_ordered_lifecycle():
@@ -34,40 +56,110 @@ def test_release_runbook_is_current_and_covers_the_ordered_lifecycle():
     assert positions == sorted(positions)
 
 
-def test_release_runbook_requires_mutation_disclosure_and_final_evidence():
+def test_release_runbook_uses_the_distribution_declared_by_pyproject():
+    text = runbook_text()
+    with PYPROJECT.open("rb") as pyproject_file:
+        distribution = tomllib.load(pyproject_file)["project"]["name"]
+
+    assert distribution == "pdd-cli"
+    assert 'PYPI_PROJECT="$(python -c' in text
+    assert "tomllib.load" in text
+    assert 'python -m pip index versions "$PYPI_PROJECT"' in text
+    assert 'https://pypi.org/project/${PYPI_PROJECT}/${NEXT_VERSION}/' in text
+    assert "PyPI project `pdd`" not in text
+
+
+def test_normal_release_has_one_video_creation_authority():
+    release_section = runbook_section(
+        "## 4. Release from clean `main`",
+        "## 5. Approve and verify package publication",
+    )
+    normal_video_section = runbook_section(
+        "## 6. Create, audit, and distribute the release video",
+        "### Status and safe recovery",
+    )
+    makefile = MAKEFILE.read_text(encoding="utf8")
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf8")
+
+    assert "make --no-print-directory release-video" in makefile
+    assert "make release-video" in workflow
+    assert 'RELEASE_VIDEO=0 make release-local BUMP="$BUMP"' in release_section
+    assert "sole normal creation authority" in normal_video_section
+    assert "tag-triggered `.github/workflows/release.yml`" in normal_video_section
+    assert not re.search(r"(?m)^make release-video(?:\s|$)", normal_video_section)
+    assert "authoritative status proves that no attempt was started" in runbook_text()
+
+
+def test_approval_and_post_publish_evidence_match_workflow_ordering():
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf8")
+    publish_job = workflow[workflow.index("  publish-pypi:") :]
+    approval_section = runbook_section(
+        "## 5. Approve and verify package publication",
+        "## 6. Create, audit, and distribute the release video",
+    )
+
+    assert publish_job.index("environment: pypi-publish") < publish_job.index("steps:")
+    assert "before checkout, build, Twine verification, and publication" in approval_section
+    assert "attestations do not exist yet" in approval_section
+    assert approval_section.index("Before approval") < approval_section.index(
+        "After publication"
+    )
+
+
+def test_same_tag_recovery_is_non_destructive_and_does_not_reinvoke_video():
+    recovery = runbook_section(
+        "### Same-tag package workflow recovery",
+        "## 6. Create, audit, and distribute the release video",
+    )
+
+    assert 'gh run rerun "$RUN_ID" --repo promptdriven/pdd' in recovery
+    assert "video step did not start" in recovery
+    assert "no matching production tag-push run exists" in recovery
+    assert "verify PyPI first" in recovery
+    assert "make release-local" not in recovery
+    assert "gh workflow run" not in recovery
+    assert "delete" not in recovery.lower()
+    assert "re-push" not in recovery.lower()
+
+
+def test_remote_tag_is_peeled_and_bound_to_release_sha():
+    package_evidence = runbook_section(
+        "## 5. Approve and verify package publication",
+        "## 6. Create, audit, and distribute the release video",
+    )
+
+    assert 'refs/tags/$RELEASE_TAG^{}' in package_evidence
+    assert 'REMOTE_TAG_SHA="$PEELED_TAG_SHA"' in package_evidence
+    assert 'test "$REMOTE_TAG_SHA" = "$RELEASE_GIT_SHA"' in package_evidence
+
+
+def test_final_evidence_is_parseable_and_only_represents_terminal_states():
+    evidence = final_evidence_example()
     text = runbook_text()
 
-    assert "target, rollback path, and risk" in text
-    assert "authoritative `final-evidence.json`" in text
-    for field in (
-        "releaseTag",
-        "releaseGitSha",
-        "pypiUrl",
-        "githubReleaseUrl",
-        "cloudTest",
-        "pdsProjectId",
-        "requestHash",
-        "attemptId",
-        "agentRunId",
-        "stitchedGeneration",
-        "stitchedSha256",
-        "promotedAuditGeneration",
-        "promotedAuditSha256",
-        "distributionPackageReceipt",
-        "distributionDryRunReceipt",
-        "distributionPublishReceipt",
-        "youtubeVideoId",
-        "youtubeTitle",
-        "youtubeChannel",
-        "youtubePrivacy",
-        "captionReceipt",
-        "thumbnailReceipt",
-        "discordMarker",
-        "discordWorkflowRunUrl",
-        "closureIssueUrl",
-    ):
-        assert f"`{field}`" in text
-    assert "historical/intermediate" in text
+    assert evidence["schemaVersion"] == 1
+    assert evidence["terminalState"] == "video-published | video-skipped"
+    assert "recovery-active" not in evidence["terminalState"]
+    assert isinstance(evidence["missingEvidenceReasons"], dict)
+    assert "recovery-checkpoint-<sequence>.json" in text
+    assert "previousCheckpointSha256" in text
+    assert "active recovery is not final closeout" in text
+
+
+def test_skip_supersession_requires_exact_reconciliation_before_backfill():
+    skip_section = runbook_section(
+        "### Explicit no-video skip",
+        "## Terminal decision tree",
+    )
+
+    assert "refuses to backfill while a matching skip record remains" in skip_section
+    assert "remove_release_video_skip_records" in skip_section
+    assert "verify the edited release body contains neither the skip text nor marker" in (
+        skip_section
+    )
+    assert skip_section.index("remove_release_video_skip_records") < skip_section.index(
+        "release-video-discord-backfill"
+    )
 
 
 def test_release_runbook_recovery_is_non_duplicating_and_fail_closed():
@@ -78,6 +170,7 @@ def test_release_runbook_recovery_is_non_duplicating_and_fail_closed():
     assert "must never create or push another package tag" in text
     assert "must never republish to PyPI" in text
     assert "must never weaken, bypass, or relabel a failed audit" in text
+    assert "target, rollback path, and risk" in text
     for marker in (
         "pdd-release-video-discord-backfill-pending",
         "pdd-release-video-discord-backfill",

--- a/tests/test_release_process_runbook.py
+++ b/tests/test_release_process_runbook.py
@@ -80,11 +80,12 @@ def test_normal_release_has_one_video_creation_authority():
     )
     makefile = MAKEFILE.read_text(encoding="utf8")
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf8")
+    compact_video_section = " ".join(normal_video_section.split())
 
     assert "make --no-print-directory release-video" in makefile
     assert "make release-video" in workflow
     assert 'RELEASE_VIDEO=0 make release-local BUMP="$BUMP"' in release_section
-    assert "sole normal creation authority" in normal_video_section
+    assert "sole normal creation authority" in compact_video_section
     assert "tag-triggered `.github/workflows/release.yml`" in normal_video_section
     assert not re.search(r"(?m)^make release-video(?:\s|$)", normal_video_section)
     assert "authoritative status proves that no attempt was started" in runbook_text()
@@ -98,9 +99,11 @@ def test_approval_and_post_publish_evidence_match_workflow_ordering():
         "## 6. Create, audit, and distribute the release video",
     )
 
+    compact_approval = " ".join(approval_section.split())
+
     assert publish_job.index("environment: pypi-publish") < publish_job.index("steps:")
-    assert "before checkout, build, Twine verification, and publication" in approval_section
-    assert "attestations do not exist yet" in approval_section
+    assert "before checkout, build, Twine verification, and publication" in compact_approval
+    assert "attestations do not exist yet" in compact_approval
     assert approval_section.index("Before approval") < approval_section.index(
         "After publication"
     )
@@ -138,12 +141,26 @@ def test_final_evidence_is_parseable_and_only_represents_terminal_states():
     text = runbook_text()
 
     assert evidence["schemaVersion"] == 1
+    assert {
+        "releaseTag",
+        "releaseGitSha",
+        "pypiUrl",
+        "cloudTest",
+        "agentRunId",
+        "stitchedGeneration",
+        "promotedAuditGeneration",
+        "distributionPublishReceipt",
+        "youtubeVideoId",
+        "discordMarker",
+        "closureIssueUrl",
+    } <= evidence.keys()
     assert evidence["terminalState"] == "video-published | video-skipped"
     assert "recovery-active" not in evidence["terminalState"]
     assert isinstance(evidence["missingEvidenceReasons"], dict)
     assert "recovery-checkpoint-<sequence>.json" in text
     assert "previousCheckpointSha256" in text
     assert "active recovery is not final closeout" in text
+    assert "pending" not in evidence["discordMarker"]
 
 
 def test_skip_supersession_requires_exact_reconciliation_before_backfill():
@@ -152,11 +169,12 @@ def test_skip_supersession_requires_exact_reconciliation_before_backfill():
         "## Terminal decision tree",
     )
 
-    assert "refuses to backfill while a matching skip record remains" in skip_section
+    compact_skip = " ".join(skip_section.split())
+
+    assert "refuses to backfill while a matching skip record remains" in compact_skip
     assert "remove_release_video_skip_records" in skip_section
-    assert "verify the edited release body contains neither the skip text nor marker" in (
-        skip_section
-    )
+    assert "verify the edited release body contains neither the skip text nor marker" in compact_skip
+    assert "allowed only before `final-evidence.json` exists" in compact_skip
     assert skip_section.index("remove_release_video_skip_records") < skip_section.index(
         "release-video-discord-backfill"
     )
@@ -186,3 +204,4 @@ def test_onboarding_points_maintainers_to_the_canonical_runbook():
 
     assert "contributors/pdd-cli-release-process.md" in text
     assert "canonical release runbook" in text.lower()
+    assert "RELEASE_VIDEO=0 make release-local" in text

--- a/tests/test_release_video_discord_backfill.py
+++ b/tests/test_release_video_discord_backfill.py
@@ -595,6 +595,36 @@ def test_record_skip_marks_release_without_discord_or_youtube_url():
     ) in github.body
 
 
+def test_backfill_rejects_existing_skip_before_release_or_discord_mutation():
+    module = load_backfill_module()
+    reason = "Provider quota and audit gate failures blocked safe publication."
+    marker = module.release_video_skip_marker("v0.0.297", reason)
+    original_body = (
+        "Release video: skipped for v0.0.297.\n"
+        f"Reason: {reason}\n\n"
+        "Existing notes\n\n"
+        f"{marker}\n"
+    )
+    github = FakeGitHubReleaseClient(original_body)
+    posts = []
+
+    with pytest.raises(module.BackfillError, match="skip record"):
+        module.backfill_release_video_discord(
+            tag="v0.0.297",
+            youtube_url="https://youtu.be/recoveredvideo",
+            repo="promptdriven/pdd",
+            webhook_url="https://discord.example/webhook",
+            github=github,
+            post_discord=lambda webhook_url, payload: posts.append(
+                (webhook_url, payload)
+            ),
+        )
+
+    assert posts == []
+    assert github.edits == []
+    assert github.body == original_body
+
+
 def test_record_skip_is_idempotent_for_same_reason():
     module = load_backfill_module()
     reason = "Provider quota and audit gate failures blocked safe publication."

--- a/tests/test_release_video_discord_backfill.py
+++ b/tests/test_release_video_discord_backfill.py
@@ -625,6 +625,105 @@ def test_backfill_rejects_existing_skip_before_release_or_discord_mutation():
     assert github.body == original_body
 
 
+def test_backfill_rejects_stale_mismatched_skip_marker_before_mutation():
+    module = load_backfill_module()
+    stale_marker = module.release_video_skip_marker(
+        "v0.0.296",
+        "An older release was intentionally skipped.",
+    )
+    original_body = f"Existing notes\n\n{stale_marker}\n"
+    github = FakeGitHubReleaseClient(original_body)
+    posts = []
+
+    with pytest.raises(module.BackfillError, match="stale or mismatched"):
+        module.backfill_release_video_discord(
+            tag="v0.0.297",
+            youtube_url="https://youtu.be/recoveredvideo",
+            repo="promptdriven/pdd",
+            webhook_url="https://discord.example/webhook",
+            github=github,
+            post_discord=lambda webhook_url, payload: posts.append(
+                (webhook_url, payload)
+            ),
+        )
+
+    assert posts == []
+    assert github.edits == []
+    assert github.body == original_body
+
+
+def test_reconciled_skip_can_transition_to_one_completed_backfill():
+    module = load_backfill_module()
+    reason = "Provider quota blocked safe publication."
+    skipped_body, _updated, _marker_added = module.ensure_release_body_has_skip_record(
+        "Existing notes\n",
+        "v0.0.297",
+        reason,
+    )
+    reconciled_body = module.remove_release_video_skip_records(
+        skipped_body,
+        "v0.0.297",
+    )
+    github = FakeGitHubReleaseClient(reconciled_body)
+    posts = []
+    youtube_url = "https://youtu.be/recoveredvideo"
+
+    result = module.backfill_release_video_discord(
+        tag="v0.0.297",
+        youtube_url=youtube_url,
+        repo="promptdriven/pdd",
+        webhook_url="https://discord.example/webhook",
+        github=github,
+        post_discord=lambda webhook_url, payload: posts.append(
+            (webhook_url, payload)
+        ),
+    )
+
+    assert result.posted is True
+    assert len(posts) == 1
+    assert module.SKIP_MARKER_NAME not in github.body
+    assert "Release video: skipped" not in github.body
+    assert module.discord_backfill_marker("v0.0.297", youtube_url) in github.body
+    assert module.discord_backfill_pending_marker("v0.0.297", youtube_url) not in github.body
+
+
+def test_reconciled_skip_ambiguous_delivery_stays_pending_not_skipped_or_complete():
+    module = load_backfill_module()
+    reason = "Provider quota blocked safe publication."
+    skipped_body, _updated, _marker_added = module.ensure_release_body_has_skip_record(
+        "Existing notes\n",
+        "v0.0.297",
+        reason,
+    )
+    reconciled_body = module.remove_release_video_skip_records(
+        skipped_body,
+        "v0.0.297",
+    )
+    github = FakeGitHubReleaseClient(reconciled_body)
+    youtube_url = "https://youtu.be/recoveredvideo"
+
+    def ambiguous_post(_webhook_url, _payload):
+        raise module.DiscordWebhookError(
+            "Discord webhook request failed: timed out",
+            post_definitely_failed=False,
+        )
+
+    with pytest.raises(module.BackfillError, match="Inspect Discord before rerunning"):
+        module.backfill_release_video_discord(
+            tag="v0.0.297",
+            youtube_url=youtube_url,
+            repo="promptdriven/pdd",
+            webhook_url="https://discord.example/webhook",
+            github=github,
+            post_discord=ambiguous_post,
+        )
+
+    assert module.SKIP_MARKER_NAME not in github.body
+    assert "Release video: skipped" not in github.body
+    assert module.discord_backfill_pending_marker("v0.0.297", youtube_url) in github.body
+    assert module.discord_backfill_marker("v0.0.297", youtube_url) not in github.body
+
+
 def test_record_skip_is_idempotent_for_same_reason():
     module = load_backfill_module()
     reason = "Provider quota and audit gate failures blocked safe publication."

--- a/tests/test_release_video_discord_backfill.py
+++ b/tests/test_release_video_discord_backfill.py
@@ -749,6 +749,85 @@ def test_record_skip_is_idempotent_for_same_reason():
     assert github.edits == []
 
 
+@pytest.mark.parametrize("marker_kind", ["completed", "pending"])
+def test_record_skip_rejects_tag_bound_backfill_marker_before_mutation(marker_kind):
+    module = load_backfill_module()
+    youtube_url = "https://youtu.be/RIkxCaylRAQ"
+    if marker_kind == "completed":
+        marker = module.discord_backfill_marker("v0.0.297", youtube_url)
+    else:
+        marker = module.discord_backfill_pending_marker("v0.0.297", youtube_url)
+    original_body = f"Release video: {youtube_url}\n\nExisting notes\n\n{marker}\n"
+    github = FakeGitHubReleaseClient(original_body)
+    posts = []
+
+    with pytest.raises(module.BackfillError, match="video backfill state"):
+        module.record_release_video_skip(
+            tag="v0.0.297",
+            repo="promptdriven/pdd",
+            reason="Provider quota blocked safe publication.",
+            github=github,
+            post_discord=lambda webhook_url, payload: posts.append(
+                (webhook_url, payload)
+            ),
+        )
+
+    assert github.edits == []
+    assert github.body == original_body
+    assert posts == []
+
+
+def test_record_skip_rejects_release_video_url_without_marker_before_mutation():
+    module = load_backfill_module()
+    youtube_url = "https://youtu.be/RIkxCaylRAQ"
+    original_body = f"Release video: {youtube_url}\n\nExisting notes\n"
+    github = FakeGitHubReleaseClient(original_body)
+    posts = []
+
+    with pytest.raises(module.BackfillError, match="release-video URL"):
+        module.record_release_video_skip(
+            tag="v0.0.297",
+            repo="promptdriven/pdd",
+            reason="Provider quota blocked safe publication.",
+            github=github,
+            post_discord=lambda webhook_url, payload: posts.append(
+                (webhook_url, payload)
+            ),
+        )
+
+    assert github.edits == []
+    assert github.body == original_body
+    assert posts == []
+
+
+@pytest.mark.parametrize("marker_kind", ["completed", "pending"])
+def test_record_skip_rejects_stale_mismatched_backfill_marker(marker_kind):
+    module = load_backfill_module()
+    youtube_url = "https://youtu.be/RIkxCaylRAQ"
+    if marker_kind == "completed":
+        marker = module.discord_backfill_marker("v0.0.296", youtube_url)
+    else:
+        marker = module.discord_backfill_pending_marker("v0.0.296", youtube_url)
+    original_body = f"Existing notes\n\n{marker}\n"
+    github = FakeGitHubReleaseClient(original_body)
+    posts = []
+
+    with pytest.raises(module.BackfillError, match="stale or mismatched"):
+        module.record_release_video_skip(
+            tag="v0.0.297",
+            repo="promptdriven/pdd",
+            reason="Provider quota blocked safe publication.",
+            github=github,
+            post_discord=lambda webhook_url, payload: posts.append(
+                (webhook_url, payload)
+            ),
+        )
+
+    assert github.edits == []
+    assert github.body == original_body
+    assert posts == []
+
+
 def test_record_skip_replaces_prior_skip_reason():
     module = load_backfill_module()
     old_reason = "Provider quota blocked publication."


### PR DESCRIPTION
## Summary

- expand the contributor release guide into the canonical cloud-test through package, video, live YouTube, Discord, and closeout lifecycle
- make the tag-triggered GitHub Actions job the sole normal video-create authority and disable local create for the normal tag command
- correct production identity/ordering: derive `pdd-cli`, peel the remote tag, document protected approval before build, and separate pre-approval from post-publication evidence
- provide fail-closed same-tag recovery without tag movement, production dispatch, accidental video reinvocation, or premature GitHub Release creation
- reserve immutable `final-evidence.json` for published/skipped terminal states and use hash-linked recovery checkpoints while active
- make Discord backfill reject exact, stale, or mismatched skip state; document a controlled pre-final skip reconciliation with completed/pending terminal consistency
- update onboarding and add semantic documentation/behavior contracts

Closes #1845.
Related automation follow-ups: #2041 and #2044.

## TDD evidence

- Initial red contract: `b4d0e4ef4` — 4 intended documentation lifecycle failures
- Correction red contract: `18fddb559` — 8 intended semantic/state failures, including Discord mutation under a durable skip
- Supplemental stale-marker red: the new mismatched-marker behavior test failed before the final guard (`DID NOT RAISE`); exact reconciliation success and ambiguous-pending tests already passed
- Green implementation: `9bb79279c`

## Verification

- `python -m pytest -q tests/test_release_process_runbook.py tests/test_release_video.py tests/test_release_video_discord_backfill.py` → **278 passed**, one pre-existing pandas warning
- `pylint --disable=all --enable=E,F scripts/backfill_release_video_discord.py tests/test_release_process_runbook.py tests/test_release_video_discord_backfill.py` → **10.00/10**
- parsed authoritative JSON evidence example + documentation whitespace/final-newline checks → passed
- `git diff --check` → passed
- latest reciprocal correction: **283 passed** plus compileall/static checks
- clean worktree; exact head pushed

## Scope and risk

No tag, package, PyPI, GitHub Release, cloud job, release video, deploy, or Discord mutation was performed. Runtime transitions are reciprocal and fail-closed: backfill refuses exact/stale/mismatched skip records, while skip recording refuses completed/pending markers and attributable release-video URLs before any release edit or webhook. Operators must follow the safety-recorded reconciliation path first. General state-machine automation remains #2044; final-manifest automation remains #2041.

