### PR TITLE
fix(sync): preserve candidate Python stdlib in sandbox

### DIFF
--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -280,6 +280,53 @@ def _runtime_directories() -> tuple[tuple[str, Path], ...]:
     return tuple(result)
 
 
+def _python_version(value: str) -> str | None:
+    """Return a validated major.minor prefix from a Python version spelling."""
+    parts = value.strip().split(".")
+    if len(parts) < 2 or not all(part.isdigit() for part in parts[:2]):
+        return None
+    return f"{int(parts[0])}.{int(parts[1])}"
+
+
+def _native_python_runtime_roots(executable: Path) -> tuple[Path, ...]:
+    """Derive only the native stdlib root selected by a Python executable."""
+    try:
+        resolved = executable.resolve(strict=True)
+    except OSError:
+        return ()
+    versions: list[tuple[Path, str]] = []
+    configuration = executable.parent.parent / "pyvenv.cfg"
+    try:
+        with configuration.open("r", encoding="utf-8") as stream:
+            payload = stream.read(64 * 1024 + 1)
+        if len(payload) > 64 * 1024:
+            return ()
+        values = {
+            key.strip().lower(): value.strip()
+            for line in payload.splitlines()
+            if "=" in line
+            for key, value in (line.split("=", 1),)
+        }
+        home = Path(values.get("home", ""))
+        version = _python_version(values.get("version", ""))
+        if home.is_absolute() and home.name in {"bin", "Scripts"} and version:
+            versions.append((home.parent, version))
+    except (OSError, UnicodeError):
+        pass
+    resolved_version = _python_version(resolved.name.removeprefix("python"))
+    if resolved_version:
+        versions.append((resolved.parent.parent, resolved_version))
+    elif resolved == _SUPERVISOR_EXECUTABLE.resolve():
+        current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        versions.append((resolved.parent.parent, current_version))
+    roots = []
+    for prefix, version in versions:
+        root = (prefix / "lib" / f"python{version}").resolve()
+        if root.is_dir() and root not in roots:
+            roots.append(root)
+    return tuple(roots)
+
+
 @lru_cache(maxsize=1)
 def released_runtime_closure_paths() -> tuple[tuple[str, Path], ...]:
     """Return every regular file exposed by the sandbox with logical names."""
@@ -330,6 +377,7 @@ def _runtime_roots(command: list[str], cwd: Path) -> tuple[Path, ...]:
         _SUPERVISOR_EXECUTABLE, Path(shutil.which(command[0]) or command[0]),
     )
     for executable in executables:
+        roots.update(_native_python_runtime_roots(executable))
         resolved_executable = executable.resolve()
         if not executable.is_relative_to(cwd):
             roots.add(executable)

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -320,33 +320,51 @@ def _discovered_python_version(
 ) -> str | None:
     """Return one unambiguous bounded version from native stdlib directories."""
     discovered = set()
+    matching_entries = 0
     for library_name in library_names:
+        library_root = prefix / library_name
+        if not library_root.is_dir():
+            continue
         try:
-            entries = tuple((prefix / library_name).iterdir())
+            entries = library_root.iterdir()
         except OSError:
             continue
-        if len(entries) > 64:
-            return None
-        for entry in entries:
-            version = _python_version(entry.name.removeprefix("python"))
-            if version and entry.name.startswith("python") and entry.is_dir():
+        try:
+            for entry in entries:
+                version = _python_version(entry.name.removeprefix("python"))
+                if not version or not entry.name.startswith("python"):
+                    continue
+                if not entry.is_dir():
+                    continue
+                matching_entries += 1
+                if matching_entries > 64:
+                    return None
                 discovered.add(version)
+        except OSError:
+            return None
     return discovered.pop() if len(discovered) == 1 else None
 
 
 def _native_stdlib_root(
     prefix: Path, version: str, library_names: tuple[str, ...],
+    preferred_library_name: str | None = None,
 ) -> Path | None:
-    """Select the first exact existing stdlib root for one native runtime."""
+    """Select one unambiguous exact stdlib root for a native runtime."""
+    roots: dict[str, Path] = {}
     for library_name in library_names:
         try:
             root = (
                 prefix / library_name / f"python{version}"
             ).resolve(strict=True)
             if root.is_dir() and (root / "linecache.py").is_file():
-                return root
+                roots[library_name] = root
         except (OSError, RuntimeError):
             continue
+    unique_roots = set(roots.values())
+    if len(unique_roots) == 1:
+        return unique_roots.pop()
+    if preferred_library_name and preferred_library_name in roots:
+        return roots[preferred_library_name]
     return None
 
 
@@ -356,30 +374,38 @@ def _native_python_runtime_roots(executable: Path) -> tuple[Path, ...]:
         resolved = executable.resolve(strict=True)
     except (OSError, RuntimeError):
         return ()
-    versions: list[tuple[Path, str]] = []
-    configured = _configured_python_runtime(executable)
-    if configured:
-        versions.append(configured)
-    resolved_version = _python_version(resolved.name.removeprefix("python"))
-    if resolved_version:
-        versions.append((resolved.parent.parent, resolved_version))
     try:
         current_executable = _SUPERVISOR_EXECUTABLE.resolve(strict=True)
     except (OSError, RuntimeError):
         current_executable = None
+    versions: list[tuple[Path, str, str | None]] = []
+    configured = _configured_python_runtime(executable)
+    if configured:
+        versions.append((*configured, None))
+    resolved_version = _python_version(resolved.name.removeprefix("python"))
+    if resolved_version:
+        preference = sys.platlibdir if resolved == current_executable else None
+        versions.append((resolved.parent.parent, resolved_version, preference))
     if not resolved_version and resolved == current_executable:
         current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-        versions.append((resolved.parent.parent, current_version))
+        versions.append((resolved.parent.parent, current_version, sys.platlibdir))
     library_names = tuple(dict.fromkeys((sys.platlibdir, "lib", "lib64")))
-    if not versions:
+    unversioned_python_names = {"python", "python3"}
+    if (
+        not versions
+        and executable.name in unversioned_python_names
+        and resolved.name in unversioned_python_names
+    ):
         discovered = _discovered_python_version(
             resolved.parent.parent, library_names,
         )
         if discovered:
-            versions.append((resolved.parent.parent, discovered))
+            versions.append((resolved.parent.parent, discovered, None))
     roots = []
-    for prefix, version in versions:
-        root = _native_stdlib_root(prefix, version, library_names)
+    for prefix, version, preference in versions:
+        root = _native_stdlib_root(
+            prefix, version, library_names, preference,
+        )
         if root is not None and root not in roots:
             roots.append(root)
     return tuple(roots)

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -283,24 +283,23 @@ def _runtime_directories() -> tuple[tuple[str, Path], ...]:
 def _python_version(value: str) -> str | None:
     """Return a validated major.minor prefix from a Python version spelling."""
     parts = value.strip().split(".")
-    if len(parts) < 2 or not all(part.isdigit() for part in parts[:2]):
+    if len(parts) < 2 or not all(
+        1 <= len(part) <= 3
+        and all("0" <= character <= "9" for character in part)
+        for part in parts[:2]
+    ):
         return None
     return f"{int(parts[0])}.{int(parts[1])}"
 
 
-def _native_python_runtime_roots(executable: Path) -> tuple[Path, ...]:
-    """Derive only the native stdlib root selected by a Python executable."""
-    try:
-        resolved = executable.resolve(strict=True)
-    except OSError:
-        return ()
-    versions: list[tuple[Path, str]] = []
+def _configured_python_runtime(executable: Path) -> tuple[Path, str] | None:
+    """Read a bounded native prefix/version pair from adjacent venv metadata."""
     configuration = executable.parent.parent / "pyvenv.cfg"
     try:
         with configuration.open("r", encoding="utf-8") as stream:
             payload = stream.read(64 * 1024 + 1)
         if len(payload) > 64 * 1024:
-            return ()
+            return None
         values = {
             key.strip().lower(): value.strip()
             for line in payload.splitlines()
@@ -310,19 +309,78 @@ def _native_python_runtime_roots(executable: Path) -> tuple[Path, ...]:
         home = Path(values.get("home", ""))
         version = _python_version(values.get("version", ""))
         if home.is_absolute() and home.name in {"bin", "Scripts"} and version:
-            versions.append((home.parent, version))
+            return home.parent, version
     except (OSError, UnicodeError):
-        pass
+        return None
+    return None
+
+
+def _discovered_python_version(
+    prefix: Path, library_names: tuple[str, ...],
+) -> str | None:
+    """Return one unambiguous bounded version from native stdlib directories."""
+    discovered = set()
+    for library_name in library_names:
+        try:
+            entries = tuple((prefix / library_name).iterdir())
+        except OSError:
+            continue
+        if len(entries) > 64:
+            return None
+        for entry in entries:
+            version = _python_version(entry.name.removeprefix("python"))
+            if version and entry.name.startswith("python") and entry.is_dir():
+                discovered.add(version)
+    return discovered.pop() if len(discovered) == 1 else None
+
+
+def _native_stdlib_root(
+    prefix: Path, version: str, library_names: tuple[str, ...],
+) -> Path | None:
+    """Select the first exact existing stdlib root for one native runtime."""
+    for library_name in library_names:
+        try:
+            root = (
+                prefix / library_name / f"python{version}"
+            ).resolve(strict=True)
+            if root.is_dir() and (root / "linecache.py").is_file():
+                return root
+        except (OSError, RuntimeError):
+            continue
+    return None
+
+
+def _native_python_runtime_roots(executable: Path) -> tuple[Path, ...]:
+    """Derive only the native stdlib root selected by a Python executable."""
+    try:
+        resolved = executable.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return ()
+    versions: list[tuple[Path, str]] = []
+    configured = _configured_python_runtime(executable)
+    if configured:
+        versions.append(configured)
     resolved_version = _python_version(resolved.name.removeprefix("python"))
     if resolved_version:
         versions.append((resolved.parent.parent, resolved_version))
-    elif resolved == _SUPERVISOR_EXECUTABLE.resolve():
+    try:
+        current_executable = _SUPERVISOR_EXECUTABLE.resolve(strict=True)
+    except (OSError, RuntimeError):
+        current_executable = None
+    if not resolved_version and resolved == current_executable:
         current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
         versions.append((resolved.parent.parent, current_version))
+    library_names = tuple(dict.fromkeys((sys.platlibdir, "lib", "lib64")))
+    if not versions:
+        discovered = _discovered_python_version(
+            resolved.parent.parent, library_names,
+        )
+        if discovered:
+            versions.append((resolved.parent.parent, discovered))
     roots = []
     for prefix, version in versions:
-        root = (prefix / "lib" / f"python{version}").resolve()
-        if root.is_dir() and root not in roots:
+        root = _native_stdlib_root(prefix, version, library_names)
+        if root is not None and root not in roots:
             roots.append(root)
     return tuple(roots)
 

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -160,6 +160,13 @@ def test_runtime_directories_collapse_nested_but_keep_disjoint_roots(
     )
 
 
+@pytest.mark.parametrize("version", ("².12", "1234.12", "3.1234"))
+def test_python_runtime_version_rejects_non_ascii_or_unbounded_fields(
+    version: str,
+) -> None:
+    assert supervisor._python_version(version) is None
+
+
 def test_runtime_roots_include_candidate_interpreter_native_stdlib(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -160,6 +160,40 @@ def test_runtime_directories_collapse_nested_but_keep_disjoint_roots(
     )
 
 
+def test_runtime_roots_include_candidate_interpreter_native_stdlib(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A venv command retains the exact native stdlib selected by pyvenv.cfg."""
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    native_bin = tmp_path / "native" / "bin"
+    native_bin.mkdir(parents=True)
+    native_python = native_bin / "python"
+    native_python.write_bytes(b"native-python")
+    native_python.chmod(0o755)
+    native_stdlib = tmp_path / "native" / "lib" / "python3.12"
+    native_stdlib.mkdir(parents=True)
+    (native_stdlib / "linecache.py").write_text("cache = {}\n", encoding="utf-8")
+    environment = tmp_path / "candidate-venv"
+    candidate_bin = environment / "bin"
+    candidate_bin.mkdir(parents=True)
+    candidate_python = candidate_bin / "python"
+    candidate_python.symlink_to(native_python)
+    (environment / "pyvenv.cfg").write_text(
+        f"home = {native_bin}\n"
+        "include-system-site-packages = false\n"
+        "version = 3.12.9\n"
+        f"executable = {native_python}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(supervisor, "_runtime_directories", lambda: ())
+    monkeypatch.setattr(supervisor, "released_runtime_closure_paths", lambda: ())
+
+    roots = _runtime_roots([str(candidate_python), "-c", "pass"], workdir)
+
+    assert native_stdlib.resolve() in roots
+
+
 def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -274,6 +274,66 @@ def test_native_runtime_roots_support_unversioned_lib64_interpreter(
     assert unrelated.resolve() not in roots
 
 
+def test_native_runtime_roots_reject_non_python_unversioned_executable(
+    tmp_path: Path,
+) -> None:
+    """Adjacent Python libraries do not make an arbitrary command Python."""
+    prefix = tmp_path / "native"
+    native_bin = prefix / "bin"
+    native_bin.mkdir(parents=True)
+    native_node = native_bin / "node"
+    native_node.write_bytes(b"native-node")
+    native_node.chmod(0o755)
+    native_stdlib = prefix / "lib" / "python3.12"
+    native_stdlib.mkdir(parents=True)
+    (native_stdlib / "linecache.py").write_text("cache = {}\n", encoding="utf-8")
+
+    assert supervisor._native_python_runtime_roots(native_node) == ()
+
+
+def test_native_runtime_roots_ignore_unrelated_busy_prefix_entries(
+    tmp_path: Path,
+) -> None:
+    """Only matching Python roots count toward bounded fallback discovery."""
+    prefix = tmp_path / "native"
+    native_bin = prefix / "bin"
+    native_bin.mkdir(parents=True)
+    native_python = native_bin / "python"
+    native_python.write_bytes(b"native-python")
+    native_python.chmod(0o755)
+    library = prefix / "lib"
+    for index in range(65):
+        (library / f"unrelated-{index}").mkdir(parents=True)
+    native_stdlib = library / "python3.12"
+    native_stdlib.mkdir()
+    (native_stdlib / "linecache.py").write_text("cache = {}\n", encoding="utf-8")
+
+    assert supervisor._native_python_runtime_roots(native_python) == (
+        native_stdlib.resolve(),
+    )
+
+
+def test_native_runtime_roots_reject_ambiguous_library_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ambient platlibdir cannot choose between candidate lib and lib64."""
+    prefix = tmp_path / "native"
+    native_bin = prefix / "bin"
+    native_bin.mkdir(parents=True)
+    native_python = native_bin / "python"
+    native_python.write_bytes(b"native-python")
+    native_python.chmod(0o755)
+    for library_name in ("lib", "lib64"):
+        native_stdlib = prefix / library_name / "python3.12"
+        native_stdlib.mkdir(parents=True)
+        (native_stdlib / "linecache.py").write_text(
+            "cache = {}\n", encoding="utf-8",
+        )
+    monkeypatch.setattr(sys, "platlibdir", "lib64")
+
+    assert supervisor._native_python_runtime_roots(native_python) == ()
+
+
 def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -194,6 +194,79 @@ def test_runtime_roots_include_candidate_interpreter_native_stdlib(
     assert native_stdlib.resolve() in roots
 
 
+@pytest.mark.parametrize("failure", ("invalid-version", "resolve-error"))
+def test_candidate_runtime_metadata_failures_remain_supervised(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure: str,
+) -> None:
+    """Candidate metadata/path errors retain the status-125 failure contract."""
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    native_bin = tmp_path / "native" / "bin"
+    native_bin.mkdir(parents=True)
+    native_python = native_bin / "python"
+    native_python.write_bytes(b"native-python")
+    native_python.chmod(0o755)
+    environment = tmp_path / "candidate-venv"
+    candidate_bin = environment / "bin"
+    candidate_bin.mkdir(parents=True)
+    candidate_python = candidate_bin / "python"
+    candidate_python.symlink_to(native_python)
+    version = "².12" if failure == "invalid-version" else "3.12.9"
+    (environment / "pyvenv.cfg").write_text(
+        f"home = {native_bin}\nversion = {version}\n", encoding="utf-8",
+    )
+    native_stdlib = tmp_path / "native" / "lib" / "python3.12"
+    if failure == "resolve-error":
+        native_stdlib.mkdir(parents=True)
+        original_resolve = Path.resolve
+
+        def guarded_resolve(path, *args, **kwargs):
+            if path == native_stdlib:
+                raise OSError("candidate runtime resolution failed")
+            return original_resolve(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", guarded_resolve)
+    monkeypatch.setattr(supervisor, "_runtime_directories", lambda: ())
+    monkeypatch.setattr(supervisor, "released_runtime_closure_paths", lambda: ())
+
+    def fail_closed(command, *_args, **_kwargs):
+        _runtime_roots(command, workdir)
+        raise RuntimeError("protected candidate runtime unavailable")
+
+    monkeypatch.setattr(supervisor, "_sandbox_command", fail_closed)
+    result, surviving = run_supervised(
+        [str(candidate_python), "-c", "pass"], cwd=workdir, timeout=1,
+        env={}, writable_roots=(workdir,),
+    )
+
+    assert result.returncode == 125
+    assert result.stderr == "protected candidate runtime unavailable"
+    assert surviving is False
+
+
+def test_native_runtime_roots_support_unversioned_lib64_interpreter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A distinct unversioned Python retains one relocated native stdlib."""
+    prefix = tmp_path / "native"
+    native_bin = prefix / "bin"
+    native_bin.mkdir(parents=True)
+    native_python = native_bin / "python"
+    native_python.write_bytes(b"native-python")
+    native_python.chmod(0o755)
+    native_stdlib = prefix / "lib64" / "python3.12"
+    native_stdlib.mkdir(parents=True)
+    (native_stdlib / "linecache.py").write_text("cache = {}\n", encoding="utf-8")
+    unrelated = prefix / "share" / "python3.12"
+    unrelated.mkdir(parents=True)
+    monkeypatch.setattr(sys, "platlibdir", "lib64")
+
+    roots = supervisor._native_python_runtime_roots(native_python)
+
+    assert roots == (native_stdlib.resolve(),)
+    assert unrelated.resolve() not in roots
+
+
 def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- derive the candidate interpreter's exact native stdlib root from bounded `pyvenv.cfg` metadata
- retain the native stdlib for the exact supervisor interpreter even when ambient `sysconfig` paths differ
- mount only an existing `lib/python<major.minor>` root read-only inside the existing private Bubblewrap namespace

## Root cause

PR #2054 moved staged bind mounts into a private mount namespace. The runtime closure still came only from the checker process's `sysconfig` paths. A candidate venv or native interpreter with a different base prefix therefore retained its executable but lost its own stdlib, producing prefix warnings and `ModuleNotFoundError: linecache`. The same shared boundary caused lifecycle, supervisor, runner, and reporting failures in the v0.0.305 cloud gate.

Malformed, non-absolute, non-bin `home`, oversized, or missing `pyvenv.cfg` data contributes no mount. The private namespace, exact trusted-tool identity checks, post-drop handoff, and fail-closed behavior are unchanged.

## Validation

- red: focused regression failed at `a57473934` because the native stdlib was absent
- green: `26 passed, 17 skipped` — `tests/test_sync_core_supervisor.py` on macOS
- green: `3 passed, 1 skipped, 12 deselected` — candidate install/lifecycle focus on macOS
- `pylint pdd/sync_core/supervisor.py` — 10.00/10
- `python -m compileall -q pdd/sync_core/supervisor.py`
- `git diff --check`

Hosted Ubuntu Unit Tests are the authoritative real Bubblewrap/passwordless-sudo end-to-end check. The canonical 77-task `make cloud-test` rerun remains a post-merge release-orchestrator gate.

Fixes #2066
