### PR TITLE
fix(sync): classify protected cgroup terminations

### DIFF
--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -55,6 +55,7 @@ from .supervisor import (
     PlaywrightSnapshotAggregate,
     SnapshotBindingProof,
     SupervisorLimits,
+    SupervisorTermination,
     TerminationKind,
     _vitest_descriptor_attestation,
     released_runtime_closure_paths,
@@ -4476,6 +4477,14 @@ def _vitest_infrastructure_termination(
         )
     elif kind == "resource-limit":
         fields.append(f"resource_limit={getattr(termination, 'resource_limit', None) or 'unknown'}")
+    if isinstance(termination, SupervisorTermination):
+        telemetry = termination.resource_telemetry
+        if telemetry is not None:
+            fields.extend((
+                f"cgroup_memory_oom_delta={telemetry.memory_oom_delta}",
+                f"cgroup_memory_oom_kill_delta={telemetry.memory_oom_kill_delta}",
+                f"cgroup_pids_max_delta={telemetry.pids_max_delta}",
+            ))
     diagnostic = result.stderr or result.stdout
     if diagnostic:
         fields.append("diagnostic_sha256=" + hashlib.sha256(

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -132,6 +132,15 @@ class TerminationKind(str, Enum):
 
 
 @dataclass(frozen=True)
+class CgroupResourceTelemetry:
+    """Trusted deltas from the candidate leaf's kernel event counters."""
+
+    memory_oom_delta: int
+    memory_oom_kill_delta: int
+    pids_max_delta: int
+
+
+@dataclass(frozen=True)
 class SupervisorTermination:
     """Typed termination evidence retained outside candidate-controlled output."""
 
@@ -140,6 +149,7 @@ class SupervisorTermination:
     signal_number: int | None = None
     timeout_seconds: int | None = None
     resource_limit: str | None = None
+    resource_telemetry: CgroupResourceTelemetry | None = None
 
 
 class SupervisedCompletedProcess(subprocess.CompletedProcess[str]):  # pylint: disable=too-few-public-methods
@@ -189,19 +199,32 @@ def _termination_evidence(
     timed_out: bool,
     timeout_seconds: int,
     resource_limit: str | None,
+    resource_telemetry: CgroupResourceTelemetry | None = None,
 ) -> SupervisorTermination:
     """Classify only termination causes observed by the trusted supervisor."""
     if resource_limit is not None:
         return SupervisorTermination(
-            TerminationKind.RESOURCE_LIMIT, resource_limit=resource_limit
+            TerminationKind.RESOURCE_LIMIT,
+            resource_limit=resource_limit,
+            resource_telemetry=resource_telemetry,
         )
     if timed_out:
         return SupervisorTermination(
-            TerminationKind.TIMEOUT, timeout_seconds=timeout_seconds
+            TerminationKind.TIMEOUT,
+            timeout_seconds=timeout_seconds,
+            resource_telemetry=resource_telemetry,
         )
     if returncode < 0:
-        return SupervisorTermination(TerminationKind.SIGNAL, signal_number=-returncode)
-    return SupervisorTermination(TerminationKind.EXIT, exit_code=returncode)
+        return SupervisorTermination(
+            TerminationKind.SIGNAL,
+            signal_number=-returncode,
+            resource_telemetry=resource_telemetry,
+        )
+    return SupervisorTermination(
+        TerminationKind.EXIT,
+        exit_code=returncode,
+        resource_telemetry=resource_telemetry,
+    )
 
 
 @dataclass(frozen=True)
@@ -2752,6 +2775,32 @@ def _cgroup_events(cgroup: Path, filename: str) -> dict[str, int]:
     return events
 
 
+def _cgroup_resource_telemetry(
+    memory_before: dict[str, int],
+    memory_after: dict[str, int],
+    pids_before: dict[str, int],
+    pids_after: dict[str, int],
+) -> CgroupResourceTelemetry:
+    """Return monotonic kernel-event deltas for one proven candidate leaf."""
+    values = {
+        "memory.events oom": memory_after["oom"] - memory_before["oom"],
+        "memory.events oom_kill": (
+            memory_after["oom_kill"] - memory_before["oom_kill"]
+        ),
+        "pids.events max": pids_after["max"] - pids_before["max"],
+    }
+    regressed = [name for name, value in values.items() if value < 0]
+    if regressed:
+        raise RuntimeError(
+            "protected cgroup event counter regressed: " + ",".join(regressed)
+        )
+    return CgroupResourceTelemetry(
+        memory_oom_delta=values["memory.events oom"],
+        memory_oom_kill_delta=values["memory.events oom_kill"],
+        pids_max_delta=values["pids.events max"],
+    )
+
+
 def _probe_scope(
     plan: _ScopePlan, limits: SupervisorLimits,
 ) -> tuple[Path, dict[str, int], dict[str, int]]:
@@ -2975,8 +3024,12 @@ def _sandbox_command(
         storage_roots = _writable_storage_roots(writable_sources)
         if _writable_size(storage_roots) > limits.max_writable_bytes:
             raise RuntimeError("initial writable quota exceeded")
+        # Keep the host cgroup namespace while exposing only the candidate leaf
+        # below. A namespace rooted at the monitor cannot migrate the child into
+        # its sibling candidate leaf; the read-only candidate uid still cannot
+        # change membership or limits after the root supervisor performs it.
         argv = [str(tools.bwrap), "--unshare-ipc", "--unshare-pid", "--unshare-net",
-                "--unshare-uts", "--unshare-cgroup", "--die-with-parent", "--new-session",
+                "--unshare-uts", "--die-with-parent", "--new-session",
                 "--tmpfs", "/", "--proc", "/proc", "--dir", "/tmp",
                 "--dir", "/sys", "--dir", "/sys/fs", "--dir", "/sys/fs/cgroup"]
         sources: list[Path] = []
@@ -3349,6 +3402,7 @@ def _run_playwright_descriptor_supervised(
     candidate_returncode = 125
     failed_closed = False
     resource_limit: str | None = None
+    resource_telemetry: CgroupResourceTelemetry | None = None
     phase = "construction"
     candidate_stdout = b""
     candidate_stderr = b""
@@ -3430,14 +3484,18 @@ def _run_playwright_descriptor_supervised(
                 raise RuntimeError("candidate used reserved exit status 124")
             # The helper holds the candidate leaf until this acknowledgement.
             # Capture authoritative kernel deltas before permitting that cleanup.
-            memory_after = _cgroup_events(cgroup, "memory.events")
-            pids_after = _cgroup_events(cgroup, "pids.events")
+            resource_telemetry = _cgroup_resource_telemetry(
+                memory_before,
+                _cgroup_events(cgroup, "memory.events"),
+                pids_before,
+                _cgroup_events(cgroup, "pids.events"),
+            )
             if max(
-                memory_after["oom"] - memory_before["oom"],
-                memory_after["oom_kill"] - memory_before["oom_kill"],
+                resource_telemetry.memory_oom_delta,
+                resource_telemetry.memory_oom_kill_delta,
             ) > 0:
                 resource_limit = "memory"
-            elif pids_after["max"] - pids_before["max"] > 0:
+            elif resource_telemetry.pids_max_delta > 0:
                 resource_limit = "pids"
             handoff_deadline = time.monotonic() + _TRUSTED_POSTPROCESS_SECONDS
             _write_all_descriptor_bytes(
@@ -3511,6 +3569,7 @@ def _run_playwright_descriptor_supervised(
                 124 if timed_out else candidate_returncode,
                 timed_out=timed_out, timeout_seconds=timeout,
                 resource_limit=resource_limit,
+                resource_telemetry=resource_telemetry,
             )
         ),
     ), False
@@ -3565,6 +3624,7 @@ def run_supervised(
     candidate_returncode: int | None = None
     candidate_record: _CandidateRecord | None = None
     resource_limit: str | None = None
+    resource_telemetry: CgroupResourceTelemetry | None = None
     process: subprocess.Popen[bytes] | None = None
     plan: _ScopePlan | None = None
     cgroup: Path | None = None
@@ -3622,16 +3682,19 @@ def run_supervised(
         return True
 
     def record_events() -> None:
-        nonlocal resource_limit
+        nonlocal resource_limit, resource_telemetry
         if cgroup is None:
             return
         memory_after = _cgroup_events(cgroup, "memory.events")
         pids_after = _cgroup_events(cgroup, "pids.events")
-        oom_delta = max(
-            memory_after["oom"] - memory_before["oom"],
-            memory_after["oom_kill"] - memory_before["oom_kill"],
+        resource_telemetry = _cgroup_resource_telemetry(
+            memory_before, memory_after, pids_before, pids_after,
         )
-        pids_delta = pids_after["max"] - pids_before["max"]
+        oom_delta = max(
+            resource_telemetry.memory_oom_delta,
+            resource_telemetry.memory_oom_kill_delta,
+        )
+        pids_delta = resource_telemetry.pids_max_delta
         if oom_delta > 0:
             resource_limit = "memory"
             add_diagnostic(f"cgroup memory.events oom delta={oom_delta}\n")
@@ -3955,6 +4018,7 @@ def run_supervised(
             if failed_closed else _termination_evidence(
                 returncode, timed_out=candidate_timed_out, timeout_seconds=timeout,
                 resource_limit=resource_limit,
+                resource_telemetry=resource_telemetry,
             )
         ),
     ), surviving

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import signal
 import shutil
 import subprocess
 import sys
@@ -40,7 +41,13 @@ from pdd.sync_core.runner import (
     vitest_validator_config_digest,
 )
 from pdd.sync_core.evidence_store import attestation_payload, decode_attestation
-from pdd.sync_core.supervisor import SupervisorLimits
+from pdd.sync_core.supervisor import (
+    CgroupResourceTelemetry,
+    SupervisedCompletedProcess,
+    SupervisorLimits,
+    SupervisorTermination,
+    TerminationKind,
+)
 
 
 def test_framework_observation_fifo_eof_waits_for_late_writer(
@@ -1894,6 +1901,48 @@ def test_vitest_result_fifo_without_writer_is_distinct_collection_error(
 
     assert executions[0].outcome is EvidenceOutcome.COLLECTION_ERROR
     assert executions[0].detail == "Vitest reporter produced no result"
+
+
+def test_vitest_sigabrt_reports_only_trusted_zero_cgroup_deltas(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A generic abort stays fail-closed and is not mislabeled as a limit breach."""
+    root, _commit = _repository(tmp_path)
+    result = SupervisedCompletedProcess(
+        ["vitest"],
+        -signal.SIGABRT,
+        "candidate stdout must not be exposed",
+        "candidate stderr must not be exposed",
+        termination=SupervisorTermination(
+            TerminationKind.SIGNAL,
+            signal_number=signal.SIGABRT,
+            resource_telemetry=CgroupResourceTelemetry(0, 0, 0),
+        ),
+    )
+    monkeypatch.setattr(
+        "pdd.sync_core.runner.run_supervised",
+        lambda *_args, **_kwargs: (result, False),
+    )
+
+    execution, identities = _run_vitest(
+        root,
+        (PurePosixPath("tests/widget.test.ts"),),
+        30,
+        _runner_config(tmp_path, _fake_vitest(tmp_path)),
+    )
+
+    assert execution.outcome is EvidenceOutcome.ERROR
+    assert execution.detail == (
+        "Vitest infrastructure termination: reporter=missing; kind=signal; "
+        "signal=SIGABRT; signal_number=6; cgroup_memory_oom_delta=0; "
+        "cgroup_memory_oom_kill_delta=0; cgroup_pids_max_delta=0; "
+        "diagnostic_sha256=a56506d06ba82ba55af2e5593dab5a2044555b5f75d8389f"
+        "c90dd9679fe43f20"
+    )
+    assert "candidate stdout" not in execution.detail
+    assert "candidate stderr" not in execution.detail
+    assert identities == ()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -1108,7 +1108,8 @@ def test_linux_sandbox_uses_privileged_namespace_setup_then_drops_uid(
     assert plan.unit_name.startswith("pdd-validator-")
     assert argv[:3] == [str(plan.tools.sudo), "-n", str(plan.tools.systemd_run)]
     bwrap = plan.bwrap_argv
-    assert {"--unshare-pid", "--unshare-net", "--unshare-cgroup"} <= set(bwrap)
+    assert {"--unshare-pid", "--unshare-net"} <= set(bwrap)
+    assert "--unshare-cgroup" not in bwrap
     assert "--unshare-user" not in bwrap
     separator = bwrap.index("--")
     assert bwrap.index("--bind") < separator < bwrap.index("--reuid")

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -3307,6 +3307,39 @@ def test_cgroup_event_counters_require_authoritative_keys(
         supervisor._cgroup_events(tmp_path, filename)
 
 
+def test_signal_termination_retains_zero_cgroup_event_deltas() -> None:
+    """A signal stays a signal while proving configured cgroup limits did not fire."""
+    telemetry = supervisor.CgroupResourceTelemetry(
+        memory_oom_delta=0,
+        memory_oom_kill_delta=0,
+        pids_max_delta=0,
+    )
+
+    termination = supervisor._termination_evidence(
+        -signal.SIGABRT,
+        timed_out=False,
+        timeout_seconds=30,
+        resource_limit=None,
+        resource_telemetry=telemetry,
+    )
+
+    assert termination.kind is supervisor.TerminationKind.SIGNAL
+    assert termination.signal_number == signal.SIGABRT
+    assert termination.resource_limit is None
+    assert termination.resource_telemetry == telemetry
+
+
+def test_cgroup_resource_telemetry_rejects_counter_regression() -> None:
+    """Kernel counters must be monotonic before becoming trusted diagnostics."""
+    with pytest.raises(RuntimeError, match="counter regressed"):
+        supervisor._cgroup_resource_telemetry(
+            {"oom": 2, "oom_kill": 1},
+            {"oom": 1, "oom_kill": 1},
+            {"max": 0},
+            {"max": 0},
+        )
+
+
 def test_scope_cleanup_targets_only_validated_unique_unit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Stacked dependency

This draft is stacked on #1995 at exact head f5e0b9b57eef7bd07b2a5da033ec980913764794. Do not merge it before #1995, and do not close #2083 from this draft.

## Root cause

Run 29444363591 job 87451007833 failed the first protected Linux sandbox smoke at the inline workflow assertion. The installed-package smoke consistently exited 127. The #1995 architecture starts the inner root status supervisor inside a cgroup namespace rooted at the monitor cgroup, then asks it to migrate the candidate into a sibling limited leaf. That sibling is outside the namespace root, so placement fails before candidate exec.

This removes only Bubblewrap cgroup-namespace isolation. The sandbox still exposes only the candidate leaf under /sys/fs/cgroup, and the dropped candidate UID cannot change membership or limits. PID, network, IPC, and UTS namespaces remain.

It also preserves trusted monotonic memory OOM, OOM-kill, and pids-max deltas on typed termination evidence. Vitest infrastructure details include only those kernel counters plus the existing hash of untrusted diagnostics. Candidate stdout and stderr remain undisclosed. Generic SIGABRT remains ERROR and is not retried.

## TDD and validation

RED commits:
- 14648b07f: missing cgroup termination telemetry reproduced as ImportError
- 2f3eb2b61: sibling-placement construction reproduced by the unexpected --unshare-cgroup flag

GREEN:
- focused regression set: 6 passed
- full touched suites: 357 passed, 41 skipped
- production pylint with the environment-preexisting tree_sitter import diagnostic excluded: 10.00/10
- touched-test E/F pylint with the environment-preexisting dataclass false positive excluded: 10.00/10
- py_compile and git diff --check: passed

## Hosted evidence still required

This remains draft because Unit Tests has no workflow_dispatch and making it ready would also invoke secret-bearing staging auto-heal automation. No hosted diagnostic was triggered.

After stack integration, verify:
1. protected Linux sandbox smoke
2. cgroup OOM, pids, and timeout smokes with trusted telemetry
3. repeated real Vitest serial execution
4. pressure xdist execution, confirming SIGABRT is absent or classified with zero/nonzero kernel deltas
5. source and installed-wheel Playwright paths
6. complete Unit Tests workflow

Related: #2083