### PR TITLE
fix(sync): preauthorize drift example contract rotation

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -11194,6 +11194,13 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "tests/test_ci_drift_heal_example_contract.py",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "tests/test_ci_drift_heal_e2e.py",
       "role": "human-maintained"
     },

--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "rotations": [
     {
       "obligation_id": "threshold-human-attestation",
@@ -10,13 +10,15 @@
   ],
   "requirement_rotations": [
     {
-      "prompt_path": "pdd/prompts/ci_detect_changed_modules_python.prompt",
+      "prompt_path": "pdd/prompts/ci_drift_heal_python.prompt",
       "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:ef30764861a3080d2fb093ca747f86a3f46bba733a0cdc6a5634efc1b36a73a2",
-      "to_requirement_id": "CONTRACT-SHA256:2d5d65f695fc6c8cd2f3e82f5c5d2a55ad3eb30fc4791b2a1d94ff8465ab6d10",
+      "from_requirement_id": "CONTRACT-SHA256:93a67c25264e04e4c84cc15d2ad23a90c9f982f0778a8de79fa4954b963e8601",
+      "to_requirement_id": "CONTRACT-SHA256:e12dc6b48f34111182afb4a73b9ba66596617b9a6d8e393766d2cd6b847562ec",
       "policy_path": ".pdd/verification-profiles.json",
-      "from_policy_sha256": "ffd867088a7c9a92840130ffd9db9eb8f279e611a02afe501d02855ebb03930f",
-      "to_policy_sha256": "8a957dfa94fdc78ec9d1eb5ea6dfb0a08ff2452928a8b9f6a4dbd5368cb25f53"
+      "base_policy_sha256": "ee4146f5b24eab5172d3cba0ef57bec967abfe21b271252f3c1fea9fa54ae8b6",
+      "head_policy_sha256": "58a704c9d5d351e6b83e2c42126cfe85214aa3ffbf6cb3e64ac4105f3fb19b3e",
+      "base_prompt_sha256": "93a67c25264e04e4c84cc15d2ad23a90c9f982f0778a8de79fa4954b963e8601",
+      "head_prompt_sha256": "e12dc6b48f34111182afb4a73b9ba66596617b9a6d8e393766d2cd6b847562ec"
     }
   ]
 }

--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -19,6 +19,17 @@
       "head_policy_sha256": "58a704c9d5d351e6b83e2c42126cfe85214aa3ffbf6cb3e64ac4105f3fb19b3e",
       "base_prompt_sha256": "93a67c25264e04e4c84cc15d2ad23a90c9f982f0778a8de79fa4954b963e8601",
       "head_prompt_sha256": "e12dc6b48f34111182afb4a73b9ba66596617b9a6d8e393766d2cd6b847562ec"
+    },
+    {
+      "prompt_path": "pdd/prompts/ci_detect_changed_modules_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:2d5d65f695fc6c8cd2f3e82f5c5d2a55ad3eb30fc4791b2a1d94ff8465ab6d10",
+      "to_requirement_id": "CONTRACT-SHA256:f0d873e5505d40035d3c7364fd3961b5602d21519ec9be2049c2f38b16239712",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "58a704c9d5d351e6b83e2c42126cfe85214aa3ffbf6cb3e64ac4105f3fb19b3e",
+      "head_policy_sha256": "7df63fe892ac14382f226ea97dbd2ac186a8cb48213faec958ad32c51d51aeb5",
+      "base_prompt_sha256": "2d5d65f695fc6c8cd2f3e82f5c5d2a55ad3eb30fc4791b2a1d94ff8465ab6d10",
+      "head_prompt_sha256": "f0d873e5505d40035d3c7364fd3961b5602d21519ec9be2049c2f38b16239712"
     }
   ]
 }

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -683,10 +683,16 @@ def _authorized_rotation_updates(
         ]
         if not protected:
             continue
-        unchanged = _rotation_updates(
-            head, protected, authorization.from_config_digest
+        config_unchanged = all(
+            any(
+                candidate.obligation_id == obligation.obligation_id
+                and candidate.validator_config_digest
+                == authorization.from_config_digest
+                for candidate in head.get(unit_id, _ProfileInput((), ())).obligations
+            )
+            for unit_id, obligation in protected
         )
-        if unchanged is not None:
+        if config_unchanged:
             continue
         policy = read_git_blob(root, manifest.head_ref, authorization.policy_path)
         if policy is None:

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -126,6 +126,19 @@ _BOOTSTRAP_REQUIREMENT_TRANSITIONS = (
             "e12dc6b48f34111182afb4a73b9ba66596617b9a6d8e393766d2cd6b847562ec",
         ),
     ),
+    _RequirementTransitionAuthorization(
+        PurePosixPath("pdd/prompts/ci_detect_changed_modules_python.prompt"),
+        "python",
+        "CONTRACT-SHA256:2d5d65f695fc6c8cd2f3e82f5c5d2a55ad3eb30fc4791b2a1d94ff8465ab6d10",
+        "CONTRACT-SHA256:f0d873e5505d40035d3c7364fd3961b5602d21519ec9be2049c2f38b16239712",
+        PROFILE_PATH,
+        _RequirementTransitionBindings(
+            "58a704c9d5d351e6b83e2c42126cfe85214aa3ffbf6cb3e64ac4105f3fb19b3e",
+            "7df63fe892ac14382f226ea97dbd2ac186a8cb48213faec958ad32c51d51aeb5",
+            "2d5d65f695fc6c8cd2f3e82f5c5d2a55ad3eb30fc4791b2a1d94ff8465ab6d10",
+            "f0d873e5505d40035d3c7364fd3961b5602d21519ec9be2049c2f38b16239712",
+        ),
+    ),
 )
 
 

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -541,6 +541,33 @@ def _matches_bound_stationary_state(
     )
 
 
+def _matches_unchanged_requirement_state(
+    profile: _ProfileInput,
+    prompts: tuple[bytes | None, bytes | None],
+    authorization: _RequirementTransitionAuthorization,
+) -> bool:
+    """Keep one exact row dormant across unrelated profile-file rotations."""
+    if prompts[0] is None or prompts[0] != prompts[1]:
+        return False
+    prompt_digest = _sha256(prompts[0])
+    states = (
+        (
+            authorization.from_requirement_id,
+            authorization.bindings.base_prompt_sha256,
+        ),
+        (
+            authorization.to_requirement_id,
+            authorization.bindings.head_prompt_sha256,
+        ),
+    )
+    return any(
+        profile.requirements == (requirement_id,)
+        and prompt_digest == bound_prompt_digest
+        and _prompt_requirements(prompts[0]) == (requirement_id,)
+        for requirement_id, bound_prompt_digest in states
+    )
+
+
 def _evaluate_requirement_authorization(
     context: _RequirementTransitionContext,
     authorization: _RequirementTransitionAuthorization,
@@ -566,7 +593,8 @@ def _evaluate_requirement_authorization(
     )
     bindings = authorization.bindings
     stationary = protected == candidate and (
-        _matches_bound_stationary_state(
+        _matches_unchanged_requirement_state(protected, prompts, authorization)
+        or _matches_bound_stationary_state(
             protected,
             context.policies,
             prompts,

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -552,6 +552,10 @@ def _evaluate_requirement_authorization(
         authorization.language_id,
     )
     protected, candidate = context.base.get(unit_id), context.head.get(unit_id)
+    if protected is None or candidate is None:
+        # Existing profile accounting owns missing/candidate-only units. A
+        # dormant transition must not duplicate those stable reasons or counts.
+        return unit_id, None, None
     prompts = (
         read_git_blob(
             context.root, context.manifest.base_ref, authorization.prompt_path
@@ -586,9 +590,7 @@ def _evaluate_requirement_authorization(
     if stationary:
         return unit_id, None, None
     if (
-        protected is None
-        or candidate is None
-        or not _transition_bytes_match(
+        not _transition_bytes_match(
             authorization,
             context.policies[0],
             context.policies[1],

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -21,6 +21,9 @@ TRUST_POLICY_PATH = PurePosixPath(".pdd/attestation-trust.json")
 _HUMAN_OBLIGATION_ID = "threshold-human-attestation"
 _HUMAN_VALIDATOR_ID = "threshold-ed25519"
 _PLACEHOLDER_POLICY_DIGEST = "threshold-ed25519-v1"
+_MAX_REQUIREMENT_TRANSITIONS = 1_024
+_PDD_REPOSITORY_ID = "3b4d7b1c-d6cc-4752-ba93-6b98d1a710e0"
+_OPAQUE_REQUIREMENT_ID = re.compile(r"CONTRACT-SHA256:[0-9a-f]{64}")
 
 
 class VerificationProfileError(ValueError):
@@ -63,6 +66,67 @@ class _PolicyRotationAuthorization:
     validator_id: str
     from_config_digest: str
     policy_path: PurePosixPath
+
+
+@dataclass(frozen=True)
+class _RequirementTransitionBindings:
+    """Exact immutable byte identities for both sides of a transition."""
+
+    base_policy_sha256: str
+    head_policy_sha256: str
+    base_prompt_sha256: str
+    head_prompt_sha256: str
+
+
+@dataclass(frozen=True)
+class _RequirementTransitionAuthorization:
+    """One exact-byte-bound opaque prompt requirement transition."""
+
+    prompt_path: PurePosixPath
+    language_id: str
+    from_requirement_id: str
+    to_requirement_id: str
+    policy_path: PurePosixPath
+    bindings: _RequirementTransitionBindings
+
+
+@dataclass(frozen=True)
+class _AuthorizedProfileUpdates:
+    """Narrowly authorized deltas, separated by transition dimension."""
+
+    obligations: dict[tuple[UnitId, str], VerificationObligation]
+    requirements: dict[UnitId, _ProfileInput]
+
+
+@dataclass(frozen=True)
+class _RequirementTransitionContext:
+    """Immutable inputs shared while evaluating exact transition rules."""
+
+    root: Path
+    manifest: UnitManifest
+    base: Mapping[UnitId, _ProfileInput]
+    head: Mapping[UnitId, _ProfileInput]
+    policies: tuple[bytes | None, bytes | None]
+
+
+# Schema 2 cannot pre-authorize its own first protected installation. This exact
+# repository-bound tuple is the one-time trust root for this dormant rule. Every
+# later transition must already be present in the protected-base policy.
+_BOOTSTRAP_REQUIREMENT_TRANSITIONS = (
+    _RequirementTransitionAuthorization(
+        PurePosixPath("pdd/prompts/ci_drift_heal_python.prompt"),
+        "python",
+        "CONTRACT-SHA256:93a67c25264e04e4c84cc15d2ad23a90c9f982f0778a8de79fa4954b963e8601",
+        "CONTRACT-SHA256:e12dc6b48f34111182afb4a73b9ba66596617b9a6d8e393766d2cd6b847562ec",
+        PROFILE_PATH,
+        _RequirementTransitionBindings(
+            "ee4146f5b24eab5172d3cba0ef57bec967abfe21b271252f3c1fea9fa54ae8b6",
+            "58a704c9d5d351e6b83e2c42126cfe85214aa3ffbf6cb3e64ac4105f3fb19b3e",
+            "93a67c25264e04e4c84cc15d2ad23a90c9f982f0778a8de79fa4954b963e8601",
+            "e12dc6b48f34111182afb4a73b9ba66596617b9a6d8e393766d2cd6b847562ec",
+        ),
+    ),
+)
 
 
 _REQUIREMENT_ID = re.compile(r"\bREQ-[A-Za-z0-9_.:-]+\b")
@@ -231,7 +295,7 @@ def _load_rotation_authorizations(
     try:
         payload = json.loads(raw)
         rows = payload["rotations"]
-        if payload.get("schema_version") != 1 or not isinstance(rows, list):
+        if payload.get("schema_version") not in {1, 2} or not isinstance(rows, list):
             raise TypeError
     except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as exc:
         raise VerificationProfileError("protected profile rotation policy is malformed") from exc
@@ -262,6 +326,308 @@ def _load_rotation_authorizations(
     if len(authorizations) != len(set(authorizations)):
         raise VerificationProfileError("protected profile rotation rules are duplicated")
     return tuple(authorizations)
+
+
+def _sha256(raw: bytes) -> str:
+    """Return the lowercase SHA-256 identity used by rotation policy."""
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _valid_requirement_transition(
+    authorization: _RequirementTransitionAuthorization,
+) -> bool:
+    """Validate one bounded, repository-relative opaque transition rule."""
+    prompt_path = authorization.prompt_path
+    path_valid = (
+        not prompt_path.is_absolute()
+        and bool(prompt_path.parts)
+        and ".." not in prompt_path.parts
+    )
+    requirements_valid = (
+        authorization.from_requirement_id != authorization.to_requirement_id
+        and _OPAQUE_REQUIREMENT_ID.fullmatch(authorization.from_requirement_id)
+        is not None
+        and _OPAQUE_REQUIREMENT_ID.fullmatch(authorization.to_requirement_id)
+        is not None
+    )
+    bindings = authorization.bindings
+    digest_valid = all(
+        re.fullmatch(r"[0-9a-f]{64}", item) is not None
+        for item in (
+            bindings.base_policy_sha256,
+            bindings.head_policy_sha256,
+            bindings.base_prompt_sha256,
+            bindings.head_prompt_sha256,
+        )
+    )
+    return (
+        authorization.policy_path == PROFILE_PATH
+        and path_valid
+        and bool(authorization.language_id)
+        and authorization.language_id.strip() == authorization.language_id
+        and requirements_valid
+        and digest_valid
+    )
+
+
+def _parse_requirement_transition_authorizations(
+    raw: bytes | None, source: str
+) -> tuple[_RequirementTransitionAuthorization, ...]:
+    """Parse one strict schema-2 transition policy without granting authority."""
+    if raw is None:
+        return ()
+    try:
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise TypeError
+        if payload.get("schema_version") == 1:
+            return ()
+        rows = payload["requirement_rotations"]
+        if (
+            payload.get("schema_version") != 2
+            or not isinstance(rows, list)
+            or len(rows) > _MAX_REQUIREMENT_TRANSITIONS
+        ):
+            raise TypeError
+    except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as exc:
+        raise VerificationProfileError(
+            f"{source} requirement transition policy is malformed"
+        ) from exc
+
+    required_keys = {
+        "prompt_path",
+        "language_id",
+        "from_requirement_id",
+        "to_requirement_id",
+        "policy_path",
+        "base_policy_sha256",
+        "head_policy_sha256",
+        "base_prompt_sha256",
+        "head_prompt_sha256",
+    }
+    authorizations = []
+    for row in rows:
+        if (
+            not isinstance(row, dict)
+            or set(row) != required_keys
+            or any(not isinstance(row[key], str) for key in required_keys)
+        ):
+            raise VerificationProfileError(
+                f"{source} requirement transition rule is malformed"
+            )
+        authorization = _RequirementTransitionAuthorization(
+            PurePosixPath(row["prompt_path"]),
+            row["language_id"],
+            row["from_requirement_id"],
+            row["to_requirement_id"],
+            PurePosixPath(row["policy_path"]),
+            _RequirementTransitionBindings(
+                row["base_policy_sha256"],
+                row["head_policy_sha256"],
+                row["base_prompt_sha256"],
+                row["head_prompt_sha256"],
+            ),
+        )
+        if not _valid_requirement_transition(authorization):
+            raise VerificationProfileError(
+                f"{source} requirement transition rule is malformed"
+            )
+        authorizations.append(authorization)
+    identities = [(item.prompt_path, item.language_id) for item in authorizations]
+    if len(authorizations) != len(set(authorizations)) or len(identities) != len(
+        set(identities)
+    ):
+        raise VerificationProfileError(
+            f"{source} requirement transition rules are duplicated or ambiguous"
+        )
+    return tuple(authorizations)
+
+
+def _load_requirement_transition_authorizations(
+    root: Path, manifest: UnitManifest
+) -> tuple[_RequirementTransitionAuthorization, ...]:
+    """Accept candidate rules only when protected earlier or exactly bootstrapped."""
+    protected = _parse_requirement_transition_authorizations(
+        read_git_blob(root, manifest.base_ref, ROTATION_POLICY_PATH), "protected"
+    )
+    candidate = _parse_requirement_transition_authorizations(
+        read_git_blob(root, manifest.head_ref, ROTATION_POLICY_PATH), "candidate"
+    )
+    authority = set(protected)
+    if manifest.repository_id == _PDD_REPOSITORY_ID:
+        authority.update(_BOOTSTRAP_REQUIREMENT_TRANSITIONS)
+    if any(item not in authority for item in candidate):
+        raise VerificationProfileError(
+            "candidate requirement transition lacks protected authorization"
+        )
+    return candidate
+
+
+def _transition_bytes_match(
+    authorization: _RequirementTransitionAuthorization,
+    base_policy: bytes | None,
+    head_policy: bytes | None,
+    base_prompt: bytes | None,
+    head_prompt: bytes | None,
+) -> bool:
+    """Check all four byte identities and both derived requirement identities."""
+    if None in (base_policy, head_policy, base_prompt, head_prompt):
+        return False
+    assert base_policy is not None and head_policy is not None
+    assert base_prompt is not None and head_prompt is not None
+    bindings = authorization.bindings
+    return (
+        _sha256(base_policy) == bindings.base_policy_sha256
+        and _sha256(head_policy) == bindings.head_policy_sha256
+        and _sha256(base_prompt) == bindings.base_prompt_sha256
+        and _sha256(head_prompt) == bindings.head_prompt_sha256
+        and _prompt_requirements(base_prompt)
+        == (authorization.from_requirement_id,)
+        and _prompt_requirements(head_prompt) == (authorization.to_requirement_id,)
+    )
+
+
+def _expected_requirement_update(
+    authorization: _RequirementTransitionAuthorization,
+    protected: _ProfileInput,
+    candidate: _ProfileInput,
+) -> tuple[_ProfileInput | None, str | None]:
+    """Return the sole permitted profile delta for one exact prompt transition."""
+    obligations = {item.obligation_id: item for item in protected.obligations}
+    human = obligations.get(_HUMAN_OBLIGATION_ID)
+    human_matches = (
+        human is not None
+        and human.kind == "human-attestation"
+        and human.validator_id == _HUMAN_VALIDATOR_ID
+        and human.requirement_ids == (authorization.from_requirement_id,)
+        and human.required
+    )
+    if (
+        protected.requirements != (authorization.from_requirement_id,)
+        or candidate.requirements != (authorization.to_requirement_id,)
+        or not human_matches
+    ):
+        return None, "requirement transition is partial or mismatched"
+    assert human is not None
+    obligations[_HUMAN_OBLIGATION_ID] = replace(
+        human, requirement_ids=(authorization.to_requirement_id,)
+    )
+    expected = _ProfileInput(
+        (authorization.to_requirement_id,), tuple(sorted(obligations.values()))
+    )
+    if candidate != expected:
+        return None, "requirement transition changes protected fields"
+    return expected, None
+
+
+def _matches_bound_stationary_state(
+    profile: _ProfileInput | None,
+    policies: tuple[bytes | None, bytes | None],
+    prompts: tuple[bytes | None, bytes | None],
+    state: tuple[str, str, str],
+) -> bool:
+    """Return whether both refs hold one exact dormant or consumed state."""
+    requirement_id, policy_digest, prompt_digest = state
+    return (
+        profile is not None
+        and profile.requirements == (requirement_id,)
+        and policies[0] == policies[1]
+        and prompts[0] == prompts[1]
+        and policies[0] is not None
+        and prompts[0] is not None
+        and _sha256(policies[0]) == policy_digest
+        and _sha256(prompts[0]) == prompt_digest
+        and _prompt_requirements(prompts[0]) == (requirement_id,)
+    )
+
+
+def _evaluate_requirement_authorization(
+    context: _RequirementTransitionContext,
+    authorization: _RequirementTransitionAuthorization,
+) -> tuple[UnitId, _ProfileInput | None, str | None]:
+    """Evaluate one rule as dormant, consumed, exact, or invalid."""
+    unit_id = UnitId(
+        context.manifest.repository_id,
+        authorization.prompt_path,
+        authorization.language_id,
+    )
+    protected, candidate = context.base.get(unit_id), context.head.get(unit_id)
+    prompts = (
+        read_git_blob(
+            context.root, context.manifest.base_ref, authorization.prompt_path
+        ),
+        read_git_blob(
+            context.root, context.manifest.head_ref, authorization.prompt_path
+        ),
+    )
+    bindings = authorization.bindings
+    stationary = protected == candidate and (
+        _matches_bound_stationary_state(
+            protected,
+            context.policies,
+            prompts,
+            (
+                authorization.from_requirement_id,
+                bindings.base_policy_sha256,
+                bindings.base_prompt_sha256,
+            ),
+        )
+        or _matches_bound_stationary_state(
+            protected,
+            context.policies,
+            prompts,
+            (
+                authorization.to_requirement_id,
+                bindings.head_policy_sha256,
+                bindings.head_prompt_sha256,
+            ),
+        )
+    )
+    if stationary:
+        return unit_id, None, None
+    if (
+        protected is None
+        or candidate is None
+        or not _transition_bytes_match(
+            authorization,
+            context.policies[0],
+            context.policies[1],
+            prompts[0],
+            prompts[1],
+        )
+    ):
+        return unit_id, None, "requirement transition bindings mismatch"
+    result, reason = _expected_requirement_update(
+        authorization, protected, candidate
+    )
+    return unit_id, result, reason
+
+
+def _authorized_requirement_updates(
+    root: Path,
+    manifest: UnitManifest,
+    base: dict[UnitId, _ProfileInput],
+    head: dict[UnitId, _ProfileInput],
+    authorizations: tuple[_RequirementTransitionAuthorization, ...],
+) -> tuple[dict[UnitId, _ProfileInput], list[str]]:
+    """Authorize only exact opaque requirement and human mapping replacements."""
+    updates: dict[UnitId, _ProfileInput] = {}
+    invalid: list[str] = []
+    policies = (
+        read_git_blob(root, manifest.base_ref, PROFILE_PATH),
+        read_git_blob(root, manifest.head_ref, PROFILE_PATH),
+    )
+    context = _RequirementTransitionContext(root, manifest, base, head, policies)
+    for authorization in authorizations:
+        unit_id, result, reason = _evaluate_requirement_authorization(
+            context, authorization
+        )
+        if reason is not None:
+            invalid.append(f"{authorization.prompt_path}: {reason}")
+            continue
+        if result is not None:
+            updates[unit_id] = result
+    return updates, invalid
 
 
 def _rotation_updates(
@@ -340,7 +706,7 @@ def _effective_profile(
     unit_id: UnitId,
     base: _ProfileInput | None,
     head: _ProfileInput | None,
-    authorized_updates: dict[tuple[UnitId, str], VerificationObligation],
+    authorized: _AuthorizedProfileUpdates,
 ) -> tuple[VerificationProfile, list[str]]:
     invalid: list[str] = []
     if base is None and head is not None:
@@ -348,6 +714,8 @@ def _effective_profile(
             f"{unit_id.prompt_relpath}: candidate-only profile lacks protected approval"
         )
         head = None
+    if unit_id in authorized.requirements:
+        base = authorized.requirements[unit_id]
     base_requirements = set(base.requirements if base else ())
     if base_requirements - set(head.requirements if head else ()):
         invalid.append(f"{unit_id.prompt_relpath}: candidate removed protected requirements")
@@ -358,7 +726,7 @@ def _effective_profile(
     for obligation_id, obligation in head_obligations.items():
         protected = base_obligations.get(obligation_id)
         if protected is not None and protected != obligation:
-            if authorized_updates.get((unit_id, obligation_id)) == obligation:
+            if authorized.obligations.get((unit_id, obligation_id)) == obligation:
                 effective[obligation_id] = obligation
                 continue
             invalid.append(
@@ -383,30 +751,15 @@ def _effective_profile(
     return profile, invalid
 
 
-def load_verification_profiles(root: Path, manifest: UnitManifest) -> ProfileSet:
-    """Load the protected base/candidate union for every expected-managed unit."""
-    alias_invalid: list[str] = []
-    try:
-        approved_aliases = load_protected_aliases(root, manifest)
-    except ValueError as exc:
-        approved_aliases = {}
-        alias_invalid.append(str(exc))
-    base, base_invalid = _load_inputs(
-        root, manifest.base_ref, manifest.repository_id, approved_aliases
-    )
-    head, head_invalid = _load_inputs(
-        root, manifest.head_ref, manifest.repository_id, approved_aliases
-    )
-    invalid = alias_invalid + base_invalid + head_invalid
-    authorized_updates, rotation_invalid = _authorized_rotation_updates(
-        root,
-        manifest,
-        base,
-        head,
-        _load_rotation_authorizations(root, manifest.base_ref),
-    )
-    invalid.extend(rotation_invalid)
+def _build_effective_profiles(
+    manifest: UnitManifest,
+    base: dict[UnitId, _ProfileInput],
+    head: dict[UnitId, _ProfileInput],
+    authorized: _AuthorizedProfileUpdates,
+) -> tuple[list[VerificationProfile], list[str]]:
+    """Build the protected denominator without reducing missing or unknown units."""
     profiles: list[VerificationProfile] = []
+    invalid: list[str] = []
     expected = set(manifest.expected_managed)
     unknown = (set(base) | set(head)) - expected
     invalid.extend(
@@ -417,8 +770,50 @@ def load_verification_profiles(root: Path, manifest: UnitManifest) -> ProfileSet
         if unit_id not in base and unit_id not in head:
             invalid.append(f"{unit_id.prompt_relpath}: verification profile is missing")
         profile, profile_invalid = _effective_profile(
-            unit_id, base.get(unit_id), head.get(unit_id), authorized_updates
+            unit_id, base.get(unit_id), head.get(unit_id), authorized
         )
         profiles.append(profile)
         invalid.extend(profile_invalid)
+    return profiles, invalid
+
+
+def load_verification_profiles(root: Path, manifest: UnitManifest) -> ProfileSet:
+    """Load the protected base/candidate union for every expected-managed unit."""
+    invalid: list[str] = []
+    try:
+        approved_aliases = load_protected_aliases(root, manifest)
+    except ValueError as exc:
+        approved_aliases = {}
+        invalid.append(str(exc))
+    base, loaded_invalid = _load_inputs(
+        root, manifest.base_ref, manifest.repository_id, approved_aliases
+    )
+    invalid.extend(loaded_invalid)
+    head, loaded_invalid = _load_inputs(
+        root, manifest.head_ref, manifest.repository_id, approved_aliases
+    )
+    invalid.extend(loaded_invalid)
+    requirement_updates, requirement_invalid = _authorized_requirement_updates(
+        root,
+        manifest,
+        base,
+        head,
+        _load_requirement_transition_authorizations(root, manifest),
+    )
+    invalid.extend(requirement_invalid)
+    authorized_updates, rotation_invalid = _authorized_rotation_updates(
+        root,
+        manifest,
+        base,
+        head,
+        _load_rotation_authorizations(root, manifest.base_ref),
+    )
+    invalid.extend(rotation_invalid)
+    profiles, profile_invalid = _build_effective_profiles(
+        manifest,
+        base,
+        head,
+        _AuthorizedProfileUpdates(authorized_updates, requirement_updates),
+    )
+    invalid.extend(profile_invalid)
     return ProfileSet(tuple(profiles), tuple(sorted(set(invalid))))

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -56,6 +56,7 @@ FOUNDATION_OBLIGATIONS = {
     },
 }
 PREAUTHORIZED_CHILD_PATHS = {
+    "tests/test_ci_drift_heal_example_contract.py",
     "tests/test_sync_core_runner_jest.py",
     "tests/test_sync_core_runner_vitest.py",
     "tests/test_sync_core_runner_playwright.py",

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -18,6 +18,7 @@ ROOT = Path(__file__).resolve().parents[1]
 EXPECTED_PATH = ROOT / ".pdd" / "expected-managed.json"
 OWNERSHIP_PATH = ROOT / ".pdd" / "sync-ownership.json"
 PROFILE_FILE = ROOT / PROFILE_REL_PATH
+ROTATION_FILE = ROOT / ".pdd" / "verification-profile-rotations.json"
 REPOSITORY_ID = "3b4d7b1c-d6cc-4752-ba93-6b98d1a710e0"
 EXPECTED_MANAGED_UNITS = 466
 FOUNDATION_PROFILE_PATHS = {
@@ -70,6 +71,29 @@ PREAUTHORIZED_CHILD_OWNERSHIP = {
     "role": "human-maintained",
     "owner": "pdd-maintainers",
     "preauthorize_absent": True,
+}
+CI_DETECT_REQUIREMENT_ROTATION = {
+    "prompt_path": "pdd/prompts/ci_detect_changed_modules_python.prompt",
+    "language_id": "python",
+    "from_requirement_id": (
+        "CONTRACT-SHA256:2d5d65f695fc6c8cd2f3e82f5c5d2a55ad3eb30fc4791b2a1d94ff8465ab6d10"
+    ),
+    "to_requirement_id": (
+        "CONTRACT-SHA256:f0d873e5505d40035d3c7364fd3961b5602d21519ec9be2049c2f38b16239712"
+    ),
+    "policy_path": ".pdd/verification-profiles.json",
+    "base_policy_sha256": (
+        "58a704c9d5d351e6b83e2c42126cfe85214aa3ffbf6cb3e64ac4105f3fb19b3e"
+    ),
+    "head_policy_sha256": (
+        "7df63fe892ac14382f226ea97dbd2ac186a8cb48213faec958ad32c51d51aeb5"
+    ),
+    "base_prompt_sha256": (
+        "2d5d65f695fc6c8cd2f3e82f5c5d2a55ad3eb30fc4791b2a1d94ff8465ab6d10"
+    ),
+    "head_prompt_sha256": (
+        "f0d873e5505d40035d3c7364fd3961b5602d21519ec9be2049c2f38b16239712"
+    ),
 }
 
 
@@ -184,6 +208,28 @@ def test_pdd_protected_inventory_is_complete_and_exact() -> None:
         item.candidate_id.artifact_relpath.as_posix()
         for item in manifest.candidates
     } == set(tracked)
+
+
+def test_detector_contract_rotation_is_exact_and_dormant() -> None:
+    """Preauthorize only the reviewed future detector prompt/profile bytes."""
+    policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
+    rules = policy["requirement_rotations"]
+    detector_rules = [
+        row
+        for row in rules
+        if row["prompt_path"]
+        == "pdd/prompts/ci_detect_changed_modules_python.prompt"
+    ]
+    assert detector_rules == [CI_DETECT_REQUIREMENT_ROTATION]
+    prompt = ROOT / CI_DETECT_REQUIREMENT_ROTATION["prompt_path"]
+    assert hashlib.sha256(prompt.read_bytes()).hexdigest() == (
+        CI_DETECT_REQUIREMENT_ROTATION["base_prompt_sha256"]
+    )
+
+    manifest = build_unit_manifest(ROOT, base_ref="HEAD", head_ref="HEAD")
+    profiles = load_verification_profiles(ROOT, manifest)
+    assert not profiles.invalid_reasons
+    assert profiles.coverage == 1.0
 
 
 def test_rollout_profiles_cover_the_protected_pdd_denominator(monkeypatch) -> None:

--- a/tests/test_sync_core_verification_profiles.py
+++ b/tests/test_sync_core_verification_profiles.py
@@ -116,7 +116,7 @@ def _requirement_transition(
     head_profile = json.dumps(candidate_profile).encode()
     policy = {
         "schema_version": 2,
-        "rotations": [],
+        "rotations": _rotation_authorization()["rotations"],
         "requirement_rotations": [
             {
                 "prompt_path": "prompts/widget_python.prompt",

--- a/tests/test_sync_core_verification_profiles.py
+++ b/tests/test_sync_core_verification_profiles.py
@@ -82,6 +82,50 @@ def _human_profile(root: Path, config_digest: str) -> dict:
     }
 
 
+def _human_row(prompt_path: str, prompt_bytes: bytes) -> dict:
+    """Build one opaque-contract profile row for multi-unit rotation tests."""
+    requirement = f"CONTRACT-SHA256:{hashlib.sha256(prompt_bytes).hexdigest()}"
+    return {
+        "prompt_path": prompt_path,
+        "language_id": "python",
+        "required_requirement_ids": [requirement],
+        "obligations": [
+            {
+                "obligation_id": "threshold-human-attestation",
+                "kind": "human-attestation",
+                "validator_id": "threshold-ed25519",
+                "validator_config_digest": "threshold-ed25519-v1",
+                "requirement_ids": [requirement],
+                "artifact_paths": [prompt_path],
+                "required": True,
+            }
+        ],
+    }
+
+
+def _requirement_rule(
+    prompt_path: str,
+    base_prompt: bytes,
+    head_prompt: bytes,
+    base_profile: bytes,
+    head_profile: bytes,
+) -> dict:
+    """Bind one requirement transition to exact prompt and profile bytes."""
+    base_digest = hashlib.sha256(base_prompt).hexdigest()
+    head_digest = hashlib.sha256(head_prompt).hexdigest()
+    return {
+        "prompt_path": prompt_path,
+        "language_id": "python",
+        "from_requirement_id": f"CONTRACT-SHA256:{base_digest}",
+        "to_requirement_id": f"CONTRACT-SHA256:{head_digest}",
+        "policy_path": ".pdd/verification-profiles.json",
+        "base_policy_sha256": hashlib.sha256(base_profile).hexdigest(),
+        "head_policy_sha256": hashlib.sha256(head_profile).hexdigest(),
+        "base_prompt_sha256": base_digest,
+        "head_prompt_sha256": head_digest,
+    }
+
+
 def _rotation_authorization() -> dict:
     """Authorize the one future protected trust-policy transition."""
     return {
@@ -289,6 +333,126 @@ def test_exact_requirement_transition_updates_human_mapping(tmp_path) -> None:
     assert profiles.coverage == 1.0
     assert profiles.profiles[0].required_requirement_ids == (requirement,)
     assert profiles.profiles[0].obligations[0].requirement_ids == (requirement,)
+
+
+def test_dormant_requirement_transition_survives_unrelated_exact_transition(
+    tmp_path,
+) -> None:
+    """A future row stays dormant while a sibling consumes its exact rule."""
+    root = _repository(tmp_path)
+    widget_path = "prompts/widget_python.prompt"
+    gadget_path = "prompts/gadget_python.prompt"
+    widget_v1 = b"Opaque widget contract version one\n"
+    widget_v2 = b"Opaque widget contract version two\n"
+    gadget_v1 = b"Opaque gadget contract version one\n"
+    gadget_v2 = b"Opaque gadget contract version two\n"
+    (root / widget_path).write_bytes(widget_v1)
+    (root / gadget_path).write_bytes(gadget_v1)
+
+    profile_path = root / ".pdd/verification-profiles.json"
+    profile_v0 = {
+        "profiles": [
+            _human_row(widget_path, widget_v1),
+            _human_row(gadget_path, gadget_v1),
+        ]
+    }
+    profile_v1 = {
+        "profiles": [
+            _human_row(widget_path, widget_v1),
+            _human_row(gadget_path, gadget_v2),
+        ]
+    }
+    profile_v2 = {
+        "profiles": [
+            _human_row(widget_path, widget_v2),
+            _human_row(gadget_path, gadget_v2),
+        ]
+    }
+    profile_bytes = [
+        json.dumps(item).encode() for item in (profile_v0, profile_v1, profile_v2)
+    ]
+    profile_path.write_bytes(profile_bytes[0])
+    policy = {
+        "schema_version": 2,
+        "rotations": _rotation_authorization()["rotations"],
+        "requirement_rotations": [
+            _requirement_rule(
+                gadget_path, gadget_v1, gadget_v2, profile_bytes[0], profile_bytes[1]
+            ),
+            _requirement_rule(
+                widget_path, widget_v1, widget_v2, profile_bytes[1], profile_bytes[2]
+            ),
+        ],
+    }
+    (root / ".pdd/verification-profile-rotations.json").write_text(json.dumps(policy))
+    base = _commit(root, "preauthorize staggered exact transitions")
+
+    (root / gadget_path).write_bytes(gadget_v2)
+    profile_path.write_bytes(profile_bytes[1])
+    head = _commit(root, "consume gadget transition only")
+
+    profiles = load_verification_profiles(root, _manifest(root, base, head))
+    assert not profiles.invalid_reasons
+    assert profiles.coverage == 1.0
+
+
+@pytest.mark.parametrize("substitution", ["removed-requirement", "cross-profile"])
+def test_exact_requirement_transition_rejects_profile_substitution(
+    tmp_path, substitution
+) -> None:
+    """Exact file digests cannot authorize a partial or cross-unit remap."""
+    root = _repository(tmp_path)
+    widget_path = "prompts/widget_python.prompt"
+    gadget_path = "prompts/gadget_python.prompt"
+    widget_v1 = b"Opaque widget contract version one\n"
+    widget_v2 = b"Opaque widget contract version two\n"
+    gadget = b"Opaque gadget contract\n"
+    (root / widget_path).write_bytes(widget_v1)
+    (root / gadget_path).write_bytes(gadget)
+    profile_path = root / ".pdd/verification-profiles.json"
+    base_profile = {
+        "profiles": [
+            _human_row(widget_path, widget_v1),
+            _human_row(gadget_path, gadget),
+        ]
+    }
+    candidate_profile = json.loads(json.dumps(base_profile))
+    target_requirement = f"CONTRACT-SHA256:{hashlib.sha256(widget_v2).hexdigest()}"
+    target = candidate_profile["profiles"][
+        0 if substitution == "removed-requirement" else 1
+    ]
+    target["required_requirement_ids"] = (
+        [] if substitution == "removed-requirement" else [target_requirement]
+    )
+    target["obligations"][0]["requirement_ids"] = target["required_requirement_ids"]
+    base_bytes = json.dumps(base_profile).encode()
+    candidate_bytes = json.dumps(candidate_profile).encode()
+    profile_path.write_bytes(base_bytes)
+    policy = {
+        "schema_version": 2,
+        "rotations": _rotation_authorization()["rotations"],
+        "requirement_rotations": [
+            _requirement_rule(
+                widget_path, widget_v1, widget_v2, base_bytes, candidate_bytes
+            )
+        ],
+    }
+    (root / ".pdd/verification-profile-rotations.json").write_text(json.dumps(policy))
+    base = _commit(root, "authorize exact widget transition")
+
+    (root / widget_path).write_bytes(widget_v2)
+    profile_path.write_bytes(candidate_bytes)
+    head = _commit(root, f"attempt {substitution}")
+
+    profiles = load_verification_profiles(root, _manifest(root, base, head))
+    assert any(
+        marker in reason
+        for reason in profiles.invalid_reasons
+        for marker in (
+            "requirement transition is partial or mismatched",
+            "candidate removed protected requirements",
+        )
+    )
 
 
 def test_candidate_cannot_add_its_own_requirement_authorization(tmp_path) -> None:

--- a/tests/test_sync_core_verification_profiles.py
+++ b/tests/test_sync_core_verification_profiles.py
@@ -339,6 +339,7 @@ def test_dormant_requirement_transition_survives_unrelated_exact_transition(
     tmp_path,
 ) -> None:
     """A future row stays dormant while a sibling consumes its exact rule."""
+    # pylint: disable=too-many-locals
     root = _repository(tmp_path)
     widget_path = "prompts/widget_python.prompt"
     gadget_path = "prompts/gadget_python.prompt"
@@ -401,6 +402,7 @@ def test_exact_requirement_transition_rejects_profile_substitution(
     tmp_path, substitution
 ) -> None:
     """Exact file digests cannot authorize a partial or cross-unit remap."""
+    # pylint: disable=too-many-locals
     root = _repository(tmp_path)
     widget_path = "prompts/widget_python.prompt"
     gadget_path = "prompts/gadget_python.prompt"

--- a/tests/test_sync_core_verification_profiles.py
+++ b/tests/test_sync_core_verification_profiles.py
@@ -5,8 +5,11 @@ import hashlib
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from pdd.sync_core import build_unit_manifest, load_verification_profiles
 from pdd.sync_core.identity import initialize_repository_identity
+from pdd.sync_core.verification import VerificationProfileError
 
 
 REPOSITORY_ID = "3b4d7b1c-d6cc-4752-ba93-6b98d1a710e0"
@@ -92,6 +95,45 @@ def _rotation_authorization() -> dict:
             }
         ],
     }
+
+
+def _requirement_transition(
+    root: Path, target_prompt: str, candidate_profile: dict | None = None
+) -> tuple[dict, dict]:
+    """Preauthorize one future exact opaque prompt/profile transition."""
+    prompt_path = root / "prompts/widget_python.prompt"
+    profile_path = root / ".pdd/verification-profiles.json"
+    base_prompt = prompt_path.read_bytes()
+    base_profile = profile_path.read_bytes()
+    head_prompt = target_prompt.encode()
+    requirement = f"CONTRACT-SHA256:{hashlib.sha256(head_prompt).hexdigest()}"
+    if candidate_profile is None:
+        candidate_profile = json.loads(profile_path.read_text())
+        candidate_profile["profiles"][0]["required_requirement_ids"] = [requirement]
+        candidate_profile["profiles"][0]["obligations"][0]["requirement_ids"] = [
+            requirement
+        ]
+    head_profile = json.dumps(candidate_profile).encode()
+    policy = {
+        "schema_version": 2,
+        "rotations": [],
+        "requirement_rotations": [
+            {
+                "prompt_path": "prompts/widget_python.prompt",
+                "language_id": "python",
+                "from_requirement_id": (
+                    f"CONTRACT-SHA256:{hashlib.sha256(base_prompt).hexdigest()}"
+                ),
+                "to_requirement_id": requirement,
+                "policy_path": ".pdd/verification-profiles.json",
+                "base_policy_sha256": hashlib.sha256(base_profile).hexdigest(),
+                "head_policy_sha256": hashlib.sha256(head_profile).hexdigest(),
+                "base_prompt_sha256": hashlib.sha256(base_prompt).hexdigest(),
+                "head_prompt_sha256": hashlib.sha256(head_prompt).hexdigest(),
+            }
+        ],
+    }
+    return policy, candidate_profile
 
 
 def _repository(tmp_path: Path) -> Path:
@@ -203,6 +245,129 @@ def test_policy_rotation_rejects_arbitrary_human_config_digest(tmp_path) -> None
         "threshold-ed25519-v1"
     )
     assert any("changed protected obligation" in item for item in profiles.invalid_reasons)
+
+
+def test_protected_requirement_transition_is_valid_while_dormant(tmp_path) -> None:
+    """Protected future authority must not invalidate unchanged protected bytes."""
+    root = _repository(tmp_path)
+    prompt = root / "prompts/widget_python.prompt"
+    prompt.write_text("Opaque contract version one\n")
+    profile_path = root / ".pdd/verification-profiles.json"
+    profile_path.write_text(json.dumps(_human_profile(root, "threshold-ed25519-v1")))
+    policy, _candidate_profile = _requirement_transition(
+        root, "Opaque contract version two\n"
+    )
+    (root / ".pdd/verification-profile-rotations.json").write_text(json.dumps(policy))
+    protected = _commit(root, "preauthorize future transition")
+
+    profiles = load_verification_profiles(root, _manifest(root, protected, protected))
+
+    assert not profiles.invalid_reasons
+    assert profiles.coverage == 1.0
+
+
+def test_exact_requirement_transition_updates_human_mapping(tmp_path) -> None:
+    """Exact Git-bound prompt and human requirement replacement is accepted."""
+    root = _repository(tmp_path)
+    prompt = root / "prompts/widget_python.prompt"
+    prompt.write_text("Opaque contract version one\n")
+    profile_path = root / ".pdd/verification-profiles.json"
+    profile_path.write_text(json.dumps(_human_profile(root, "threshold-ed25519-v1")))
+    policy, candidate_profile = _requirement_transition(
+        root, "Opaque contract version two\n"
+    )
+    (root / ".pdd/verification-profile-rotations.json").write_text(json.dumps(policy))
+    base = _commit(root, "protected transition authority")
+
+    prompt.write_text("Opaque contract version two\n")
+    profile_path.write_text(json.dumps(candidate_profile))
+    head = _commit(root, "consume exact transition")
+
+    profiles = load_verification_profiles(root, _manifest(root, base, head))
+    requirement = f"CONTRACT-SHA256:{hashlib.sha256(prompt.read_bytes()).hexdigest()}"
+    assert not profiles.invalid_reasons
+    assert profiles.coverage == 1.0
+    assert profiles.profiles[0].required_requirement_ids == (requirement,)
+    assert profiles.profiles[0].obligations[0].requirement_ids == (requirement,)
+
+
+def test_candidate_cannot_add_its_own_requirement_authorization(tmp_path) -> None:
+    """Exact candidate bytes still lack authority without a protected rule."""
+    root = _repository(tmp_path)
+    prompt = root / "prompts/widget_python.prompt"
+    prompt.write_text("Opaque contract version one\n")
+    profile_path = root / ".pdd/verification-profiles.json"
+    profile_path.write_text(json.dumps(_human_profile(root, "threshold-ed25519-v1")))
+    policy, candidate_profile = _requirement_transition(
+        root, "Opaque contract version two\n"
+    )
+    base = _commit(root, "protected profile without transition authority")
+
+    prompt.write_text("Opaque contract version two\n")
+    profile_path.write_text(json.dumps(candidate_profile))
+    (root / ".pdd/verification-profile-rotations.json").write_text(json.dumps(policy))
+    head = _commit(root, "candidate self-authorization attempt")
+
+    with pytest.raises(
+        VerificationProfileError,
+        match="candidate requirement transition lacks protected authorization",
+    ):
+        load_verification_profiles(root, _manifest(root, base, head))
+
+
+def test_requirement_transition_rejects_wrong_bound_prompt(tmp_path) -> None:
+    """Protected authority cannot cover bytes outside its exact four digests."""
+    root = _repository(tmp_path)
+    prompt = root / "prompts/widget_python.prompt"
+    prompt.write_text("Opaque contract version one\n")
+    profile_path = root / ".pdd/verification-profiles.json"
+    profile_path.write_text(json.dumps(_human_profile(root, "threshold-ed25519-v1")))
+    policy, candidate_profile = _requirement_transition(
+        root, "Opaque contract version two\n"
+    )
+    policy["requirement_rotations"][0]["base_prompt_sha256"] = "0" * 64
+    (root / ".pdd/verification-profile-rotations.json").write_text(json.dumps(policy))
+    base = _commit(root, "protected mismatched transition")
+
+    prompt.write_text("Opaque contract version two\n")
+    profile_path.write_text(json.dumps(candidate_profile))
+    head = _commit(root, "attempt mismatched transition")
+
+    profiles = load_verification_profiles(root, _manifest(root, base, head))
+    assert profiles.coverage == 0.0
+    assert any("bindings mismatch" in item for item in profiles.invalid_reasons)
+
+
+def test_exact_requirement_transition_cannot_remap_validator(tmp_path) -> None:
+    """Exact byte bindings permit only the human requirement-ID replacement."""
+    root = _repository(tmp_path)
+    prompt = root / "prompts/widget_python.prompt"
+    prompt.write_text("Opaque contract version one\n")
+    profile_path = root / ".pdd/verification-profiles.json"
+    profile_path.write_text(json.dumps(_human_profile(root, "threshold-ed25519-v1")))
+    changed = json.loads(profile_path.read_text())
+    target_prompt = "Opaque contract version two\n"
+    target_requirement = f"CONTRACT-SHA256:{hashlib.sha256(target_prompt.encode()).hexdigest()}"
+    changed["profiles"][0]["required_requirement_ids"] = [target_requirement]
+    changed["profiles"][0]["obligations"][0]["requirement_ids"] = [
+        target_requirement
+    ]
+    changed["profiles"][0]["obligations"][0]["validator_id"] = "candidate-validator"
+    policy, changed = _requirement_transition(root, target_prompt, changed)
+    (root / ".pdd/verification-profile-rotations.json").write_text(json.dumps(policy))
+    base = _commit(root, "protected exact transition")
+
+    prompt.write_text(target_prompt)
+    profile_path.write_text(json.dumps(changed))
+    head = _commit(root, "attempt validator remap")
+
+    profiles = load_verification_profiles(root, _manifest(root, base, head))
+    assert profiles.coverage == 0.0
+    assert any(
+        "requirement transition changes protected fields" in item
+        for item in profiles.invalid_reasons
+    )
+    assert profiles.profiles[0].obligations[0].validator_id == "threshold-ed25519"
 
 
 def test_profile_digest_binds_declared_code_under_test(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- establish protected-base provenance for the exact absent `tests/test_ci_drift_heal_example_contract.py` path
- enforce exact-byte-bound opaque prompt/profile requirement rotations
- preauthorize only the #2063 `ci_drift_heal` transition before its feature diff consumes it

This is a prerequisite for #2063 / #2061. It does not change the drift example, prompt, metadata, or verification profile.

## TDD

The first commit contains failing tests only. Red evidence is posted separately.

## Test plan

- targeted requirement-transition tests
- sync rollout-policy and verification-profile suites
- exact protected-base → candidate evaluator probe for this PR and stacked #2063
- pylint and diff checks

No merge or deployment is part of this task.