### PR TITLE
fix(sync): preserve protected Vitest termination evidence

### DIFF
--- a/.github/toolchains/vitest/package-lock.json
+++ b/.github/toolchains/vitest/package-lock.json
@@ -1,0 +1,1192 @@
+{
+  "name": "pdd-protected-vitest-toolchain",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pdd-protected-vitest-toolchain",
+      "version": "1.0.0",
+      "dependencies": {
+        "vitest": "4.1.10"
+      },
+      "engines": {
+        "node": "22.x"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/.github/toolchains/vitest/package.json
+++ b/.github/toolchains/vitest/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pdd-protected-vitest-toolchain",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": "22.x"
+  },
+  "dependencies": {
+    "vitest": "4.1.10"
+  }
+}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,7 +57,10 @@ jobs:
         run: |
           set -euo pipefail
           toolchain="$RUNNER_TEMP/pdd-vitest-toolchain"
-          npm install --prefix "$toolchain" --ignore-scripts --no-audit --no-fund vitest@4.1.10
+          mkdir -p "$toolchain"
+          cp .github/toolchains/vitest/package.json "$toolchain/"
+          cp .github/toolchains/vitest/package-lock.json "$toolchain/"
+          npm ci --prefix "$toolchain" --ignore-scripts --no-audit --no-fund
           TOOLCHAIN="$toolchain" python - <<'PY'
           import json
           import os

--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -27,6 +27,18 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".github/toolchains/vitest/package-lock.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".github/toolchains/vitest/package.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".github/workflows/auto-heal.yml",
       "role": "human-maintained"
     },

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -45,10 +45,13 @@ from .types import (
     VerificationObligation,
     VerificationProfile,
 )
-from .supervisor import released_runtime_closure_paths, run_supervised
+from .supervisor import SupervisorLimits, released_runtime_closure_paths, run_supervised
 
 
 TRUSTED_RUNNER_VERSION = "pdd-trusted-runner-v2"
+_VITEST_SUPERVISOR_LIMITS = SupervisorLimits(
+    max_memory_bytes=4 * 1024 * 1024 * 1024
+)
 PYTEST_CONFIG_PATHS = (
     PurePosixPath("pytest.ini"),
     PurePosixPath("pyproject.toml"),
@@ -3062,6 +3065,7 @@ def _run_vitest(
                 cwd=root,
                 timeout=timeout_seconds,
                 env=_vitest_environment(home),
+                limits=_VITEST_SUPERVISOR_LIMITS,
                 writable_roots=(scratch, *cache_roots),
                 readable_roots=(reporter, *phase_toolchain.readable_roots),
                 readable_bindings=phase_toolchain.readable_bindings,

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -16,6 +16,7 @@ import platform
 import re
 import select
 import shlex
+import signal
 import stat
 import subprocess
 import sys
@@ -2872,6 +2873,57 @@ def _vitest_result(
     return EvidenceOutcome.PASS, f"{len(identities)} protected Vitest tests passed", identities
 
 
+def _vitest_infrastructure_termination(
+    result: subprocess.CompletedProcess[str],
+    timeout_seconds: int,
+) -> tuple[EvidenceOutcome, str]:
+    """Describe trusted no-reporter termination without trusting stderr prose."""
+    termination = getattr(result, "termination", None)
+    kind = getattr(termination, "kind", None)
+    kind = getattr(kind, "value", kind)
+    if kind is None:
+        if result.returncode == 124:
+            kind = "timeout"
+        elif result.returncode < 0:
+            kind = "signal"
+        else:
+            kind = "exit"
+    fields = ["Vitest infrastructure termination: reporter=missing", f"kind={kind}"]
+    if kind in {"exit", "sandbox-error"}:
+        exit_code = getattr(termination, "exit_code", None)
+        fields.append(f"exit_code={result.returncode if exit_code is None else exit_code}")
+    elif kind == "signal":
+        signal_number = getattr(termination, "signal_number", None)
+        if signal_number is None and result.returncode < 0:
+            signal_number = -result.returncode
+        try:
+            signal_name = signal.Signals(signal_number).name
+        except (TypeError, ValueError):
+            signal_name = "UNKNOWN"
+        fields.extend((f"signal={signal_name}", f"signal_number={signal_number}"))
+    elif kind == "timeout":
+        measured_timeout = getattr(termination, "timeout_seconds", None)
+        fields.append(
+            f"timeout_seconds={timeout_seconds if measured_timeout is None else measured_timeout}"
+        )
+    elif kind == "resource-limit":
+        resource_limit = getattr(termination, "resource_limit", None) or "unknown"
+        fields.append(f"resource_limit={resource_limit}")
+        signal_number = getattr(termination, "signal_number", None)
+        if signal_number is not None:
+            fields.append(f"signal_number={signal_number}")
+    diagnostic = result.stderr or result.stdout
+    if diagnostic:
+        fields.append(
+            "diagnostic_sha256="
+            + hashlib.sha256(diagnostic.encode("utf-8")).hexdigest()
+        )
+    outcome = (
+        EvidenceOutcome.TIMEOUT if kind == "timeout" else EvidenceOutcome.ERROR
+    )
+    return outcome, "; ".join(fields)
+
+
 def _vitest_reporter_source(result_fd: int) -> str:
     """Return a checker-owned reporter that writes only from the coordinator."""
     return f"""import fs from 'node:fs';
@@ -3039,16 +3091,24 @@ def _run_vitest(
             ), ()
         finally:
             os.close(read_fd)
-        if result.returncode == 124:
-            return RunnerExecution("vitest", EvidenceOutcome.TIMEOUT, digest, "Vitest execution timed out"), ()
         if surviving:
             return RunnerExecution("vitest", EvidenceOutcome.ERROR, digest, "Vitest left a surviving process-group descendant"), ()
         output_data = output.read_bytes()
         if result.returncode in {126, 127} and not output_data:
             return RunnerExecution("vitest", EvidenceOutcome.ERROR, digest, "Vitest launcher is missing or not executable"), ()
+        termination = getattr(result, "termination", None)
+        termination_kind = getattr(termination, "kind", None)
+        termination_kind = getattr(termination_kind, "value", termination_kind)
+        if termination_kind == "timeout" or result.returncode == 124:
+            outcome, detail = _vitest_infrastructure_termination(
+                result, timeout_seconds
+            )
+            return RunnerExecution("vitest", outcome, digest, detail), ()
         if result.returncode and not output_data:
-            detail = (result.stderr or result.stdout or "Vitest exited without a result")[-2000:]
-            return RunnerExecution("vitest", EvidenceOutcome.FAIL, digest, detail), ()
+            outcome, detail = _vitest_infrastructure_termination(
+                result, timeout_seconds
+            )
+            return RunnerExecution("vitest", outcome, digest, detail), ()
         if not output_data:
             return RunnerExecution(
                 "vitest", EvidenceOutcome.COLLECTION_ERROR, digest,

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -109,18 +109,9 @@ def _termination_evidence(
         )
     if returncode < 0:
         signal_number = -returncode
-        signal_limit = {
-            getattr(signal, "SIGXCPU", -1): "cpu-seconds",
-            getattr(signal, "SIGXFSZ", -2): "file-size-bytes",
-        }.get(signal_number)
         return SupervisorTermination(
-            (
-                TerminationKind.RESOURCE_LIMIT
-                if signal_limit is not None
-                else TerminationKind.SIGNAL
-            ),
+            TerminationKind.SIGNAL,
             signal_number=signal_number,
-            resource_limit=signal_limit,
         )
     return SupervisorTermination(TerminationKind.EXIT, exit_code=returncode)
 
@@ -489,6 +480,19 @@ def _candidate_environment_launcher() -> str:
     ))
 
 
+def _subprocess_status_handoff() -> str:
+    """Return helper code that preserves a nested subprocess signal exactly."""
+    return "\n".join((
+        "import signal",
+        "status=result.returncode if result is not None else 1",
+        "if status<0:",
+        " signal.signal(-status,signal.SIG_DFL)",
+        " os.kill(os.getpid(),-status)",
+        " raise RuntimeError('subprocess signal handoff returned')",
+        "raise SystemExit(status)",
+    ))
+
+
 def _staged_bwrap(
     argv: list[str], sources: list[Path],
     tools: dict[str, _ExecutableIdentity], *, candidate_command: list[str],
@@ -570,7 +574,7 @@ def _staged_bwrap(
         "  umount=verify('umount')",
         "  subprocess.run([umount,str(target)],check=False)",
         " shutil.rmtree(base,ignore_errors=True)",
-        "raise SystemExit(result.returncode if result is not None else 1)",
+        *_subprocess_status_handoff().splitlines(),
     ))
     manifest = json.dumps({name: identity.payload() for name, identity in tools.items()})
     return [

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -26,6 +26,8 @@ import sysconfig
 # replace ``sys.executable`` to model argv-prefix portability; that synthetic
 # spelling must never become a measured file or sandbox mount source.
 _SUPERVISOR_EXECUTABLE = Path(sys.executable)
+_TERMINATION_HEADER_BYTES = 256
+_TERMINATION_HEADER_PREFIX = b"PDD-TERMINATION-V1 "
 
 
 @dataclass(frozen=True)
@@ -89,6 +91,44 @@ def _supervised_result(
     return SupervisedCompletedProcess(
         command, returncode, stdout, stderr, termination=termination
     )
+
+
+def _termination_status_header(token: str, returncode: int) -> bytes:
+    """Encode one fixed-size authenticated nested-process status record."""
+    payload = json.dumps(
+        {"returncode": returncode, "token": token},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+    record = _TERMINATION_HEADER_PREFIX + payload + b"\n"
+    if len(record) > _TERMINATION_HEADER_BYTES:
+        raise ValueError("protected termination status record is too large")
+    return record.ljust(_TERMINATION_HEADER_BYTES, b" ")
+
+
+def _authenticated_nested_returncode(header: bytes, token: str) -> int | None:
+    """Return only a well-formed status bearing the supervisor's secret token."""
+    if len(header) != _TERMINATION_HEADER_BYTES or not header.startswith(
+        _TERMINATION_HEADER_PREFIX
+    ):
+        return None
+    try:
+        payload = json.loads(
+            header[len(_TERMINATION_HEADER_PREFIX):].rstrip(b" \n").decode("ascii")
+        )
+    except (UnicodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or set(payload) != {"returncode", "token"}:
+        return None
+    returncode = payload["returncode"]
+    if (
+        payload["token"] != token
+        or isinstance(returncode, bool)
+        or not isinstance(returncode, int)
+        or not -255 <= returncode <= 255
+    ):
+        return None
+    return returncode
 
 
 def _termination_evidence(
@@ -612,14 +652,32 @@ def _candidate_environment_launcher() -> str:
     ))
 
 
-def _subprocess_status_handoff() -> str:
-    """Return helper code that preserves a nested subprocess signal exactly."""
+def _subprocess_status_observation() -> str:
+    """Return helper code that observes exits, signals, and stops without hanging."""
     return "\n".join((
-        "import signal",
-        "status=result.returncode if result is not None else 1",
+        "process=subprocess.Popen(argv,env=helper_env)",
+        "pid,wait_status=os.waitpid(process.pid,os.WUNTRACED)",
+        "if os.WIFSTOPPED(wait_status):",
+        " status=-os.WSTOPSIG(wait_status)",
+        " os.kill(process.pid,signal.SIGKILL)",
+        " os.waitpid(process.pid,0)",
+        "elif os.WIFSIGNALED(wait_status): status=-os.WTERMSIG(wait_status)",
+        "elif os.WIFEXITED(wait_status): status=os.WEXITSTATUS(wait_status)",
+        "else: raise RuntimeError('unrecognized protected subprocess status')",
+        "process.returncode=status",
+    ))
+
+
+def _subprocess_status_handoff() -> str:
+    """Return helper code that safely re-emits a trusted nested status."""
+    return "\n".join((
         "if status<0:",
-        " signal.signal(-status,signal.SIG_DFL)",
-        " os.kill(os.getpid(),-status)",
+        " observed_signal=-status",
+        " stopping={signal.SIGSTOP,signal.SIGTSTP,signal.SIGTTIN,signal.SIGTTOU}",
+        " if observed_signal in stopping: raise SystemExit(125)",
+        " if observed_signal!=signal.SIGKILL:",
+        "  signal.signal(observed_signal,signal.SIG_DFL)",
+        " os.kill(os.getpid(),observed_signal)",
         " raise RuntimeError('subprocess signal handoff returned')",
         "raise SystemExit(status)",
     ))
@@ -628,17 +686,20 @@ def _subprocess_status_handoff() -> str:
 def _staged_bwrap(
     argv: list[str], sources: list[Path],
     tools: dict[str, _ExecutableIdentity], *, candidate_command: list[str],
-    candidate_uid: int, candidate_gid: int,
+    candidate_uid: int, candidate_gid: int, termination_token: str,
 ) -> list[str]:
     """Stage exact bind mounts wholly inside a private mount namespace."""
     helper = "\n".join((
-        "import hashlib,json,os,pathlib,shutil,stat,subprocess,sys,tempfile",
+        "import hashlib,json,os,pathlib,shutil,signal,stat,subprocess,sys,tempfile",
         "helper_env={'HOME':'/root','LANG':'C','LC_ALL':'C',"
         "'PATH':'/usr/sbin:/usr/bin:/sbin:/bin'}",
         "os.environ.clear(); os.environ.update(helper_env)",
         "candidate_command=json.loads(sys.argv[1]); uid=int(sys.argv[2]); gid=int(sys.argv[3])",
-        "manifest=json.loads(sys.argv[4]); argv=json.loads(sys.argv[5]); "
-        "paths=json.loads(sys.argv[6])",
+        "termination_token=sys.argv[4]",
+        "if len(termination_token)!=32 or any(c not in '0123456789abcdef' "
+        "for c in termination_token): raise RuntimeError('invalid termination token')",
+        "manifest=json.loads(sys.argv[5]); argv=json.loads(sys.argv[6]); "
+        "paths=json.loads(sys.argv[7])",
         "def verify_chain(path):",
         " for parent in reversed(path.parents):",
         "  metadata=parent.lstat()",
@@ -676,8 +737,11 @@ def _staged_bwrap(
         "for k,v in candidate_env.items()): raise RuntimeError('invalid candidate environment')",
         "for name in manifest: verify(name)",
         "mount=verify('mount'); umount=verify('umount'); bwrap=verify('bwrap')",
+        f"termination_header_bytes={_TERMINATION_HEADER_BYTES}",
+        f"termination_prefix={_TERMINATION_HEADER_PREFIX!r}",
+        "os.write(2,b' '*termination_header_bytes)",
         "base=pathlib.Path(tempfile.mkdtemp(prefix='pdd-binds-',dir='/run'))",
-        "os.chmod(base,0o700); staged=[]; result=None",
+        "os.chmod(base,0o700); staged=[]",
         "try:",
         " env_path=base/'candidate-env'",
         " env_items=[f'{key}={value}' for key,value in sorted(candidate_env.items())]",
@@ -700,12 +764,19 @@ def _staged_bwrap(
         " argv[separator:separator]=['--ro-bind',str(env_path),'/run/pdd-candidate-env']",
         " if argv[0]!=bwrap: raise RuntimeError('protected bwrap identity mismatch')",
         " verify('bwrap')",
-        " result=subprocess.run(argv,check=False,env=helper_env)",
+        *(f" {line}" for line in _subprocess_status_observation().splitlines()),
         "finally:",
         " for target in reversed(staged):",
         "  umount=verify('umount')",
         "  subprocess.run([umount,str(target)],check=False)",
         " shutil.rmtree(base,ignore_errors=True)",
+        "payload=json.dumps({'returncode':status,'token':termination_token},"
+        "sort_keys=True,separators=(',',':')).encode('ascii')",
+        "record=termination_prefix+payload+b'\\n'",
+        "if len(record)>termination_header_bytes: raise RuntimeError('termination record too large')",
+        "written=os.pwrite(2,record.ljust(termination_header_bytes,b' '),0)",
+        "if written!=termination_header_bytes: raise RuntimeError('short termination record')",
+        "os.fsync(2)",
         *_subprocess_status_handoff().splitlines(),
     ))
     manifest = json.dumps({name: identity.payload() for name, identity in tools.items()})
@@ -713,7 +784,8 @@ def _staged_bwrap(
         str(tools["sudo"].path), "-n", "--", str(tools["unshare"].path),
         "--mount", "--propagation", "private", "--wd", "/",
         str(tools["python"].path), "-I", "-S", "-c", helper,
-        json.dumps(candidate_command), str(candidate_uid), str(candidate_gid), manifest,
+        json.dumps(candidate_command), str(candidate_uid), str(candidate_gid),
+        termination_token, manifest,
         json.dumps(argv), json.dumps([str(path) for path in sources]),
     ]
 
@@ -836,6 +908,7 @@ def _sandbox_command(
     readable_bindings: tuple[tuple[Path, Path], ...] = (),
     result_fifo: Path | None = None,
     result_fd: int = 198,
+    termination_token: str | None = None,
 ) -> tuple[list[str], Path | None]:
     # pylint: disable=too-many-locals,too-many-branches
     """Return an explicitly detected macOS/Linux sandbox command."""
@@ -928,6 +1001,7 @@ def _sandbox_command(
         return _staged_bwrap(
             argv, sources, tools, candidate_command=sandboxed,
             candidate_uid=os.getuid(), candidate_gid=os.getgid(),
+            termination_token=termination_token or uuid.uuid4().hex,
         ), None
     raise RuntimeError("unsupported sandbox platform or mechanism")
 
@@ -943,12 +1017,14 @@ def run_supervised(
 ) -> tuple[SupervisedCompletedProcess, bool]:
     """Run sandboxed and terminate marked descendants across session changes."""
     # pylint: disable=consider-using-with,too-many-locals,too-many-branches,too-many-statements
+    termination_token = uuid.uuid4().hex
     try:
         argv, profile = _sandbox_command(
             command, writable_roots, cwd=cwd, writable_files=writable_files,
             limits=limits, readable_roots=readable_roots,
             readable_bindings=readable_bindings,
             result_fifo=result_fifo, result_fd=result_fd,
+            termination_token=termination_token,
         )
         _revalidate_privileged_command(argv)
     except RuntimeError as exc:
@@ -1021,7 +1097,10 @@ def run_supervised(
             if _writable_size(writable_roots) > limits.max_writable_bytes:
                 resource_limit = "writable-bytes"
                 break
-            if stdout_file.tell() + stderr_file.tell() > limits.max_output_bytes:
+            protected_stderr_bytes = max(
+                0, stderr_file.tell() - _TERMINATION_HEADER_BYTES
+            )
+            if stdout_file.tell() + protected_stderr_bytes > limits.max_output_bytes:
                 resource_limit = "output-bytes"
                 break
             time.sleep(0.01)
@@ -1052,16 +1131,26 @@ def run_supervised(
     remaining = limits.max_output_bytes
     stdout_bytes = stdout_file.read(remaining)
     remaining -= len(stdout_bytes)
-    stderr_bytes = stderr_file.read(remaining)
+    header = stderr_file.read(_TERMINATION_HEADER_BYTES)
+    nested_returncode = _authenticated_nested_returncode(
+        header, termination_token
+    )
+    if nested_returncode is None:
+        stderr_bytes = (header + stderr_file.read(remaining))[:remaining]
+    else:
+        stderr_bytes = stderr_file.read(remaining)
     if stdout_file.read(1) or stderr_file.read(1):
         resource_limit = "output-bytes"
     stdout_file.close()
     stderr_file.close()
     stdout = stdout_bytes.decode("utf-8", errors="replace")
     stderr = stderr_bytes.decode("utf-8", errors="replace")
-    returncode = 125 if resource_limit else (124 if timed_out else process.returncode)
+    observed_returncode = (
+        nested_returncode if nested_returncode is not None else process.returncode
+    )
+    returncode = 125 if resource_limit else (124 if timed_out else observed_returncode)
     termination = _termination_evidence(
-        process.returncode,
+        observed_returncode,
         timed_out=timed_out,
         timeout_seconds=timeout,
         resource_limit=resource_limit,

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -17,6 +17,7 @@ import time
 import uuid
 from functools import lru_cache
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 import sysconfig
 
@@ -36,6 +37,92 @@ class SupervisorLimits:
     max_memory_bytes: int = 2 * 1024 * 1024 * 1024
     max_cpu_seconds: int = 300
     max_processes: int = 128
+
+
+class TerminationKind(str, Enum):
+    """Trusted reason the supervised process stopped."""
+
+    EXIT = "exit"
+    SIGNAL = "signal"
+    TIMEOUT = "timeout"
+    RESOURCE_LIMIT = "resource-limit"
+    SANDBOX_ERROR = "sandbox-error"
+
+
+@dataclass(frozen=True)
+class SupervisorTermination:
+    """Typed termination evidence retained outside candidate-controlled output."""
+
+    kind: TerminationKind
+    exit_code: int | None = None
+    signal_number: int | None = None
+    timeout_seconds: int | None = None
+    resource_limit: str | None = None
+
+
+class SupervisedCompletedProcess(subprocess.CompletedProcess[str]):  # pylint: disable=too-few-public-methods
+    """Completed process carrying trusted supervisor termination evidence."""
+
+    termination: SupervisorTermination
+
+    def __init__(
+        self,
+        args: list[str],
+        returncode: int,
+        stdout: str,
+        stderr: str,
+        *,
+        termination: SupervisorTermination,
+    ) -> None:
+        super().__init__(args, returncode, stdout, stderr)
+        self.termination = termination
+
+
+def _supervised_result(
+    command: list[str],
+    returncode: int,
+    stdout: str,
+    stderr: str,
+    termination: SupervisorTermination,
+) -> SupervisedCompletedProcess:
+    """Construct one subprocess-compatible result with trusted termination data."""
+    return SupervisedCompletedProcess(
+        command, returncode, stdout, stderr, termination=termination
+    )
+
+
+def _termination_evidence(
+    returncode: int,
+    *,
+    timed_out: bool,
+    timeout_seconds: int,
+    resource_limit: str | None,
+) -> SupervisorTermination:
+    """Classify only termination causes observed by the trusted supervisor."""
+    if resource_limit is not None:
+        return SupervisorTermination(
+            TerminationKind.RESOURCE_LIMIT, resource_limit=resource_limit
+        )
+    if timed_out:
+        return SupervisorTermination(
+            TerminationKind.TIMEOUT, timeout_seconds=timeout_seconds
+        )
+    if returncode < 0:
+        signal_number = -returncode
+        signal_limit = {
+            getattr(signal, "SIGXCPU", -1): "cpu-seconds",
+            getattr(signal, "SIGXFSZ", -2): "file-size-bytes",
+        }.get(signal_number)
+        return SupervisorTermination(
+            (
+                TerminationKind.RESOURCE_LIMIT
+                if signal_limit is not None
+                else TerminationKind.SIGNAL
+            ),
+            signal_number=signal_number,
+            resource_limit=signal_limit,
+        )
+    return SupervisorTermination(TerminationKind.EXIT, exit_code=returncode)
 
 
 @dataclass(frozen=True)
@@ -717,7 +804,7 @@ def run_supervised(
     readable_bindings: tuple[tuple[Path, Path], ...] = (),
     result_fifo: Path | None = None,
     result_fd: int = 198,
-) -> tuple[subprocess.CompletedProcess[str], bool]:
+) -> tuple[SupervisedCompletedProcess, bool]:
     """Run sandboxed and terminate marked descendants across session changes."""
     # pylint: disable=consider-using-with,too-many-locals,too-many-branches,too-many-statements
     try:
@@ -729,7 +816,13 @@ def run_supervised(
         )
         _revalidate_privileged_command(argv)
     except RuntimeError as exc:
-        return subprocess.CompletedProcess(command, 125, "", str(exc)), False
+        return _supervised_result(
+            command,
+            125,
+            "",
+            str(exc),
+            SupervisorTermination(TerminationKind.SANDBOX_ERROR, exit_code=125),
+        ), False
     token = uuid.uuid4().hex
     stdout_file = tempfile.TemporaryFile(mode="w+b")
     stderr_file = tempfile.TemporaryFile(mode="w+b")
@@ -763,8 +856,12 @@ def run_supervised(
         process.wait()
         stdout_file.close()
         stderr_file.close()
-        return subprocess.CompletedProcess(
-            command, 125, "", f"protected helper startup failed: {exc}"
+        return _supervised_result(
+            command,
+            125,
+            "",
+            f"protected helper startup failed: {exc}",
+            SupervisorTermination(TerminationKind.SANDBOX_ERROR, exit_code=125),
         ), False
     timed_out = False
     surviving = False
@@ -779,17 +876,17 @@ def run_supervised(
     tracker = threading.Thread(target=track_process_tree, daemon=True)
     tracker.start()
     deadline = time.monotonic() + timeout
-    output_limited = False
+    resource_limit: str | None = None
     try:
         while process.poll() is None:
             if time.monotonic() >= deadline:
                 timed_out = True
                 break
             if _writable_size(writable_roots) > limits.max_writable_bytes:
-                output_limited = True
+                resource_limit = "writable-bytes"
                 break
             if stdout_file.tell() + stderr_file.tell() > limits.max_output_bytes:
-                output_limited = True
+                resource_limit = "output-bytes"
                 break
             time.sleep(0.01)
     finally:
@@ -821,12 +918,18 @@ def run_supervised(
     remaining -= len(stdout_bytes)
     stderr_bytes = stderr_file.read(remaining)
     if stdout_file.read(1) or stderr_file.read(1):
-        output_limited = True
+        resource_limit = "output-bytes"
     stdout_file.close()
     stderr_file.close()
     stdout = stdout_bytes.decode("utf-8", errors="replace")
     stderr = stderr_bytes.decode("utf-8", errors="replace")
-    return subprocess.CompletedProcess(
-        command, 125 if output_limited else (124 if timed_out else process.returncode),
-        stdout, stderr,
+    returncode = 125 if resource_limit else (124 if timed_out else process.returncode)
+    termination = _termination_evidence(
+        process.returncode,
+        timed_out=timed_out,
+        timeout_seconds=timeout,
+        resource_limit=resource_limit,
+    )
+    return _supervised_result(
+        command, returncode, stdout, stderr, termination
     ), surviving

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -658,7 +658,7 @@ def _candidate_environment_launcher() -> str:
 def _inner_status_supervisor() -> str:
     """Return the root-side sandbox helper that observes candidate wait status."""
     return "\n".join((
-        "import os,signal,sys",
+        "import os,sys",
         "path=sys.argv[1]",
         "status_fd=os.open(path,os.O_WRONLY|os.O_CLOEXEC|os.O_NOFOLLOW)",
         "os.unlink(path)",
@@ -674,7 +674,7 @@ def _inner_status_supervisor() -> str:
         "stopped=os.WIFSTOPPED(wait_status)",
         "if os.WIFSTOPPED(wait_status):",
         " status=-os.WSTOPSIG(wait_status)",
-        " os.killpg(pid,signal.SIGKILL)",
+        " os.killpg(pid,9)",
         " os.waitpid(pid,0)",
         "elif os.WIFSIGNALED(wait_status): status=-os.WTERMSIG(wait_status)",
         "elif os.WIFEXITED(wait_status): status=os.WEXITSTATUS(wait_status)",
@@ -831,7 +831,8 @@ def _staged_bwrap(
         "   if os.read(status_read,1): inner_record=b''",
         "   break",
         *(f" {line}" for line in _inner_status_record_parser().splitlines()),
-        " if inner_status is not None: status=inner_status",
+        " if inner_status is None: raise RuntimeError('missing authenticated inner status')",
+        " status=inner_status",
         "finally:",
         " if 'status_read' in locals(): os.close(status_read)",
         " for target in reversed(staged):",
@@ -1221,16 +1222,22 @@ def run_supervised(
     stderr_file.close()
     stdout = stdout_bytes.decode("utf-8", errors="replace")
     stderr = stderr_bytes.decode("utf-8", errors="replace")
+    authenticated_status_missing = nested_returncode is None
     observed_returncode = (
-        nested_returncode if nested_returncode is not None else process.returncode
+        125 if authenticated_status_missing else nested_returncode
     )
     returncode = 125 if resource_limit else (124 if timed_out else observed_returncode)
-    termination = _termination_evidence(
-        observed_returncode,
-        timed_out=timed_out,
-        timeout_seconds=timeout,
-        resource_limit=resource_limit,
-    )
+    if authenticated_status_missing and not timed_out and resource_limit is None:
+        termination = SupervisorTermination(
+            TerminationKind.SANDBOX_ERROR, exit_code=125
+        )
+    else:
+        termination = _termination_evidence(
+            observed_returncode,
+            timed_out=timed_out,
+            timeout_seconds=timeout,
+            resource_limit=resource_limit,
+        )
     return _supervised_result(
         command, returncode, stdout, stderr, termination
     ), surviving

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -125,7 +125,10 @@ def _authenticated_nested_returncode(header: bytes, token: str) -> int | None:
         payload["token"] != token
         or isinstance(returncode, bool)
         or not isinstance(returncode, int)
-        or not -255 <= returncode <= 255
+        or not (
+            0 <= returncode <= 255
+            or -getattr(signal, "NSIG", 128) < returncode < 0
+        )
     ):
         return None
     return returncode
@@ -652,6 +655,56 @@ def _candidate_environment_launcher() -> str:
     ))
 
 
+def _inner_status_supervisor() -> str:
+    """Return the root-side sandbox helper that observes candidate wait status."""
+    return "\n".join((
+        "import os,signal,sys",
+        "path=sys.argv[1]",
+        "status_fd=os.open(path,os.O_WRONLY|os.O_CLOEXEC|os.O_NOFOLLOW)",
+        "os.unlink(path)",
+        "command=sys.argv[2:]",
+        "if not command: raise RuntimeError('candidate command missing')",
+        "pid=os.fork()",
+        "if pid==0:",
+        " try:",
+        "  os.setsid()",
+        "  os.execv(command[0],command)",
+        " except OSError: os._exit(127)",
+        "pid,wait_status=os.waitpid(pid,os.WUNTRACED)",
+        "stopped=os.WIFSTOPPED(wait_status)",
+        "if os.WIFSTOPPED(wait_status):",
+        " status=-os.WSTOPSIG(wait_status)",
+        " os.killpg(pid,signal.SIGKILL)",
+        " os.waitpid(pid,0)",
+        "elif os.WIFSIGNALED(wait_status): status=-os.WTERMSIG(wait_status)",
+        "elif os.WIFEXITED(wait_status): status=os.WEXITSTATUS(wait_status)",
+        "else: raise RuntimeError('unrecognized candidate status')",
+        "payload=f'{status}\\n'.encode('ascii')",
+        "try:",
+        " remaining=memoryview(payload)",
+        " while remaining: remaining=remaining[os.write(status_fd,remaining):]",
+        "finally: os.close(status_fd)",
+        "if stopped: raise SystemExit(125)",
+        "if status<0: raise SystemExit(128-status)",
+        "raise SystemExit(status)",
+    ))
+
+
+def _inner_status_record_parser() -> str:
+    """Return helper code accepting exactly one canonical bounded status record."""
+    return "\n".join((
+        "inner_status=None",
+        "try:",
+        " parsed_status=int(inner_record.decode('ascii').removesuffix('\\n'))",
+        " if inner_record!=f'{parsed_status}\\n'.encode('ascii'):",
+        "  raise ValueError('noncanonical inner status')",
+        " if not (0<=parsed_status<=255 or -signal.NSIG<parsed_status<0):",
+        "  raise ValueError('inner status out of range')",
+        "except (UnicodeError,ValueError): pass",
+        "else: inner_status=parsed_status",
+    ))
+
+
 def _subprocess_status_observation() -> str:
     """Return helper code that observes exits, signals, and stops without hanging."""
     return "\n".join((
@@ -752,6 +805,9 @@ def _staged_bwrap(
         "  while remaining: remaining=remaining[os.write(env_fd,remaining):]",
         "  os.fsync(env_fd)",
         " finally: os.close(env_fd)",
+        " status_dir=base/'termination'; status_dir.mkdir(mode=0o700)",
+        " status_fifo=status_dir/'status'; os.mkfifo(status_fifo,mode=0o600)",
+        " status_read=os.open(status_fifo,os.O_RDONLY|os.O_NONBLOCK|os.O_CLOEXEC|os.O_NOFOLLOW)",
         " for index,source in enumerate(paths):",
         "  source=pathlib.Path(source); target=base/str(index)",
         "  target.mkdir() if source.is_dir() else target.touch()",
@@ -760,12 +816,24 @@ def _staged_bwrap(
         "  staged.append(target)",
         " argv=[str(staged[int(x[4:-1])]) if x.startswith('@FD:') else x for x in argv]",
         " argv=[('/run/pdd-candidate-env' if x=='@PDD-CANDIDATE-ENV@' else x) for x in argv]",
+        " argv=[(str(status_dir) if x=='@PDD-TERMINATION-DIR@' else x) for x in argv]",
         " separator=argv.index('--')",
         " argv[separator:separator]=['--ro-bind',str(env_path),'/run/pdd-candidate-env']",
         " if argv[0]!=bwrap: raise RuntimeError('protected bwrap identity mismatch')",
         " verify('bwrap')",
         *(f" {line}" for line in _subprocess_status_observation().splitlines()),
+        " inner_record=b''",
+        " while True:",
+        "  chunk=os.read(status_read,128-len(inner_record))",
+        "  if not chunk: break",
+        "  inner_record+=chunk",
+        "  if len(inner_record)==128:",
+        "   if os.read(status_read,1): inner_record=b''",
+        "   break",
+        *(f" {line}" for line in _inner_status_record_parser().splitlines()),
+        " if inner_status is not None: status=inner_status",
         "finally:",
+        " if 'status_read' in locals(): os.close(status_read)",
         " for target in reversed(staged):",
         "  umount=verify('umount')",
         "  subprocess.run([umount,str(target)],check=False)",
@@ -997,7 +1065,15 @@ def _sandbox_command(
             "--clear-groups", "--", str(tools["python"].path), "-I", "-S",
             "-c", _candidate_environment_launcher(), "@PDD-CANDIDATE-ENV@",
         ]
-        argv.extend(("--", *drop))
+        inner = [
+            str(tools["python"].path), "-I", "-S", "-c",
+            _inner_status_supervisor(), "/run/pdd-termination/status", *drop,
+        ]
+        separator = len(argv)
+        argv.extend(("--", *inner))
+        argv[separator:separator] = [
+            "--bind", "@PDD-TERMINATION-DIR@", "/run/pdd-termination",
+        ]
         return _staged_bwrap(
             argv, sources, tools, candidate_command=sandboxed,
             candidate_uid=os.getuid(), candidate_gid=os.getgid(),

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -42,6 +42,7 @@ from pdd.sync_core.runner import (
     vitest_validator_config_digest,
 )
 from pdd.sync_core.evidence_store import attestation_payload, decode_attestation
+from pdd.sync_core.supervisor import SupervisorLimits
 
 
 UNIT = UnitId("repository-1", PurePosixPath("prompts/widget_ts.prompt"), "typescript")
@@ -1932,9 +1933,11 @@ def test_vitest_linux_command_binds_wasm_guard(tmp_path: Path, monkeypatch: pyte
     root, _commit = _repository(tmp_path)
     config = _runner_config(tmp_path, _fake_vitest(tmp_path))
     observed: list[list[str]] = []
+    observed_limits: list[SupervisorLimits] = []
 
-    def capture(command, *, result_fifo, result_fd, **_kwargs):
+    def capture(command, *, result_fifo, result_fd, limits, **_kwargs):
         observed.append(command)
+        observed_limits.append(limits)
         writer = os.open(result_fifo, os.O_WRONLY)
         try:
             os.write(
@@ -1953,6 +1956,10 @@ def test_vitest_linux_command_binds_wasm_guard(tmp_path: Path, monkeypatch: pyte
 
     assert execution.outcome is EvidenceOutcome.PASS
     assert observed[0][1] == "--disable-wasm-trap-handler"
+    assert observed_limits == [
+        SupervisorLimits(max_memory_bytes=4 * 1024 * 1024 * 1024)
+    ]
+    assert SupervisorLimits().max_memory_bytes == 2 * 1024 * 1024 * 1024
 
 
 def test_mixed_adapter_identities_survive_manifest_removal_and_round_trip(

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -456,6 +456,23 @@ def test_vitest_grammar_dependencies_are_exactly_pinned() -> None:
     assert not any(item.startswith("tree-sitter-language-pack") for item in dependencies)
 
 
+def test_real_vitest_workflow_uses_checked_in_locked_toolchain() -> None:
+    """Hosted protected Vitest must resolve one reviewed transitive closure."""
+    root = Path(__file__).parents[1]
+    toolchain = root / ".github/toolchains/vitest"
+    package = json.loads((toolchain / "package.json").read_text(encoding="utf-8"))
+    lock = json.loads((toolchain / "package-lock.json").read_text(encoding="utf-8"))
+    workflow = (root / ".github/workflows/unit-tests.yml").read_text(encoding="utf-8")
+
+    assert package["private"] is True
+    assert package["dependencies"] == {"vitest": "4.1.10"}
+    assert lock["packages"][""]["dependencies"] == package["dependencies"]
+    assert 'cp .github/toolchains/vitest/package.json "$toolchain/"' in workflow
+    assert 'cp .github/toolchains/vitest/package-lock.json "$toolchain/"' in workflow
+    assert 'npm ci --prefix "$toolchain" --ignore-scripts --no-audit --no-fund' in workflow
+    assert 'npm install --prefix "$toolchain"' not in workflow
+
+
 def test_vitest_uses_packaged_grammars_without_language_pack(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1884,7 +1901,7 @@ def test_vitest_missing_reporter_preserves_typed_infrastructure_termination(
 
 @pytest.mark.parametrize(
     ("returncode", "outcome"),
-    [(126, EvidenceOutcome.ERROR), (127, EvidenceOutcome.ERROR), (1, EvidenceOutcome.FAIL)],
+    [(126, EvidenceOutcome.ERROR), (127, EvidenceOutcome.ERROR), (1, EvidenceOutcome.ERROR)],
 )
 def test_vitest_exit_failure_precedes_empty_fifo_collection_error(
     tmp_path: Path, returncode: int, outcome: EvidenceOutcome

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -9,6 +9,7 @@ import tomllib
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
+from types import SimpleNamespace
 
 import pytest
 
@@ -1797,6 +1798,88 @@ def test_vitest_result_fifo_without_writer_is_distinct_collection_error(
 
     assert executions[0].outcome is EvidenceOutcome.COLLECTION_ERROR
     assert executions[0].detail == "Vitest reporter produced no result"
+
+
+@pytest.mark.parametrize(
+    ("termination", "returncode", "outcome", "detail"),
+    [
+        (
+            SimpleNamespace(
+                kind="exit", exit_code=23, signal_number=None,
+                timeout_seconds=None, resource_limit=None,
+            ),
+            23,
+            EvidenceOutcome.ERROR,
+            "Vitest infrastructure termination: reporter=missing; kind=exit; "
+            "exit_code=23; diagnostic_sha256=ae8dd1580e8e3b5004f46f110fdcd006"
+            "444f03e81dd6faa10721ec41fdf737f3",
+        ),
+        (
+            SimpleNamespace(
+                kind="signal", exit_code=None, signal_number=9,
+                timeout_seconds=None, resource_limit=None,
+            ),
+            -9,
+            EvidenceOutcome.ERROR,
+            "Vitest infrastructure termination: reporter=missing; kind=signal; "
+            "signal=SIGKILL; signal_number=9; diagnostic_sha256=ae8dd1580e8e3b5"
+            "004f46f110fdcd006444f03e81dd6faa10721ec41fdf737f3",
+        ),
+        (
+            SimpleNamespace(
+                kind="timeout", exit_code=None, signal_number=None,
+                timeout_seconds=7, resource_limit=None,
+            ),
+            124,
+            EvidenceOutcome.TIMEOUT,
+            "Vitest infrastructure termination: reporter=missing; kind=timeout; "
+            "timeout_seconds=7; diagnostic_sha256=ae8dd1580e8e3b5004f46f110fdcd006"
+            "444f03e81dd6faa10721ec41fdf737f3",
+        ),
+        (
+            SimpleNamespace(
+                kind="resource-limit", exit_code=None, signal_number=None,
+                timeout_seconds=None, resource_limit="output-bytes",
+            ),
+            125,
+            EvidenceOutcome.ERROR,
+            "Vitest infrastructure termination: reporter=missing; "
+            "kind=resource-limit; resource_limit=output-bytes; "
+            "diagnostic_sha256=ae8dd1580e8e3b5004f46f110fdcd006444f03e81dd6faa1"
+            "0721ec41fdf737f3",
+        ),
+    ],
+)
+def test_vitest_missing_reporter_preserves_typed_infrastructure_termination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    termination: SimpleNamespace,
+    returncode: int,
+    outcome: EvidenceOutcome,
+    detail: str,
+) -> None:
+    """Empty private evidence must retain trusted termination diagnostics."""
+    root, _commit = _repository(tmp_path)
+    result = subprocess.CompletedProcess(
+        ["vitest"], returncode, "", "benign MIXED_EXPORTS warning"
+    )
+    result.termination = termination
+    monkeypatch.setattr(
+        "pdd.sync_core.runner.run_supervised",
+        lambda *_args, **_kwargs: (result, False),
+    )
+
+    execution, identities = _run_vitest(
+        root,
+        (PurePosixPath("tests/widget.test.ts"),),
+        7,
+        _runner_config(tmp_path, _fake_vitest(tmp_path)),
+    )
+
+    assert execution.outcome is outcome
+    assert execution.detail == detail
+    assert "MIXED_EXPORTS" not in execution.detail
+    assert not identities
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import signal
 import shutil
 import subprocess
 import sys
@@ -1841,6 +1842,18 @@ def test_vitest_result_fifo_without_writer_is_distinct_collection_error(
             "Vitest infrastructure termination: reporter=missing; kind=signal; "
             "signal=SIGKILL; signal_number=9; diagnostic_sha256=ae8dd1580e8e3b5"
             "004f46f110fdcd006444f03e81dd6faa10721ec41fdf737f3",
+        ),
+        (
+            SimpleNamespace(
+                kind="signal", exit_code=None, signal_number=signal.SIGXCPU,
+                timeout_seconds=None, resource_limit=None,
+            ),
+            -signal.SIGXCPU,
+            EvidenceOutcome.ERROR,
+            "Vitest infrastructure termination: reporter=missing; kind=signal; "
+            f"signal=SIGXCPU; signal_number={signal.SIGXCPU}; "
+            "diagnostic_sha256=ae8dd1580e8e3b5004f46f110fdcd006444f03e81dd"
+            "6faa10721ec41fdf737f3",
         ),
         (
             SimpleNamespace(

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -388,6 +388,13 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     )
     assert "SystemExit(result.returncode" not in helper
     assert "@PDD-CANDIDATE-ENV@" in bwrap
+    termination_token = argv[-4]
+    assert len(termination_token) == 32
+    assert termination_token not in json.dumps(bwrap)
+    status_mount = bwrap.index("/run/pdd-termination")
+    assert bwrap[status_mount - 2:status_mount] == [
+        "--bind", "@PDD-TERMINATION-DIR@",
+    ]
     helper_index = bwrap.index(str(helper_encodings))
     assert bwrap[helper_index - 2] == "--ro-bind"
     assert "/usr/bin/xargs" in bwrap and "/usr/bin/env" in bwrap
@@ -397,10 +404,18 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     separator = bwrap.index("--")
     assert bwrap.index("--bind") < separator < bwrap.index("--reuid")
     candidate_argv = bwrap[separator + 1:]
-    assert candidate_argv[candidate_argv.index("--") + 1] == "/usr/bin/python3"
+    inner_launcher = candidate_argv[candidate_argv.index("-c") + 1]
+    assert inner_launcher == supervisor._inner_status_supervisor()
+    assert "os.unlink(path)" in inner_launcher
+    assert "os.O_CLOEXEC" in inner_launcher
+    assert "os.execv(command[0],command)" in inner_launcher
+    assert "os.waitpid(pid,os.WUNTRACED)" in inner_launcher
+    assert "os.killpg(pid,signal.SIGKILL)" in inner_launcher
+    drop_argv = candidate_argv[candidate_argv.index("/usr/bin/setpriv"):]
+    assert drop_argv[drop_argv.index("--") + 1] == "/usr/bin/python3"
     assert "/usr/bin/xargs" not in candidate_argv
     assert "/usr/bin/env" not in candidate_argv
-    launcher = candidate_argv[candidate_argv.index("-c") + 1]
+    launcher = drop_argv[drop_argv.index("-c") + 1]
     compile(launcher, "<candidate-environment-launcher>", "exec")
     assert "os.execve(command[0],command,environment)" in launcher
     assert bwrap[bwrap.index("--reuid") + 1] == "1234"
@@ -920,6 +935,129 @@ def test_nested_stopping_status_requires_authenticated_header() -> None:
     assert _authenticated_nested_returncode(header, token) == -signal.SIGSTOP
     assert _authenticated_nested_returncode(header, "b" * 32) is None
     assert _authenticated_nested_returncode(b" " * len(header), token) is None
+    assert _authenticated_nested_returncode(
+        _termination_status_header(token, -255), token
+    ) is None
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_status"),
+    [
+        ("exit", 23),
+        ("exit152", 152),
+        ("catchable", -signal.SIGXCPU),
+        ("uncatchable", -signal.SIGKILL),
+        ("stopping", -signal.SIGSTOP),
+    ],
+)
+@pytest.mark.timeout(10)
+def test_inner_status_supervisor_observes_candidate_before_boundary_normalization(
+    tmp_path: Path, mode: str, expected_status: int,
+) -> None:
+    """The exact inner helper distinguishes exit 152 from signal 24 safely."""
+    channel = tmp_path / "inner-status.fifo"
+    os.mkfifo(channel, mode=0o600)
+    read_fd = os.open(channel, os.O_RDONLY | os.O_NONBLOCK)
+    child = ";".join((
+        "import os,signal,sys",
+        "mode=sys.argv[1]",
+        "number={'catchable':signal.SIGXCPU,'uncatchable':signal.SIGKILL,"
+        "'stopping':signal.SIGSTOP}.get(mode)",
+        "signal.signal(number,signal.SIG_DFL) if number is not None "
+        "and number not in {signal.SIGKILL,signal.SIGSTOP} else None",
+        "os.kill(os.getpid(),number) if number is not None else None",
+        "raise SystemExit(152 if mode=='exit152' else 23)",
+    ))
+    try:
+        completed = subprocess.run(
+            [
+                sys.executable, "-I", "-S", "-c",
+                supervisor._inner_status_supervisor(),
+                str(channel), sys.executable, "-c", child, mode,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        record = os.read(read_fd, 128)
+    finally:
+        os.close(read_fd)
+
+    assert record == f"{expected_status}\n".encode("ascii")
+    assert completed.returncode == (
+        125 if mode == "stopping" else (
+            128 - expected_status if expected_status < 0 else expected_status
+        )
+    )
+    assert not channel.exists()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or not shutil.which("bwrap"),
+    reason="requires Linux Bubblewrap boundary",
+)
+@pytest.mark.parametrize(
+    ("mode", "expected_status"),
+    [
+        ("exit", 23),
+        ("exit152", 152),
+        ("catchable", -signal.SIGXCPU),
+        ("uncatchable", -signal.SIGKILL),
+        ("stopping", -signal.SIGSTOP),
+    ],
+)
+@pytest.mark.timeout(10)
+def test_real_sandbox_preserves_candidate_status_before_bwrap_normalization(
+    tmp_path: Path, mode: str, expected_status: int,
+) -> None:
+    """Exercise the real staged helper, bwrap PID namespace, and inner helper."""
+    child = (
+        "import os,signal,sys;mode=sys.argv[1];"
+        "number={'catchable':signal.SIGXCPU,'uncatchable':signal.SIGKILL,"
+        "'stopping':signal.SIGSTOP}.get(mode);"
+        "signal.signal(number,signal.SIG_DFL) if number is not None and number "
+        "not in {signal.SIGKILL,signal.SIGSTOP} else None;"
+        "os.kill(os.getpid(),number) if number is not None else None;"
+        "raise SystemExit(152 if mode=='exit152' else 23)"
+    )
+    result, surviving = run_supervised(
+        [sys.executable, "-c", child, mode], cwd=tmp_path, timeout=5,
+        env={}, writable_roots=(tmp_path,),
+    )
+
+    if result.termination.kind is TerminationKind.SANDBOX_ERROR:
+        pytest.skip(result.stderr)
+    assert result.returncode == expected_status
+    assert result.termination.kind is (
+        TerminationKind.EXIT if expected_status >= 0 else TerminationKind.SIGNAL
+    )
+    assert surviving is False
+
+
+@pytest.mark.parametrize(
+    ("record", "expected"),
+    [
+        (b"-24\n", -24),
+        (b"152\n", 152),
+        (b"", None),
+        (b"-24", None),
+        (b"-24\n-24\n", None),
+        (b"+24\n", None),
+        (b"025\n", None),
+        (b"256\n", None),
+        (b"-256\n", None),
+        (b"-255\n", None),
+        (b"signal=24\n", None),
+        (b"\xff\n", None),
+    ],
+)
+def test_inner_status_record_rejects_spoof_replay_partial_and_malformed(
+    record: bytes, expected: int | None,
+) -> None:
+    namespace = {"inner_record": record, "signal": signal}
+    exec(supervisor._inner_status_record_parser(), {}, namespace)
+    assert namespace["inner_status"] == expected
 
 
 def test_supervised_result_remains_subprocess_compatible() -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -4,6 +4,7 @@ import os
 import json
 import math
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -15,6 +16,7 @@ import pytest
 from pdd.sync_core import supervisor
 from pdd.sync_core.supervisor import (
     SupervisorLimits,
+    TerminationKind,
     _linked_libraries,
     _limited_command,
     _live_processes,
@@ -22,6 +24,8 @@ from pdd.sync_core.supervisor import (
     _runtime_roots,
     _sandbox_library_path,
     _sandbox_command,
+    _supervised_result,
+    _termination_evidence,
     _runtime_directories,
     run_supervised,
 )
@@ -612,6 +616,53 @@ def test_protected_runner_declares_finite_resource_limits() -> None:
     assert 0 < limits.max_memory_bytes <= 4 * 1024 * 1024 * 1024
     assert 0 < limits.max_cpu_seconds <= 600
     assert 0 < limits.max_processes <= 256
+
+
+@pytest.mark.parametrize(
+    ("returncode", "timed_out", "resource_limit", "kind", "field"),
+    [
+        (23, False, None, TerminationKind.EXIT, ("exit_code", 23)),
+        (-9, False, None, TerminationKind.SIGNAL, ("signal_number", 9)),
+        (0, True, None, TerminationKind.TIMEOUT, ("timeout_seconds", 7)),
+        (
+            0,
+            False,
+            "output-bytes",
+            TerminationKind.RESOURCE_LIMIT,
+            ("resource_limit", "output-bytes"),
+        ),
+        (
+            -signal.SIGXCPU,
+            False,
+            None,
+            TerminationKind.RESOURCE_LIMIT,
+            ("resource_limit", "cpu-seconds"),
+        ),
+    ],
+)
+def test_termination_evidence_preserves_trusted_cause(
+    returncode, timed_out, resource_limit, kind, field
+) -> None:
+    evidence = _termination_evidence(
+        returncode,
+        timed_out=timed_out,
+        timeout_seconds=7,
+        resource_limit=resource_limit,
+    )
+
+    assert evidence.kind is kind
+    assert getattr(evidence, field[0]) == field[1]
+
+
+def test_supervised_result_remains_subprocess_compatible() -> None:
+    evidence = _termination_evidence(
+        3, timed_out=False, timeout_seconds=7, resource_limit=None
+    )
+    result = _supervised_result(["checker"], 3, "out", "err", evidence)
+
+    assert isinstance(result, subprocess.CompletedProcess)
+    assert result.returncode == 3
+    assert result.termination is evidence
 
 
 @pytest.mark.skipif(

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -386,6 +386,7 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     assert all(
         line in helper for line in _subprocess_status_handoff().splitlines()
     )
+    assert "if inner_status is None: raise RuntimeError" in helper
     assert "SystemExit(result.returncode" not in helper
     assert "@PDD-CANDIDATE-ENV@" in bwrap
     termination_token = argv[-4]
@@ -406,11 +407,13 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     candidate_argv = bwrap[separator + 1:]
     inner_launcher = candidate_argv[candidate_argv.index("-c") + 1]
     assert inner_launcher == supervisor._inner_status_supervisor()
+    assert inner_launcher.splitlines()[0] == "import os,sys"
+    assert "import signal" not in inner_launcher
     assert "os.unlink(path)" in inner_launcher
     assert "os.O_CLOEXEC" in inner_launcher
     assert "os.execv(command[0],command)" in inner_launcher
     assert "os.waitpid(pid,os.WUNTRACED)" in inner_launcher
-    assert "os.killpg(pid,signal.SIGKILL)" in inner_launcher
+    assert "os.killpg(pid,9)" in inner_launcher
     drop_argv = candidate_argv[candidate_argv.index("/usr/bin/setpriv"):]
     assert drop_argv[drop_argv.index("--") + 1] == "/usr/bin/python3"
     assert "/usr/bin/xargs" not in candidate_argv
@@ -944,6 +947,7 @@ def test_nested_stopping_status_requires_authenticated_header() -> None:
     ("mode", "expected_status"),
     [
         ("exit", 23),
+        ("exit137", 137),
         ("exit152", 152),
         ("catchable", -signal.SIGXCPU),
         ("uncatchable", -signal.SIGKILL),
@@ -966,7 +970,7 @@ def test_inner_status_supervisor_observes_candidate_before_boundary_normalizatio
         "signal.signal(number,signal.SIG_DFL) if number is not None "
         "and number not in {signal.SIGKILL,signal.SIGSTOP} else None",
         "os.kill(os.getpid(),number) if number is not None else None",
-        "raise SystemExit(152 if mode=='exit152' else 23)",
+        "raise SystemExit(137 if mode=='exit137' else 152 if mode=='exit152' else 23)",
     ))
     try:
         completed = subprocess.run(
@@ -993,6 +997,18 @@ def test_inner_status_supervisor_observes_candidate_before_boundary_normalizatio
     assert not channel.exists()
 
 
+def test_inner_status_supervisor_uses_only_narrow_bootstrap_runtime() -> None:
+    """The in-bwrap helper must not require an unmounted stdlib module."""
+    helper = supervisor._inner_status_supervisor()
+
+    assert helper.splitlines()[0] == "import os,sys"
+    assert "import signal" not in helper
+    assert "import subprocess" not in helper
+    assert "__import__" not in helper
+    assert "os.killpg(pid,9)" in helper
+    compile(helper, "<narrow-inner-status-supervisor>", "exec")
+
+
 @pytest.mark.skipif(
     not sys.platform.startswith("linux") or not shutil.which("bwrap"),
     reason="requires Linux Bubblewrap boundary",
@@ -1001,6 +1017,7 @@ def test_inner_status_supervisor_observes_candidate_before_boundary_normalizatio
     ("mode", "expected_status"),
     [
         ("exit", 23),
+        ("exit137", 137),
         ("exit152", 152),
         ("catchable", -signal.SIGXCPU),
         ("uncatchable", -signal.SIGKILL),
@@ -1019,7 +1036,7 @@ def test_real_sandbox_preserves_candidate_status_before_bwrap_normalization(
         "signal.signal(number,signal.SIG_DFL) if number is not None and number "
         "not in {signal.SIGKILL,signal.SIGSTOP} else None;"
         "os.kill(os.getpid(),number) if number is not None else None;"
-        "raise SystemExit(152 if mode=='exit152' else 23)"
+        "raise SystemExit(137 if mode=='exit137' else 152 if mode=='exit152' else 23)"
     )
     result, surviving = run_supervised(
         [sys.executable, "-c", child, mode], cwd=tmp_path, timeout=5,
@@ -1039,6 +1056,7 @@ def test_real_sandbox_preserves_candidate_status_before_bwrap_normalization(
     ("record", "expected"),
     [
         (b"-24\n", -24),
+        (b"137\n", 137),
         (b"152\n", 152),
         (b"", None),
         (b"-24", None),
@@ -1058,6 +1076,83 @@ def test_inner_status_record_rejects_spoof_replay_partial_and_malformed(
     namespace = {"inner_record": record, "signal": signal}
     exec(supervisor._inner_status_record_parser(), {}, namespace)
     assert namespace["inner_status"] == expected
+
+
+@pytest.mark.parametrize("mode", ["missing", "malformed", "wrong-token"])
+def test_missing_or_unauthenticated_outer_status_is_sandbox_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str,
+) -> None:
+    """Infrastructure evidence must not fall back to an ambiguous outer exit."""
+    def fake_sandbox(*_args, termination_token: str, **_kwargs):
+        if mode == "missing":
+            header = b""
+        elif mode == "malformed":
+            header = b"x" * supervisor._TERMINATION_HEADER_BYTES
+        else:
+            header = _termination_status_header("b" * 32, -signal.SIGKILL)
+        script = (
+            "import os,sys;sys.stdin.buffer.read();"
+            "os.write(2,bytes.fromhex(sys.argv[1]));raise SystemExit(137)"
+        )
+        return [sys.executable, "-c", script, header.hex()], None
+
+    monkeypatch.setattr(supervisor, "_sandbox_command", fake_sandbox)
+    monkeypatch.setattr(supervisor, "_revalidate_privileged_command", lambda _argv: None)
+    monkeypatch.setattr(supervisor, "_sandbox_library_path", lambda _env: "")
+
+    result, surviving = run_supervised(
+        ["candidate"], cwd=tmp_path, timeout=5, env={},
+        writable_roots=(tmp_path,),
+    )
+
+    assert result.returncode == 125
+    assert result.termination.kind is TerminationKind.SANDBOX_ERROR
+    assert result.termination.exit_code == 125
+    assert surviving is False
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or not shutil.which("bwrap"),
+    reason="requires Linux Bubblewrap boundary",
+)
+@pytest.mark.timeout(10)
+def test_real_sandbox_candidate_cannot_tamper_with_root_status_monitor(
+    tmp_path: Path,
+) -> None:
+    """Candidate uid cannot forge the private record or signal its root parent."""
+    candidate = "\n".join((
+        "import json,os,signal",
+        "parent=os.getppid()",
+        "opened=[]",
+        "for number in range(64):",
+        " try:",
+        "  fd=os.open(f'/proc/{parent}/fd/{number}',os.O_WRONLY|os.O_NONBLOCK)",
+        " except OSError: continue",
+        " else:",
+        "  opened.append(number);os.write(fd,b'-9\\n');os.close(fd)",
+        "try:",
+        " os.kill(parent,signal.SIGSTOP);signal_denied=False",
+        "except OSError: signal_denied=True",
+        "try:",
+        " os.listdir('/run/pdd-termination');private_path_denied=False",
+        "except OSError: private_path_denied=True",
+        "print(json.dumps({'opened':opened,'signal_denied':signal_denied,",
+        " 'private_path_denied':private_path_denied}),flush=True)",
+        "raise SystemExit(137)",
+    ))
+
+    result, surviving = run_supervised(
+        [sys.executable, "-c", candidate], cwd=tmp_path, timeout=5,
+        env={}, writable_roots=(tmp_path,),
+    )
+
+    assert result.returncode == 137, result.stderr
+    assert result.termination.kind is TerminationKind.EXIT
+    assert result.termination.exit_code == 137
+    assert json.loads(result.stdout) == {
+        "opened": [], "signal_denied": True, "private_path_denied": True,
+    }
+    assert surviving is False
 
 
 def test_supervised_result_remains_subprocess_compatible() -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -21,6 +21,7 @@ from pdd.sync_core.supervisor import (
     _limited_command,
     _live_processes,
     _private_result_command,
+    _subprocess_status_handoff,
     _runtime_roots,
     _sandbox_library_path,
     _sandbox_command,
@@ -203,6 +204,10 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     assert "subprocess.run([mount,'--bind'" in helper
     assert "subprocess.run([umount,str(target)]" in helper
     assert "subprocess.run(argv,check=False,env=helper_env)" in helper
+    assert all(
+        line in helper for line in _subprocess_status_handoff().splitlines()
+    )
+    assert "SystemExit(result.returncode" not in helper
     assert "@PDD-CANDIDATE-ENV@" in bwrap
     helper_index = bwrap.index(str(helper_encodings))
     assert bwrap[helper_index - 2] == "--ro-bind"
@@ -635,8 +640,8 @@ def test_protected_runner_declares_finite_resource_limits() -> None:
             -signal.SIGXCPU,
             False,
             None,
-            TerminationKind.RESOURCE_LIMIT,
-            ("resource_limit", "cpu-seconds"),
+            TerminationKind.SIGNAL,
+            ("signal_number", signal.SIGXCPU),
         ),
     ],
 )
@@ -652,6 +657,60 @@ def test_termination_evidence_preserves_trusted_cause(
 
     assert evidence.kind is kind
     assert getattr(evidence, field[0]) == field[1]
+
+
+@pytest.mark.parametrize("candidate_signal", [signal.SIGXCPU, signal.SIGXFSZ])
+def test_candidate_self_resource_signal_is_only_observed_as_signal(
+    candidate_signal: signal.Signals,
+) -> None:
+    """An untrusted child signal is not proof that a configured limit fired."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os,signal;s=int(os.environ['signal_number']);"
+            "signal.signal(s,signal.SIG_DFL);os.kill(os.getpid(),s)",
+        ],
+        env={**os.environ, "signal_number": str(int(candidate_signal))},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    evidence = _termination_evidence(
+        completed.returncode,
+        timed_out=False,
+        timeout_seconds=7,
+        resource_limit=None,
+    )
+
+    assert completed.returncode == -candidate_signal
+    assert evidence.kind is TerminationKind.SIGNAL
+    assert evidence.signal_number == candidate_signal
+    assert evidence.resource_limit is None
+
+
+@pytest.mark.parametrize("candidate_signal", [signal.SIGXCPU, signal.SIGXFSZ])
+def test_staged_wrapper_preserves_nested_subprocess_signal(
+    candidate_signal: signal.Signals,
+) -> None:
+    """Exercise the exact helper handoff after its nested subprocess.run call."""
+    script = "\n".join((
+        "import os,signal,subprocess,sys",
+        "result=subprocess.run([sys.executable,'-c',"
+        "'import os,signal,sys;s=int(sys.argv[1]);signal.signal(s,signal.SIG_DFL);"
+        "os.kill(os.getpid(),s)',sys.argv[1]],"
+        "check=False)",
+        _subprocess_status_handoff(),
+    ))
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(int(candidate_signal))],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == -candidate_signal
 
 
 def test_supervised_result_remains_subprocess_compatible() -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -1019,6 +1019,7 @@ def test_inner_status_supervisor_uses_only_narrow_bootstrap_runtime() -> None:
         ("exit", 23),
         ("exit137", 137),
         ("exit152", 152),
+        ("isolation", 0),
         ("catchable", -signal.SIGXCPU),
         ("uncatchable", -signal.SIGKILL),
         ("stopping", -signal.SIGSTOP),
@@ -1029,22 +1030,40 @@ def test_real_sandbox_preserves_candidate_status_before_bwrap_normalization(
     tmp_path: Path, mode: str, expected_status: int,
 ) -> None:
     """Exercise the real staged helper, bwrap PID namespace, and inner helper."""
-    child = (
-        "import os,signal,sys;mode=sys.argv[1];"
+    required = ("bwrap", "sudo", "unshare", "mount", "umount", "setpriv")
+    if any(shutil.which(tool) is None for tool in required):
+        pytest.skip("requires the privileged Linux sandbox toolchain")
+    if subprocess.run(
+        ["sudo", "-n", "true"], capture_output=True, check=False,
+    ).returncode != 0:
+        pytest.skip("requires passwordless sudo")
+    child = "\n".join((
+        "import os,signal,sys",
+        "mode=sys.argv[1]",
+        "if mode=='isolation':",
+        " checks=(",
+        "  lambda: os.open(f'/proc/{os.getppid()}/fd',os.O_RDONLY|os.O_DIRECTORY),",
+        "  lambda: os.kill(os.getppid(),0),",
+        "  lambda: os.open('/run/pdd-termination',os.O_RDONLY|os.O_DIRECTORY),",
+        "  lambda: os.chmod('/run/pdd-termination',0o755),",
+        " )",
+        " for check in checks:",
+        "  try: check()",
+        "  except (PermissionError,FileNotFoundError): continue",
+        "  raise SystemExit(41)",
+        " raise SystemExit(0)",
         "number={'catchable':signal.SIGXCPU,'uncatchable':signal.SIGKILL,"
-        "'stopping':signal.SIGSTOP}.get(mode);"
-        "signal.signal(number,signal.SIG_DFL) if number is not None and number "
-        "not in {signal.SIGKILL,signal.SIGSTOP} else None;"
-        "os.kill(os.getpid(),number) if number is not None else None;"
-        "raise SystemExit(137 if mode=='exit137' else 152 if mode=='exit152' else 23)"
-    )
+        "'stopping':signal.SIGSTOP}.get(mode)",
+        "if number is not None and number not in {signal.SIGKILL,signal.SIGSTOP}:",
+        " signal.signal(number,signal.SIG_DFL)",
+        "if number is not None: os.kill(os.getpid(),number)",
+        "raise SystemExit(137 if mode=='exit137' else 152 if mode=='exit152' else 23)",
+    ))
     result, surviving = run_supervised(
         [sys.executable, "-c", child, mode], cwd=tmp_path, timeout=5,
         env={}, writable_roots=(tmp_path,),
     )
 
-    if result.termination.kind is TerminationKind.SANDBOX_ERROR:
-        pytest.skip(result.stderr)
     assert result.returncode == expected_status
     assert result.termination.kind is (
         TerminationKind.EXIT if expected_status >= 0 else TerminationKind.SIGNAL
@@ -1111,6 +1130,40 @@ def test_missing_or_unauthenticated_outer_status_is_sandbox_error(
     assert surviving is False
 
 
+@pytest.mark.parametrize(
+    ("mode", "kind", "returncode"),
+    [
+        ("timeout", TerminationKind.TIMEOUT, 124),
+        ("output", TerminationKind.RESOURCE_LIMIT, 125),
+    ],
+)
+def test_supervisor_observation_precedes_missing_outer_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str,
+    kind: TerminationKind, returncode: int,
+) -> None:
+    """A missing status cannot erase limits directly observed by the supervisor."""
+    def fake_sandbox(*_args, **_kwargs):
+        action = (
+            "import time;time.sleep(5)" if mode == "timeout"
+            else "import os;os.write(1,b'x'*2048)"
+        )
+        return [sys.executable, "-c", action], None
+
+    monkeypatch.setattr(supervisor, "_sandbox_command", fake_sandbox)
+    monkeypatch.setattr(supervisor, "_revalidate_privileged_command", lambda _argv: None)
+    monkeypatch.setattr(supervisor, "_sandbox_library_path", lambda _env: "")
+    limits = SupervisorLimits(max_output_bytes=512)
+
+    result, surviving = run_supervised(
+        ["candidate"], cwd=tmp_path, timeout=1, env={},
+        writable_roots=(tmp_path,), limits=limits,
+    )
+
+    assert result.returncode == returncode
+    assert result.termination.kind is kind
+    assert surviving is False
+
+
 @pytest.mark.skipif(
     not sys.platform.startswith("linux") or not shutil.which("bwrap"),
     reason="requires Linux Bubblewrap boundary",
@@ -1120,6 +1173,13 @@ def test_real_sandbox_candidate_cannot_tamper_with_root_status_monitor(
     tmp_path: Path,
 ) -> None:
     """Candidate uid cannot forge the private record or signal its root parent."""
+    required = ("bwrap", "sudo", "unshare", "mount", "umount", "setpriv")
+    if any(shutil.which(tool) is None for tool in required):
+        pytest.skip("requires the privileged Linux sandbox toolchain")
+    if subprocess.run(
+        ["sudo", "-n", "true"], capture_output=True, check=False,
+    ).returncode != 0:
+        pytest.skip("requires passwordless sudo")
     candidate = "\n".join((
         "import json,os,signal",
         "parent=os.getppid()",

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -21,7 +21,10 @@ from pdd.sync_core.supervisor import (
     _limited_command,
     _live_processes,
     _private_result_command,
+    _authenticated_nested_returncode,
+    _subprocess_status_observation,
     _subprocess_status_handoff,
+    _termination_status_header,
     _runtime_roots,
     _sandbox_library_path,
     _sandbox_command,
@@ -377,7 +380,9 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     compile(helper, "<privileged-helper>", "exec")
     assert "subprocess.run([mount,'--bind'" in helper
     assert "subprocess.run([umount,str(target)]" in helper
-    assert "subprocess.run(argv,check=False,env=helper_env)" in helper
+    assert all(
+        line in helper for line in _subprocess_status_observation().splitlines()
+    )
     assert all(
         line in helper for line in _subprocess_status_handoff().splitlines()
     )
@@ -863,28 +868,58 @@ def test_candidate_self_resource_signal_is_only_observed_as_signal(
     assert evidence.resource_limit is None
 
 
-@pytest.mark.parametrize("candidate_signal", [signal.SIGXCPU, signal.SIGXFSZ])
-def test_staged_wrapper_preserves_nested_subprocess_signal(
-    candidate_signal: signal.Signals,
+@pytest.mark.parametrize(
+    ("mode", "expected_status", "expected_returncode"),
+    [
+        ("exit", 23, 23),
+        ("catchable", -signal.SIGXCPU, -signal.SIGXCPU),
+        ("uncatchable", -signal.SIGKILL, -signal.SIGKILL),
+        ("stopping", -signal.SIGSTOP, 125),
+    ],
+)
+def test_staged_wrapper_safely_preserves_nested_subprocess_status(
+    mode: str, expected_status: int, expected_returncode: int,
 ) -> None:
-    """Exercise the exact helper handoff after its nested subprocess.run call."""
+    """Exercise the exact helper observation/handoff in an isolated process."""
+    child = ";".join((
+        "import os,signal,sys",
+        "mode=sys.argv[1]",
+        "number={'catchable':signal.SIGXCPU,'uncatchable':signal.SIGKILL,"
+        "'stopping':signal.SIGSTOP}.get(mode)",
+        "signal.signal(number,signal.SIG_DFL) if number is not None "
+        "and number not in {signal.SIGKILL,signal.SIGSTOP} else None",
+        "os.kill(os.getpid(),number) if number is not None else None",
+        "raise SystemExit(23)",
+    ))
     script = "\n".join((
         "import os,signal,subprocess,sys",
-        "result=subprocess.run([sys.executable,'-c',"
-        "'import os,signal,sys;s=int(sys.argv[1]);signal.signal(s,signal.SIG_DFL);"
-        "os.kill(os.getpid(),s)',sys.argv[1]],"
-        "check=False)",
+        f"argv=[sys.executable,'-c',{child!r},sys.argv[1]]",
+        "helper_env=os.environ.copy()",
+        _subprocess_status_observation(),
+        "print(status,flush=True)",
         _subprocess_status_handoff(),
     ))
 
     completed = subprocess.run(
-        [sys.executable, "-c", script, str(int(candidate_signal))],
+        [sys.executable, "-c", script, mode],
         capture_output=True,
         text=True,
+        timeout=5,
         check=False,
     )
 
-    assert completed.returncode == -candidate_signal
+    assert completed.stdout == f"{expected_status}\n"
+    assert completed.returncode == expected_returncode
+    assert "Invalid argument" not in completed.stderr
+
+
+def test_nested_stopping_status_requires_authenticated_header() -> None:
+    token = "a" * 32
+    header = _termination_status_header(token, -signal.SIGSTOP)
+
+    assert _authenticated_nested_returncode(header, token) == -signal.SIGSTOP
+    assert _authenticated_nested_returncode(header, "b" * 32) is None
+    assert _authenticated_nested_returncode(b" " * len(header), token) is None
 
 
 def test_supervised_result_remains_subprocess_compatible() -> None:


### PR DESCRIPTION
Closes #2042

## Root cause

Protected Vitest execution collapsed every nonzero exit without authenticated reporter output into candidate `FAIL` and exposed candidate-controlled stderr as the detail. The supervisor returned only a conventional return code, so callers could not distinguish a normal exit, signal, timeout, resource ceiling, or sandbox startup error. The workflow also installed a nominal Vitest version without a checked-in transitive lock.

## Fix

- preserve trusted typed termination evidence on a `CompletedProcess`-compatible supervisor result
- classify missing-reporter exits as infrastructure `ERROR`/`TIMEOUT` with exact trusted fields
- include only a SHA-256 fingerprint of untrusted diagnostic output
- retain authenticated reporter PASS/FAIL/SKIP semantics and existing launcher/collection distinctions
- check in the protected Vitest 4.1.10 npm lock and consume it with `npm ci`

## Validation

- red tests committed separately: `bf47df5b1`, `fc5b10a26`
- `tests/test_sync_core_supervisor.py`: 31 passed, 17 skipped
- missing-reporter + no-writer focused cases: 5 passed
- authenticated reporter/launcher cases: 10 passed individually
- xdist typed termination cases: 4 passed with 2 workers
- workflow/lock contract: 2 passed
- scoped pylint and py_compile: passed
- clean `npm ci` from checked-in lock: Vitest 4.1.10

## Local environment note

The broad touched-file run reached 102 passed / 18 skipped but 74 unrelated parser-dependent cases failed because the nominal local `pdd` interpreter lacks the existing `tree-sitter` distributions. Issue-specific tests pass in the dependency-complete runtime; hosted CI is the authoritative full-suite gate.