### PR TITLE
fix(sync): avoid hosted helper fork deadlock

### DIFF
--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -1790,6 +1790,8 @@ def _candidate_environment_record(
         raise RuntimeError("protected candidate environment is invalid")
     candidate = dict(environment)
     candidate.update({
+        "LANG": "C",
+        "LC_ALL": "C",
         "PATH": _TRUSTED_ROOT_PATH,
         "PDD_SUPERVISION_TOKEN": supervision_token,
         "PYTHONDONTWRITEBYTECODE": "1",
@@ -2237,7 +2239,7 @@ def _staged_bwrap(
         "    observation_size+=len(chunk)",
         "    if observation_size>limits['observation']: observation_overflow=True",
         "    elif not observation_overflow: observation_chunks.append(chunk)",
-        "  observation_thread=threading.Thread(target=drain_observation,daemon=True); observation_thread.start()",
+        "  observation_thread=threading.Thread(target=drain_observation,daemon=True)",
         " configure_candidate_leaf()",
         " subprocess.run([mount,'--bind',str(candidate_cgroup),str(cgroup_target)],"
         "check=True,timeout=limits['trusted_timeout'])",
@@ -2273,7 +2275,6 @@ def _staged_bwrap(
         "     elif not candidate_output_overflow: chunks.append(chunk)",
         "   os.close(fd)",
         "  candidate_output_threads=[threading.Thread(target=drain_candidate,args=(candidate_stdout_read,candidate_stdout),daemon=True),threading.Thread(target=drain_candidate,args=(candidate_stderr_read,candidate_stderr),daemon=True)]",
-        "  [thread.start() for thread in candidate_output_threads]",
         " pid=os.fork()",
         " if pid == 0:",
         "  os.close(release_write)",
@@ -2298,6 +2299,8 @@ def _staged_bwrap(
         " os.close(status_write)",
         " if anonymous_observation: os.close(observation_write)",
         " if descriptor_protocol: os.close(candidate_stdout_write); os.close(candidate_stderr_write)",
+        " if anonymous_observation: observation_thread.start()",
+        " if descriptor_protocol: [thread.start() for thread in candidate_output_threads]",
         " parent_watch_done=threading.Event(); parent_watch=None",
         " if descriptor_protocol:",
         "  def watch_parent():",

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -37,6 +37,11 @@ from pdd.sync_core.supervisor import (
 )
 
 
+def _credential_free_environment(home: Path) -> dict[str, str]:
+    """Return a fixed candidate environment independent of hosted CI secrets."""
+    return {"HOME": str(home), "NODE_ENV": "test"}
+
+
 def _mock_linux_tools(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> dict[str, str]:
@@ -2796,7 +2801,7 @@ def test_sandboxed_python_minimal_smoke(tmp_path: Path) -> None:
         [sys.executable, "-c", "pass"],
         cwd=tmp_path,
         timeout=10,
-        env=dict(os.environ),
+        env=_credential_free_environment(tmp_path),
         writable_roots=(tmp_path,),
     )
 
@@ -3280,7 +3285,7 @@ def test_exact_supervisor_candidate_leaf_preserves_monitor_and_events(
     )
     result, surviving = run_supervised(
         commands[case], cwd=tmp_path, timeout=.1 if case == "timeout" else 10,
-        env=dict(os.environ), writable_roots=(tmp_path,), limits=limits,
+        env=_credential_free_environment(tmp_path), writable_roots=(tmp_path,), limits=limits,
     )
 
     assert not surviving
@@ -3410,7 +3415,7 @@ def test_sandboxed_python_imports_standard_library_after_command_construction(
         [sys.executable, "-c", "import math; print(math.pi)"],
         cwd=tmp_path,
         timeout=10,
-        env=dict(os.environ),
+        env=_credential_free_environment(tmp_path),
         writable_roots=(tmp_path,),
     )
 
@@ -3478,7 +3483,7 @@ def test_detached_session_descendant_is_terminated(tmp_path: Path) -> None:
         [sys.executable, "-c", parent, child, str(marker)],
         cwd=tmp_path,
         timeout=10,
-        env=dict(os.environ),
+        env=_credential_free_environment(tmp_path),
         writable_roots=(tmp_path,),
     )
     assert result.returncode == 0
@@ -3505,7 +3510,7 @@ def test_detached_descendant_cannot_escape_by_removing_marker(tmp_path: Path) ->
     )
     result, surviving = run_supervised(
         [sys.executable, "-c", parent, child, str(marker)], cwd=tmp_path,
-        timeout=10, env=dict(os.environ), writable_roots=(tmp_path,),
+        timeout=10, env=_credential_free_environment(tmp_path), writable_roots=(tmp_path,),
     )
     assert result.returncode == 0
     assert surviving is False
@@ -3523,7 +3528,7 @@ def test_candidate_cannot_read_absolute_host_sentinel(tmp_path: Path) -> None:
             "import pathlib,sys; pathlib.Path(sys.argv[1]).read_text()",
             str(sentinel),
         ],
-        cwd=tmp_path, timeout=10, env=dict(os.environ), writable_roots=(tmp_path,),
+        cwd=tmp_path, timeout=10, env=_credential_free_environment(tmp_path), writable_roots=(tmp_path,),
     )
     assert result.returncode != 0
     assert surviving is False
@@ -3548,7 +3553,7 @@ def test_immediate_detached_child_cannot_forge_checker_result_channel(
     )
     completed, _surviving = run_supervised(
         [sys.executable, "-c", parent, child, str(result_channel)],
-        cwd=scratch, timeout=10, env=dict(os.environ),
+        cwd=scratch, timeout=10, env=_credential_free_environment(tmp_path),
         writable_roots=(scratch,),
     )
     assert completed.returncode == 0
@@ -3560,7 +3565,7 @@ def test_immediate_detached_child_cannot_forge_checker_result_channel(
 def test_output_is_bounded(tmp_path: Path) -> None:
     result, _surviving = run_supervised(
         [sys.executable, "-c", "print('x' * 20000000)"], cwd=tmp_path,
-        timeout=10, env=dict(os.environ), writable_roots=(tmp_path,),
+        timeout=10, env=_credential_free_environment(tmp_path), writable_roots=(tmp_path,),
     )
     assert len(result.stdout.encode()) <= 16 * 1024 * 1024
     assert result.returncode != 0
@@ -3587,7 +3592,7 @@ def test_memory_disk_and_process_limits_fail_closed(tmp_path: Path, program: str
     )
     result, _surviving = run_supervised(
         [sys.executable, "-c", program], cwd=tmp_path, timeout=10,
-        env=dict(os.environ), writable_roots=(tmp_path,), limits=limits,
+        env=_credential_free_environment(tmp_path), writable_roots=(tmp_path,), limits=limits,
     )
     assert result.returncode != 0
 
@@ -3699,7 +3704,7 @@ def test_binary_output_has_aggregate_limit_and_deterministic_decode(tmp_path: Pa
     limits = SupervisorLimits(max_output_bytes=1024)
     result, _surviving = run_supervised(
         [sys.executable, "-c", "import os; os.write(1, b'\\xff' * 800); os.write(2, b'x' * 800)"],
-        cwd=tmp_path, timeout=10, env=dict(os.environ),
+        cwd=tmp_path, timeout=10, env=_credential_free_environment(tmp_path),
         writable_roots=(tmp_path,), limits=limits,
     )
     assert result.returncode == 125
@@ -3776,7 +3781,8 @@ def test_real_linux_authenticated_termination_and_cleanup(tmp_path: Path) -> Non
     )
     for command, timeout, kind, returncode in cases:
         result, surviving = run_supervised(
-            command, cwd=tmp_path, timeout=timeout, env=dict(os.environ),
+            command, cwd=tmp_path, timeout=timeout,
+            env=_credential_free_environment(tmp_path),
             writable_roots=(tmp_path,),
         )
         assert isinstance(result, supervisor.SupervisedCompletedProcess)
@@ -3794,7 +3800,7 @@ def test_real_linux_authenticated_termination_and_cleanup(tmp_path: Path) -> Non
     )
     result, surviving = run_supervised(
         [sys.executable, "-c", fork_program], cwd=tmp_path, timeout=5,
-        env=dict(os.environ), writable_roots=(tmp_path,),
+        env=_credential_free_environment(tmp_path), writable_roots=(tmp_path,),
         limits=replace(SupervisorLimits(), max_processes=8),
     )
     assert result.termination.kind is supervisor.TerminationKind.RESOURCE_LIMIT
@@ -5705,7 +5711,7 @@ def test_simultaneous_high_volume_stdio_has_one_aggregate_bound(tmp_path: Path) 
     )
     result, surviving = run_supervised(
         [sys.executable, "-c", program], cwd=tmp_path, timeout=10,
-        env=dict(os.environ), writable_roots=(tmp_path,),
+        env=_credential_free_environment(tmp_path), writable_roots=(tmp_path,),
         limits=replace(SupervisorLimits(), max_output_bytes=1024 * 1024),
     )
     assert result.returncode == 0
@@ -6042,7 +6048,7 @@ def test_writable_churn_cannot_escape_supervisor_cleanup(tmp_path: Path) -> None
     )
     result, surviving = run_supervised(
         [sys.executable, "-c", program], cwd=tmp_path, timeout=5,
-        env=dict(os.environ), writable_roots=(tmp_path,),
+        env=_credential_free_environment(tmp_path), writable_roots=(tmp_path,),
     )
     assert result.returncode == 0
     assert surviving is False

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -98,6 +98,7 @@ def test_candidate_environment_record_is_canonical_and_complete(tmp_path: Path) 
     parsed = supervisor._parse_candidate_environment_record(encoded)
 
     assert parsed == environment | {
+        "LANG": "C", "LC_ALL": "C",
         "LD_LIBRARY_PATH": supervisor._sandbox_library_path(environment),
         "PATH": supervisor._TRUSTED_ROOT_PATH,
         "PDD_SUPERVISION_TOKEN": "a" * 32,
@@ -2916,6 +2917,9 @@ def test_linux_sandbox_stages_candidate_in_limited_leaf_before_exec(
     assert "ready" in helper and "start" in helper
     assert helper.index("start") < helper.index("os.fork()")
     assert "release_read,release_write=os.pipe()" in helper
+    fork_offset = helper.index("pid=os.fork()")
+    assert fork_offset < helper.index("observation_thread.start()")
+    assert fork_offset < helper.index("[thread.start() for thread in candidate_output_threads]")
     assert "os.read(release_read,1)" in helper
     assert "(candidate_cgroup/'cgroup.procs').write_text(str(pid)" not in helper
     assert helper.index("os.read(release_read,1)") < helper.index(


### PR DESCRIPTION
Stacked on #1995 exact head 82c1671d94176f3cd5204f7ab9345b301abe2a95. Keep this PR draft and do not merge independently.\n\nCloses #2091\n\nRoot cause:\n- The privileged Python 3.12 helper started the observation drain plus two candidate-output drain threads before os.fork(). Hosted logs emitted the matching multi-threaded-fork deadlock warning, and the installed-wheel Playwright lane then blocked awaiting the helper result frame for every admitted config suffix.\n- Real Linux supervisor tests passed raw GitHub Actions environment state into the candidate record. Credential-marked hosted variables were intentionally rejected by the protected boundary. With a minimal environment, CPython could also synthesize LC_CTYPE after the exact record was formed.\n\nFix:\n- Create the bounded pipes and thread objects before the fork, but start every drain only in the trusted parent after the child exists.\n- Pin LANG and LC_ALL to C in the exact candidate record.\n- Give real Bubblewrap tests a fixed credential-free candidate environment; no credential filtering or boundary weakening was added.\n\nSecurity properties retained:\n- Candidate-only limited cgroup leaf and trusted monitor topology.\n- Exact path translation and bounded authenticated descriptor frames.\n- Monotonic cgroup event telemetry.\n- No raw candidate-output disclosure, retry, or timeout increase.\n\nTDD:\n- RED 18bb6c4b0 reproduces the locale mismatch and pre-fork thread starts.\n- GREEN 48c7318d1 implements the correction.\n\nLocal evidence:\n- supervisor: 213 passed, 40 skipped\n- Playwright: 252 passed, 16 skipped\n- Vitest: 144 passed, 1 skipped\n- production pylint: 10.00/10\n- py_compile and diff check: pass\n- real Vitest serial/two-worker and installed-wheel Playwright are hosted-only on this macOS worktree and remain required.\n\nThis PR must stay draft until its exact head completes the privileged Linux, installed-wheel Playwright, real Vitest serial/two-worker, focused, and full hosted gates.