### PR TITLE
fix(sync): preauthorize hosted workflow contract test

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -13445,6 +13445,13 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "tests/test_unit_tests_workflow.py",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "tests/test_update_command.py",
       "role": "human-maintained"
     },

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -57,6 +57,7 @@ FOUNDATION_OBLIGATIONS = {
     },
 }
 PREAUTHORIZED_CHILD_PATHS = {
+    "tests/test_unit_tests_workflow.py",
     "tests/test_ci_drift_heal_example_contract.py",
     "tests/test_sync_core_runner_jest.py",
     "tests/test_sync_core_runner_vitest.py",


### PR DESCRIPTION
Closes #2089

## Summary
- preauthorize only the absent `tests/test_unit_tests_workflow.py` path from the protected base
- classify it as exact human-maintained PDD ownership with no wildcard or detector weakening
- extend the existing absent-child rollout contract

## Dependency rationale
PR #1995 introduces this hosted workflow contract test, but candidate-side ownership cannot authorize itself. This dormant prerequisite follows the protected-side bootstrap convention from #2074. Stacked #2088 remains dependent on #1995 and is otherwise unchanged.

## Tests
- `pytest -q tests/test_sync_core_pdd_rollout_policy.py`
- focused inventory + absent-child rollout tests
- `python -m json.tool .pdd/sync-ownership.json`
- `pylint tests/test_sync_core_pdd_rollout_policy.py`
- `git diff --check`

## Scope
No runner, supervisor, workflow, provider, wildcard, deploy, release, or merge changes.