### PR TITLE
fix(cloud-test): accept canonical Batch task and agent log identities

### DIFF
--- a/ci/cloud-batch/verify-secret-logs.py
+++ b/ci/cloud-batch/verify-secret-logs.py
@@ -13,6 +13,7 @@ import sys
 import urllib.parse
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
+from typing import NamedTuple
 
 
 RESOURCE_PATTERN = re.compile(
@@ -30,8 +31,12 @@ TASK_RESOURCE_PATTERN = re.compile(
     r"^projects/(?P<project>[^/]+)/locations/(?P<location>[^/]+)/jobs/"
     r"(?P<job>[^/]+)/taskGroups/(?P<group>[^/]+)/tasks/(?P<index>[^/]+)$"
 )
+TASK_GROUP_RESOURCE_PATTERN = re.compile(
+    r"^projects/(?P<project>[^/]+)/locations/(?P<location>[^/]+)/jobs/"
+    r"(?P<job>[^/]+)/taskGroups/(?P<group>[^/]+)$"
+)
 AGENT_ACTION_PATTERN = re.compile(
-    r"^action/[A-Z][A-Z0-9_-]*/(?:0|[1-9][0-9]*)/"
+    r"^action/STARTUP/(?:0|[1-9][0-9]*)/"
     r"(?:0|[1-9][0-9]*)/group0$"
 )
 EXPECTED_SECRET_IDS = {
@@ -44,6 +49,17 @@ EXPECTED_SECRET_IDS = {
     "CLAUDE_CODE_OAUTH_TOKEN",
 }
 PERCENT_ESCAPE = re.compile(r"%[0-9A-Fa-f]{2}")
+
+
+class _ExpectedLogIdentity(NamedTuple):
+    """Evidence-bound identity expected from one job's log streams."""
+
+    project: str
+    job_name: str
+    uid: str
+    task_count: int
+    region: str
+    command_runner: Callable[[list[str]], str]
 
 
 def fingerprint(value: str) -> str:
@@ -168,7 +184,7 @@ def _secret_values(
 def _job_logs(
     job_specs: Mapping[str, tuple[str, int]],
     project: str,
-    _region: str,
+    region: str,
     *,
     command_runner: Callable[[list[str]], str] = _run,
 ) -> list[str]:
@@ -203,7 +219,17 @@ def _job_logs(
             raise RuntimeError("credential-log verification dependency failed") from error
         if not isinstance(parsed_logs, list) or not parsed_logs:
             raise RuntimeError("attributable Batch logs unavailable")
-        _validate_log_entries(parsed_logs, project, uid, task_count)
+        _validate_log_entries(
+            parsed_logs,
+            _ExpectedLogIdentity(
+                project=project,
+                job_name=job_name,
+                uid=uid,
+                task_count=task_count,
+                region=region,
+                command_runner=command_runner,
+            ),
+        )
         logs.append(log_document)
     return logs
 
@@ -298,14 +324,76 @@ def _project_number(
     return project_number
 
 
+def _agent_identity_valid(
+    entry: Mapping[str, object],
+    labels: Mapping[str, object],
+    task_id: str,
+    expected: _ExpectedLogIdentity,
+    expected_project: Callable[[str], bool],
+) -> bool:
+    """Return whether one startup action proves its canonical Batch job."""
+    task_group_name = labels.get("task_group_name")
+    resource = entry.get("resource")
+    if (
+        not isinstance(task_group_name, str)
+        or not isinstance(resource, dict)
+        or resource.get("type") != "batch.googleapis.com/Job"
+        or not isinstance(resource.get("labels"), dict)
+    ):
+        return False
+    task_group = TASK_GROUP_RESOURCE_PATTERN.fullmatch(task_group_name)
+    resource_labels = resource["labels"]
+    resource_location = resource_labels.get("location")
+    resource_container = resource_labels.get("resource_container")
+    if not task_group:
+        return False
+    canonical_identity = (
+        (
+            task_group.group("location"),
+            task_group.group("job"),
+            task_group.group("group"),
+        ) == (expected.region, expected.job_name, "group0")
+        and expected_project(task_group.group("project"))
+        and resource_labels.get("job_id") == expected.uid
+    )
+    if not canonical_identity:
+        return False
+    if not isinstance(resource_container, str) or not expected_project(
+        resource_container
+    ):
+        return False
+    if not isinstance(resource_location, str):
+        return False
+    exact_region_or_zone = re.fullmatch(
+        rf"{re.escape(expected.region)}(?:-[a-z])?", resource_location
+    )
+    return bool(exact_region_or_zone and AGENT_ACTION_PATTERN.fullmatch(task_id))
+
+
 def _validate_log_entries(
-    entries: list[object], project: str, uid: str, task_count: int
+    entries: list[object],
+    expected: _ExpectedLogIdentity,
 ) -> None:
     """Validate the distinct task-log and agent-action identity contracts."""
     observed_tasks: set[str] = set()
     observed_actions: set[str] = set()
+    authoritative_project_number: str | None = None
+
+    def expected_project(value: str) -> bool:
+        nonlocal authoritative_project_number
+        if value == expected.project:
+            return True
+        if not PROJECT_NUMBER_PATTERN.fullmatch(value):
+            return False
+        if authoritative_project_number is None:
+            authoritative_project_number = _project_number(
+                expected.project, expected.command_runner
+            )
+        return value == authoritative_project_number
+
     allowed_log_names = {
-        f"projects/{project}/logs/{log_id}": log_id for log_id in EXPECTED_LOG_IDS
+        f"projects/{expected.project}/logs/{log_id}": log_id
+        for log_id in EXPECTED_LOG_IDS
     }
     for entry in entries:
         if not isinstance(entry, dict):
@@ -314,7 +402,7 @@ def _validate_log_entries(
         log_name = entry.get("logName")
         if (
             not isinstance(labels, dict)
-            or labels.get("job_uid") != uid
+            or labels.get("job_uid") != expected.uid
             or log_name not in allowed_log_names
             or not isinstance(labels.get("task_id"), str)
             or not labels["task_id"]
@@ -323,11 +411,19 @@ def _validate_log_entries(
         task_id = labels["task_id"]
         if allowed_log_names[log_name] == "batch_task_logs":
             observed_tasks.add(task_id)
-        elif not AGENT_ACTION_PATTERN.fullmatch(task_id):
+        elif not _agent_identity_valid(
+            entry,
+            labels,
+            task_id,
+            expected,
+            expected_project,
+        ):
             raise RuntimeError("attributable Batch logs invalid")
         else:
             observed_actions.add(task_id)
-    expected_tasks = {f"{uid}-group0-{index}" for index in range(task_count)}
+    expected_tasks = {
+        f"{expected.uid}-group0-{index}" for index in range(expected.task_count)
+    }
     if observed_tasks != expected_tasks or not observed_actions:
         raise RuntimeError("attributable Batch logs incomplete")
 

--- a/ci/cloud-batch/verify-secret-logs.py
+++ b/ci/cloud-batch/verify-secret-logs.py
@@ -24,6 +24,16 @@ JOB_SPEC_PATTERN = re.compile(
     r"(?P<count>[1-9][0-9]*)$"
 )
 EXPECTED_LOG_IDS = ("batch_agent_logs", "batch_task_logs")
+PROJECT_ID_PATTERN = re.compile(r"^[a-z][a-z0-9-]{4,28}[a-z0-9]$")
+PROJECT_NUMBER_PATTERN = re.compile(r"^[1-9][0-9]*$")
+TASK_RESOURCE_PATTERN = re.compile(
+    r"^projects/(?P<project>[^/]+)/locations/(?P<location>[^/]+)/jobs/"
+    r"(?P<job>[^/]+)/taskGroups/(?P<group>[^/]+)/tasks/(?P<index>[^/]+)$"
+)
+AGENT_ACTION_PATTERN = re.compile(
+    r"^action/[A-Z][A-Z0-9_-]*/(?:0|[1-9][0-9]*)/"
+    r"(?:0|[1-9][0-9]*)/group0$"
+)
 EXPECTED_SECRET_IDS = {
     "GCS_HMAC_ACCESS_KEY_ID",
     "GCS_HMAC_SECRET_ACCESS_KEY",
@@ -206,6 +216,8 @@ def _job_tasks(
     command_runner: Callable[[list[str]], str] = _run,
 ) -> None:
     """Require the Batch API's exact canonical task-resource set per job."""
+    if not PROJECT_ID_PATTERN.fullmatch(project):
+        raise RuntimeError("credential-log verification configuration invalid")
     for job_name, (_uid, task_count) in job_specs.items():
         document = command_runner(
             [
@@ -228,21 +240,70 @@ def _job_tasks(
             for task in parsed
         ):
             raise RuntimeError("Batch task identity unavailable")
-        observed = [task["name"] for task in parsed]
+        observed = _canonical_task_identities(parsed, project, command_runner)
         expected = {
-            f"projects/{project}/locations/{region}/jobs/{job_name}/"
-            f"taskGroups/group0/tasks/{index}"
-            for index in range(task_count)
+            (region, job_name, "group0", index) for index in range(task_count)
         }
-        if len(observed) != len(set(observed)) or set(observed) != expected:
+        if observed != expected:
             raise RuntimeError("Batch task identity mismatch")
+
+
+def _canonical_task_identities(
+    tasks: list[dict[str, object]],
+    project: str,
+    command_runner: Callable[[list[str]], str],
+) -> set[tuple[str, str, str, int]]:
+    """Canonicalize task resources while preserving explicit project binding."""
+    identities: list[tuple[str, str, str, int]] = []
+    resource_projects: set[str] = set()
+    for task in tasks:
+        task_name = task["name"]
+        if not isinstance(task_name, str):
+            raise RuntimeError("Batch task identity unavailable")
+        match = TASK_RESOURCE_PATTERN.fullmatch(task_name)
+        if not match or not re.fullmatch(r"0|[1-9][0-9]*", match.group("index")):
+            raise RuntimeError("Batch task identity mismatch")
+        resource_projects.add(match.group("project"))
+        identities.append(
+            (
+                match.group("location"),
+                match.group("job"),
+                match.group("group"),
+                int(match.group("index")),
+            )
+        )
+    allowed_projects = {project}
+    if resource_projects - allowed_projects:
+        allowed_projects.add(_project_number(project, command_runner))
+    if not resource_projects <= allowed_projects or len(identities) != len(set(identities)):
+        raise RuntimeError("Batch task identity mismatch")
+    return set(identities)
+
+
+def _project_number(
+    project: str, command_runner: Callable[[list[str]], str]
+) -> str:
+    """Resolve the configured project ID to its authoritative numeric identity."""
+    project_number = command_runner(
+        [
+            "gcloud",
+            "projects",
+            "describe",
+            project,
+            "--format=value(projectNumber)",
+        ]
+    ).strip()
+    if not PROJECT_NUMBER_PATTERN.fullmatch(project_number):
+        raise RuntimeError("Batch task identity unavailable")
+    return project_number
 
 
 def _validate_log_entries(
     entries: list[object], project: str, uid: str, task_count: int
 ) -> None:
-    """Require every expected task in both attributable Batch log streams."""
-    observed_tasks = {log_id: set() for log_id in EXPECTED_LOG_IDS}
+    """Validate the distinct task-log and agent-action identity contracts."""
+    observed_tasks: set[str] = set()
+    observed_actions: set[str] = set()
     allowed_log_names = {
         f"projects/{project}/logs/{log_id}": log_id for log_id in EXPECTED_LOG_IDS
     }
@@ -259,9 +320,15 @@ def _validate_log_entries(
             or not labels["task_id"]
         ):
             raise RuntimeError("attributable Batch logs invalid")
-        observed_tasks[allowed_log_names[log_name]].add(labels["task_id"])
+        task_id = labels["task_id"]
+        if allowed_log_names[log_name] == "batch_task_logs":
+            observed_tasks.add(task_id)
+        elif not AGENT_ACTION_PATTERN.fullmatch(task_id):
+            raise RuntimeError("attributable Batch logs invalid")
+        else:
+            observed_actions.add(task_id)
     expected_tasks = {f"{uid}-group0-{index}" for index in range(task_count)}
-    if any(tasks != expected_tasks for tasks in observed_tasks.values()):
+    if observed_tasks != expected_tasks or not observed_actions:
         raise RuntimeError("attributable Batch logs incomplete")
 
 

--- a/tests/test_cloud_batch_secret_boundary.py
+++ b/tests/test_cloud_batch_secret_boundary.py
@@ -432,6 +432,89 @@ def test_log_verifier_requires_exact_batch_task_resources() -> None:
         )
 
 
+def test_log_verifier_accepts_authoritative_numeric_project_task_resources() -> None:
+    """Batch returns canonical task names with the project's numeric identity."""
+    verifier = _load_script(
+        "cloud_batch_numeric_task_resources", "verify-secret-logs.py"
+    )
+    tasks = [
+        {
+            "name": (
+                "projects/590888610376/locations/us-central1/jobs/job-name/"
+                f"taskGroups/group0/tasks/{index}"
+            )
+        }
+        for index in range(2)
+    ]
+
+    def run(command: list[str]) -> str:
+        if command[1:3] == ["projects", "describe"]:
+            return "590888610376\n"
+        return json.dumps(tasks)
+
+    verifier._job_tasks(
+        {"job-name": ("job-uid", 2)},
+        "trusted-project",
+        "us-central1",
+        command_runner=run,
+    )
+
+
+def test_log_verifier_accepts_agent_action_identity_with_exact_task_coverage() -> None:
+    """Agent logs identify startup actions, while task logs identify every task."""
+    verifier = _load_script(
+        "cloud_batch_agent_action_identity", "verify-secret-logs.py"
+    )
+    group_name = (
+        "projects/590888610376/locations/us-central1/jobs/job-name/"
+        "taskGroups/group0"
+    )
+    resource = {
+        "labels": {
+            "job_id": "job-uid",
+            "location": "us-central1-b",
+            "resource_container": "trusted-project",
+        }
+    }
+    entries = [
+        {
+            "labels": {
+                "job_uid": "job-uid",
+                "task_group_name": group_name,
+                "task_id": f"job-uid-group0-{index}",
+            },
+            "logName": "projects/trusted-project/logs/batch_task_logs",
+            "resource": resource,
+        }
+        for index in range(2)
+    ]
+    entries.append(
+        {
+            "labels": {
+                "job_uid": "job-uid",
+                "task_group_name": group_name,
+                "task_id": "action/STARTUP/0/0/group0",
+            },
+            "logName": "projects/trusted-project/logs/batch_agent_logs",
+            "resource": resource,
+        }
+    )
+
+    def run(command: list[str]) -> str:
+        if command[1:3] == ["projects", "describe"]:
+            return "590888610376\n"
+        return json.dumps(entries)
+
+    logs = verifier._job_logs(
+        {"job-name": ("job-uid", 2)},
+        "trusted-project",
+        "us-central1",
+        command_runner=run,
+    )
+
+    assert len(logs) == 1
+
+
 def test_log_verifier_rejects_unexpected_log_name() -> None:
     verifier = _load_script("cloud_batch_secret_verifier_log_name", "verify-secret-logs.py")
     entries = _complete_log_entries("trusted-project", "job-uid", 1)

--- a/tests/test_cloud_batch_secret_boundary.py
+++ b/tests/test_cloud_batch_secret_boundary.py
@@ -358,22 +358,41 @@ def test_secret_manager_reader_rejects_redirected_response() -> None:
 
 
 def _complete_log_entries(project: str, uid: str, task_count: int) -> list[dict]:
+    group_name = (
+        f"projects/{project}/locations/us-central1/jobs/job-name/"
+        "taskGroups/group0"
+    )
+    resource = {
+        "type": "batch.googleapis.com/Job",
+        "labels": {
+            "job_id": uid,
+            "location": "us-central1-b",
+            "resource_container": project,
+        },
+    }
     entries = []
     for task_index in range(task_count):
         task_id = f"{uid}-group0-{task_index}"
         entries.append(
             {
-                "labels": {"job_uid": uid, "task_id": task_id},
+                "labels": {
+                    "job_uid": uid,
+                    "task_group_name": group_name,
+                    "task_id": task_id,
+                },
                 "logName": f"projects/{project}/logs/batch_task_logs",
+                "resource": resource,
             }
         )
     entries.append(
         {
             "labels": {
                 "job_uid": uid,
+                "task_group_name": group_name,
                 "task_id": "action/STARTUP/0/0/group0",
             },
             "logName": f"projects/{project}/logs/batch_agent_logs",
+            "resource": resource,
         }
     )
     return entries
@@ -511,6 +530,7 @@ def test_log_verifier_accepts_agent_action_identity_with_exact_task_coverage() -
         "taskGroups/group0"
     )
     resource = {
+        "type": "batch.googleapis.com/Job",
         "labels": {
             "job_id": "job-uid",
             "location": "us-central1-b",
@@ -554,6 +574,104 @@ def test_log_verifier_accepts_agent_action_identity_with_exact_task_coverage() -
     )
 
     assert len(logs) == 1
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "wrong-group-project",
+        "missing-group-project",
+        "wrong-group-location",
+        "wrong-group-job",
+        "wrong-group-name",
+        "wrong-resource-type",
+        "missing-resource-type",
+        "wrong-resource-uid",
+        "missing-resource-uid",
+        "wrong-resource-container",
+        "missing-resource-container",
+        "wrong-resource-location",
+        "missing-resource-location",
+        "wrong-action-structure",
+        "unrelated-agent",
+    ],
+)
+def test_log_verifier_rejects_unrelated_or_malformed_agent_identity(
+    mutation: str,
+) -> None:
+    """Only the evidence-bound Batch job's startup agent can satisfy the gate."""
+    verifier = _load_script(
+        f"cloud_batch_agent_identity_{mutation}", "verify-secret-logs.py"
+    )
+    entries = _complete_log_entries("trusted-project", "job-uid", 1)
+    agent = entries[-1]
+    group_name = agent["labels"]["task_group_name"]
+    resource = agent["resource"]
+    resource_labels = resource["labels"]
+    if mutation == "wrong-group-project":
+        agent["labels"]["task_group_name"] = group_name.replace(
+            "projects/trusted-project", "projects/590888610377"
+        )
+    elif mutation == "missing-group-project":
+        agent["labels"]["task_group_name"] = group_name.removeprefix(
+            "projects/trusted-project/"
+        )
+    elif mutation == "wrong-group-location":
+        agent["labels"]["task_group_name"] = group_name.replace(
+            "locations/us-central1", "locations/europe-west1"
+        )
+    elif mutation == "wrong-group-job":
+        agent["labels"]["task_group_name"] = group_name.replace(
+            "jobs/job-name", "jobs/unrelated-job"
+        )
+    elif mutation == "wrong-group-name":
+        agent["labels"]["task_group_name"] = group_name.replace(
+            "taskGroups/group0", "taskGroups/group1"
+        )
+    elif mutation == "wrong-resource-type":
+        resource["type"] = "batch.googleapis.com/Task"
+    elif mutation == "missing-resource-type":
+        resource.pop("type")
+    elif mutation == "wrong-resource-uid":
+        resource_labels["job_id"] = "unrelated-job-uid"
+    elif mutation == "missing-resource-uid":
+        resource_labels.pop("job_id")
+    elif mutation == "wrong-resource-container":
+        resource_labels["resource_container"] = "unrelated-project"
+    elif mutation == "missing-resource-container":
+        resource_labels.pop("resource_container")
+    elif mutation == "wrong-resource-location":
+        resource_labels["location"] = "europe-west1-b"
+    elif mutation == "missing-resource-location":
+        resource_labels.pop("location")
+    elif mutation == "wrong-action-structure":
+        agent["labels"]["task_id"] = "action/SHUTDOWN/0/0/group0"
+    elif mutation == "unrelated-agent":
+        agent["labels"]["task_group_name"] = (
+            "projects/590888610377/locations/europe-west1/"
+            "jobs/unrelated-job/taskGroups/group1"
+        )
+        resource["type"] = "batch.googleapis.com/Task"
+        resource_labels.update(
+            {
+                "job_id": "unrelated-job-uid",
+                "location": "europe-west1-b",
+                "resource_container": "unrelated-project",
+            }
+        )
+
+    def run(command: list[str]) -> str:
+        if command[1:3] == ["projects", "describe"]:
+            return "590888610376\n"
+        return json.dumps(entries)
+
+    with pytest.raises(RuntimeError, match="attributable Batch logs invalid"):
+        verifier._job_logs(
+            {"job-name": ("job-uid", 1)},
+            "trusted-project",
+            "us-central1",
+            command_runner=run,
+        )
 
 
 def test_log_verifier_rejects_agent_action_with_wrong_job_uid() -> None:

--- a/tests/test_cloud_batch_secret_boundary.py
+++ b/tests/test_cloud_batch_secret_boundary.py
@@ -361,13 +361,21 @@ def _complete_log_entries(project: str, uid: str, task_count: int) -> list[dict]
     entries = []
     for task_index in range(task_count):
         task_id = f"{uid}-group0-{task_index}"
-        for log_id in ("batch_agent_logs", "batch_task_logs"):
-            entries.append(
-                {
-                    "labels": {"job_uid": uid, "task_id": task_id},
-                    "logName": f"projects/{project}/logs/{log_id}",
-                }
-            )
+        entries.append(
+            {
+                "labels": {"job_uid": uid, "task_id": task_id},
+                "logName": f"projects/{project}/logs/batch_task_logs",
+            }
+        )
+    entries.append(
+        {
+            "labels": {
+                "job_uid": uid,
+                "task_id": "action/STARTUP/0/0/group0",
+            },
+            "logName": f"projects/{project}/logs/batch_agent_logs",
+        }
+    )
     return entries
 
 
@@ -460,6 +468,39 @@ def test_log_verifier_accepts_authoritative_numeric_project_task_resources() -> 
     )
 
 
+@pytest.mark.parametrize(
+    "original,replacement",
+    [
+        ("projects/590888610376", "projects/590888610377"),
+        ("locations/us-central1", "locations/europe-west1"),
+        ("jobs/job-name", "jobs/other-job"),
+    ],
+)
+def test_log_verifier_rejects_wrong_numeric_task_resource_identity(
+    original: str, replacement: str
+) -> None:
+    verifier = _load_script(
+        "cloud_batch_wrong_numeric_task_resource", "verify-secret-logs.py"
+    )
+    task_name = (
+        "projects/590888610376/locations/us-central1/jobs/job-name/"
+        "taskGroups/group0/tasks/0"
+    ).replace(original, replacement)
+
+    def run(command: list[str]) -> str:
+        if command[1:3] == ["projects", "describe"]:
+            return "590888610376\n"
+        return json.dumps([{"name": task_name}])
+
+    with pytest.raises(RuntimeError, match="Batch task identity mismatch"):
+        verifier._job_tasks(
+            {"job-name": ("job-uid", 1)},
+            "trusted-project",
+            "us-central1",
+            command_runner=run,
+        )
+
+
 def test_log_verifier_accepts_agent_action_identity_with_exact_task_coverage() -> None:
     """Agent logs identify startup actions, while task logs identify every task."""
     verifier = _load_script(
@@ -513,6 +554,22 @@ def test_log_verifier_accepts_agent_action_identity_with_exact_task_coverage() -
     )
 
     assert len(logs) == 1
+
+
+def test_log_verifier_rejects_agent_action_with_wrong_job_uid() -> None:
+    verifier = _load_script(
+        "cloud_batch_agent_wrong_job_uid", "verify-secret-logs.py"
+    )
+    entries = _complete_log_entries("trusted-project", "job-uid", 1)
+    entries[-1]["labels"]["job_uid"] = "other-job-uid"
+
+    with pytest.raises(RuntimeError, match="attributable Batch logs invalid"):
+        verifier._job_logs(
+            {"job-name": ("job-uid", 1)},
+            "trusted-project",
+            "us-central1",
+            command_runner=lambda _command: json.dumps(entries),
+        )
 
 
 def test_log_verifier_rejects_unexpected_log_name() -> None:


### PR DESCRIPTION
## Summary

- canonicalize Batch task resources structurally while binding numeric project numbers to the configured project ID through an authoritative `gcloud projects describe` lookup
- require exact task-log coverage separately from attributable agent action identities such as `action/STARTUP/0/0/group0`
- preserve exact job UID, stream, job/location/task index, result evidence, and fail-closed credential fingerprint scanning

## Root cause

The release verifier compared API task resource names literally against names built with the project ID, while Batch returned the equivalent canonical names with the numeric project number. It also applied the per-task identity contract from `batch_task_logs` to `batch_agent_logs`, whose actual identity is an attributable agent action.

Closes #2068

## TDD evidence

- red test commit: `dc893f850`
- before the fix: 2 focused failures for numeric-project task resources and agent action identity
- implementation commit: `db6bf54dd`

## Validation

- `conda run -n pdd python -m pytest -q tests/test_cloud_batch_secret_boundary.py` — 40 passed
- `conda run -n pdd pylint ci/cloud-batch/verify-secret-logs.py` — 10.00/10
- Python compile and `git diff --check` — passed
- negative contracts reject wrong numeric project, location, job, and agent job UID
- read-only retained-run verifier using `/tmp/pdd-cloud-batch-identity-run-20260714-214639-d500253f6.json` and `/tmp/pdd-cloud-results-run-20260714-214639-d500253f6` — `Credential-log boundary verified (no matching fingerprints).`

No Batch job, build, deploy, release, secret mutation, or other cloud mutation was performed by this PR.