### PR TITLE
fix(sync): isolate staged mounts in private namespace

### DIFF
--- a/pdd/sync_core/signer_process.py
+++ b/pdd/sync_core/signer_process.py
@@ -151,10 +151,10 @@ def _wait_for_signer_start(
     deadline = time.monotonic() + 0.5
     while not ready_path.exists():
         if process.poll() is not None:
-            stdout, stderr = process.communicate()
-            raise subprocess.TimeoutExpired(
-                command, timeout, output=stdout, stderr=stderr
-            )
+            # Bubblewrap/setup failures are terminal exits, not elapsed
+            # signer deadlines. Let the caller collect the exact status and
+            # diagnostics through the normal CompletedProcess path.
+            return
         if time.monotonic() >= deadline:
             _kill_bounded(process, token)
             raise subprocess.TimeoutExpired(command, timeout)

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -60,35 +60,72 @@ class _ExecutableIdentity:
 def _executable_identity(
     path: Path, *, require_root: bool = True,
 ) -> _ExecutableIdentity:
-    """Measure one exact regular executable and reject unsafe ownership/mode."""
+    """Measure one executable fd and reject mutable path ancestry."""
+    descriptor = None
     try:
         resolved = path.resolve(strict=True)
-        metadata = resolved.stat()
-        executable = os.access(resolved, os.X_OK)
+        if require_root:
+            _validate_trusted_executable_chain(resolved)
+        descriptor = os.open(
+            resolved, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW
+        )
+        metadata = os.fstat(descriptor)
     except OSError as exc:
         raise RuntimeError("protected sandbox requires a trusted root-owned executable") from exc
     if (
         not stat.S_ISREG(metadata.st_mode)
-        or not executable
+        or not metadata.st_mode & 0o111
         or (require_root and metadata.st_uid != 0)
         or metadata.st_mode & 0o022
     ):
+        if descriptor is not None:
+            os.close(descriptor)
         raise RuntimeError("protected sandbox requires a trusted root-owned executable")
     digest = hashlib.sha256()
     try:
-        with resolved.open("rb") as stream:
-            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-                digest.update(chunk)
+        for chunk in iter(lambda: os.read(descriptor, 1024 * 1024), b""):
+            digest.update(chunk)
+        final_metadata = os.fstat(descriptor)
+        if require_root:
+            _validate_trusted_executable_chain(resolved)
     except OSError as exc:
         raise RuntimeError("protected sandbox requires a trusted root-owned executable") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+    measured = (
+        metadata.st_dev, metadata.st_ino, stat.S_IMODE(metadata.st_mode),
+        metadata.st_uid, metadata.st_size, metadata.st_mtime_ns,
+    )
+    final = (
+        final_metadata.st_dev, final_metadata.st_ino,
+        stat.S_IMODE(final_metadata.st_mode), final_metadata.st_uid,
+        final_metadata.st_size, final_metadata.st_mtime_ns,
+    )
+    if measured != final:
+        raise RuntimeError("protected executable identity changed during measurement")
     return _ExecutableIdentity(
-        resolved,
-        (
-            metadata.st_dev, metadata.st_ino, stat.S_IMODE(metadata.st_mode),
-            metadata.st_uid, metadata.st_size, metadata.st_mtime_ns,
-        ),
+        resolved, measured,
         digest.hexdigest(), require_root,
     )
+
+
+def _validate_trusted_executable_chain(path: Path) -> None:
+    """Require every resolved ancestor to be immutable to unprivileged users."""
+    if not path.is_absolute():
+        raise RuntimeError("protected executable path is not absolute")
+    for directory in reversed(path.parents):
+        try:
+            metadata = directory.lstat()
+        except OSError as exc:
+            raise RuntimeError("protected executable ancestor is unavailable") from exc
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_uid != 0
+            or metadata.st_mode & 0o022
+        ):
+            raise RuntimeError("protected executable ancestor is attacker-writable")
 
 
 def _revalidate_executable(expected: _ExecutableIdentity) -> None:
@@ -137,6 +174,7 @@ def _revalidate_privileged_command(argv: list[str]) -> None:
         manifest = json.loads(argv[-3])
         expected_names = {
             "sudo", "unshare", "python", "mount", "umount", "bwrap", "setpriv",
+            "sh", "xargs", "env",
         }
         if not isinstance(manifest, dict) or set(manifest) != expected_names:
             raise ValueError("invalid executable manifest")
@@ -303,7 +341,8 @@ def _limited_command(command: list[str], limits: SupervisorLimits) -> list[str]:
 
 def _staged_bwrap(
     argv: list[str], sources: list[Path],
-    tools: dict[str, _ExecutableIdentity],
+    tools: dict[str, _ExecutableIdentity], *, candidate_command: list[str],
+    candidate_uid: int, candidate_gid: int,
 ) -> list[str]:
     """Stage exact bind mounts wholly inside a private mount namespace."""
     helper = "\n".join((
@@ -311,26 +350,58 @@ def _staged_bwrap(
         "helper_env={'HOME':'/root','LANG':'C','LC_ALL':'C',"
         "'PATH':'/usr/sbin:/usr/bin:/sbin:/bin'}",
         "os.environ.clear(); os.environ.update(helper_env)",
-        "manifest=json.loads(sys.argv[1]); argv=json.loads(sys.argv[2]); "
-        "paths=json.loads(sys.argv[3])",
+        "candidate_command=json.loads(sys.argv[1]); uid=int(sys.argv[2]); gid=int(sys.argv[3])",
+        "manifest=json.loads(sys.argv[4]); argv=json.loads(sys.argv[5]); "
+        "paths=json.loads(sys.argv[6])",
+        "def verify_chain(path):",
+        " for parent in reversed(path.parents):",
+        "  metadata=parent.lstat()",
+        "  if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode) "
+        "or metadata.st_uid!=0 or metadata.st_mode&0o022: "
+        "raise RuntimeError('protected executable ancestor changed')",
         "def verify(name):",
         " expected=manifest[name]; path=pathlib.Path(expected['path'])",
-        " metadata=path.stat()",
-        " digest=hashlib.sha256(path.read_bytes()).hexdigest()",
+        " verify_chain(path)",
+        " fd=os.open(path,os.O_RDONLY|os.O_CLOEXEC|os.O_NOFOLLOW)",
+        " try:",
+        "  metadata=os.fstat(fd); digest=hashlib.sha256()",
+        "  while True:",
+        "   chunk=os.read(fd,1024*1024)",
+        "   if not chunk: break",
+        "   digest.update(chunk)",
+        "  final=os.fstat(fd)",
+        " finally: os.close(fd)",
+        " verify_chain(path)",
+        " if (metadata.st_dev,metadata.st_ino,metadata.st_mode,metadata.st_uid,"
+        "metadata.st_size,metadata.st_mtime_ns)!=(final.st_dev,final.st_ino,"
+        "final.st_mode,final.st_uid,final.st_size,final.st_mtime_ns): "
+        "raise RuntimeError('protected executable changed during measurement')",
         " actual={'path':str(path.resolve(strict=True)),'device':metadata.st_dev,"
         "'inode':metadata.st_ino,'mode':stat.S_IMODE(metadata.st_mode),"
         "'uid':metadata.st_uid,'size':metadata.st_size,"
-        "'mtime_ns':metadata.st_mtime_ns,'sha256':digest}",
+        "'mtime_ns':metadata.st_mtime_ns,'sha256':digest.hexdigest()}",
         " if actual!=expected or metadata.st_uid!=0 or metadata.st_mode&0o022 "
         "or not stat.S_ISREG(metadata.st_mode): "
         "raise RuntimeError(f'protected executable identity changed: {name}')",
         " return str(path)",
         "candidate_env=json.load(sys.stdin)",
+        "if not isinstance(candidate_env,dict) or not all(isinstance(k,str) and k "
+        "and '=' not in k and '\\x00' not in k and isinstance(v,str) and '\\x00' not in v "
+        "for k,v in candidate_env.items()): raise RuntimeError('invalid candidate environment')",
         "for name in manifest: verify(name)",
         "mount=verify('mount'); umount=verify('umount'); bwrap=verify('bwrap')",
         "base=pathlib.Path(tempfile.mkdtemp(prefix='pdd-binds-',dir='/run'))",
-        "os.chmod(base,0o755); staged=[]; result=None",
+        "os.chmod(base,0o700); staged=[]; result=None",
         "try:",
+        " env_path=base/'candidate-env'",
+        " env_items=[f'{key}={value}' for key,value in sorted(candidate_env.items())]",
+        " env_payload=b'\\0'.join(value.encode() for value in (*env_items,*candidate_command))",
+        " env_fd=os.open(env_path,os.O_WRONLY|os.O_CREAT|os.O_EXCL|os.O_NOFOLLOW,0o600)",
+        " try:",
+        "  os.fchown(env_fd,uid,gid); remaining=memoryview(env_payload)",
+        "  while remaining: remaining=remaining[os.write(env_fd,remaining):]",
+        "  os.fsync(env_fd)",
+        " finally: os.close(env_fd)",
         " for index,source in enumerate(paths):",
         "  source=pathlib.Path(source); target=base/str(index)",
         "  target.mkdir() if source.is_dir() else target.touch()",
@@ -338,9 +409,12 @@ def _staged_bwrap(
         "  subprocess.run([mount,'--bind',str(source),str(target)],check=True)",
         "  staged.append(target)",
         " argv=[str(staged[int(x[4:-1])]) if x.startswith('@FD:') else x for x in argv]",
+        " argv=[('/run/pdd-candidate-env' if x=='@PDD-CANDIDATE-ENV@' else x) for x in argv]",
+        " separator=argv.index('--')",
+        " argv[separator:separator]=['--ro-bind',str(env_path),'/run/pdd-candidate-env']",
         " if argv[0]!=bwrap: raise RuntimeError('protected bwrap identity mismatch')",
         " verify('bwrap')",
-        " result=subprocess.run(argv,check=False,env=candidate_env)",
+        " result=subprocess.run(argv,check=False,env=helper_env)",
         "finally:",
         " for target in reversed(staged):",
         "  umount=verify('umount')",
@@ -352,7 +426,8 @@ def _staged_bwrap(
     return [
         str(tools["sudo"].path), "-n", "--", str(tools["unshare"].path),
         "--mount", "--propagation", "private", "--wd", "/",
-        str(tools["python"].path), "-I", "-S", "-c", helper, manifest,
+        str(tools["python"].path), "-I", "-S", "-c", helper,
+        json.dumps(candidate_command), str(candidate_uid), str(candidate_gid), manifest,
         json.dumps(argv), json.dumps([str(path) for path in sources]),
     ]
 
@@ -496,6 +571,9 @@ def _sandbox_command(
             "umount": _trusted_tool("umount"),
             "bwrap": _trusted_tool("bwrap"),
             "setpriv": _trusted_tool("setpriv"),
+            "sh": _trusted_tool("sh"),
+            "xargs": _trusted_tool("xargs"),
+            "env": _trusted_tool("env"),
         }
         if subprocess.run(
             [str(tools["sudo"].path), "-n", "true"],
@@ -507,7 +585,8 @@ def _sandbox_command(
         argv = [str(tools["bwrap"].path),
                 "--unshare-ipc", "--unshare-pid", "--unshare-net",
                 "--unshare-uts", "--unshare-cgroup", "--die-with-parent", "--new-session",
-                "--tmpfs", "/", "--proc", "/proc", "--dir", "/tmp"]
+                "--tmpfs", "/", "--proc", "/proc", "--dir", "/tmp",
+                "--dir", "/run"]
         sources: list[Path] = []
         destination_dirs = {Path("/tmp")}
         def bind(option: str, source: Path, destination: Path | None = None) -> None:
@@ -530,9 +609,9 @@ def _sandbox_command(
             bind("--ro-bind", item.resolve(), item)
         # ``setpriv`` executes after the namespace root is installed, so bind
         # it and its ELF closure directly even when PATH resolution differs.
-        if setpriv is not None:
-            setpriv_path = Path(setpriv)
-            for item in (setpriv_path, *_linked_libraries(setpriv_path)):
+        for tool_name in ("setpriv", "sh", "xargs", "env"):
+            tool_path = tools[tool_name].path
+            for item in (tool_path, *_linked_libraries(tool_path)):
                 bind("--ro-bind", item.resolve(), item)
         for item in readable_roots:
             bind("--ro-bind", item.resolve())
@@ -549,15 +628,23 @@ def _sandbox_command(
             # dedicated directory keeps the reporter and toolchain immutable.
             bind("--bind", result_fifo.parent.resolve())
         argv.extend(("--chdir", str(workdir)))
-        drop = (
-            [setpriv, "--reuid", str(os.getuid()), "--regid", str(os.getgid()),
-             "--clear-groups", "--"] if setpriv else []
-        )
         sandboxed = _limited_command(command, limits)
         if result_fifo is not None:
             sandboxed = _private_result_command(sandboxed, result_fifo, result_fd)
-        argv.extend(("--", *drop, *sandboxed))
-        return _staged_bwrap(argv, sources, tools), None
+        launcher = (
+            'exec < "$1"; exec "$2" -0 -x -- "$3" -i'
+        )
+        drop = [
+            setpriv, "--reuid", str(os.getuid()), "--regid", str(os.getgid()),
+            "--clear-groups", "--", str(tools["sh"].path), "-c", launcher,
+            "pdd-env-launcher", "@PDD-CANDIDATE-ENV@",
+            str(tools["xargs"].path), str(tools["env"].path),
+        ]
+        argv.extend(("--", *drop))
+        return _staged_bwrap(
+            argv, sources, tools, candidate_command=sandboxed,
+            candidate_uid=os.getuid(), candidate_gid=os.getgid(),
+        ), None
     raise RuntimeError("unsupported sandbox platform or mechanism")
 
 

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -339,6 +339,33 @@ def _limited_command(command: list[str], limits: SupervisorLimits) -> list[str]:
             str(limits.max_output_bytes), "256", *command]
 
 
+def _candidate_environment_launcher() -> str:
+    """Return the post-uid-drop launcher that preserves exact child status."""
+    return "\n".join((
+        "import os,sys",
+        "fd=os.open(sys.argv[1],os.O_RDONLY|os.O_CLOEXEC|os.O_NOFOLLOW)",
+        "try:",
+        " chunks=[]",
+        " while True:",
+        "  chunk=os.read(fd,1024*1024)",
+        "  if not chunk: break",
+        "  chunks.append(chunk)",
+        "finally: os.close(fd)",
+        "items=b''.join(chunks).split(b'\\0')",
+        "boundary=next((i for i,item in enumerate(items) if b'=' not in item),None)",
+        "if boundary is None: raise RuntimeError('candidate command missing')",
+        "environment={}",
+        "for item in items[:boundary]:",
+        " key,value=item.split(b'=',1)",
+        " key=key.decode('utf-8');value=value.decode('utf-8')",
+        " if not key or key in environment: raise RuntimeError('invalid candidate environment')",
+        " environment[key]=value",
+        "command=[item.decode('utf-8') for item in items[boundary:]]",
+        "if not command or not command[0]: raise RuntimeError('candidate command missing')",
+        "os.execve(command[0],command,environment)",
+    ))
+
+
 def _staged_bwrap(
     argv: list[str], sources: list[Path],
     tools: dict[str, _ExecutableIdentity], *, candidate_command: list[str],
@@ -609,7 +636,7 @@ def _sandbox_command(
             bind("--ro-bind", item.resolve(), item)
         # ``setpriv`` executes after the namespace root is installed, so bind
         # it and its ELF closure directly even when PATH resolution differs.
-        for tool_name in ("setpriv", "sh", "xargs", "env"):
+        for tool_name in ("setpriv", "python", "sh", "xargs", "env"):
             tool_path = tools[tool_name].path
             for item in (tool_path, *_linked_libraries(tool_path)):
                 bind("--ro-bind", item.resolve(), item)
@@ -631,14 +658,10 @@ def _sandbox_command(
         sandboxed = _limited_command(command, limits)
         if result_fifo is not None:
             sandboxed = _private_result_command(sandboxed, result_fifo, result_fd)
-        launcher = (
-            'exec < "$1"; exec "$2" -0 -x -- "$3" -i'
-        )
         drop = [
             setpriv, "--reuid", str(os.getuid()), "--regid", str(os.getgid()),
-            "--clear-groups", "--", str(tools["sh"].path), "-c", launcher,
-            "pdd-env-launcher", "@PDD-CANDIDATE-ENV@",
-            str(tools["xargs"].path), str(tools["env"].path),
+            "--clear-groups", "--", str(tools["python"].path), "-I", "-S",
+            "-c", _candidate_environment_launcher(), "@PDD-CANDIDATE-ENV@",
         ]
         argv.extend(("--", *drop))
         return _staged_bwrap(

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
-import os
+import hashlib
 import json
+import os
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -34,6 +36,122 @@ class SupervisorLimits:
     max_memory_bytes: int = 2 * 1024 * 1024 * 1024
     max_cpu_seconds: int = 300
     max_processes: int = 128
+
+
+@dataclass(frozen=True)
+class _ExecutableIdentity:
+    """Immutable identity for one executable admitted across the root boundary."""
+
+    path: Path
+    stat_identity: tuple[int, int, int, int, int, int]
+    sha256: str
+    require_root: bool = True
+
+    def payload(self) -> dict[str, object]:
+        """Return a strict JSON representation for root-side revalidation."""
+        device, inode, mode, uid, size, mtime_ns = self.stat_identity
+        return {
+            "path": str(self.path), "device": device, "inode": inode,
+            "mode": mode, "uid": uid, "size": size,
+            "mtime_ns": mtime_ns, "sha256": self.sha256,
+        }
+
+
+def _executable_identity(
+    path: Path, *, require_root: bool = True,
+) -> _ExecutableIdentity:
+    """Measure one exact regular executable and reject unsafe ownership/mode."""
+    try:
+        resolved = path.resolve(strict=True)
+        metadata = resolved.stat()
+        executable = os.access(resolved, os.X_OK)
+    except OSError as exc:
+        raise RuntimeError("protected sandbox requires a trusted root-owned executable") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or not executable
+        or (require_root and metadata.st_uid != 0)
+        or metadata.st_mode & 0o022
+    ):
+        raise RuntimeError("protected sandbox requires a trusted root-owned executable")
+    digest = hashlib.sha256()
+    try:
+        with resolved.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise RuntimeError("protected sandbox requires a trusted root-owned executable") from exc
+    return _ExecutableIdentity(
+        resolved,
+        (
+            metadata.st_dev, metadata.st_ino, stat.S_IMODE(metadata.st_mode),
+            metadata.st_uid, metadata.st_size, metadata.st_mtime_ns,
+        ),
+        digest.hexdigest(), require_root,
+    )
+
+
+def _revalidate_executable(expected: _ExecutableIdentity) -> None:
+    """Fail if an admitted executable changed since its trust measurement."""
+    try:
+        current = _executable_identity(expected.path, require_root=expected.require_root)
+    except RuntimeError as exc:
+        raise RuntimeError("protected executable identity changed") from exc
+    if current != expected:
+        raise RuntimeError("protected executable identity changed")
+
+
+def _trusted_tool(name: str) -> _ExecutableIdentity:
+    """Resolve one tool once and bind its root-owned executable identity."""
+    value = shutil.which(name)
+    if value is None:
+        raise RuntimeError("protected sandbox requires a trusted root-owned executable")
+    return _executable_identity(Path(value))
+
+
+def _trusted_helper_python() -> _ExecutableIdentity:
+    """Select a system Python whose ownership is independent of the candidate."""
+    candidates = (Path("/usr/bin/python3"), Path("/bin/python3"))
+    for candidate in candidates:
+        if candidate.exists():
+            try:
+                return _executable_identity(candidate)
+            except RuntimeError:
+                continue
+    return _trusted_tool("python3")
+
+
+def _privileged_helper_environment(
+    _candidate_environment: dict[str, str],
+) -> dict[str, str]:
+    """Return a constant environment that cannot load candidate Python hooks."""
+    return {
+        "HOME": "/root", "LANG": "C", "LC_ALL": "C",
+        "PATH": "/usr/sbin:/usr/bin:/sbin:/bin",
+    }
+
+
+def _revalidate_privileged_command(argv: list[str]) -> None:
+    """Revalidate every bound executable immediately before sudo execution."""
+    try:
+        manifest = json.loads(argv[-3])
+        expected_names = {
+            "sudo", "unshare", "python", "mount", "umount", "bwrap", "setpriv",
+        }
+        if not isinstance(manifest, dict) or set(manifest) != expected_names:
+            raise ValueError("invalid executable manifest")
+        for payload in manifest.values():
+            identity = _ExecutableIdentity(
+                Path(payload["path"]),
+                (
+                    payload["device"], payload["inode"], payload["mode"],
+                    payload["uid"], payload["size"], payload["mtime_ns"],
+                ),
+                payload["sha256"], True,
+            )
+            _revalidate_executable(identity)
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError("protected executable identity manifest is invalid") from exc
 
 
 def _linked_libraries(path: Path) -> tuple[Path, ...]:
@@ -112,6 +230,14 @@ def released_runtime_closure_paths() -> tuple[tuple[str, Path], ...]:
             path = Path(value).resolve()
             entries[f"sandbox/{name}"] = path
             native.add(path)
+    if sys.platform.startswith("linux"):
+        try:
+            helper_python = _trusted_helper_python().path
+        except RuntimeError:
+            helper_python = None
+        if helper_python is not None:
+            entries["sandbox/python-helper"] = helper_python
+            native.add(helper_python)
     entries["interpreter/python"] = _SUPERVISOR_EXECUTABLE.resolve()
     for path in sorted(native):
         for library in _linked_libraries(path):
@@ -135,10 +261,8 @@ def _runtime_roots(command: list[str], cwd: Path) -> tuple[Path, ...]:
             roots.add(executable)
         if not resolved_executable.is_relative_to(cwd):
             roots.add(resolved_executable)
-    for _label, path in released_runtime_closure_paths():
-        if path.name in {
-            "bwrap", "setpriv", "sudo", "unshare", "mount", "umount",
-        } or any(
+    for label, path in released_runtime_closure_paths():
+        if label.startswith("sandbox/") or any(
             path.is_relative_to(directory) for directory in directories
         ):
             continue
@@ -178,32 +302,58 @@ def _limited_command(command: list[str], limits: SupervisorLimits) -> list[str]:
 
 
 def _staged_bwrap(
-    argv: list[str], sources: list[Path], unshare: Path,
+    argv: list[str], sources: list[Path],
+    tools: dict[str, _ExecutableIdentity],
 ) -> list[str]:
     """Stage exact bind mounts wholly inside a private mount namespace."""
     helper = "\n".join((
-        "import json,os,pathlib,shutil,subprocess,sys,tempfile",
-        "argv=json.loads(sys.argv[1]); paths=json.loads(sys.argv[2])",
+        "import hashlib,json,os,pathlib,shutil,stat,subprocess,sys,tempfile",
+        "helper_env={'HOME':'/root','LANG':'C','LC_ALL':'C',"
+        "'PATH':'/usr/sbin:/usr/bin:/sbin:/bin'}",
+        "os.environ.clear(); os.environ.update(helper_env)",
+        "manifest=json.loads(sys.argv[1]); argv=json.loads(sys.argv[2]); "
+        "paths=json.loads(sys.argv[3])",
+        "def verify(name):",
+        " expected=manifest[name]; path=pathlib.Path(expected['path'])",
+        " metadata=path.stat()",
+        " digest=hashlib.sha256(path.read_bytes()).hexdigest()",
+        " actual={'path':str(path.resolve(strict=True)),'device':metadata.st_dev,"
+        "'inode':metadata.st_ino,'mode':stat.S_IMODE(metadata.st_mode),"
+        "'uid':metadata.st_uid,'size':metadata.st_size,"
+        "'mtime_ns':metadata.st_mtime_ns,'sha256':digest}",
+        " if actual!=expected or metadata.st_uid!=0 or metadata.st_mode&0o022 "
+        "or not stat.S_ISREG(metadata.st_mode): "
+        "raise RuntimeError(f'protected executable identity changed: {name}')",
+        " return str(path)",
+        "candidate_env=json.load(sys.stdin)",
+        "for name in manifest: verify(name)",
+        "mount=verify('mount'); umount=verify('umount'); bwrap=verify('bwrap')",
         "base=pathlib.Path(tempfile.mkdtemp(prefix='pdd-binds-',dir='/run'))",
         "os.chmod(base,0o755); staged=[]; result=None",
         "try:",
         " for index,source in enumerate(paths):",
         "  source=pathlib.Path(source); target=base/str(index)",
         "  target.mkdir() if source.is_dir() else target.touch()",
-        "  subprocess.run(['mount','--bind',str(source),str(target)],check=True)",
+        "  mount=verify('mount')",
+        "  subprocess.run([mount,'--bind',str(source),str(target)],check=True)",
         "  staged.append(target)",
         " argv=[str(staged[int(x[4:-1])]) if x.startswith('@FD:') else x for x in argv]",
-        " result=subprocess.run(argv,check=False)",
+        " if argv[0]!=bwrap: raise RuntimeError('protected bwrap identity mismatch')",
+        " verify('bwrap')",
+        " result=subprocess.run(argv,check=False,env=candidate_env)",
         "finally:",
         " for target in reversed(staged):",
-        "  subprocess.run(['umount',str(target)],check=False)",
+        "  umount=verify('umount')",
+        "  subprocess.run([umount,str(target)],check=False)",
         " shutil.rmtree(base,ignore_errors=True)",
         "raise SystemExit(result.returncode if result is not None else 1)",
     ))
+    manifest = json.dumps({name: identity.payload() for name, identity in tools.items()})
     return [
-        "sudo", "-n", "-E", str(unshare), "--mount", "--propagation", "private",
-        str(_SUPERVISOR_EXECUTABLE), "-c", helper, json.dumps(argv),
-        json.dumps([str(path) for path in sources]),
+        str(tools["sudo"].path), "-n", "--", str(tools["unshare"].path),
+        "--mount", "--propagation", "private", "--wd", "/",
+        str(tools["python"].path), "-I", "-S", "-c", helper, manifest,
+        json.dumps(argv), json.dumps([str(path) for path in sources]),
     ]
 
 
@@ -332,30 +482,30 @@ def _sandbox_command(
         raise RuntimeError(
             "unsupported protected sandbox: macOS cannot prove process lifetime isolation"
         )
-    if sys.platform.startswith("linux") and shutil.which("bwrap"):
+    if sys.platform.startswith("linux"):
         if os.getuid() == 0:
             raise RuntimeError(
                 "protected sandbox requires a non-root caller so process limits "
                 "remain kernel-enforced"
             )
-        if not (bool(shutil.which("sudo")) and subprocess.run(
-                ["sudo", "-n", "true"], capture_output=True, check=False,
-        ).returncode == 0):
+        tools = {
+            "sudo": _trusted_tool("sudo"),
+            "unshare": _trusted_tool("unshare"),
+            "python": _trusted_helper_python(),
+            "mount": _trusted_tool("mount"),
+            "umount": _trusted_tool("umount"),
+            "bwrap": _trusted_tool("bwrap"),
+            "setpriv": _trusted_tool("setpriv"),
+        }
+        if subprocess.run(
+            [str(tools["sudo"].path), "-n", "true"],
+            capture_output=True, check=False,
+        ).returncode != 0:
             raise RuntimeError("protected sandbox requires privileged bind staging")
-        setpriv = shutil.which("setpriv")
-        if setpriv is None:
-            raise RuntimeError("protected sandbox requires setpriv for post-mount uid drop")
-        unshare_value = shutil.which("unshare")
-        if unshare_value is None:
-            raise RuntimeError(
-                "protected sandbox requires a private mount namespace tool"
-            )
-        # Execute the resolved spelling, never a later PATH lookup. If the
-        # discovered symlink is retargeted or removed, exec fails closed rather
-        # than selecting a different executable identity from PATH.
-        unshare = Path(unshare_value).resolve()
+        setpriv = str(tools["setpriv"].path)
         workdir = (cwd or Path.cwd()).resolve()
-        argv = ["bwrap", "--unshare-ipc", "--unshare-pid", "--unshare-net",
+        argv = [str(tools["bwrap"].path),
+                "--unshare-ipc", "--unshare-pid", "--unshare-net",
                 "--unshare-uts", "--unshare-cgroup", "--die-with-parent", "--new-session",
                 "--tmpfs", "/", "--proc", "/proc", "--dir", "/tmp"]
         sources: list[Path] = []
@@ -407,7 +557,7 @@ def _sandbox_command(
         if result_fifo is not None:
             sandboxed = _private_result_command(sandboxed, result_fifo, result_fd)
         argv.extend(("--", *drop, *sandboxed))
-        return _staged_bwrap(argv, sources, unshare), None
+        return _staged_bwrap(argv, sources, tools), None
     raise RuntimeError("unsupported sandbox platform or mechanism")
 
 
@@ -429,6 +579,7 @@ def run_supervised(
             readable_bindings=readable_bindings,
             result_fifo=result_fifo, result_fd=result_fd,
         )
+        _revalidate_privileged_command(argv)
     except RuntimeError as exc:
         return subprocess.CompletedProcess(command, 125, "", str(exc)), False
     token = uuid.uuid4().hex
@@ -445,10 +596,28 @@ def run_supervised(
     if library_path:
         sandbox_environment["LD_LIBRARY_PATH"] = library_path
     process = subprocess.Popen(
-        argv, cwd=cwd, stdout=stdout_file, stderr=stderr_file,
-        env=sandbox_environment,
+        argv, cwd=Path("/"), stdin=subprocess.PIPE,
+        stdout=stdout_file, stderr=stderr_file,
+        env=_privileged_helper_environment(sandbox_environment),
         start_new_session=True,
     )
+    try:
+        if process.stdin is None:
+            raise RuntimeError("protected helper environment channel is unavailable")
+        process.stdin.write(json.dumps(sandbox_environment).encode("utf-8"))
+        process.stdin.close()
+        process.stdin = None
+    except (BrokenPipeError, OSError, RuntimeError) as exc:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait()
+        stdout_file.close()
+        stderr_file.close()
+        return subprocess.CompletedProcess(
+            command, 125, "", f"protected helper startup failed: {exc}"
+        ), False
     timed_out = False
     surviving = False
     tracked: dict[int, str | None] = {}

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -158,6 +158,42 @@ def _trusted_helper_python() -> _ExecutableIdentity:
     return _trusted_tool("python3")
 
 
+def _trusted_helper_runtime_roots(
+    identity: _ExecutableIdentity,
+) -> tuple[Path, ...]:
+    """Return the minimal immutable stdlib root needed for Python startup."""
+    version = identity.path.name.removeprefix("python")
+    if (
+        version.count(".") != 1
+        or not all(part.isdigit() for part in version.split("."))
+    ):
+        raise RuntimeError("protected helper Python version is not identity-bound")
+    try:
+        encodings = (
+            identity.path.parent.parent / "lib" / f"python{version}" / "encodings"
+        ).resolve(strict=True)
+        metadata = encodings.lstat()
+        _validate_trusted_executable_chain(encodings / "__init__.py")
+        init_metadata = (encodings / "__init__.py").lstat()
+    except OSError as exc:
+        raise RuntimeError("protected helper Python runtime is unavailable") from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != 0
+        or metadata.st_mode & 0o022
+    ):
+        raise RuntimeError("protected helper Python runtime is not immutable")
+    if (
+        not stat.S_ISREG(init_metadata.st_mode)
+        or stat.S_ISLNK(init_metadata.st_mode)
+        or init_metadata.st_uid != 0
+        or init_metadata.st_mode & 0o022
+    ):
+        raise RuntimeError("protected helper Python runtime is not immutable")
+    return (encodings,)
+
+
 def _privileged_helper_environment(
     _candidate_environment: dict[str, str],
 ) -> dict[str, str]:
@@ -640,6 +676,8 @@ def _sandbox_command(
             tool_path = tools[tool_name].path
             for item in (tool_path, *_linked_libraries(tool_path)):
                 bind("--ro-bind", item.resolve(), item)
+        for item in _trusted_helper_runtime_roots(tools["python"]):
+            bind("--ro-bind", item.resolve(), item)
         for item in readable_roots:
             bind("--ro-bind", item.resolve())
         for source, destination in readable_bindings:

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -103,6 +103,7 @@ def released_runtime_closure_paths() -> tuple[tuple[str, Path], ...]:
         "bwrap": shutil.which("bwrap"),
         "setpriv": shutil.which("setpriv"),
         "sudo": shutil.which("sudo"),
+        "unshare": shutil.which("unshare"),
         "mount": shutil.which("mount"),
         "umount": shutil.which("umount"),
     }
@@ -135,7 +136,9 @@ def _runtime_roots(command: list[str], cwd: Path) -> tuple[Path, ...]:
         if not resolved_executable.is_relative_to(cwd):
             roots.add(resolved_executable)
     for _label, path in released_runtime_closure_paths():
-        if path.name in {"bwrap", "setpriv", "sudo", "mount", "umount"} or any(
+        if path.name in {
+            "bwrap", "setpriv", "sudo", "unshare", "mount", "umount",
+        } or any(
             path.is_relative_to(directory) for directory in directories
         ):
             continue
@@ -174,8 +177,10 @@ def _limited_command(command: list[str], limits: SupervisorLimits) -> list[str]:
             str(limits.max_output_bytes), "256", *command]
 
 
-def _staged_bwrap(argv: list[str], sources: list[Path]) -> list[str]:
-    """Stage exact bind mounts before replacing the namespace root."""
+def _staged_bwrap(
+    argv: list[str], sources: list[Path], unshare: Path,
+) -> list[str]:
+    """Stage exact bind mounts wholly inside a private mount namespace."""
     helper = "\n".join((
         "import json,os,pathlib,shutil,subprocess,sys,tempfile",
         "argv=json.loads(sys.argv[1]); paths=json.loads(sys.argv[2])",
@@ -195,8 +200,11 @@ def _staged_bwrap(argv: list[str], sources: list[Path]) -> list[str]:
         " shutil.rmtree(base,ignore_errors=True)",
         "raise SystemExit(result.returncode if result is not None else 1)",
     ))
-    return ["sudo", "-n", "-E", str(_SUPERVISOR_EXECUTABLE), "-c", helper,
-            json.dumps(argv), json.dumps([str(path) for path in sources])]
+    return [
+        "sudo", "-n", "-E", str(unshare), "--mount", "--propagation", "private",
+        str(_SUPERVISOR_EXECUTABLE), "-c", helper, json.dumps(argv),
+        json.dumps([str(path) for path in sources]),
+    ]
 
 
 def _private_result_command(
@@ -337,6 +345,15 @@ def _sandbox_command(
         setpriv = shutil.which("setpriv")
         if setpriv is None:
             raise RuntimeError("protected sandbox requires setpriv for post-mount uid drop")
+        unshare_value = shutil.which("unshare")
+        if unshare_value is None:
+            raise RuntimeError(
+                "protected sandbox requires a private mount namespace tool"
+            )
+        # Execute the resolved spelling, never a later PATH lookup. If the
+        # discovered symlink is retargeted or removed, exec fails closed rather
+        # than selecting a different executable identity from PATH.
+        unshare = Path(unshare_value).resolve()
         workdir = (cwd or Path.cwd()).resolve()
         argv = ["bwrap", "--unshare-ipc", "--unshare-pid", "--unshare-net",
                 "--unshare-uts", "--unshare-cgroup", "--die-with-parent", "--new-session",
@@ -390,7 +407,7 @@ def _sandbox_command(
         if result_fifo is not None:
             sandboxed = _private_result_command(sandboxed, result_fifo, result_fd)
         argv.extend(("--", *drop, *sandboxed))
-        return _staged_bwrap(argv, sources), None
+        return _staged_bwrap(argv, sources, unshare), None
     raise RuntimeError("unsupported sandbox platform or mechanism")
 
 

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -6,6 +6,7 @@ import math
 import shutil
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -23,6 +24,7 @@ from pdd.sync_core.supervisor import (
     _runtime_directories,
     run_supervised,
 )
+from pdd.sync_core.signer_process import run_signer
 
 
 def test_private_result_wrapper_unlinks_channel_before_candidate(
@@ -114,6 +116,9 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     argv, profile = _sandbox_command(["/bin/true"], (tmp_path,))
     assert profile is None
     assert argv[:3] == ["sudo", "-n", "-E"]
+    assert argv[3:7] == [
+        "/usr/bin/unshare", "--mount", "--propagation", "private",
+    ]
     bwrap = json.loads(argv[-2])
     assert {"--unshare-pid", "--unshare-net", "--unshare-cgroup"} <= set(bwrap)
     assert "--unshare-user" not in bwrap
@@ -123,6 +128,45 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     assert bwrap[bwrap.index("--regid") + 1] == "2345"
     assert bwrap.index("--proc") < separator
     assert bwrap[bwrap.index("--ro-bind") + 1].startswith("@FD:")
+
+
+def test_linux_sandbox_fails_closed_without_private_mount_namespace_tool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(os, "getuid", lambda: 1234)
+    monkeypatch.setattr(
+        shutil, "which",
+        lambda name: None if name == "unshare" else f"/usr/bin/{name}",
+    )
+    monkeypatch.setattr(
+        "pdd.sync_core.supervisor.subprocess.run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "", ""),
+    )
+    monkeypatch.setattr(
+        "pdd.sync_core.supervisor.released_runtime_closure_paths", lambda: ()
+    )
+
+    with pytest.raises(RuntimeError, match="private mount namespace"):
+        _sandbox_command(["/bin/true"], (tmp_path,))
+
+
+def test_runtime_closure_measures_unshare_and_excludes_it_from_candidate_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    unshare = tmp_path / "unshare"
+    unshare.write_bytes(b"trusted-unshare")
+    monkeypatch.setattr(
+        shutil, "which", lambda name: str(unshare) if name == "unshare" else None
+    )
+    supervisor.released_runtime_closure_paths.cache_clear()
+    try:
+        closure = dict(supervisor.released_runtime_closure_paths())
+        assert closure["sandbox/unshare"] == unshare.resolve()
+        roots = supervisor._runtime_roots([sys.executable], tmp_path)
+        assert unshare.resolve() not in roots
+    finally:
+        supervisor.released_runtime_closure_paths.cache_clear()
 
 
 def test_linux_sandbox_maps_copied_runtime_to_manifest_destination(
@@ -584,3 +628,74 @@ def test_writable_churn_cannot_escape_supervisor_cleanup(tmp_path: Path) -> None
     )
     assert result.returncode == 0
     assert surviving is False
+
+
+def test_parallel_staged_and_signer_bwrap_do_not_share_host_mounts(
+    tmp_path: Path,
+) -> None:
+    """Keep a staged sandbox live while a signer starts in a sibling process."""
+    if not sys.platform.startswith("linux"):
+        pytest.skip("requires Linux mount namespaces")
+    required = ("bwrap", "sudo", "unshare", "mount", "umount", "setpriv")
+    if any(shutil.which(tool) is None for tool in required):
+        pytest.skip("requires the privileged Linux sandbox toolchain")
+    if subprocess.run(
+        ["sudo", "-n", "true"], capture_output=True, check=False,
+    ).returncode != 0:
+        pytest.skip("requires passwordless sudo")
+
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    started = scratch / "candidate-started"
+    outcome: list[tuple[subprocess.CompletedProcess[str], bool]] = []
+    observed_mount_leak = threading.Event()
+    sampling_done = threading.Event()
+
+    def sample_parent_mounts() -> None:
+        while not sampling_done.wait(0.001):
+            if "pdd-binds-" in Path("/proc/self/mountinfo").read_text(
+                encoding="utf-8"
+            ):
+                observed_mount_leak.set()
+
+    def run_staged_candidate() -> None:
+        outcome.append(run_supervised(
+            [
+                sys.executable, "-c",
+                "import pathlib,sys,time; "
+                "pathlib.Path(sys.argv[1]).write_text('started'); time.sleep(1.5)",
+                str(started),
+            ],
+            cwd=scratch,
+            timeout=10,
+            env=dict(os.environ),
+            writable_roots=(scratch,),
+        ))
+
+    sampler = threading.Thread(target=sample_parent_mounts)
+    candidate = threading.Thread(target=run_staged_candidate)
+    sampler.start()
+    candidate.start()
+    try:
+        deadline = time.monotonic() + 10
+        while not started.exists() and candidate.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.005)
+        assert started.exists(), outcome
+
+        signer = run_signer(
+            (sys.executable, "-c", "print('signer-started')"), b"", timeout=5,
+        )
+        assert signer.returncode == 0, signer.stderr.decode(errors="replace")
+        assert signer.stdout.strip() == b"signer-started"
+    finally:
+        candidate.join(timeout=15)
+        sampling_done.set()
+        sampler.join(timeout=2)
+
+    assert not candidate.is_alive()
+    assert outcome and outcome[0][0].returncode == 0, outcome
+    assert outcome[0][1] is False
+    assert not observed_mount_leak.is_set()
+    assert "pdd-binds-" not in Path("/proc/self/mountinfo").read_text(
+        encoding="utf-8"
+    )

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -83,6 +83,41 @@ def test_private_result_wrapper_unlinks_channel_before_candidate(
         os.close(read_fd)
 
 
+def test_candidate_environment_launcher_preserves_exact_exit_and_environment(
+    tmp_path: Path,
+) -> None:
+    """The post-drop handoff must exec the child without xargs exit remapping."""
+    environment_file = tmp_path / "candidate-env"
+    candidate = [
+        sys.executable,
+        "-c",
+        "import os;raise SystemExit(5 if os.environ.get('ONLY') == 'value' "
+        "and 'HOSTILE' not in os.environ else 6)",
+    ]
+    environment_file.write_bytes(
+        b"ONLY=value\0" + b"\0".join(item.encode("utf-8") for item in candidate)
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            supervisor._candidate_environment_launcher(),
+            str(environment_file),
+        ],
+        env={"HOSTILE": "must-not-propagate"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 5
+    assert completed.stdout == ""
+    assert completed.stderr == ""
+
+
 def test_runtime_closure_ignores_synthetic_argv_interpreter_prefix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -151,6 +151,7 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     assert "-E" not in argv
     bwrap = json.loads(argv[-2])
     helper = argv[argv.index("-c") + 1]
+    compile(helper, "<privileged-helper>", "exec")
     assert "subprocess.run([mount,'--bind'" in helper
     assert "subprocess.run([umount,str(target)]" in helper
     assert "subprocess.run(argv,check=False,env=helper_env)" in helper
@@ -233,7 +234,7 @@ def test_privileged_helper_rejects_user_owned_path_shadow_tools(
         "pdd.sync_core.supervisor.released_runtime_closure_paths", lambda: ()
     )
 
-    with pytest.raises(RuntimeError, match="trusted root-owned executable"):
+    with pytest.raises(RuntimeError, match="protected executable"):
         _sandbox_command(["/bin/true"], (tmp_path,))
 
 
@@ -294,6 +295,26 @@ def test_executable_measurement_uses_descriptor_not_path_read(
     identity = supervisor._executable_identity(executable, require_root=False)
 
     assert identity.sha256
+
+
+@pytest.mark.parametrize("swap", ["rename", "symlink"])
+def test_privileged_helper_rejects_path_entry_swaps(
+    tmp_path: Path, swap: str,
+) -> None:
+    executable = tmp_path / "tool"
+    executable.write_bytes(b"trusted")
+    executable.chmod(0o755)
+    measured = supervisor._executable_identity(executable, require_root=False)
+    original = tmp_path / "original"
+    executable.rename(original)
+    if swap == "symlink":
+        executable.symlink_to(original)
+    else:
+        executable.write_bytes(b"replacement")
+        executable.chmod(0o755)
+
+    with pytest.raises(RuntimeError, match="identity changed"):
+        supervisor._revalidate_executable(measured)
 
 
 def test_linux_sandbox_maps_copied_runtime_to_manifest_destination(
@@ -381,10 +402,12 @@ def test_linux_sandbox_opens_and_unlinks_checker_fifo_before_candidate(
     assert str(channel) in bwrap
     separator = bwrap.index("--")
     candidate_argv = bwrap[separator + 1:]
-    assert str(fifo) in candidate_argv
-    wrapper = candidate_argv[candidate_argv.index("-c") + 1]
+    protected_command = json.loads(argv[argv.index("-c") + 2])
+    assert str(fifo) in protected_command
+    wrapper = protected_command[protected_command.index("-c") + 1]
     assert "os.open(path,os.O_WRONLY);os.unlink(path)" in wrapper
-    assert candidate_argv.index(str(fifo)) < candidate_argv.index("/bin/true")
+    assert protected_command.index(str(fifo)) < protected_command.index("/bin/true")
+    assert "@PDD-CANDIDATE-ENV@" in candidate_argv
 
 
 def test_sandbox_directory_bind_provides_parent_for_nested_file(

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -28,6 +28,30 @@ from pdd.sync_core.supervisor import (
 from pdd.sync_core.signer_process import run_signer
 
 
+def _mock_trusted_tools(
+    monkeypatch: pytest.MonkeyPatch, *, missing: frozenset[str] = frozenset(),
+    unsafe: dict[str, Path] | None = None,
+) -> None:
+    """Install explicit synthetic identities for command-construction tests."""
+    unsafe = unsafe or {}
+
+    def identity(name: str):
+        if name in missing:
+            raise RuntimeError(
+                "protected sandbox requires a trusted root-owned executable"
+            )
+        if name in unsafe:
+            return supervisor._executable_identity(unsafe[name])
+        path = Path(f"/usr/bin/{name}")
+        return supervisor._ExecutableIdentity(
+            path, (1, len(name), 0o755, 0, len(name), 1),
+            name.ljust(64, "0")[:64],
+        )
+
+    monkeypatch.setattr(supervisor, "_trusted_tool", identity)
+    monkeypatch.setattr(supervisor, "_trusted_helper_python", lambda: identity("python3"))
+
+
 def test_private_result_wrapper_unlinks_channel_before_candidate(
     tmp_path: Path,
 ) -> None:
@@ -107,6 +131,7 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     monkeypatch.setattr(os, "getuid", lambda: 1234)
     monkeypatch.setattr(os, "getgid", lambda: 2345)
     monkeypatch.setattr(supervisor, "_SUPERVISOR_EXECUTABLE", Path("/usr/bin/python"))
+    _mock_trusted_tools(monkeypatch)
     monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(
         "pdd.sync_core.supervisor.subprocess.run",
@@ -120,10 +145,15 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     assert argv[:3] == ["/usr/bin/sudo", "-n", "--"]
     assert argv[3:10] == [
         "/usr/bin/unshare", "--mount", "--propagation", "private",
-        "--wd", "/", "/usr/bin/python",
+        "--wd", "/", "/usr/bin/python3",
     ]
     assert argv[10:12] == ["-I", "-S"]
     assert "-E" not in argv
+    helper = argv[argv.index("-c") + 1]
+    assert "subprocess.run([mount,'--bind'" in helper
+    assert "subprocess.run([umount,str(target)]" in helper
+    assert "subprocess.run(argv,check=False,env=candidate_env)" in helper
+    assert "['mount'" not in helper and "['umount'" not in helper
     bwrap = json.loads(argv[-2])
     assert {"--unshare-pid", "--unshare-net", "--unshare-cgroup"} <= set(bwrap)
     assert "--unshare-user" not in bwrap
@@ -141,6 +171,7 @@ def test_linux_sandbox_fails_closed_without_private_mount_namespace_tool(
     """Protected staging must not fall back to the host mount namespace."""
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setattr(os, "getuid", lambda: 1234)
+    _mock_trusted_tools(monkeypatch, missing=frozenset({"unshare"}))
     monkeypatch.setattr(
         shutil, "which",
         lambda name: None if name == "unshare" else f"/usr/bin/{name}",
@@ -153,7 +184,7 @@ def test_linux_sandbox_fails_closed_without_private_mount_namespace_tool(
         "pdd.sync_core.supervisor.released_runtime_closure_paths", lambda: ()
     )
 
-    with pytest.raises(RuntimeError, match="private mount namespace"):
+    with pytest.raises(RuntimeError, match="trusted root-owned executable"):
         _sandbox_command(["/bin/true"], (tmp_path,))
 
 
@@ -185,6 +216,9 @@ def test_privileged_helper_rejects_user_owned_path_shadow_tools(
     shadow.chmod(0o755)
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setattr(os, "getuid", lambda: 1234)
+    _mock_trusted_tools(
+        monkeypatch, unsafe={"unshare": shadow, "mount": shadow}
+    )
     monkeypatch.setattr(
         shutil, "which",
         lambda name: str(shadow) if name in {"unshare", "mount"} else f"/usr/bin/{name}",
@@ -231,12 +265,24 @@ def test_privileged_helper_revalidates_bound_executable_identity(
         supervisor._revalidate_executable(measured)
 
 
+def test_privileged_helper_rejects_mode_change_before_exec(tmp_path: Path) -> None:
+    executable = tmp_path / "tool"
+    executable.write_bytes(b"trusted")
+    executable.chmod(0o755)
+    measured = supervisor._executable_identity(executable, require_root=False)
+    executable.chmod(0o777)
+
+    with pytest.raises(RuntimeError, match="identity changed"):
+        supervisor._revalidate_executable(measured)
+
+
 def test_linux_sandbox_maps_copied_runtime_to_manifest_destination(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setattr(os, "getuid", lambda: 1234)
     monkeypatch.setattr(os, "getgid", lambda: 2345)
+    _mock_trusted_tools(monkeypatch)
     monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(
         "pdd.sync_core.supervisor.subprocess.run",
@@ -269,6 +315,7 @@ def test_linux_sandbox_fails_closed_for_root_caller(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
+    _mock_trusted_tools(monkeypatch)
     monkeypatch.setattr(os, "getuid", lambda: 0)
     monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
 
@@ -286,6 +333,7 @@ def test_linux_sandbox_opens_and_unlinks_checker_fifo_before_candidate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
+    _mock_trusted_tools(monkeypatch)
     monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(
         "pdd.sync_core.supervisor.subprocess.run",
@@ -304,7 +352,8 @@ def test_linux_sandbox_opens_and_unlinks_checker_fifo_before_candidate(
     )
 
     assert profile is None
-    assert argv[:3] == ["sudo", "-n", "-E"]
+    assert argv[:3] == ["/usr/bin/sudo", "-n", "--"]
+    assert "-E" not in argv
     assert "-C" not in argv[:6]
     bwrap = json.loads(argv[-2])
     assert "--preserve-fds" not in bwrap
@@ -326,6 +375,7 @@ def test_sandbox_directory_bind_provides_parent_for_nested_file(
     interpreter = nested / "python"
     interpreter.write_text("python", encoding="utf-8")
     monkeypatch.setattr(sys, "platform", "linux")
+    _mock_trusted_tools(monkeypatch)
     monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(
         "pdd.sync_core.supervisor.subprocess.run",
@@ -367,6 +417,7 @@ def test_sandbox_binds_resolved_runtime_sources_at_original_destinations(
     workdir.mkdir()
 
     monkeypatch.setattr(sys, "platform", "linux")
+    _mock_trusted_tools(monkeypatch)
     monkeypatch.setattr(
         "pdd.sync_core.supervisor._SUPERVISOR_EXECUTABLE",
         executable_destination,
@@ -762,3 +813,39 @@ def test_parallel_staged_and_signer_bwrap_do_not_share_host_mounts(
     assert "pdd-binds-" not in Path("/proc/self/mountinfo").read_text(
         encoding="utf-8"
     )
+
+
+def test_privileged_helper_cannot_import_candidate_sitecustomize(
+    tmp_path: Path,
+) -> None:
+    """Candidate Python hooks must not execute before the sandbox uid drop."""
+    if not sys.platform.startswith("linux"):
+        pytest.skip("requires Linux privileged sandbox startup")
+    required = ("bwrap", "sudo", "unshare", "mount", "umount", "setpriv")
+    if any(shutil.which(tool) is None for tool in required):
+        pytest.skip("requires the privileged Linux sandbox toolchain")
+    if subprocess.run(
+        ["sudo", "-n", "true"], capture_output=True, check=False,
+    ).returncode != 0:
+        pytest.skip("requires passwordless sudo")
+
+    hooks = tmp_path / "hooks"
+    scratch = tmp_path / "scratch"
+    hooks.mkdir()
+    scratch.mkdir()
+    sentinel = scratch / "root-hook-ran"
+    (hooks / "sitecustomize.py").write_text(
+        "import os, pathlib\n"
+        f"if os.geteuid() == 0: pathlib.Path({str(sentinel)!r}).write_text('unsafe')\n",
+        encoding="utf-8",
+    )
+
+    result, surviving = run_supervised(
+        ["/bin/true"], cwd=scratch, timeout=10,
+        env={"PATH": os.environ.get("PATH", ""), "PYTHONPATH": str(hooks)},
+        writable_roots=(scratch,), readable_roots=(hooks,),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert surviving is False
+    assert not sentinel.exists()

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -149,12 +149,14 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     ]
     assert argv[10:12] == ["-I", "-S"]
     assert "-E" not in argv
+    bwrap = json.loads(argv[-2])
     helper = argv[argv.index("-c") + 1]
     assert "subprocess.run([mount,'--bind'" in helper
     assert "subprocess.run([umount,str(target)]" in helper
-    assert "subprocess.run(argv,check=False,env=candidate_env)" in helper
+    assert "subprocess.run(argv,check=False,env=helper_env)" in helper
+    assert "@PDD-CANDIDATE-ENV@" in bwrap
+    assert "/usr/bin/xargs" in bwrap and "/usr/bin/env" in bwrap
     assert "['mount'" not in helper and "['umount'" not in helper
-    bwrap = json.loads(argv[-2])
     assert {"--unshare-pid", "--unshare-net", "--unshare-cgroup"} <= set(bwrap)
     assert "--unshare-user" not in bwrap
     separator = bwrap.index("--")
@@ -274,6 +276,24 @@ def test_privileged_helper_rejects_mode_change_before_exec(tmp_path: Path) -> No
 
     with pytest.raises(RuntimeError, match="identity changed"):
         supervisor._revalidate_executable(measured)
+
+
+def test_executable_measurement_uses_descriptor_not_path_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    executable = tmp_path / "tool"
+    executable.write_bytes(b"trusted")
+    executable.chmod(0o755)
+    monkeypatch.setattr(
+        Path, "open",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("path read crossed identity boundary")
+        ),
+    )
+
+    identity = supervisor._executable_identity(executable, require_root=False)
+
+    assert identity.sha256
 
 
 def test_linux_sandbox_maps_copied_runtime_to_manifest_destination(
@@ -844,6 +864,49 @@ def test_privileged_helper_cannot_import_candidate_sitecustomize(
         ["/bin/true"], cwd=scratch, timeout=10,
         env={"PATH": os.environ.get("PATH", ""), "PYTHONPATH": str(hooks)},
         writable_roots=(scratch,), readable_roots=(hooks,),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert surviving is False
+    assert not sentinel.exists()
+
+
+def test_candidate_ld_preload_never_loads_in_root_setup_processes(
+    tmp_path: Path,
+) -> None:
+    """A candidate loader hook may run only after the sandbox credential drop."""
+    if not sys.platform.startswith("linux"):
+        pytest.skip("requires Linux dynamic-loader and sudo boundaries")
+    required = (
+        "bwrap", "sudo", "unshare", "mount", "umount", "setpriv", "gcc",
+    )
+    if any(shutil.which(tool) is None for tool in required):
+        pytest.skip("requires the privileged Linux sandbox toolchain and gcc")
+    if subprocess.run(
+        ["sudo", "-n", "true"], capture_output=True, check=False,
+    ).returncode != 0:
+        pytest.skip("requires passwordless sudo")
+
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    sentinel = scratch / "root-preload-ran"
+    source = tmp_path / "preload.c"
+    library = scratch / "preload.so"
+    source.write_text(
+        "#include <fcntl.h>\n#include <unistd.h>\n"
+        "__attribute__((constructor)) static void probe(void) {\n"
+        f'  if (geteuid() == 0) {{ int fd=open("{sentinel}",O_CREAT|O_WRONLY,0600); '
+        "if(fd>=0) close(fd); }\n}\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["gcc", "-shared", "-fPIC", "-o", str(library), str(source)], check=True,
+    )
+
+    result, surviving = run_supervised(
+        ["/bin/true"], cwd=scratch, timeout=10,
+        env={"PATH": os.environ.get("PATH", ""), "LD_PRELOAD": str(library)},
+        writable_roots=(scratch,),
     )
 
     assert result.returncode == 0, result.stderr

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -197,6 +197,13 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     assert "--unshare-user" not in bwrap
     separator = bwrap.index("--")
     assert bwrap.index("--bind") < separator < bwrap.index("--reuid")
+    candidate_argv = bwrap[separator + 1:]
+    assert candidate_argv[candidate_argv.index("--") + 1] == "/usr/bin/python3"
+    assert "/usr/bin/xargs" not in candidate_argv
+    assert "/usr/bin/env" not in candidate_argv
+    launcher = candidate_argv[candidate_argv.index("-c") + 1]
+    compile(launcher, "<candidate-environment-launcher>", "exec")
+    assert "os.execve(command[0],command,environment)" in launcher
     assert bwrap[bwrap.index("--reuid") + 1] == "1234"
     assert bwrap[bwrap.index("--regid") + 1] == "2345"
     assert bwrap.index("--proc") < separator

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -50,6 +50,7 @@ def _mock_trusted_tools(
 
     monkeypatch.setattr(supervisor, "_trusted_tool", identity)
     monkeypatch.setattr(supervisor, "_trusted_helper_python", lambda: identity("python3"))
+    monkeypatch.setattr(supervisor, "_trusted_helper_runtime_roots", lambda _identity: ())
 
 
 def test_private_result_wrapper_unlinks_channel_before_candidate(

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -19,6 +19,7 @@ from pdd.sync_core.supervisor import (
     _limited_command,
     _live_processes,
     _private_result_command,
+    _runtime_roots,
     _sandbox_library_path,
     _sandbox_command,
     _runtime_directories,
@@ -133,6 +134,7 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
 def test_linux_sandbox_fails_closed_without_private_mount_namespace_tool(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Protected staging must not fall back to the host mount namespace."""
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setattr(os, "getuid", lambda: 1234)
     monkeypatch.setattr(
@@ -154,6 +156,7 @@ def test_linux_sandbox_fails_closed_without_private_mount_namespace_tool(
 def test_runtime_closure_measures_unshare_and_excludes_it_from_candidate_roots(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """The namespace executable is measured but hidden from candidate roots."""
     unshare = tmp_path / "unshare"
     unshare.write_bytes(b"trusted-unshare")
     monkeypatch.setattr(
@@ -163,7 +166,7 @@ def test_runtime_closure_measures_unshare_and_excludes_it_from_candidate_roots(
     try:
         closure = dict(supervisor.released_runtime_closure_paths())
         assert closure["sandbox/unshare"] == unshare.resolve()
-        roots = supervisor._runtime_roots([sys.executable], tmp_path)
+        roots = _runtime_roots([sys.executable], tmp_path)
         assert unshare.resolve() not in roots
     finally:
         supervisor.released_runtime_closure_paths.cache_clear()
@@ -313,6 +316,7 @@ def test_sandbox_binds_resolved_runtime_sources_at_original_destinations(
         "bwrap": "/usr/bin/bwrap",
         "sudo": "/usr/bin/sudo",
         "setpriv": "/usr/bin/setpriv",
+        "unshare": "/usr/bin/unshare",
     }
     monkeypatch.setattr(
         shutil,

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -106,6 +106,7 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setattr(os, "getuid", lambda: 1234)
     monkeypatch.setattr(os, "getgid", lambda: 2345)
+    monkeypatch.setattr(supervisor, "_SUPERVISOR_EXECUTABLE", Path("/usr/bin/python"))
     monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(
         "pdd.sync_core.supervisor.subprocess.run",
@@ -116,10 +117,13 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     )
     argv, profile = _sandbox_command(["/bin/true"], (tmp_path,))
     assert profile is None
-    assert argv[:3] == ["sudo", "-n", "-E"]
-    assert argv[3:7] == [
+    assert argv[:3] == ["/usr/bin/sudo", "-n", "--"]
+    assert argv[3:10] == [
         "/usr/bin/unshare", "--mount", "--propagation", "private",
+        "--wd", "/", "/usr/bin/python",
     ]
+    assert argv[10:12] == ["-I", "-S"]
+    assert "-E" not in argv
     bwrap = json.loads(argv[-2])
     assert {"--unshare-pid", "--unshare-net", "--unshare-cgroup"} <= set(bwrap)
     assert "--unshare-user" not in bwrap
@@ -170,6 +174,61 @@ def test_runtime_closure_measures_unshare_and_excludes_it_from_candidate_roots(
         assert unshare.resolve() not in roots
     finally:
         supervisor.released_runtime_closure_paths.cache_clear()
+
+
+def test_privileged_helper_rejects_user_owned_path_shadow_tools(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Caller-owned executables must never cross the sudo boundary."""
+    shadow = tmp_path / "unshare"
+    shadow.write_text("malicious", encoding="utf-8")
+    shadow.chmod(0o755)
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(os, "getuid", lambda: 1234)
+    monkeypatch.setattr(
+        shutil, "which",
+        lambda name: str(shadow) if name in {"unshare", "mount"} else f"/usr/bin/{name}",
+    )
+    monkeypatch.setattr(
+        "pdd.sync_core.supervisor.subprocess.run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "", ""),
+    )
+    monkeypatch.setattr(
+        "pdd.sync_core.supervisor.released_runtime_closure_paths", lambda: ()
+    )
+
+    with pytest.raises(RuntimeError, match="trusted root-owned executable"):
+        _sandbox_command(["/bin/true"], (tmp_path,))
+
+
+def test_privileged_helper_environment_is_fixed_and_candidate_independent() -> None:
+    candidate = {
+        "PATH": "/candidate/bin",
+        "PYTHONPATH": "/candidate/hooks",
+        "PYTHONHOME": "/candidate/python",
+    }
+
+    helper_environment = supervisor._privileged_helper_environment(candidate)
+
+    assert helper_environment == {
+        "HOME": "/root",
+        "LANG": "C",
+        "LC_ALL": "C",
+        "PATH": "/usr/sbin:/usr/bin:/sbin:/bin",
+    }
+
+
+def test_privileged_helper_revalidates_bound_executable_identity(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "tool"
+    executable.write_bytes(b"first")
+    executable.chmod(0o755)
+    measured = supervisor._executable_identity(executable, require_root=False)
+    executable.write_bytes(b"second")
+
+    with pytest.raises(RuntimeError, match="identity changed"):
+        supervisor._revalidate_executable(measured)
 
 
 def test_linux_sandbox_maps_copied_runtime_to_manifest_destination(

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -162,11 +162,19 @@ def test_runtime_directories_collapse_nested_but_keep_disjoint_roots(
 def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    helper_encodings = tmp_path / "system-python" / "encodings"
+    helper_encodings.mkdir(parents=True)
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setattr(os, "getuid", lambda: 1234)
     monkeypatch.setattr(os, "getgid", lambda: 2345)
     monkeypatch.setattr(supervisor, "_SUPERVISOR_EXECUTABLE", Path("/usr/bin/python"))
     _mock_trusted_tools(monkeypatch)
+    monkeypatch.setattr(
+        supervisor,
+        "_trusted_helper_runtime_roots",
+        lambda _identity: (helper_encodings,),
+        raising=False,
+    )
     monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(
         "pdd.sync_core.supervisor.subprocess.run",
@@ -191,6 +199,8 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     assert "subprocess.run([umount,str(target)]" in helper
     assert "subprocess.run(argv,check=False,env=helper_env)" in helper
     assert "@PDD-CANDIDATE-ENV@" in bwrap
+    helper_index = bwrap.index(str(helper_encodings))
+    assert bwrap[helper_index - 2] == "--ro-bind"
     assert "/usr/bin/xargs" in bwrap and "/usr/bin/env" in bwrap
     assert "['mount'" not in helper and "['umount'" not in helper
     assert {"--unshare-pid", "--unshare-net", "--unshare-cgroup"} <= set(bwrap)
@@ -567,6 +577,30 @@ def test_sandboxed_python_minimal_smoke(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
+    assert surviving is False
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or not shutil.which("bwrap"),
+    reason="requires Linux kernel namespace containment",
+)
+def test_sandboxed_launcher_preserves_exit_five_and_clears_inherited_env(
+    tmp_path: Path,
+) -> None:
+    """Exercise the exact post-drop handoff inside the empty Linux root."""
+    candidate = (
+        "import os;raise SystemExit(5 if os.environ.get('ONLY') == 'value' "
+        "and 'HOSTILE' not in os.environ else 6)"
+    )
+    result, surviving = run_supervised(
+        [sys.executable, "-c", candidate],
+        cwd=tmp_path,
+        timeout=10,
+        env={"ONLY": "value"},
+        writable_roots=(tmp_path,),
+    )
+
+    assert result.returncode == 5, result.stderr
     assert surviving is False
 
 

--- a/tests/test_sync_core_trust.py
+++ b/tests/test_sync_core_trust.py
@@ -141,6 +141,23 @@ def test_signer_timeout_is_bounded_with_detached_pipe_holder() -> None:
     assert time.monotonic() - started < 1.5
 
 
+def test_linux_signer_pre_readiness_exit_is_not_reported_as_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        signer_process_module,
+        "_linux_contained_command",
+        lambda command, _writable_root: command,
+    )
+
+    result = run_signer(
+        (sys.executable, "-c", "raise SystemExit(23)"), b"", timeout=1,
+    )
+
+    assert result.returncode == 23
+
+
 def test_linux_signer_containment_binds_only_ready_root_writable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_sync_core_trust.py
+++ b/tests/test_sync_core_trust.py
@@ -144,6 +144,7 @@ def test_signer_timeout_is_bounded_with_detached_pipe_holder() -> None:
 def test_linux_signer_pre_readiness_exit_is_not_reported_as_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A setup exit retains its status instead of becoming a fake timeout."""
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setattr(
         signer_process_module,


### PR DESCRIPTION
## Summary

- run the complete privileged bind-staging helper under a private mount namespace created by the exact resolved `unshare` executable
- measure `unshare` in the released sandbox runtime closure while keeping it out of candidate-readable roots
- fail closed when private mount namespace support is absent
- preserve a pre-readiness Bubblewrap/setup exit as a terminal signer rejection instead of misreporting it as an elapsed signer timeout

## Root cause and prior history

PR #1985 introduced privileged source staging in `6f7e70af2` and destination ancestry in `6d9f1aad6`. Each invocation used a unique `/run/pdd-binds-*` directory, but the helper performed those mounts in the hosted runner's parent mount namespace before Bubblewrap began. Parallel xdist processes could therefore observe and interfere with another staging lifecycle, matching the intermittent `Invalid argument` remount failures from runs 29352802773 and 29369277717.

Commit `a2424de3f` correctly retained Bubblewrap's startup diagnostics, but represented every pre-readiness exit as `TimeoutExpired`. This PR keeps those diagnostics on the normal nonzero `CompletedProcess` path; actual elapsed deadlines still use `TimeoutExpired` and retain all existing descendant reaping.

Repository search found one privileged staged-mount implementation, `_staged_bwrap`. The signer has a separate direct Bubblewrap PID-containment path and does not stage host mounts, so no sibling mount helper needs the namespace change.

## TDD evidence

At `11aa9c7e5`, all three new command/trust-boundary checks failed against the old implementation:

- no private `unshare --mount --propagation private` command prefix
- missing `unshare` did not fail closed
- `unshare` was absent from the measured closure

At `8abaa8382`, the pre-readiness signer test failed because an immediate exit status 23 was converted to `TimeoutExpired`.

## Validation

- `17 passed, 14 skipped` — `tests/test_sync_core_supervisor.py` on macOS; Linux-only cases skipped
- `26 passed, 8 skipped` — `tests/test_sync_core_trust.py` on macOS; Linux-only cases skipped
- `37 passed, 46 skipped` — `tests/test_sync_core_runner.py` on macOS; protected Linux cases skipped
- `4 passed` — focused new command, closure, fail-closed, and signer-status contracts
- Pylint 10.00/10 for `supervisor.py` and `signer_process.py`
- compileall and `git diff --check`

The hosted Linux unit lane is required evidence for the deterministic sudo integration test. It keeps one staged candidate Bubblewrap alive while starting/reaping a signer Bubblewrap and continuously proves the parent `/proc/self/mountinfo` never contains an active `pdd-binds-*` mount.

Closes #2047
