### PR TITLE
fix(cloud-test): reuse one JWT across serial regression cases

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -561,6 +561,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "ci/cloud-batch/cloud-regression-runner.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "ci/cloud-batch/cloudbuild.yaml",
       "role": "human-maintained"
     },
@@ -11225,6 +11231,12 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_cli_theme.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_cloud_batch_cloud_regression_runner.py",
       "role": "human-maintained"
     },
     {

--- a/Makefile
+++ b/Makefile
@@ -607,7 +607,7 @@ GCS_BUCKET ?= pdd-stg-ci-results
 AR_IMAGE := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/pdd-ci/pdd-test
 
 # Files baked into the Docker image — changes to these require a rebuild
-CLOUD_IMAGE_DEPS := requirements.txt pyproject.toml $(CLOUD_BATCH_DIR)/entrypoint.sh $(CLOUD_BATCH_DIR)/runtime-secrets.py $(CLOUD_BATCH_DIR)/firebase-token-exchange.py $(CLOUD_BATCH_DIR)/source-identity.py $(CLOUD_BATCH_DIR)/Dockerfile
+CLOUD_IMAGE_DEPS := requirements.txt pyproject.toml $(CLOUD_BATCH_DIR)/entrypoint.sh $(CLOUD_BATCH_DIR)/runtime-secrets.py $(CLOUD_BATCH_DIR)/firebase-token-exchange.py $(CLOUD_BATCH_DIR)/cloud-regression-runner.py $(CLOUD_BATCH_DIR)/source-identity.py $(CLOUD_BATCH_DIR)/Dockerfile
 CLOUD_IMAGE_HASH_FILE := .cloud-image-hash
 CLOUD_IMAGE_HASH ?= $(shell cat $(CLOUD_IMAGE_DEPS) | shasum -a 256 | cut -d' ' -f1)
 

--- a/ci/cloud-batch/Dockerfile
+++ b/ci/cloud-batch/Dockerfile
@@ -47,7 +47,8 @@ RUN pip install --no-cache-dir -r requirements.txt && \
 COPY ci/cloud-batch/entrypoint.sh /entrypoint.sh
 COPY ci/cloud-batch/runtime-secrets.py /runtime-secrets.py
 COPY ci/cloud-batch/firebase-token-exchange.py /firebase-token-exchange.py
+COPY ci/cloud-batch/cloud-regression-runner.py /cloud-regression-runner.py
 COPY ci/cloud-batch/source-identity.py /source-identity.py
-RUN chmod +x /entrypoint.sh /runtime-secrets.py /firebase-token-exchange.py /source-identity.py
+RUN chmod +x /entrypoint.sh /runtime-secrets.py /firebase-token-exchange.py /cloud-regression-runner.py /source-identity.py
 
 ENTRYPOINT ["/runtime-secrets.py"]

--- a/ci/cloud-batch/cloud-regression-runner.py
+++ b/ci/cloud-batch/cloud-regression-runner.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import importlib.util
 import json
 import os
@@ -14,6 +15,7 @@ import subprocess
 import sys
 import time
 import uuid
+import urllib.parse
 from collections.abc import Callable, Mapping, MutableMapping
 from datetime import datetime, timezone
 from pathlib import Path
@@ -130,6 +132,30 @@ def _write_json(path: Path, document: object) -> None:
     os.replace(temporary, path)
 
 
+def _jwt_fingerprint(token: str) -> str:
+    return "sha256:" + hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _sanitize_jwt_log(path: Path, token: str) -> bool:
+    """Remove every common token rendering and report whether one was present."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    representations = {
+        token,
+        json.dumps(token)[1:-1],
+        urllib.parse.quote(token, safe=""),
+        urllib.parse.quote_plus(token, safe=""),
+    }
+    leaked = any(value and value in text for value in representations)
+    if leaked:
+        for value in sorted(representations, key=len, reverse=True):
+            if value:
+                text = text.replace(value, "[REDACTED JWT]")
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.redacted")
+        temporary.write_text(text, encoding="utf-8")
+        os.replace(temporary, path)
+    return leaked
+
+
 def run_cloud_regression(
     environment: Mapping[str, str],
     results_dir: Path,
@@ -197,11 +223,13 @@ def run_cloud_regression(
                 token, token_expiry = candidate, candidate_expiry
                 auth_elapsed += monotonic() - started
                 child_environment["PDD_JWT_TOKEN"] = token
+                token_fingerprint = _jwt_fingerprint(token)
                 auth_exhausted = False
                 event(
                     "auth_succeeded",
                     auth_attempt_count=auth_attempt_count,
                     auth_elapsed_seconds=round(auth_elapsed, 3),
+                    jwt_fingerprint=token_fingerprint,
                 )
                 return
             except CloudRegressionError as error:
@@ -246,11 +274,13 @@ def run_cloud_regression(
             )
         else:
             return_code = invoke_case(case, log_path, dict(child_environment))
-            status = "passed" if return_code == 0 else "failed"
-            detail = f"case_{case}"
-            overall_failed = overall_failed or return_code != 0
+            leaked = _sanitize_jwt_log(log_path, token)
+            status = "error" if leaked else ("passed" if return_code == 0 else "failed")
+            detail = f"jwt_log_boundary_failed_case_{case}" if leaked else f"case_{case}"
+            overall_failed = overall_failed or return_code != 0 or leaked
         duration = auth_elapsed if not token else max(0.0, monotonic() - started)
         result = {
+            "attempt_id": nonce,
             "task_index": logical_index,
             "suite": "cloud_regression",
             "detail": detail,
@@ -263,12 +293,22 @@ def run_cloud_regression(
                 "auth_attempt_count": auth_attempt_count,
                 "batch_task_retry_attempt": retry_attempt,
                 "logical_case": case,
+                "jwt_fingerprint": _jwt_fingerprint(token) if token else None,
             },
             "timestamp": _timestamp(wall_time),
         }
         _write_json(results_dir / f"task_{logical_index}.json", result)
-        event("case_finished", logical_case=case, status=status)
-    event("attempt_finished", status="failed" if overall_failed else "passed")
+        event(
+            "case_finished", logical_case=case, status=status,
+            auth_attempt_count=auth_attempt_count,
+            auth_elapsed_seconds=round(auth_elapsed, 3),
+            jwt_fingerprint=_jwt_fingerprint(token) if token else None,
+        )
+    event(
+        "attempt_finished", status="failed" if overall_failed else "passed",
+        cases_completed=len(LOGICAL_CASES), auth_attempt_count=auth_attempt_count,
+        auth_elapsed_seconds=round(auth_elapsed, 3),
+    )
     attempt_log.close()
     return 1 if overall_failed else 0
 

--- a/ci/cloud-batch/cloud-regression-runner.py
+++ b/ci/cloud-batch/cloud-regression-runner.py
@@ -138,12 +138,19 @@ def _jwt_fingerprint(token: str) -> str:
 
 def _sanitize_jwt_log(path: Path, token: str) -> bool:
     """Remove every common token rendering and report whether one was present."""
+    token_bytes = token.encode("utf-8")
+    standard_base64 = base64.b64encode(token_bytes).decode("ascii")
+    urlsafe_base64 = base64.urlsafe_b64encode(token_bytes).decode("ascii")
     text = path.read_text(encoding="utf-8", errors="replace")
     representations = {
         token,
         json.dumps(token)[1:-1],
         urllib.parse.quote(token, safe=""),
         urllib.parse.quote_plus(token, safe=""),
+        standard_base64,
+        standard_base64.rstrip("="),
+        urlsafe_base64,
+        urlsafe_base64.rstrip("="),
     }
     leaked = any(value and value in text for value in representations)
     if leaked:

--- a/ci/cloud-batch/cloud-regression-runner.py
+++ b/ci/cloud-batch/cloud-regression-runner.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Run all cloud-regression cases in one identity-bound Batch task."""
+# pylint: disable=invalid-name,too-many-arguments,too-many-locals,too-many-statements
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import os
+import random
+import re
+import subprocess
+import sys
+import time
+import uuid
+from collections.abc import Callable, Mapping, MutableMapping
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+LOGICAL_CASES = tuple(range(1, 9))
+LOGICAL_START = 68
+JWT_MAX_ATTEMPTS = 6
+JWT_QUOTA_BACKOFF_SECONDS = 30
+JWT_REFRESH_MARGIN_SECONDS = 30
+
+
+class CloudRegressionError(RuntimeError):
+    """A sanitized, fail-closed cloud-regression runner error."""
+
+    def __init__(self, category: str, *, quota: bool = False) -> None:
+        super().__init__(category)
+        self.category = category
+        self.quota = quota
+
+
+def _firebase_exchange(api_key: str, refresh_token: str) -> bytes:
+    """Call the no-redirect exchange helper without exposing credentials in argv."""
+    helper = Path(__file__).with_name("firebase-token-exchange.py")
+    spec = importlib.util.spec_from_file_location("firebase_token_exchange", helper)
+    if not spec or not spec.loader:
+        raise CloudRegressionError("transport_failed")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    try:
+        return module.exchange_token(api_key, refresh_token)
+    except RuntimeError as error:
+        raise CloudRegressionError("transport_failed") from error
+
+
+def _parse_token(response: bytes) -> tuple[str, int]:
+    """Return an ID token and expiry while never rendering the provider body."""
+    try:
+        document = json.loads(response)
+    except (TypeError, ValueError) as error:
+        raise CloudRegressionError("parse_failed") from error
+    if not isinstance(document, dict):
+        raise CloudRegressionError("invalid_response")
+    provider_error = document.get("error")
+    if provider_error:
+        message = provider_error.get("message", "") if isinstance(provider_error, dict) else ""
+        quota = "QUOTA_EXCEEDED" in str(message)
+        raise CloudRegressionError("quota_exceeded" if quota else "provider_rejected", quota=quota)
+    token = document.get("id_token")
+    if not isinstance(token, str) or token.count(".") != 2 or any(char.isspace() for char in token):
+        raise CloudRegressionError("invalid_token")
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+        expiry = claims.get("exp") if isinstance(claims, dict) else None
+    except (UnicodeError, ValueError) as error:
+        raise CloudRegressionError("invalid_token") from error
+    if not isinstance(expiry, int) or isinstance(expiry, bool) or expiry <= 0:
+        raise CloudRegressionError("invalid_token")
+    return token, expiry
+
+
+def _default_invoke(case: int, log_path: Path, environment: dict[str, str]) -> int:
+    """Invoke one real logical case, writing its dedicated sanitized artifact log."""
+    with log_path.open("wb") as output:
+        result = subprocess.run(
+            ["bash", "tests/cloud_regression.sh", str(case)],
+            check=False,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            env=environment,
+        )
+    return result.returncode
+
+
+def _required(environment: Mapping[str, str], name: str, pattern: str) -> str:
+    value = environment.get(name, "")
+    if not re.fullmatch(pattern, value):
+        raise CloudRegressionError("configuration_invalid")
+    return value
+
+
+def _identity(environment: Mapping[str, str]) -> dict[str, object]:
+    project = _required(environment, "PDD_BATCH_PROJECT", r"[a-z][a-z0-9-]{4,28}[a-z0-9]")
+    location = _required(environment, "PDD_BATCH_LOCATION", r"[a-z0-9-]+")
+    job_name = _required(environment, "PDD_BATCH_JOB_NAME", r"[a-z][a-z0-9-]{0,62}")
+    raw_index = int(_required(environment, "BATCH_TASK_INDEX", r"0|[1-9][0-9]*"))
+    return {
+        "candidate_sha": _required(environment, "PDD_CANDIDATE_SHA", r"[0-9a-f]{40}"),
+        "candidate_tree": _required(environment, "PDD_CANDIDATE_TREE", r"[0-9a-f]{40}"),
+        "source_sha256": _required(environment, "PDD_SOURCE_SHA256", r"[0-9a-f]{64}"),
+        "source_generation": _required(environment, "PDD_SOURCE_GCS_GENERATION", r"[1-9][0-9]*"),
+        "image_digest": _required(environment, "PDD_IMAGE_DIGEST", r"sha256:[0-9a-f]{64}"),
+        "job_name": job_name,
+        "task_group": "group0",
+        "raw_task_index": raw_index,
+        "task_resource": (
+            f"projects/{project}/locations/{location}/jobs/{job_name}/"
+            f"taskGroups/group0/tasks/{raw_index}"
+        ),
+    }
+
+
+def _timestamp(wall_time: Callable[[], float]) -> str:
+    return datetime.fromtimestamp(wall_time(), timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _write_json(path: Path, document: object) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    with temporary.open("x", encoding="utf-8") as handle:
+        json.dump(document, handle, sort_keys=True, indent=2)
+        handle.write("\n")
+    os.replace(temporary, path)
+
+
+def run_cloud_regression(
+    environment: Mapping[str, str],
+    results_dir: Path,
+    *,
+    exchange: Callable[[str, str], bytes] = _firebase_exchange,
+    invoke_case: Callable[[int, Path, dict[str, str]], int] = _default_invoke,
+    monotonic: Callable[[], float] = time.monotonic,
+    wall_time: Callable[[], float] = time.time,
+    sleep: Callable[[float], None] = time.sleep,
+    jitter: Callable[[int], int] = random.randrange,
+) -> int:
+    """Run eight logical cases sequentially with the smallest required auth load."""
+    identity = _identity(environment)
+    retry_attempt = int(environment.get("BATCH_TASK_RETRY_ATTEMPT", "0"))
+    if retry_attempt < 0:
+        raise CloudRegressionError("configuration_invalid")
+    api_key = environment.get("FIREBASE_API_KEY", "")
+    refresh_token = environment.get("PDD_REFRESH_TOKEN", "")
+    if not api_key or not refresh_token:
+        raise CloudRegressionError("configuration_invalid")
+    results_dir.mkdir(parents=True, exist_ok=True)
+    nonce = uuid.uuid4().hex
+    attempt_path = results_dir / f"cloud_regression_attempt_{retry_attempt}_{nonce}.jsonl"
+    attempt_log = attempt_path.open("x", encoding="utf-8", buffering=1)
+
+    def event(name: str, **fields: object) -> None:
+        json.dump(
+            {
+                "event": name,
+                "attempt_id": nonce,
+                "batch_task_retry_attempt": retry_attempt,
+                "candidate_sha": identity["candidate_sha"],
+                "task_resource": identity["task_resource"],
+                **fields,
+            },
+            attempt_log,
+            sort_keys=True,
+        )
+        attempt_log.write("\n")
+        attempt_log.flush()
+
+    event("attempt_started")
+    child_environment: MutableMapping[str, str] = dict(environment)
+    child_environment.pop("FIREBASE_API_KEY", None)
+    child_environment.pop("PDD_REFRESH_TOKEN", None)
+    token = ""
+    token_expiry = 0
+    auth_attempt_count = 0
+    auth_elapsed = 0.0
+    auth_failure: CloudRegressionError | None = None
+    auth_exhausted = False
+
+    def authenticate() -> None:
+        nonlocal token, token_expiry, auth_attempt_count, auth_elapsed, auth_failure, auth_exhausted
+        auth_failure = None
+        for local_attempt in range(1, JWT_MAX_ATTEMPTS + 1):
+            started = monotonic()
+            auth_attempt_count += 1
+            try:
+                candidate, candidate_expiry = _parse_token(
+                    exchange(api_key, refresh_token)
+                )
+                if candidate_expiry <= int(wall_time()) + JWT_REFRESH_MARGIN_SECONDS:
+                    raise CloudRegressionError("expired_token")
+                token, token_expiry = candidate, candidate_expiry
+                auth_elapsed += monotonic() - started
+                child_environment["PDD_JWT_TOKEN"] = token
+                auth_exhausted = False
+                event(
+                    "auth_succeeded",
+                    auth_attempt_count=auth_attempt_count,
+                    auth_elapsed_seconds=round(auth_elapsed, 3),
+                )
+                return
+            except CloudRegressionError as error:
+                auth_elapsed += monotonic() - started
+                auth_failure = error
+                event(
+                    "auth_failed",
+                    auth_attempt_count=auth_attempt_count,
+                    auth_elapsed_seconds=round(auth_elapsed, 3),
+                    category=error.category,
+                )
+                if local_attempt < JWT_MAX_ATTEMPTS:
+                    delay = (
+                        JWT_QUOTA_BACKOFF_SECONDS + jitter(6)
+                        if error.quota
+                        else 2**local_attempt + jitter(3)
+                    )
+                    sleep_started = monotonic()
+                    sleep(delay)
+                    auth_elapsed += monotonic() - sleep_started
+        token = ""
+        token_expiry = 0
+        auth_exhausted = True
+
+    overall_failed = False
+    for case in LOGICAL_CASES:
+        if not auth_exhausted and (
+            not token or token_expiry <= int(wall_time()) + JWT_REFRESH_MARGIN_SECONDS
+        ):
+            authenticate()
+        logical_index = LOGICAL_START + case - 1
+        log_path = results_dir / f"task_{logical_index}.log"
+        started = monotonic()
+        if not token:
+            overall_failed = True
+            category = auth_failure.category if auth_failure else "unavailable"
+            status = "error"
+            detail = f"jwt_exchange_failed_case_{case}: {category}"
+            log_path.write_text(
+                "Cloud authentication unavailable; case not invoked.\n",
+                encoding="utf-8",
+            )
+        else:
+            return_code = invoke_case(case, log_path, dict(child_environment))
+            status = "passed" if return_code == 0 else "failed"
+            detail = f"case_{case}"
+            overall_failed = overall_failed or return_code != 0
+        duration = auth_elapsed if not token else max(0.0, monotonic() - started)
+        result = {
+            "task_index": logical_index,
+            "suite": "cloud_regression",
+            "detail": detail,
+            "status": status,
+            "duration_seconds": round(duration, 3),
+            "setup_seconds": int(environment.get("PDD_SETUP_SECONDS", "0")),
+            "identity": identity,
+            "execution": {
+                "auth_elapsed_seconds": round(auth_elapsed, 3),
+                "auth_attempt_count": auth_attempt_count,
+                "batch_task_retry_attempt": retry_attempt,
+                "logical_case": case,
+            },
+            "timestamp": _timestamp(wall_time),
+        }
+        _write_json(results_dir / f"task_{logical_index}.json", result)
+        event("case_finished", logical_case=case, status=status)
+    event("attempt_finished", status="failed" if overall_failed else "passed")
+    attempt_log.close()
+    return 1 if overall_failed else 0
+
+
+def main() -> int:
+    """Execute from the Batch entrypoint with sanitized terminal output."""
+    try:
+        return run_cloud_regression(os.environ, Path("/mnt/disks/results"))
+    except (CloudRegressionError, OSError, ValueError):
+        print("FATAL: cloud-regression runner failed closed", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/cloud-batch/collect-results.sh
+++ b/ci/cloud-batch/collect-results.sh
@@ -21,6 +21,7 @@ echo "=== Copying verified result artifacts ==="
 mkdir -p "${RESULTS_LOCAL}"
 cp "${VERIFIED_RESULTS_DIR}"/task_*.json "${RESULTS_LOCAL}/"
 cp "${VERIFIED_RESULTS_DIR}"/task_*.log "${RESULTS_LOCAL}/"
+cp "${VERIFIED_RESULTS_DIR}"/cloud_regression_attempt_*.jsonl "${RESULTS_LOCAL}/"
 
 python3 "${SCRIPT_DIR}/verify-result-identities.py" \
     --evidence "${EVIDENCE_FILE}" \
@@ -45,23 +46,37 @@ PASSED=0
 FAILED=0
 ERRORS=0
 
-# Derive task count from Cloud Batch job(s) (sum across primary + extras)
+# Record physical Batch task count separately from the logical result contract.
 _job_task_count() {
     gcloud batch jobs describe "$1" \
         --project="${PROJECT_ID}" \
         --location="${GCP_REGION:-us-central1}" \
         --format="value(taskGroups[0].taskCount)" 2>/dev/null || echo "0"
 }
-TOTAL_SPOT=$(_job_task_count "${JOB_NAME}")
-TOTAL_SPOT=${TOTAL_SPOT:-0}
-TOTAL_EXTRA=0
+PHYSICAL_TOTAL=$(_job_task_count "${JOB_NAME}")
+PHYSICAL_TOTAL=${PHYSICAL_TOTAL:-0}
 for _job_name in "${EXTRA_JOB_NAMES[@]}"; do
     _job_count=$(_job_task_count "${_job_name}")
     _job_count=${_job_count:-0}
-    TOTAL_EXTRA=$((TOTAL_EXTRA + _job_count))
+    PHYSICAL_TOTAL=$((PHYSICAL_TOTAL + _job_count))
 done
-TOTAL=$((TOTAL_SPOT + TOTAL_EXTRA))
-[ "${TOTAL}" -eq 0 ] && TOTAL=77
+LOGICAL_TOTAL=$(python3 - "${EVIDENCE_FILE}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    evidence = json.load(handle)
+indexes = sorted(
+    index
+    for job in evidence["job_uids"].values()
+    for index in job["task_indexes"]
+)
+if indexes != list(range(77)):
+    raise SystemExit("logical result identity set invalid")
+print(len(indexes))
+PY
+)
+TOTAL="${LOGICAL_TOTAL}"
 
 # Parse all JSON results
 TABLE_ROWS=()
@@ -120,6 +135,7 @@ done
     echo "- **Job**: ${JOB_LABEL}"
     echo "- **Commit**: ${COMMIT_SHA}"
     echo "- **Timestamp**: ${TIMESTAMP}"
+    echo "- **Execution**: ${PHYSICAL_TOTAL} physical Batch tasks, ${LOGICAL_TOTAL} logical results"
     echo ""
 
     if [ "${FAILED}" -eq 0 ] && [ "${ERRORS}" -eq 0 ]; then
@@ -296,6 +312,7 @@ if [ "${KEEP_RAW:-0}" = "1" ]; then
     mkdir -p "${RAW_RESULTS_DIR}"
     cp "${RESULTS_LOCAL}"/task_*.json "${RAW_RESULTS_DIR}/" 2>/dev/null || true
     cp "${RESULTS_LOCAL}"/task_*_junit.xml "${RAW_RESULTS_DIR}/" 2>/dev/null || true
+    cp "${RESULTS_LOCAL}"/cloud_regression_attempt_*.jsonl "${RAW_RESULTS_DIR}/" 2>/dev/null || true
 else
     rm -rf "${REPO_ROOT}/test-results/cloud-batch-raw"
     echo "(Raw JSON/XML not saved. Set KEEP_RAW=1 to preserve.)"

--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -306,9 +306,7 @@ export PDD_EXTRACTS_STRENGTH="${PDD_EXTRACTS_STRENGTH:-0.5}"
 # bad-shape tokens are each distinguishable in the WARNING/ERROR output and
 # in the final RESULT_JSON written for cloud_regression tasks.
 NEEDS_PDD_JWT=0
-if [ "${TASK_INDEX}" -ge "${CLOUD_REGRESSION_START}" ] && [ "${TASK_INDEX}" -le "${CLOUD_REGRESSION_END}" ]; then
-    NEEDS_PDD_JWT=1
-elif [ "${TASK_INDEX}" -ge "${PYTEST_START}" ] && [ "${TASK_INDEX}" -le "${PYTEST_END}" ] && [ "${PDD_BATCH_ENABLE_PYTEST_CLOUD_E2E:-}" = "1" ]; then
+if [ "${TASK_INDEX}" -ge "${PYTEST_START}" ] && [ "${TASK_INDEX}" -le "${PYTEST_END}" ] && [ "${PDD_BATCH_ENABLE_PYTEST_CLOUD_E2E:-}" = "1" ]; then
     NEEDS_PDD_JWT=1
 fi
 
@@ -433,10 +431,6 @@ else:
     fi
 elif [ "${NEEDS_PDD_JWT}" = "0" ]; then
     echo "Skipping PDD JWT exchange for task ${TASK_INDEX}; this shard does not require PDD Cloud auth."
-elif [ "${TASK_INDEX}" -ge "${CLOUD_REGRESSION_START}" ] && [ "${TASK_INDEX}" -le "${CLOUD_REGRESSION_END}" ]; then
-    JWT_FAIL_CASE_NUM=$((TASK_INDEX - CLOUD_REGRESSION_START + 1))
-    write_result "error" "${SETUP_SECONDS:-0}" "cloud_regression" "jwt_exchange_unavailable_case_${JWT_FAIL_CASE_NUM}"
-    exit 1
 fi
 
 # ── Claude Code OAuth ──────────────────────────────────────────────────
@@ -580,10 +574,17 @@ elif [ "${TASK_INDEX}" -ge "${SYNC_REGRESSION_START}" ] && [ "${TASK_INDEX}" -le
         bash tests/sync_regression.sh "${CASE_NUM}"
 
 elif [ "${TASK_INDEX}" -ge "${CLOUD_REGRESSION_START}" ] && [ "${TASK_INDEX}" -le "${CLOUD_REGRESSION_END}" ]; then
-    # ── Cloud regression test ─────────────────────────────────────────
-    CASE_NUM=$((TASK_INDEX - CLOUD_REGRESSION_START + 1))
-    run_test "cloud_regression" "case_${CASE_NUM}" \
-        bash tests/cloud_regression.sh "${CASE_NUM}"
+    # ── Cloud regression tests ────────────────────────────────────────
+    # One physical STANDARD task emits eight logical result/log pairs.
+    [ "${CLOUD_REGRESSION_CASES:-}" = "1,2,3,4,5,6,7,8" ] || {
+        echo "FATAL: cloud-regression logical case configuration invalid"
+        exit 78
+    }
+    export PDD_SETUP_SECONDS="${SETUP_SECONDS:-0}"
+    CLOUD_RUNNER_RC=0
+    python3 /cloud-regression-runner.py || CLOUD_RUNNER_RC=$?
+    WROTE_FINAL_RESULT=1
+    exit "${CLOUD_RUNNER_RC}"
 
 elif [ "${TASK_INDEX}" -ge "${VITEST_START}" ] && [ "${TASK_INDEX}" -le "${VITEST_END}" ]; then
     # ── Frontend Vitest tests ─────────────────────────────────────────

--- a/ci/cloud-batch/job-template-cloud-regression.json
+++ b/ci/cloud-batch/job-template-cloud-regression.json
@@ -14,6 +14,7 @@
                                 "PDD_TEST_HEADLESS": "1",
                                 "GCS_BUCKET_NAME": "litellm_cache",
                                 "TASK_INDEX_OFFSET": "68",
+                                "CLOUD_REGRESSION_CASES": "1,2,3,4,5,6,7,8",
                                 "PDD_CLOUD_URL": "https://{{REGION}}-{{PROJECT_ID}}.cloudfunctions.net",
                                 "PDD_ENV": "staging",
                                 "PDD_CLOUD_TIMEOUT": "1200",
@@ -67,7 +68,7 @@
                     }
                 ]
             },
-            "taskCount": "8",
+            "taskCount": "1",
             "parallelism": "1"
         }
     ],

--- a/ci/cloud-batch/job-template-cloud-regression.json
+++ b/ci/cloud-batch/job-template-cloud-regression.json
@@ -58,7 +58,7 @@
                     }
                 ],
                 "maxRetryCount": 2,
-                "maxRunDuration": "5400s",
+                "maxRunDuration": "11400s",
                 "lifecyclePolicies": [
                     {
                         "action": "RETRY_TASK",

--- a/ci/cloud-batch/submit.sh
+++ b/ci/cloud-batch/submit.sh
@@ -10,7 +10,7 @@ JOB_NAME="pdd-test-${JOB_RUN_ID}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 POLL_INTERVAL="${POLL_INTERVAL:-5}"
-POLL_TIMEOUT="${POLL_TIMEOUT:-12600}"  # Serial cloud cases: 8x1200s + bounded margins.
+POLL_TIMEOUT="${POLL_TIMEOUT:-35400}"  # Three 11400s attempts + 1200s control-plane margin.
 SPOT_PROVISIONING_MODEL="${PDD_CLOUD_BATCH_SPOT_PROVISIONING_MODEL:-SPOT}"
 AR_IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/pdd-ci/pdd-test"
 

--- a/ci/cloud-batch/submit.sh
+++ b/ci/cloud-batch/submit.sh
@@ -10,7 +10,7 @@ JOB_NAME="pdd-test-${JOB_RUN_ID}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 POLL_INTERVAL="${POLL_INTERVAL:-5}"
-POLL_TIMEOUT="${POLL_TIMEOUT:-7200}"  # Real LLM shards can exceed 30 minutes.
+POLL_TIMEOUT="${POLL_TIMEOUT:-12600}"  # Serial cloud cases: 8x1200s + bounded margins.
 SPOT_PROVISIONING_MODEL="${PDD_CLOUD_BATCH_SPOT_PROVISIONING_MODEL:-SPOT}"
 AR_IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/pdd-ci/pdd-test"
 

--- a/ci/cloud-batch/submit.sh
+++ b/ci/cloud-batch/submit.sh
@@ -256,7 +256,7 @@ PY
 _validate_rendered_template /tmp/pdd-batch-job-pytest.json 32 "${JOB_NAME_PYTEST}"
 _validate_rendered_template /tmp/pdd-batch-job-main.json 36 "${JOB_NAME_MAIN}"
 _validate_rendered_template /tmp/pdd-batch-job-std.json 1 "${JOB_NAME_STD}"
-_validate_rendered_template /tmp/pdd-batch-job-cloud.json 8 "${JOB_NAME_CLOUD}"
+_validate_rendered_template /tmp/pdd-batch-job-cloud.json 1 "${JOB_NAME_CLOUD}"
 
 # ── Submit jobs ───────────────────────────────────────────────────────────
 # Only pytest shards need privileged containers for the protected Linux
@@ -282,9 +282,9 @@ gcloud batch jobs submit "${JOB_NAME_STD}" \
     --location="${REGION}" \
     --config=/tmp/pdd-batch-job-std.json
 
-# STANDARD serial job for cloud_regression cases. These all exchange the same
-# Firebase refresh token; parallel exchange hits quota even with jitter.
-echo "=== Submitting STANDARD serial cloud-regression job: ${JOB_NAME_CLOUD} (8 tasks) ==="
+# One STANDARD task runs all eight cloud-regression cases sequentially and
+# reuses one JWT. It still emits logical task_68 through task_75 artifacts.
+echo "=== Submitting STANDARD cloud-regression job: ${JOB_NAME_CLOUD} (1 physical task, 8 logical results) ==="
 gcloud batch jobs submit "${JOB_NAME_CLOUD}" \
     --project="${PROJECT_ID}" \
     --location="${REGION}" \
@@ -344,7 +344,9 @@ evidence = {
         },
         "${JOB_NAME_STD}": {"uid": "${JOB_UID_STD}", "task_indexes": [54]},
         "${JOB_NAME_CLOUD}": {
-            "uid": "${JOB_UID_CLOUD}", "task_indexes": list(range(68, 76))
+            "uid": "${JOB_UID_CLOUD}",
+            "task_indexes": list(range(68, 76)),
+            "physical_task_indexes": [0] * 8,
         },
     },
 }
@@ -365,7 +367,7 @@ _verify_secret_log_boundary() {
         --job-spec "${JOB_NAME_PYTEST}=${JOB_UID_PYTEST}=32"
         --job-spec "${JOB_NAME_MAIN}=${JOB_UID_MAIN}=36"
         --job-spec "${JOB_NAME_STD}=${JOB_UID_STD}=1"
-        --job-spec "${JOB_NAME_CLOUD}=${JOB_UID_CLOUD}=8"
+        --job-spec "${JOB_NAME_CLOUD}=${JOB_UID_CLOUD}=1"
         --evidence "${EVIDENCE_FILE}"
         --results "${STREAMING_DIR}"
     )
@@ -375,7 +377,8 @@ _verify_secret_log_boundary() {
     done
     local artifact_log
     for artifact_log in \
-        "${STREAMING_DIR}"/task_*.json "${STREAMING_DIR}"/task_*.log; do
+        "${STREAMING_DIR}"/task_*.json "${STREAMING_DIR}"/task_*.log \
+        "${STREAMING_DIR}"/cloud_regression_attempt_*.jsonl; do
         [ -f "${artifact_log}" ] || continue
         verifier_args+=(--log-file "${artifact_log}")
     done
@@ -388,7 +391,8 @@ ELAPSED=0
 STREAMING_DIR=$(mktemp -d)
 trap 'rm -rf "${STREAMING_DIR}"; cleanup_leaked_gcloud_workers' EXIT
 
-TOTAL=77  # 32 pytest + 36 unprivileged main + 1 slow sync + 8 cloud regression
+PHYSICAL_TOTAL=70  # 32 pytest + 36 unprivileged main + 1 slow sync + 1 cloud task
+LOGICAL_TOTAL=77   # The cloud task emits eight identity-bound logical results.
 _job_status() {
     _with_timeout 15 gcloud batch jobs describe "$1" \
         --project="${PROJECT_ID}" \
@@ -423,9 +427,9 @@ while [ "${ELAPSED}" -lt "${POLL_TIMEOUT}" ]; do
 
     # ── Progress line ─────────────────────────────────────────────────
     if [ "${STREAM_FAILURES}" -gt 0 ]; then
-        echo "[$(date +%H:%M:%S)] PYTEST: ${STATUS_PYTEST} | MAIN: ${STATUS_MAIN} | STD: ${STATUS_STD} | CLOUD: ${STATUS_CLOUD} | ${COMPLETED}/${TOTAL} complete (${STREAM_FAILURES} failed) (${ELAPSED}s elapsed)"
+        echo "[$(date +%H:%M:%S)] PYTEST: ${STATUS_PYTEST} | MAIN: ${STATUS_MAIN} | STD: ${STATUS_STD} | CLOUD: ${STATUS_CLOUD} | ${COMPLETED}/${LOGICAL_TOTAL} logical results (${PHYSICAL_TOTAL} physical tasks; ${STREAM_FAILURES} failed) (${ELAPSED}s elapsed)"
     else
-        echo "[$(date +%H:%M:%S)] PYTEST: ${STATUS_PYTEST} | MAIN: ${STATUS_MAIN} | STD: ${STATUS_STD} | CLOUD: ${STATUS_CLOUD} | ${COMPLETED}/${TOTAL} complete (${ELAPSED}s elapsed)"
+        echo "[$(date +%H:%M:%S)] PYTEST: ${STATUS_PYTEST} | MAIN: ${STATUS_MAIN} | STD: ${STATUS_STD} | CLOUD: ${STATUS_CLOUD} | ${COMPLETED}/${LOGICAL_TOTAL} logical results (${PHYSICAL_TOTAL} physical tasks) (${ELAPSED}s elapsed)"
     fi
 
     # ── Check terminal states ─────────────────────────────────────────
@@ -437,6 +441,9 @@ while [ "${ELAPSED}" -lt "${POLL_TIMEOUT}" ]; do
             "gs://${BUCKET}/${JOB_RUN_ID}/results/task_*.json" "${STREAMING_DIR}/"
         _with_timeout 30 gcloud storage cp --quiet \
             "gs://${BUCKET}/${JOB_RUN_ID}/results/task_*.log" "${STREAMING_DIR}/"
+        _with_timeout 30 gcloud storage cp --quiet \
+            "gs://${BUCKET}/${JOB_RUN_ID}/results/cloud_regression_attempt_*.jsonl" \
+            "${STREAMING_DIR}/"
         echo "=== Verifying attributable logs contain no credential fingerprints ==="
         if ! _verify_secret_log_boundary; then
             echo "=== Credential-log boundary verification FAILED ==="

--- a/ci/cloud-batch/verify-result-identities.py
+++ b/ci/cloud-batch/verify-result-identities.py
@@ -171,6 +171,176 @@ def _validate_attempt_events(
         raise ResultIdentityError("cloud attempt evidence invalid")
 
 
+def _valid_auth_elapsed(value: object, minimum: float) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and value >= minimum
+    )
+
+
+def _validate_auth_metrics(
+    event: Mapping[str, object], prior_count: int, prior_elapsed: float
+) -> tuple[int, float]:
+    count = event.get("auth_attempt_count")
+    elapsed = event.get("auth_elapsed_seconds")
+    if (
+        not isinstance(count, int)
+        or isinstance(count, bool)
+        or count != prior_count + 1
+        or not _valid_auth_elapsed(elapsed, prior_elapsed)
+    ):
+        raise ResultIdentityError("cloud attempt evidence invalid")
+    return count, float(elapsed)
+
+
+def _validate_auth_event_shape(
+    event: Mapping[str, object], envelope: set[str]
+) -> tuple[bool, str | None]:
+    """Return whether an exact auth event succeeded and its fingerprint."""
+    if event["event"] == "auth_failed":
+        if set(event) != envelope | {
+            "auth_attempt_count",
+            "auth_elapsed_seconds",
+            "category",
+        } or event.get("category") not in {
+            "expired_token",
+            "invalid_response",
+            "invalid_token",
+            "parse_failed",
+            "provider_rejected",
+            "quota_exceeded",
+            "transport_failed",
+        }:
+            raise ResultIdentityError("cloud attempt evidence invalid")
+        return False, None
+    fingerprint = event.get("jwt_fingerprint")
+    if (
+        set(event)
+        != envelope
+        | {
+            "auth_attempt_count",
+            "auth_elapsed_seconds",
+            "jwt_fingerprint",
+        }
+        or not isinstance(fingerprint, str)
+        or not re.fullmatch(r"sha256:[0-9a-f]{64}", fingerprint)
+    ):
+        raise ResultIdentityError("cloud attempt evidence invalid")
+    return True, fingerprint
+
+
+def _validate_case_event(
+    event: Mapping[str, object],
+    envelope: set[str],
+    expected_case: int,
+    auth_state: tuple[int, float, object],
+) -> None:
+    """Require one exact case event bound to the current auth state."""
+    auth_count, auth_elapsed, active_fingerprint = auth_state
+    if event["event"] != "case_finished" or set(event) != envelope | {
+        "logical_case",
+        "status",
+        "auth_attempt_count",
+        "auth_elapsed_seconds",
+        "jwt_fingerprint",
+    }:
+        raise ResultIdentityError("cloud attempt evidence invalid")
+    if (
+        event.get("logical_case") != expected_case
+        or event.get("status") not in {"passed", "failed", "error"}
+    ):
+        raise ResultIdentityError("cloud attempt evidence invalid")
+    if (
+        event.get("auth_attempt_count") != auth_count
+        or event.get("auth_elapsed_seconds") != auth_elapsed
+    ):
+        raise ResultIdentityError("cloud attempt evidence invalid")
+    if event.get("jwt_fingerprint") != active_fingerprint:
+        raise ResultIdentityError("cloud attempt evidence invalid")
+    if active_fingerprint is None and event.get("status") != "error":
+        raise ResultIdentityError("cloud attempt evidence invalid")
+
+
+def _validate_attempt_grammar(
+    events: Sequence[Mapping[str, object]],
+) -> list[Mapping[str, object]]:
+    """Validate strict auth transitions and their binding to each logical case."""
+    envelope = {
+        "event",
+        "attempt_id",
+        "batch_task_retry_attempt",
+        "candidate_sha",
+        "task_resource",
+    }
+    if set(events[0]) != envelope:
+        raise ResultIdentityError("cloud attempt evidence invalid")
+    auth_count = 0
+    auth_elapsed = 0.0
+    active_fingerprint: object = None
+    consecutive_failures = 0
+    auth_succeeded_since_case = False
+    auth_exhausted = False
+    expected_case = 1
+    cases: list[Mapping[str, object]] = []
+    for event in events[1:-1]:
+        name = event["event"]
+        if name in {"auth_failed", "auth_succeeded"}:
+            if (
+                expected_case > 8
+                or auth_exhausted
+                or auth_succeeded_since_case
+                or consecutive_failures >= 6
+            ):
+                raise ResultIdentityError("cloud attempt evidence invalid")
+            auth_count, auth_elapsed = _validate_auth_metrics(
+                event, auth_count, auth_elapsed
+            )
+            succeeded, fingerprint = _validate_auth_event_shape(event, envelope)
+            if succeeded:
+                active_fingerprint = fingerprint
+                consecutive_failures = 0
+                auth_succeeded_since_case = True
+            else:
+                consecutive_failures += 1
+            continue
+        if consecutive_failures:
+            if consecutive_failures != 6:
+                raise ResultIdentityError("cloud attempt evidence invalid")
+            active_fingerprint = None
+            auth_exhausted = True
+            consecutive_failures = 0
+        _validate_case_event(
+            event,
+            envelope,
+            expected_case,
+            (auth_count, auth_elapsed, active_fingerprint),
+        )
+        cases.append(event)
+        expected_case += 1
+        auth_succeeded_since_case = False
+    if expected_case != 9:
+        raise ResultIdentityError("cloud attempt evidence incomplete")
+    final = events[-1]
+    if (
+        set(final)
+        != envelope
+        | {
+            "status",
+            "cases_completed",
+            "auth_attempt_count",
+            "auth_elapsed_seconds",
+        }
+        or final.get("status") not in {"passed", "failed"}
+        or final.get("cases_completed") != 8
+        or final.get("auth_attempt_count") != auth_count
+        or final.get("auth_elapsed_seconds") != auth_elapsed
+    ):
+        raise ResultIdentityError("cloud attempt evidence invalid")
+    return cases
+
+
 def _expected_from_evidence(
     evidence: object,
 ) -> tuple[dict[str, str], dict[int, dict[str, object]]]:
@@ -304,7 +474,7 @@ def _validate_attempt_file(
         candidate_sha=candidate_sha,
         task_resource=task_resource,
     )
-    cases = [event for event in events if event["event"] == "case_finished"]
+    cases = _validate_attempt_grammar(events)
     if [event.get("logical_case") for event in cases] != list(range(1, 9)):
         raise ResultIdentityError("cloud attempt evidence incomplete")
     for event in cases:

--- a/ci/cloud-batch/verify-result-identities.py
+++ b/ci/cloud-batch/verify-result-identities.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
+import re
 import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -23,6 +25,9 @@ TASK_IDENTITY_FIELDS = (
     "task_group",
     "raw_task_index",
     "task_resource",
+)
+ATTEMPT_FILE = re.compile(
+    r"^cloud_regression_attempt_(?P<retry>0|[1-9][0-9]*)_(?P<id>[0-9a-f]{32})\.jsonl$"
 )
 
 
@@ -59,6 +64,62 @@ def validate_results(
         observed[task_index] = result
     if set(observed) != set(expected_tasks):
         raise ResultIdentityError("result identity set incomplete")
+    _validate_cloud_execution(results)
+
+
+def _validate_cloud_execution(results: Sequence[object]) -> int | None:
+    """Validate sanitized auth/attempt evidence on the eight logical results."""
+    cloud_results = {
+        result["task_index"]: result
+        for result in results
+        if isinstance(result, dict) and result.get("task_index") in range(68, 76)
+    }
+    if not cloud_results:
+        return None
+    if set(cloud_results) != set(range(68, 76)):
+        raise ResultIdentityError("cloud execution evidence incomplete")
+    retries: set[int] = set()
+    prior_attempt_count = 0
+    prior_elapsed = 0.0
+    for task_index in range(68, 76):
+        execution = cloud_results[task_index].get("execution")
+        if not isinstance(execution, dict) or set(execution) != {
+            "auth_elapsed_seconds",
+            "auth_attempt_count",
+            "batch_task_retry_attempt",
+            "logical_case",
+        }:
+            raise ResultIdentityError("cloud execution evidence invalid")
+        elapsed = execution["auth_elapsed_seconds"]
+        attempts = execution["auth_attempt_count"]
+        retry = execution["batch_task_retry_attempt"]
+        valid_elapsed = (
+            isinstance(elapsed, (int, float))
+            and not isinstance(elapsed, bool)
+            and math.isfinite(elapsed)
+            and elapsed >= prior_elapsed
+        )
+        valid_attempts = (
+            isinstance(attempts, int)
+            and not isinstance(attempts, bool)
+            and attempts >= max(1, prior_attempt_count)
+        )
+        valid_retry = (
+            isinstance(retry, int) and not isinstance(retry, bool) and retry >= 0
+        )
+        if not (
+            valid_elapsed
+            and valid_attempts
+            and valid_retry
+            and execution["logical_case"] == task_index - 67
+        ):
+            raise ResultIdentityError("cloud execution evidence invalid")
+        prior_elapsed = float(elapsed)
+        prior_attempt_count = attempts
+        retries.add(retry)
+    if len(retries) != 1:
+        raise ResultIdentityError("cloud execution evidence invalid")
+    return next(iter(retries))
 
 
 def _expected_from_evidence(
@@ -85,7 +146,23 @@ def _expected_from_evidence(
             or not uid
         ):
             raise ResultIdentityError("result identity configuration invalid")
-        for raw_task_index, task_index in enumerate(job["task_indexes"]):
+        logical_indexes = job["task_indexes"]
+        physical_indexes = job.get("physical_task_indexes")
+        if physical_indexes is None:
+            physical_indexes = list(range(len(logical_indexes)))
+        if (
+            not isinstance(physical_indexes, list)
+            or len(physical_indexes) != len(logical_indexes)
+            or any(
+                not isinstance(index, int) or isinstance(index, bool) or index < 0
+                for index in physical_indexes
+            )
+        ):
+            raise ResultIdentityError("result identity configuration invalid")
+        physical_count = len(set(physical_indexes))
+        if set(physical_indexes) != set(range(physical_count)):
+            raise ResultIdentityError("result identity configuration invalid")
+        for task_index, raw_task_index in zip(logical_indexes, physical_indexes):
             if not isinstance(task_index, int) or task_index in tasks:
                 raise ResultIdentityError("result identity configuration invalid")
             tasks[task_index] = {
@@ -117,6 +194,66 @@ def validate_result_directory(evidence_path: Path, results_dir: Path) -> None:
         path = results_dir / f"task_{task_index}.json"
         results.append(json.loads(path.read_text(encoding="utf-8")))
     validate_results(results, expected_identity=identity, expected_tasks=tasks)
+    result_retry = _validate_cloud_execution(results)
+    attempt_retries = _validate_attempt_evidence(results_dir, identity, tasks)
+    if result_retry is not None and result_retry not in attempt_retries:
+        raise ResultIdentityError("cloud attempt evidence incomplete")
+
+
+def _validate_attempt_evidence(
+    results_dir: Path,
+    identity: Mapping[str, str],
+    tasks: Mapping[int, Mapping[str, object]],
+) -> set[int]:
+    """Bind append-only cloud auth attempts to the candidate and physical task."""
+    cloud_indexes = set(range(68, 76))
+    if not cloud_indexes <= set(tasks):
+        return set()
+    resources = {tasks[index]["task_resource"] for index in cloud_indexes}
+    raw_indexes = {tasks[index]["raw_task_index"] for index in cloud_indexes}
+    if len(resources) != 1 or len(raw_indexes) != 1:
+        raise ResultIdentityError("cloud attempt identity configuration invalid")
+    paths = sorted(results_dir.glob("cloud_regression_attempt_*.jsonl"))
+    if not paths:
+        raise ResultIdentityError("cloud attempt evidence incomplete")
+    expected_resource = next(iter(resources))
+    retries: set[int] = set()
+    for path in paths:
+        retries.add(
+            _validate_attempt_file(path, identity["candidate_sha"], expected_resource)
+        )
+    return retries
+
+
+def _validate_attempt_file(path: Path, candidate_sha: str, task_resource: object) -> int:
+    """Validate one uniquely named, append-only physical-attempt event stream."""
+    match = ATTEMPT_FILE.fullmatch(path.name)
+    if not match:
+        raise ResultIdentityError("cloud attempt evidence invalid")
+    retry = int(match.group("retry"))
+    attempt_id = match.group("id")
+    try:
+        events = [
+            json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()
+        ]
+    except ValueError as error:
+        raise ResultIdentityError("cloud attempt evidence invalid") from error
+    if (
+        not events
+        or not isinstance(events[0], dict)
+        or events[0].get("event") != "attempt_started"
+    ):
+        raise ResultIdentityError("cloud attempt evidence invalid")
+    for event in events:
+        if (
+            not isinstance(event, dict)
+            or event.get("attempt_id") != attempt_id
+            or event.get("batch_task_retry_attempt") != retry
+            or event.get("candidate_sha") != candidate_sha
+            or event.get("task_resource") != task_resource
+        ):
+            raise ResultIdentityError("cloud attempt evidence invalid")
+    return retry
 
 
 def parse_args() -> argparse.Namespace:

--- a/ci/cloud-batch/verify-result-identities.py
+++ b/ci/cloud-batch/verify-result-identities.py
@@ -67,7 +67,7 @@ def validate_results(
     _validate_cloud_execution(results)
 
 
-def _validate_cloud_execution(results: Sequence[object]) -> int | None:
+def _validate_cloud_execution(results: Sequence[object]) -> tuple[int, str] | None:
     """Validate sanitized auth/attempt evidence on the eight logical results."""
     cloud_results = {
         result["task_index"]: result
@@ -79,6 +79,7 @@ def _validate_cloud_execution(results: Sequence[object]) -> int | None:
     if set(cloud_results) != set(range(68, 76)):
         raise ResultIdentityError("cloud execution evidence incomplete")
     retries: set[int] = set()
+    attempt_ids: set[str] = set()
     prior_attempt_count = 0
     prior_elapsed = 0.0
     for task_index in range(68, 76):
@@ -88,38 +89,86 @@ def _validate_cloud_execution(results: Sequence[object]) -> int | None:
             "auth_attempt_count",
             "batch_task_retry_attempt",
             "logical_case",
+            "jwt_fingerprint",
         }:
             raise ResultIdentityError("cloud execution evidence invalid")
         elapsed = execution["auth_elapsed_seconds"]
         attempts = execution["auth_attempt_count"]
         retry = execution["batch_task_retry_attempt"]
-        valid_elapsed = (
+        attempt_id = cloud_results[task_index].get("attempt_id")
+        if not (
             isinstance(elapsed, (int, float))
             and not isinstance(elapsed, bool)
             and math.isfinite(elapsed)
             and elapsed >= prior_elapsed
-        )
-        valid_attempts = (
-            isinstance(attempts, int)
+            and isinstance(attempts, int)
             and not isinstance(attempts, bool)
             and attempts >= max(1, prior_attempt_count)
-        )
-        valid_retry = (
-            isinstance(retry, int) and not isinstance(retry, bool) and retry >= 0
-        )
-        if not (
-            valid_elapsed
-            and valid_attempts
-            and valid_retry
+            and isinstance(retry, int)
+            and not isinstance(retry, bool)
+            and retry >= 0
             and execution["logical_case"] == task_index - 67
+            and isinstance(attempt_id, str)
+            and re.fullmatch(r"[0-9a-f]{32}", attempt_id)
+            and (
+                execution["jwt_fingerprint"] is None
+                or isinstance(execution["jwt_fingerprint"], str)
+                and re.fullmatch(
+                    r"sha256:[0-9a-f]{64}", execution["jwt_fingerprint"]
+                )
+            )
         ):
             raise ResultIdentityError("cloud execution evidence invalid")
         prior_elapsed = float(elapsed)
         prior_attempt_count = attempts
         retries.add(retry)
-    if len(retries) != 1:
+        attempt_ids.add(attempt_id)
+    if len(retries) != 1 or len(attempt_ids) != 1:
         raise ResultIdentityError("cloud execution evidence invalid")
-    return next(iter(retries))
+    return next(iter(retries)), next(iter(attempt_ids))
+
+
+def _validate_attempt_events(
+    events: Sequence[object],
+    *,
+    attempt_id: str,
+    retry: int,
+    candidate_sha: str,
+    task_resource: object,
+) -> None:
+    """Validate event boundaries, names, and immutable attempt identity."""
+    if not events or not isinstance(events[0], dict):
+        raise ResultIdentityError("cloud attempt evidence invalid")
+    if events[0].get("event") != "attempt_started":
+        raise ResultIdentityError("cloud attempt evidence invalid")
+    if (
+        not isinstance(events[-1], dict)
+        or events[-1].get("event") != "attempt_finished"
+    ):
+        raise ResultIdentityError("cloud attempt evidence incomplete")
+    allowed = {
+        "attempt_started",
+        "auth_succeeded",
+        "auth_failed",
+        "case_finished",
+        "attempt_finished",
+    }
+    for event in events:
+        if not isinstance(event, dict):
+            raise ResultIdentityError("cloud attempt evidence invalid")
+        if (
+            event.get("event") not in allowed
+            or event.get("attempt_id") != attempt_id
+            or event.get("batch_task_retry_attempt") != retry
+            or event.get("candidate_sha") != candidate_sha
+            or event.get("task_resource") != task_resource
+        ):
+            raise ResultIdentityError("cloud attempt evidence invalid")
+    if (
+        sum(event["event"] == "attempt_started" for event in events) != 1
+        or sum(event["event"] == "attempt_finished" for event in events) != 1
+    ):
+        raise ResultIdentityError("cloud attempt evidence invalid")
 
 
 def _expected_from_evidence(
@@ -194,38 +243,48 @@ def validate_result_directory(evidence_path: Path, results_dir: Path) -> None:
         path = results_dir / f"task_{task_index}.json"
         results.append(json.loads(path.read_text(encoding="utf-8")))
     validate_results(results, expected_identity=identity, expected_tasks=tasks)
-    result_retry = _validate_cloud_execution(results)
-    attempt_retries = _validate_attempt_evidence(results_dir, identity, tasks)
-    if result_retry is not None and result_retry not in attempt_retries:
-        raise ResultIdentityError("cloud attempt evidence incomplete")
+    result_attempt = _validate_cloud_execution(results)
+    _validate_attempt_evidence(results_dir, identity, tasks, results, result_attempt)
 
 
 def _validate_attempt_evidence(
     results_dir: Path,
     identity: Mapping[str, str],
     tasks: Mapping[int, Mapping[str, object]],
-) -> set[int]:
+    results: Sequence[object],
+    result_attempt: tuple[int, str] | None,
+) -> None:
     """Bind append-only cloud auth attempts to the candidate and physical task."""
     cloud_indexes = set(range(68, 76))
     if not cloud_indexes <= set(tasks):
-        return set()
+        return
     resources = {tasks[index]["task_resource"] for index in cloud_indexes}
     raw_indexes = {tasks[index]["raw_task_index"] for index in cloud_indexes}
     if len(resources) != 1 or len(raw_indexes) != 1:
         raise ResultIdentityError("cloud attempt identity configuration invalid")
-    paths = sorted(results_dir.glob("cloud_regression_attempt_*.jsonl"))
-    if not paths:
+    if result_attempt is None:
         raise ResultIdentityError("cloud attempt evidence incomplete")
     expected_resource = next(iter(resources))
-    retries: set[int] = set()
-    for path in paths:
-        retries.add(
-            _validate_attempt_file(path, identity["candidate_sha"], expected_resource)
-        )
-    return retries
+    retry, attempt_id = result_attempt
+    path = results_dir / f"cloud_regression_attempt_{retry}_{attempt_id}.jsonl"
+    if not path.is_file():
+        raise ResultIdentityError("cloud attempt evidence incomplete")
+    cloud_results = {
+        result["execution"]["logical_case"]: result
+        for result in results
+        if isinstance(result, dict) and result.get("task_index") in cloud_indexes
+    }
+    _validate_attempt_file(
+        path, identity["candidate_sha"], expected_resource, cloud_results
+    )
 
 
-def _validate_attempt_file(path: Path, candidate_sha: str, task_resource: object) -> int:
+def _validate_attempt_file(
+    path: Path,
+    candidate_sha: str,
+    task_resource: object,
+    cloud_results: Mapping[int, Mapping[str, object]],
+) -> None:
     """Validate one uniquely named, append-only physical-attempt event stream."""
     match = ATTEMPT_FILE.fullmatch(path.name)
     if not match:
@@ -238,22 +297,37 @@ def _validate_attempt_file(path: Path, candidate_sha: str, task_resource: object
         ]
     except ValueError as error:
         raise ResultIdentityError("cloud attempt evidence invalid") from error
-    if (
-        not events
-        or not isinstance(events[0], dict)
-        or events[0].get("event") != "attempt_started"
-    ):
-        raise ResultIdentityError("cloud attempt evidence invalid")
-    for event in events:
+    _validate_attempt_events(
+        events,
+        attempt_id=attempt_id,
+        retry=retry,
+        candidate_sha=candidate_sha,
+        task_resource=task_resource,
+    )
+    cases = [event for event in events if event["event"] == "case_finished"]
+    if [event.get("logical_case") for event in cases] != list(range(1, 9)):
+        raise ResultIdentityError("cloud attempt evidence incomplete")
+    for event in cases:
+        result = cloud_results[event["logical_case"]]
+        execution = result["execution"]
         if (
-            not isinstance(event, dict)
-            or event.get("attempt_id") != attempt_id
-            or event.get("batch_task_retry_attempt") != retry
-            or event.get("candidate_sha") != candidate_sha
-            or event.get("task_resource") != task_resource
+            event.get("status") != result.get("status")
+            or event.get("auth_attempt_count") != execution["auth_attempt_count"]
+            or event.get("auth_elapsed_seconds") != execution["auth_elapsed_seconds"]
+            or event.get("jwt_fingerprint") != execution["jwt_fingerprint"]
         ):
             raise ResultIdentityError("cloud attempt evidence invalid")
-    return retry
+    final = events[-1]
+    expected_status = "failed" if any(
+        result.get("status") != "passed" for result in cloud_results.values()
+    ) else "passed"
+    if (
+        final.get("status") != expected_status
+        or final.get("cases_completed") != 8
+        or final.get("auth_attempt_count") != cases[-1]["auth_attempt_count"]
+        or final.get("auth_elapsed_seconds") != cases[-1]["auth_elapsed_seconds"]
+    ):
+        raise ResultIdentityError("cloud attempt evidence incomplete")
 
 
 def parse_args() -> argparse.Namespace:

--- a/ci/cloud-batch/verify-secret-logs.py
+++ b/ci/cloud-batch/verify-secret-logs.py
@@ -113,7 +113,22 @@ def _verify_job_evidence(
             or not isinstance(job.get("task_indexes"), list)
         ):
             raise RuntimeError("Batch job identity evidence invalid")
-        observed[job_name] = (job["uid"], len(job["task_indexes"]))
+        physical_indexes = job.get("physical_task_indexes")
+        if physical_indexes is None:
+            physical_indexes = list(range(len(job["task_indexes"])))
+        if (
+            not isinstance(physical_indexes, list)
+            or len(physical_indexes) != len(job["task_indexes"])
+            or any(
+                not isinstance(index, int) or isinstance(index, bool) or index < 0
+                for index in physical_indexes
+            )
+        ):
+            raise RuntimeError("Batch job identity evidence invalid")
+        physical_count = len(set(physical_indexes))
+        if set(physical_indexes) != set(range(physical_count)):
+            raise RuntimeError("Batch job identity evidence invalid")
+        observed[job_name] = (job["uid"], physical_count)
     if observed != dict(job_specs):
         raise RuntimeError("Batch job identity evidence mismatch")
 
@@ -275,7 +290,7 @@ def _parse_job_specs(specs: Sequence[str]) -> dict[str, tuple[str, int]]:
             match.group("uid"),
             int(match.group("count")),
         )
-    if len(parsed) != 4 or sorted(count for _, count in parsed.values()) != [1, 8, 32, 36]:
+    if len(parsed) != 4 or sorted(count for _, count in parsed.values()) != [1, 1, 32, 36]:
         raise RuntimeError("credential-log verification configuration invalid")
     return parsed
 

--- a/tests/test_cloud_batch_cloud_regression_runner.py
+++ b/tests/test_cloud_batch_cloud_regression_runner.py
@@ -103,6 +103,9 @@ def test_single_exchange_runs_eight_cases_and_emits_logical_artifacts(tmp_path: 
             "auth_attempt_count": 1,
             "batch_task_retry_attempt": 2,
             "logical_case": index - 67,
+            "jwt_fingerprint": runner._jwt_fingerprint(
+                json.loads(_jwt(10_000))["id_token"]
+            ),
         }
     attempt_files = list(tmp_path.glob("cloud_regression_attempt_2_*.jsonl"))
     assert len(attempt_files) == 1
@@ -252,7 +255,7 @@ def test_invalid_token_response_fails_closed_without_response_body_in_evidence(t
 
 def test_printed_jwt_is_redacted_and_fails_case_without_persisting_token(tmp_path: Path):
     runner = _load_runner()
-    token_document = _jwt(10_000)
+    token_document = _jwt(4_000_000_000)
     token = json.loads(token_document)["id_token"]
 
     def invoke(_case: int, log_path: Path, environment: dict[str, str]) -> int:

--- a/tests/test_cloud_batch_cloud_regression_runner.py
+++ b/tests/test_cloud_batch_cloud_regression_runner.py
@@ -70,6 +70,8 @@ def test_single_exchange_runs_eight_cases_and_emits_logical_artifacts(tmp_path: 
     def invoke(case: int, log_path: Path, environment: dict[str, str]) -> int:
         cases.append(case)
         assert environment["PDD_JWT_TOKEN"].count(".") == 2
+        assert "FIREBASE_API_KEY" not in environment
+        assert "PDD_REFRESH_TOKEN" not in environment
         log_path.write_text(f"case {case} safe output\n", encoding="utf-8")
         return 0
 
@@ -106,7 +108,54 @@ def test_single_exchange_runs_eight_cases_and_emits_logical_artifacts(tmp_path: 
     events = [json.loads(line) for line in attempt_files[0].read_text().splitlines()]
     assert events[0]["event"] == "attempt_started"
     assert events[-1]["event"] == "attempt_finished"
-    assert all("fake-api-key" not in event and "fake-refresh-token" not in event for event in attempt_files[0].read_text().splitlines())
+    assert {event["candidate_sha"] for event in events} == {"a" * 40}
+    assert len({event["attempt_id"] for event in events}) == 1
+    assert {event["task_resource"] for event in events} == {
+        "projects/trusted-project/locations/us-central1/jobs/job-name/"
+        "taskGroups/group0/tasks/0"
+    }
+    assert all(
+        "fake-api-key" not in event and "fake-refresh-token" not in event
+        for event in attempt_files[0].read_text().splitlines()
+    )
+
+    validator_spec = importlib.util.spec_from_file_location(
+        "cloud_result_validator",
+        REPO_ROOT / "ci" / "cloud-batch" / "verify-result-identities.py",
+    )
+    assert validator_spec and validator_spec.loader
+    validator = importlib.util.module_from_spec(validator_spec)
+    validator_spec.loader.exec_module(validator)
+    evidence = {
+        "project": "trusted-project",
+        "location": "us-central1",
+        "candidate_sha": "a" * 40,
+        "candidate_tree": "b" * 40,
+        "source_sha256": "c" * 64,
+        "source_generation": "123",
+        "image_digest": "sha256:" + "d" * 64,
+        "job_uids": {
+            "job-name": {
+                "uid": "job-uid",
+                "task_indexes": list(range(68, 76)),
+                "physical_task_indexes": [0] * 8,
+            }
+        },
+    }
+    evidence_path = tmp_path / "identity.json"
+    evidence_path.write_text(json.dumps(evidence), encoding="utf-8")
+    validator.validate_result_directory(evidence_path, tmp_path)
+
+    tampered_path = tmp_path / "task_75.json"
+    tampered = json.loads(tampered_path.read_text())
+    tampered["execution"]["auth_attempt_count"] = 0
+    tampered_path.write_text(json.dumps(tampered), encoding="utf-8")
+    try:
+        validator.validate_result_directory(evidence_path, tmp_path)
+    except validator.ResultIdentityError as error:
+        assert "cloud execution evidence invalid" in str(error)
+    else:
+        raise AssertionError("tampered auth evidence was accepted")
 
 
 def test_quota_failure_records_true_elapsed_attempt_evidence_and_invokes_no_case(tmp_path: Path):
@@ -183,4 +232,3 @@ def test_invalid_token_response_fails_closed_without_response_body_in_evidence(t
     assert outcome == 1
     rendered = "\n".join(path.read_text() for path in tmp_path.iterdir())
     assert "credential-response-body" not in rendered
-

--- a/tests/test_cloud_batch_cloud_regression_runner.py
+++ b/tests/test_cloud_batch_cloud_regression_runner.py
@@ -165,6 +165,24 @@ def test_single_exchange_runs_eight_cases_and_emits_logical_artifacts(tmp_path: 
         raise AssertionError("truncated final attempt stream was accepted")
     attempt_files[0].write_text(complete_stream)
 
+    late_auth = next(event.copy() for event in events if event["event"] == "auth_succeeded")
+    late_auth.update(
+        auth_attempt_count=999,
+        auth_elapsed_seconds=-1,
+        jwt_fingerprint="sha256:invalid",
+    )
+    contradictory_stream = [*events[:-1], late_auth, events[-1]]
+    attempt_files[0].write_text(
+        "".join(json.dumps(event) + "\n" for event in contradictory_stream)
+    )
+    try:
+        validator.validate_result_directory(evidence_path, tmp_path)
+    except validator.ResultIdentityError as error:
+        assert "cloud attempt evidence invalid" in str(error)
+    else:
+        raise AssertionError("contradictory late auth event was accepted")
+    attempt_files[0].write_text(complete_stream)
+
     tampered_path = tmp_path / "task_75.json"
     tampered = json.loads(tampered_path.read_text())
     tampered["execution"]["auth_attempt_count"] = 0
@@ -279,3 +297,36 @@ def test_printed_jwt_is_redacted_and_fails_case_without_persisting_token(tmp_pat
     }
     assert len(fingerprints) == 1
     assert next(iter(fingerprints)).startswith("sha256:")
+
+
+def test_base64_encoded_jwt_is_redacted_without_persisting_reversible_credential(
+    tmp_path: Path,
+):
+    runner = _load_runner()
+    token_document = _jwt(4_000_000_000)
+    token = json.loads(token_document)["id_token"]
+    encoded = {
+        representation
+        for representation in (
+            base64.b64encode(token.encode("utf-8")).decode("ascii"),
+            base64.urlsafe_b64encode(token.encode("utf-8")).decode("ascii"),
+        )
+        for representation in (representation, representation.rstrip("="))
+    }
+
+    def invoke(_case: int, log_path: Path, _environment: dict[str, str]) -> int:
+        log_path.write_text("unsafe " + " ".join(sorted(encoded)) + "\n", encoding="utf-8")
+        return 0
+
+    outcome = runner.run_cloud_regression(
+        _environment(),
+        tmp_path,
+        exchange=lambda *_args: token_document,
+        invoke_case=invoke,
+    )
+
+    if outcome != 1:
+        raise AssertionError("encoded runtime JWT did not fail closed")
+    rendered = "\n".join(path.read_text() for path in tmp_path.iterdir())
+    if token in rendered or any(representation in rendered for representation in encoded):
+        raise AssertionError("reversible runtime JWT representation remained in artifacts")

--- a/tests/test_cloud_batch_cloud_regression_runner.py
+++ b/tests/test_cloud_batch_cloud_regression_runner.py
@@ -1,0 +1,186 @@
+"""Deterministic tests for the single-task cloud-regression runner."""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNNER_PATH = REPO_ROOT / "ci" / "cloud-batch" / "cloud-regression-runner.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("cloud_regression_runner", RUNNER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _jwt(expiry: int) -> bytes:
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": expiry}).encode()).rstrip(b"=")
+    token = b"header." + payload + b".signature"
+    return json.dumps({"id_token": token.decode()}).encode()
+
+
+def _environment() -> dict[str, str]:
+    return {
+        "BATCH_TASK_INDEX": "0",
+        "BATCH_TASK_RETRY_ATTEMPT": "2",
+        "PDD_BATCH_PROJECT": "trusted-project",
+        "PDD_BATCH_LOCATION": "us-central1",
+        "PDD_BATCH_JOB_NAME": "job-name",
+        "PDD_CANDIDATE_SHA": "a" * 40,
+        "PDD_CANDIDATE_TREE": "b" * 40,
+        "PDD_SOURCE_SHA256": "c" * 64,
+        "PDD_SOURCE_GCS_GENERATION": "123",
+        "PDD_IMAGE_DIGEST": "sha256:" + "d" * 64,
+        "FIREBASE_API_KEY": "fake-api-key",
+        "PDD_REFRESH_TOKEN": "fake-refresh-token",
+    }
+
+
+class _Clock:
+    def __init__(self, value: float = 1_000.0) -> None:
+        self.value = value
+
+    def monotonic(self) -> float:
+        return self.value
+
+    def time(self) -> float:
+        return self.value
+
+    def sleep(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def test_single_exchange_runs_eight_cases_and_emits_logical_artifacts(tmp_path: Path):
+    runner = _load_runner()
+    clock = _Clock()
+    exchanges: list[int] = []
+    cases: list[int] = []
+
+    def fake_endpoint(_api_key: str, _refresh_token: str) -> bytes:
+        exchanges.append(1)
+        return _jwt(10_000)
+
+    def invoke(case: int, log_path: Path, environment: dict[str, str]) -> int:
+        cases.append(case)
+        assert environment["PDD_JWT_TOKEN"].count(".") == 2
+        log_path.write_text(f"case {case} safe output\n", encoding="utf-8")
+        return 0
+
+    outcome = runner.run_cloud_regression(
+        _environment(),
+        tmp_path,
+        exchange=fake_endpoint,
+        invoke_case=invoke,
+        monotonic=clock.monotonic,
+        wall_time=clock.time,
+        sleep=clock.sleep,
+    )
+
+    assert outcome == 0
+    assert len(exchanges) == 1
+    assert cases == list(range(1, 9))
+    assert {path.name for path in tmp_path.glob("task_*.json")} == {
+        f"task_{index}.json" for index in range(68, 76)
+    }
+    assert {path.name for path in tmp_path.glob("task_*.log")} == {
+        f"task_{index}.log" for index in range(68, 76)
+    }
+    for index in range(68, 76):
+        result = json.loads((tmp_path / f"task_{index}.json").read_text())
+        assert result["identity"]["raw_task_index"] == 0
+        assert result["execution"] == {
+            "auth_elapsed_seconds": 0.0,
+            "auth_attempt_count": 1,
+            "batch_task_retry_attempt": 2,
+            "logical_case": index - 67,
+        }
+    attempt_files = list(tmp_path.glob("cloud_regression_attempt_2_*.jsonl"))
+    assert len(attempt_files) == 1
+    events = [json.loads(line) for line in attempt_files[0].read_text().splitlines()]
+    assert events[0]["event"] == "attempt_started"
+    assert events[-1]["event"] == "attempt_finished"
+    assert all("fake-api-key" not in event and "fake-refresh-token" not in event for event in attempt_files[0].read_text().splitlines())
+
+
+def test_quota_failure_records_true_elapsed_attempt_evidence_and_invokes_no_case(tmp_path: Path):
+    runner = _load_runner()
+    clock = _Clock()
+    calls = 0
+
+    def quota_endpoint(_api_key: str, _refresh_token: str) -> bytes:
+        nonlocal calls
+        calls += 1
+        return b'{"error":{"message":"QUOTA_EXCEEDED"}}'
+
+    outcome = runner.run_cloud_regression(
+        _environment(),
+        tmp_path,
+        exchange=quota_endpoint,
+        invoke_case=lambda *_args: (_ for _ in ()).throw(AssertionError("case invoked")),
+        monotonic=clock.monotonic,
+        wall_time=clock.time,
+        sleep=clock.sleep,
+        jitter=lambda _upper: 0,
+    )
+
+    assert outcome == 1
+    assert calls == 6
+    assert clock.monotonic() == 1_150.0
+    for index in range(68, 76):
+        result = json.loads((tmp_path / f"task_{index}.json").read_text())
+        assert result["status"] == "error"
+        assert result["detail"] == f"jwt_exchange_failed_case_{index - 67}: quota_exceeded"
+        assert result["execution"]["auth_elapsed_seconds"] == 150.0
+        assert result["execution"]["auth_attempt_count"] == 6
+        assert (tmp_path / f"task_{index}.log").exists()
+
+
+def test_expired_token_is_refreshed_only_before_the_next_case(tmp_path: Path):
+    runner = _load_runner()
+    clock = _Clock()
+    expiries = iter((1_001, 10_000))
+    exchanges = 0
+
+    def endpoint(_api_key: str, _refresh_token: str) -> bytes:
+        nonlocal exchanges
+        exchanges += 1
+        return _jwt(next(expiries))
+
+    outcome = runner.run_cloud_regression(
+        _environment(),
+        tmp_path,
+        exchange=endpoint,
+        invoke_case=lambda _case, log, _env: (log.write_text("safe\n"), 0)[1],
+        monotonic=clock.monotonic,
+        wall_time=clock.time,
+        sleep=clock.sleep,
+    )
+
+    assert outcome == 0
+    assert exchanges == 2
+
+
+def test_invalid_token_response_fails_closed_without_response_body_in_evidence(tmp_path: Path):
+    runner = _load_runner()
+    sensitive_body = b'{"id_token":"credential-response-body"}'
+
+    outcome = runner.run_cloud_regression(
+        _environment(),
+        tmp_path,
+        exchange=lambda *_args: sensitive_body,
+        invoke_case=lambda *_args: (_ for _ in ()).throw(AssertionError("case invoked")),
+        sleep=lambda _seconds: None,
+        jitter=lambda _upper: 0,
+    )
+
+    assert outcome == 1
+    rendered = "\n".join(path.read_text() for path in tmp_path.iterdir())
+    assert "credential-response-body" not in rendered
+

--- a/tests/test_cloud_batch_cloud_regression_runner.py
+++ b/tests/test_cloud_batch_cloud_regression_runner.py
@@ -96,6 +96,7 @@ def test_single_exchange_runs_eight_cases_and_emits_logical_artifacts(tmp_path: 
     }
     for index in range(68, 76):
         result = json.loads((tmp_path / f"task_{index}.json").read_text())
+        assert len(result["attempt_id"]) == 32
         assert result["identity"]["raw_task_index"] == 0
         assert result["execution"] == {
             "auth_elapsed_seconds": 0.0,
@@ -110,6 +111,11 @@ def test_single_exchange_runs_eight_cases_and_emits_logical_artifacts(tmp_path: 
     assert events[-1]["event"] == "attempt_finished"
     assert {event["candidate_sha"] for event in events} == {"a" * 40}
     assert len({event["attempt_id"] for event in events}) == 1
+    attempt_id = events[0]["attempt_id"]
+    assert {
+        json.loads((tmp_path / f"task_{index}.json").read_text())["attempt_id"]
+        for index in range(68, 76)
+    } == {attempt_id}
     assert {event["task_resource"] for event in events} == {
         "projects/trusted-project/locations/us-central1/jobs/job-name/"
         "taskGroups/group0/tasks/0"
@@ -145,6 +151,16 @@ def test_single_exchange_runs_eight_cases_and_emits_logical_artifacts(tmp_path: 
     evidence_path = tmp_path / "identity.json"
     evidence_path.write_text(json.dumps(evidence), encoding="utf-8")
     validator.validate_result_directory(evidence_path, tmp_path)
+
+    complete_stream = attempt_files[0].read_text()
+    attempt_files[0].write_text(complete_stream.splitlines()[0] + "\n")
+    try:
+        validator.validate_result_directory(evidence_path, tmp_path)
+    except validator.ResultIdentityError as error:
+        assert "cloud attempt evidence incomplete" in str(error)
+    else:
+        raise AssertionError("truncated final attempt stream was accepted")
+    attempt_files[0].write_text(complete_stream)
 
     tampered_path = tmp_path / "task_75.json"
     tampered = json.loads(tampered_path.read_text())
@@ -232,3 +248,31 @@ def test_invalid_token_response_fails_closed_without_response_body_in_evidence(t
     assert outcome == 1
     rendered = "\n".join(path.read_text() for path in tmp_path.iterdir())
     assert "credential-response-body" not in rendered
+
+
+def test_printed_jwt_is_redacted_and_fails_case_without_persisting_token(tmp_path: Path):
+    runner = _load_runner()
+    token_document = _jwt(10_000)
+    token = json.loads(token_document)["id_token"]
+
+    def invoke(_case: int, log_path: Path, environment: dict[str, str]) -> int:
+        log_path.write_text(f"unsafe {environment['PDD_JWT_TOKEN']}\n", encoding="utf-8")
+        return 0
+
+    outcome = runner.run_cloud_regression(
+        _environment(), tmp_path, exchange=lambda *_args: token_document,
+        invoke_case=invoke,
+    )
+
+    assert outcome == 1
+    rendered = "\n".join(path.read_text() for path in tmp_path.iterdir())
+    assert token not in rendered
+    assert "jwt_log_boundary_failed" in rendered
+    fingerprints = {
+        json.loads((tmp_path / f"task_{index}.json").read_text())["execution"][
+            "jwt_fingerprint"
+        ]
+        for index in range(68, 76)
+    }
+    assert len(fingerprints) == 1
+    assert next(iter(fingerprints)).startswith("sha256:")

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -247,6 +247,30 @@ def test_cloud_batch_templates_partition_all_result_indexes_exactly_once():
     assert len(all_indexes) == 77
     assert sorted(all_indexes) == list(range(77))
 
+
+def test_cloud_regression_uses_one_physical_task_for_eight_logical_results():
+    template = json.loads(
+        (REPO_ROOT / "ci" / "cloud-batch" / "job-template-cloud-regression.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    group = template["taskGroups"][0]
+    variables = group["taskSpec"]["runnables"][0]["environment"]["variables"]
+
+    assert group["taskCount"] == "1"
+    assert group["parallelism"] == "1"
+    assert variables["TASK_INDEX_OFFSET"] == "68"
+    assert variables["CLOUD_REGRESSION_CASES"] == "1,2,3,4,5,6,7,8"
+
+    submit = (REPO_ROOT / "ci" / "cloud-batch" / "submit.sh").read_text(
+        encoding="utf-8"
+    )
+    assert '_validate_rendered_template /tmp/pdd-batch-job-cloud.json 1' in submit
+    assert '--job-spec "${JOB_NAME_CLOUD}=${JOB_UID_CLOUD}=1"' in submit
+    assert '"physical_task_indexes": [0] * 8' in submit
+    assert "PHYSICAL_TOTAL=70" in submit
+    assert "LOGICAL_TOTAL=77" in submit
+
     submit_text = (REPO_ROOT / "ci" / "cloud-batch" / "submit.sh").read_text(
         encoding="utf-8"
     )

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -393,13 +393,14 @@ def test_serial_cloud_regression_has_coherent_aggregate_runtime_budget():
     task_seconds = int(
         template["taskGroups"][0]["taskSpec"]["maxRunDuration"].removesuffix("s")
     )
+    max_retry_count = template["taskGroups"][0]["taskSpec"]["maxRetryCount"]
     submit = (REPO_ROOT / "ci" / "cloud-batch" / "submit.sh").read_text(
         encoding="utf-8"
     )
     poll_seconds = int(re.search(r'POLL_TIMEOUT="\$\{POLL_TIMEOUT:-(\d+)\}"', submit).group(1))
 
     assert task_seconds >= 8 * 1200 + 1800
-    assert poll_seconds >= task_seconds + 1200
+    assert poll_seconds >= task_seconds * (max_retry_count + 1) + 1200
 
 
 def test_cloud_batch_entrypoint_forces_pytest_shards_local_by_default():

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -385,6 +385,23 @@ def test_cloud_batch_attempt_evidence_is_collected_and_secret_scanned():
     assert 'cloud_regression_attempt_*.jsonl "${RESULTS_LOCAL}/"' in collector
 
 
+def test_serial_cloud_regression_has_coherent_aggregate_runtime_budget():
+    template = json.loads(
+        (REPO_ROOT / "ci" / "cloud-batch" / "job-template-cloud-regression.json")
+        .read_text(encoding="utf-8")
+    )
+    task_seconds = int(
+        template["taskGroups"][0]["taskSpec"]["maxRunDuration"].removesuffix("s")
+    )
+    submit = (REPO_ROOT / "ci" / "cloud-batch" / "submit.sh").read_text(
+        encoding="utf-8"
+    )
+    poll_seconds = int(re.search(r'POLL_TIMEOUT="\$\{POLL_TIMEOUT:-(\d+)\}"', submit).group(1))
+
+    assert task_seconds >= 8 * 1200 + 1800
+    assert poll_seconds >= task_seconds + 1200
+
+
 def test_cloud_batch_entrypoint_forces_pytest_shards_local_by_default():
     entrypoint_text = (
         REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -35,6 +35,12 @@ def _template_task_indexes(template_name: str) -> list[int]:
         for value in variables.get("SKIP_INDEXES", "").split(",")
         if value
     ]
+    logical_cases = variables.get("CLOUD_REGRESSION_CASES")
+    if logical_cases:
+        return [
+            int(variables.get("TASK_INDEX_OFFSET", "0")) + int(case) - 1
+            for case in logical_cases.split(",")
+        ]
     indexes = []
     for raw_index in range(int(group["taskCount"])):
         task_index = raw_index + offset
@@ -146,9 +152,10 @@ def test_cloud_batch_runs_cloud_regression_serially():
     cloud_policy = cloud_template["allocationPolicy"]["instances"][0]["policy"]
     cloud_vars = cloud_group["taskSpec"]["runnables"][0]["environment"]["variables"]
 
-    assert cloud_group["taskCount"] == "8"
+    assert cloud_group["taskCount"] == "1"
     assert cloud_group["parallelism"] == "1"
     assert cloud_vars["TASK_INDEX_OFFSET"] == "68"
+    assert cloud_vars["CLOUD_REGRESSION_CASES"] == "1,2,3,4,5,6,7,8"
     assert cloud_policy["provisioningModel"] == "STANDARD"
 
     submit_text = (REPO_ROOT / "ci" / "cloud-batch" / "submit.sh").read_text(
@@ -270,6 +277,12 @@ def test_cloud_regression_uses_one_physical_task_for_eight_logical_results():
     assert '"physical_task_indexes": [0] * 8' in submit
     assert "PHYSICAL_TOTAL=70" in submit
     assert "LOGICAL_TOTAL=77" in submit
+    collector = (REPO_ROOT / "ci" / "cloud-batch" / "collect-results.sh").read_text(
+        encoding="utf-8"
+    )
+    assert 'LOGICAL_TOTAL=$(python3 - "${EVIDENCE_FILE}"' in collector
+    assert "indexes != list(range(77))" in collector
+    assert 'TOTAL="${LOGICAL_TOTAL}"' in collector
 
     submit_text = (REPO_ROOT / "ci" / "cloud-batch" / "submit.sh").read_text(
         encoding="utf-8"
@@ -357,6 +370,19 @@ def test_cloud_batch_entrypoint_extends_quota_retry_horizon():
     assert "JWT_MAX_ATTEMPTS=6" in entrypoint_text
     assert "JWT_QUOTA_BACKOFF_SECONDS=30" in entrypoint_text
     assert '"${JWT_ERROR}" = "QUOTA_EXCEEDED"' in entrypoint_text
+
+
+def test_cloud_batch_attempt_evidence_is_collected_and_secret_scanned():
+    submit = (REPO_ROOT / "ci" / "cloud-batch" / "submit.sh").read_text(
+        encoding="utf-8"
+    )
+    collector = (REPO_ROOT / "ci" / "cloud-batch" / "collect-results.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "results/cloud_regression_attempt_*.jsonl" in submit
+    assert '"${STREAMING_DIR}"/cloud_regression_attempt_*.jsonl' in submit
+    assert 'cloud_regression_attempt_*.jsonl "${RESULTS_LOCAL}/"' in collector
 
 
 def test_cloud_batch_entrypoint_forces_pytest_shards_local_by_default():

--- a/tests/test_cloud_batch_secret_boundary.py
+++ b/tests/test_cloud_batch_secret_boundary.py
@@ -790,6 +790,55 @@ def test_result_identity_rejects_wrong_raw_task_resource() -> None:
         )
 
 
+def test_result_identity_allows_many_logical_results_from_one_physical_task(tmp_path: Path):
+    validator = _load_script(
+        "cloud_batch_result_shared_task", "verify-result-identities.py"
+    )
+    evidence = {
+        "project": "trusted-project",
+        "location": "us-central1",
+        "candidate_sha": "a" * 40,
+        "candidate_tree": "b" * 40,
+        "source_sha256": "c" * 64,
+        "source_generation": "123",
+        "image_digest": "sha256:" + "d" * 64,
+        "job_uids": {
+            "cloud-job": {
+                "uid": "cloud-uid",
+                "task_indexes": list(range(68, 76)),
+                "physical_task_indexes": [0] * 8,
+            }
+        },
+    }
+    identity, tasks = validator._expected_from_evidence(evidence)
+
+    assert set(tasks) == set(range(68, 76))
+    assert {task["raw_task_index"] for task in tasks.values()} == {0}
+    assert len({task["task_resource"] for task in tasks.values()}) == 1
+    assert identity["candidate_sha"] == "a" * 40
+
+
+def test_job_evidence_compares_physical_counts_not_logical_result_counts(tmp_path: Path):
+    verifier = _load_script("cloud_batch_physical_evidence", "verify-secret-logs.py")
+    evidence = tmp_path / "evidence.json"
+    evidence.write_text(
+        json.dumps(
+            {
+                "job_uids": {
+                    "cloud-job": {
+                        "uid": "cloud-uid",
+                        "task_indexes": list(range(68, 76)),
+                        "physical_task_indexes": [0] * 8,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    verifier._verify_job_evidence(evidence, {"cloud-job": ("cloud-uid", 1)})
+
+
 def test_worker_result_binds_canonical_batch_task_identity() -> None:
     entrypoint = (CLOUD_BATCH / "entrypoint.sh").read_text(encoding="utf-8")
 

--- a/tests/test_cloud_batch_secret_boundary.py
+++ b/tests/test_cloud_batch_secret_boundary.py
@@ -484,6 +484,7 @@ def test_worker_image_inputs_and_templates_are_immutable() -> None:
 
     assert "$(CLOUD_BATCH_DIR)/runtime-secrets.py" in makefile
     assert "$(CLOUD_BATCH_DIR)/firebase-token-exchange.py" in makefile
+    assert "$(CLOUD_BATCH_DIR)/cloud-regression-runner.py" in makefile
     assert "$(CLOUD_BATCH_DIR)/source-identity.py" in makefile
     assert "_IMAGE_TAG" in cloudbuild
     assert "{{IMAGE_URI}}" in "".join(
@@ -837,6 +838,12 @@ def test_job_evidence_compares_physical_counts_not_logical_result_counts(tmp_pat
     )
 
     verifier._verify_job_evidence(evidence, {"cloud-job": ("cloud-uid", 1)})
+
+    document = json.loads(evidence.read_text(encoding="utf-8"))
+    document["job_uids"]["cloud-job"]["physical_task_indexes"] = [1] * 8
+    evidence.write_text(json.dumps(document), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="job identity evidence invalid"):
+        verifier._verify_job_evidence(evidence, {"cloud-job": ("cloud-uid", 1)})
 
 
 def test_worker_result_binds_canonical_batch_task_identity() -> None:


### PR DESCRIPTION
## Summary

- run cloud-regression cases 1–8 inside one physical STANDARD Batch task while preserving logical `task_68` through `task_75` results and logs
- exchange one Firebase JWT and reuse it across sequential cases, refreshing only on expiry
- separate 70 physical task identities from the required 77 logical evidence identities in submit/collection/log verification
- record sanitized, append-only authentication attempt evidence with real elapsed time, attempt count, Batch retry attempt, candidate identity, and canonical task resource
- preserve PR #2049's in-process secret boundary and no-redirect credential exchange

## TDD

- red: `d7b3ec2d0`
- green: `178bf7fc9`
- ownership policy: `36618bfc5`
- focused cloud/template/security/policy suite: 63 passed after rebase onto main `11e79df22`
- production helper pylint 10.00/10; shell syntax, Python compile, template JSON, and diff checks passed before rebase

## Safety

No live cloud job, credential read, deployment, or production mutation was performed. Hosted checks and an independent security review are required before merge. The final release gate must still prove 77/77 logical evidence and GCS-FUSE append-only attempt behavior in staging.

Closes #2048
Depends on merged #2049.