### PR TITLE
fix(sync): preauthorize protected Vitest toolchain paths

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -27,6 +27,20 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".github/toolchains/vitest/package-lock.json",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".github/toolchains/vitest/package.json",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".github/workflows/auto-heal.yml",
       "role": "human-maintained"
     },

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -56,6 +56,8 @@ FOUNDATION_OBLIGATIONS = {
     },
 }
 PREAUTHORIZED_CHILD_PATHS = {
+    ".github/toolchains/vitest/package.json",
+    ".github/toolchains/vitest/package-lock.json",
     "tests/test_sync_core_runner_jest.py",
     "tests/test_sync_core_runner_vitest.py",
     "tests/test_sync_core_runner_playwright.py",


### PR DESCRIPTION
## Summary

- preauthorize only `.github/toolchains/vitest/package.json` and `.github/toolchains/vitest/package-lock.json` from the protected base
- classify both as `HUMAN_OWNED`, `human-maintained`, owner `pdd-maintainers`, with `preauthorize_absent: true`
- extend the existing exact absent-path rollout test; its global invariant rejects wildcard or broad preauthorization

## Dependency rationale

PR #2071 adds these reviewed, locked Vitest toolchain files, but protected candidate ownership must come from its base. This minimal prerequisite breaks that fixed-point cycle without importing any #2071 implementation. Issue #2042 remains open for the actual termination-evidence fix.

## TDD evidence

- Red commit `8abdca43a`: focused test failed because both exact rules resolved to `None`.
- Green commit `329a21b58`: the same absent-base/present-head manifest exercise classifies both paths with exact protected provenance.

## Tests

- `pytest -q tests/test_sync_core_pdd_rollout_policy.py` — 7 passed
- `pytest -q tests/test_sync_core_manifest.py -k absent` — 2 passed, 23 deselected
- `pytest -q tests/test_sync_core_verification_profiles.py` — 12 passed
- `python -m json.tool .pdd/sync-ownership.json` — passed
- `python -m py_compile tests/test_sync_core_pdd_rollout_policy.py` — passed
- `pylint tests/test_sync_core_pdd_rollout_policy.py` — 10.00/10
- `git diff --check origin/main...HEAD` — passed

The rollout test confirms 466 expected/managed units, exact full profile coverage, and zero invalid or unaccounted tracked paths.

## Scope

Related context: #2042. Prerequisite for #2071. This PR does not close either issue and does not merge or deploy anything.