### PR TITLE
fix(sync): admit exact dormant requirement preauthorization

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,6 +25,85 @@ The command exits non-zero when active nondeterministic tags are declared but `.
 
 **Replay path:** `pdd replay` accepts the schema v1 snapshot manifest at `.pdd/evidence/runs/<run_id>.json` or an evidence manifest (schema v2) that links `context_snapshot.manifest_path`. Preprocess with `--snapshot` without `--recursive` when the prompt uses `<shell>` or `<web>` (recursive mode defers those tags).
 
+## Verification Requirement Transition Rotation
+
+Requirement-transition authority in
+`.pdd/verification-profile-rotations.json` must be installed and consumed in two
+separate protected changes. This prevents a candidate from granting itself
+authority for prompt or verification-profile bytes introduced by the same
+change.
+
+### Phase A: install dormant rows
+
+Phase A may add only dormant `requirement_rotations`, or make the narrow
+append-only stale-authority retirement described below. The prompt named by each
+new row and `.pdd/verification-profiles.json` must remain byte-for-byte
+identical to the protected base. Every other managed prompt must likewise remain
+byte-identical, resolving approved aliases to their protected canonical prompt
+path. The rest of the policy envelope, including
+`rotations`, must preserve the protected authority exactly. A retirement/reissue
+may advance only the transition envelope from schema 2 to schema 3 to append its
+retirement record; it cannot otherwise replace policy authority.
+
+For schema 2, every surviving protected row must retain its exact JSON token and
+relative order, ahead of newly added rows. A consumed row may still be removed or
+replaced after the loader proves consumption, without permitting any surviving
+protected row to be reformatted, re-escaped, or reordered.
+
+Each row records the SHA-256 identities of the current prompt/profile bytes and
+the prepared Phase B prompt/profile bytes. Review those exact prepared bytes
+before landing Phase A. Phase A must merge and become part of the protected base
+before Phase B begins. Installing and consuming a row in the same pull request
+is forbidden.
+
+### Retire and reissue an unreachable dormant row
+
+Schema-3 policy may retain an obsolete row in `requirement_rotations` and append
+one `requirement_rotation_retirements` record with exact `obsolete` and
+`replacement` rows. This is only for a protected dormant row whose prompt and
+profile entry still hold its source state, but whose complete protected profile
+bytes match neither of that row's bound policy digests. That proves the row
+cannot be consumed from the current base.
+
+The record and replacement are exact: the obsolete row must remain unchanged in
+the protected history, the replacement must be a new dormant row for the same
+prompt/language identity, and both full byte-bound rows are embedded in the
+record. Protected rows and retirement records retain their exact JSON token
+representation: do not reformat, reorder keys, change escaping, or rewrite a
+lexically equivalent path. Duplicate JSON member names are invalid. Records are
+append-only; they cannot omit or edit historical rows, target a live or consumed
+row, fork, chain, cycle, or use wildcard identity.
+The authority-only candidate must leave all managed prompt and profile bytes
+unchanged. Its fresh replacement remains dormant until this retirement/reissue
+candidate itself is protected, and only a later Phase B can consume it.
+
+The one-time legacy bootstrap is narrower: an exact in-code bootstrap row may
+install the first schema-2 envelope over an absent or schema-1 protected source.
+A schema-1 source's active `rotations` authority must be preserved exactly; an
+old-format schema-1 `requirement_rotations` list is validated but grants no
+authority. An absent source has no active rotations to add. After schema 2 is
+protected, the normal Phase A rules above apply.
+
+### Phase B: consume protected authority
+
+Phase B may update only the prompt and verification-profile bytes authorized by
+the now-protected row. Every other managed prompt must remain byte-identical,
+resolving approved aliases to their protected canonical prompt path. Authorized
+bytes must match the row's prepared
+`head_prompt_sha256` and `head_policy_sha256` exactly, including formatting and
+line endings. Any byte drift after Phase A was prepared invalidates the
+transition: do not edit the digests in Phase B or combine replacement authority
+with consumption. Prepare and protect a new dormant row in a new Phase A
+instead.
+
+Run the deterministic verification-profile and rollout-policy suites for both
+phases. Do not use a staging registry item to prepare or validate either phase.
+
+```bash
+pytest -q tests/test_sync_core_verification_profiles.py
+pytest -q tests/test_sync_core_pdd_rollout_policy.py
+```
+
 ## Story Regression Coverage
 
 What the `story-regression` job does **today** is run the executable

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -28,6 +28,17 @@ _PLACEHOLDER_POLICY_DIGEST = "threshold-ed25519-v1"
 _MAX_REQUIREMENT_TRANSITIONS = 1_024
 _PDD_REPOSITORY_ID = "3b4d7b1c-d6cc-4752-ba93-6b98d1a710e0"
 _OPAQUE_REQUIREMENT_ID = re.compile(r"CONTRACT-SHA256:[0-9a-f]{64}")
+# #1989 predates schema-2 representation locking. Keep this one reviewed
+# historical transition readable by its complete protected policy identities;
+# all later schema-2 candidates remain token-for-token append-only.
+_LEGACY_PDD_1989_SCHEMA_2_HISTORY = (
+    "af385bc3cb0cca5692fa46b315db1c69f9caaf688eea0a69dabe29e088878b36",
+    "09bc30376c6ee5a836bef24f9123759e039dbe4a5b18d1f46b5cae513972edad",
+)
+_LEGACY_PDD_1989_PROFILE_BYTES = (
+    "f0f1d36e337541ba4425f081e236c42847f8132cb61f9f8fe06334a805fc5c7b",
+    "71b12a08e5be55b958a737decde889c189f7ca00ceaddccd7b587f9c8b2a4b64",
+)
 
 
 class VerificationProfileError(ValueError):
@@ -95,6 +106,14 @@ class _RequirementTransitionAuthorization:
 
 
 @dataclass(frozen=True)
+class _RequirementTransitionRetirement:
+    """One append-only replacement of an unreachable dormant transition."""
+
+    obsolete: _RequirementTransitionAuthorization
+    replacement: _RequirementTransitionAuthorization
+
+
+@dataclass(frozen=True)
 class _AuthorizedProfileUpdates:
     """Narrowly authorized deltas, separated by transition dimension."""
 
@@ -111,6 +130,10 @@ class _RequirementTransitionContext:
     base: Mapping[UnitId, _ProfileInput]
     head: Mapping[UnitId, _ProfileInput]
     policies: tuple[bytes | None, bytes | None]
+    prompts: Mapping[
+        PurePosixPath,
+        tuple[bytes | None, bytes | None],
+    ]
 
 
 def _exact_bootstrap_requirement_transition(
@@ -474,16 +497,9 @@ def _load_inputs(
         except (KeyError, TypeError, VerificationProfileError) as exc:
             invalid.append(f"{ref}: invalid profile entry: {exc}")
             continue
-        prompt_relpath = unit_id.prompt_relpath
-        for alias, canonical in approved_aliases.items():
-            if prompt_relpath == alias:
-                prompt_relpath = canonical
-                break
-            if prompt_relpath.parts[: len(alias.parts)] == alias.parts:
-                prompt_relpath = canonical.joinpath(
-                    *prompt_relpath.parts[len(alias.parts) :]
-                )
-                break
+        prompt_relpath = _canonical_prompt_path(
+            unit_id.prompt_relpath, approved_aliases
+        )
         prompt_raw = read_git_blob(root, ref, prompt_relpath)
         if prompt_raw is None:
             invalid.append(f"{ref}: profile prompt is absent: {unit_id.prompt_relpath}")
@@ -504,6 +520,19 @@ def _load_inputs(
         else:
             profiles[unit_id] = parsed
     return profiles, invalid
+
+
+def _canonical_prompt_path(
+    prompt_path: PurePosixPath,
+    approved_aliases: Mapping[PurePosixPath, PurePosixPath],
+) -> PurePosixPath:
+    """Resolve one protected alias exactly as profile-input loading does."""
+    for alias, canonical in approved_aliases.items():
+        if prompt_path == alias:
+            return canonical
+        if prompt_path.parts[: len(alias.parts)] == alias.parts:
+            return canonical.joinpath(*prompt_path.parts[len(alias.parts) :])
+    return prompt_path
 
 
 def _profile_digest(
@@ -546,11 +575,15 @@ def _load_rotation_authorizations(
     if raw is None:
         return ()
     try:
-        payload = json.loads(raw)
+        payload = _strict_policy_json(raw, "protected")
         rows = payload["rotations"]
-        if payload.get("schema_version") not in {1, 2} or not isinstance(rows, list):
+        if (
+            type(payload.get("schema_version")) is not int
+            or payload.get("schema_version") not in {1, 2, 3}
+            or not isinstance(rows, list)
+        ):
             raise TypeError
-    except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as exc:
+    except (json.JSONDecodeError, KeyError, TypeError, UnicodeDecodeError) as exc:
         raise VerificationProfileError(
             "protected profile rotation policy is malformed"
         ) from exc
@@ -592,6 +625,146 @@ def _load_rotation_authorizations(
 def _sha256(raw: bytes) -> str:
     """Return the lowercase SHA-256 identity used by rotation policy."""
     return hashlib.sha256(raw).hexdigest()
+
+
+class _DuplicateJsonMember(ValueError):
+    """Raised when a policy object repeats a member name."""
+
+
+def _strict_policy_json(raw: bytes, source: str) -> dict[str, Any]:
+    """Decode policy JSON while rejecting duplicate object members at every level."""
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in payload:
+                raise _DuplicateJsonMember(key)
+            payload[key] = value
+        return payload
+
+    try:
+        payload = json.loads(raw, object_pairs_hook=reject_duplicates)
+    except _DuplicateJsonMember as exc:
+        raise VerificationProfileError(
+            f"{source} requirement transition policy contains duplicate JSON members"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise TypeError
+    return payload
+
+
+def _json_skip_whitespace(raw: bytes, index: int) -> int:
+    """Return the first non-whitespace byte from one validated JSON value."""
+    while index < len(raw) and raw[index] in b" \t\r\n":
+        index += 1
+    return index
+
+
+def _json_string_end(raw: bytes, index: int) -> int:
+    """Return the byte after one validated JSON string token."""
+    if index >= len(raw) or raw[index] != ord('"'):
+        raise ValueError("JSON string is absent")
+    index += 1
+    while index < len(raw):
+        if raw[index] == ord("\\"):
+            index += 2
+        elif raw[index] == ord('"'):
+            return index + 1
+        else:
+            index += 1
+    raise ValueError("JSON string is unterminated")
+
+
+def _json_value_end(raw: bytes, index: int) -> int:
+    """Return the byte after one validated JSON value without normalizing it."""
+    index = _json_skip_whitespace(raw, index)
+    if index >= len(raw):
+        raise ValueError("JSON value is absent")
+    if raw[index] == ord('"'):
+        return _json_string_end(raw, index)
+    if raw[index] not in (ord("["), ord("{")):
+        while index < len(raw) and raw[index] not in b",]} \t\r\n":
+            index += 1
+        return index
+    stack = [ord("]") if raw[index] == ord("[") else ord("}")]
+    index += 1
+    while stack:
+        if index >= len(raw):
+            raise ValueError("JSON container is unterminated")
+        token = raw[index]
+        if token == ord('"'):
+            index = _json_string_end(raw, index)
+            continue
+        if token == ord("["):
+            stack.append(ord("]"))
+        elif token == ord("{"):
+            stack.append(ord("}"))
+        elif token == stack[-1]:
+            stack.pop()
+        index += 1
+    return index
+
+
+def _raw_json_object_members(raw: bytes) -> dict[str, bytes]:
+    """Return exact validated JSON member values from one object token."""
+    index = _json_skip_whitespace(raw, 0)
+    if index >= len(raw) or raw[index] != ord("{"):
+        raise ValueError("JSON object is absent")
+    index = _json_skip_whitespace(raw, index + 1)
+    members: dict[str, bytes] = {}
+    while index < len(raw) and raw[index] != ord("}"):
+        key_start = index
+        key_end = _json_string_end(raw, key_start)
+        key = json.loads(raw[key_start:key_end])
+        index = _json_skip_whitespace(raw, key_end)
+        if index >= len(raw) or raw[index] != ord(":"):
+            raise ValueError("JSON object member lacks a colon")
+        value_start = _json_skip_whitespace(raw, index + 1)
+        value_end = _json_value_end(raw, value_start)
+        members[key] = raw[value_start:value_end]
+        index = _json_skip_whitespace(raw, value_end)
+        if index < len(raw) and raw[index] == ord(","):
+            index = _json_skip_whitespace(raw, index + 1)
+        elif index >= len(raw) or raw[index] != ord("}"):
+            raise ValueError("JSON object member lacks a delimiter")
+    return members
+
+
+def _raw_json_array_values(raw: bytes) -> tuple[bytes, ...]:
+    """Return exact validated JSON value tokens from one array token."""
+    index = _json_skip_whitespace(raw, 0)
+    if index >= len(raw) or raw[index] != ord("["):
+        raise ValueError("JSON array is absent")
+    index = _json_skip_whitespace(raw, index + 1)
+    values = []
+    while index < len(raw) and raw[index] != ord("]"):
+        value_start = index
+        value_end = _json_value_end(raw, value_start)
+        values.append(raw[value_start:value_end])
+        index = _json_skip_whitespace(raw, value_end)
+        if index < len(raw) and raw[index] == ord(","):
+            index = _json_skip_whitespace(raw, index + 1)
+        elif index >= len(raw) or raw[index] != ord("]"):
+            raise ValueError("JSON array value lacks a delimiter")
+    return tuple(values)
+
+
+def _raw_requirement_transition_history(
+    raw: bytes | None, source: str
+) -> tuple[tuple[bytes, ...], tuple[bytes, ...]]:
+    """Extract exact row/retirement tokens after strict policy JSON validation."""
+    if raw is None:
+        return (), ()
+    try:
+        members = _raw_json_object_members(raw)
+        rows = _raw_json_array_values(members["requirement_rotations"])
+        retirements = _raw_json_array_values(
+            members.get("requirement_rotation_retirements", b"[]")
+        )
+    except (KeyError, ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise VerificationProfileError(
+            f"{source} requirement transition policy representation is malformed"
+        ) from exc
+    return rows, retirements
 
 
 def _valid_requirement_transition(
@@ -638,19 +811,42 @@ def _parse_requirement_transition_authorizations(
     if raw is None:
         return ()
     try:
-        payload = json.loads(raw)
-        if not isinstance(payload, dict):
+        payload = _strict_policy_json(raw, source)
+        schema_version = payload.get("schema_version")
+        if type(schema_version) is not int:
             raise TypeError
-        if payload.get("schema_version") == 1:
+        if schema_version == 1:
+            _parse_dormant_policy_envelope(
+                raw, source, allow_legacy_protected=True
+            )
             return ()
         rows = payload["requirement_rotations"]
         if (
-            payload.get("schema_version") != 2
+            schema_version not in {2, 3}
+            or set(payload)
+            != (
+                {
+                    "schema_version",
+                    "rotations",
+                    "requirement_rotations",
+                }
+                if schema_version == 2
+                else {
+                    "schema_version",
+                    "rotations",
+                    "requirement_rotations",
+                    "requirement_rotation_retirements",
+                }
+            )
             or not isinstance(rows, list)
             or len(rows) > _MAX_REQUIREMENT_TRANSITIONS
+            or (
+                schema_version == 3
+                and not isinstance(payload["requirement_rotation_retirements"], list)
+            )
         ):
             raise TypeError
-    except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as exc:
+    except (json.JSONDecodeError, KeyError, TypeError, UnicodeDecodeError) as exc:
         raise VerificationProfileError(
             f"{source} requirement transition policy is malformed"
         ) from exc
@@ -695,8 +891,8 @@ def _parse_requirement_transition_authorizations(
             )
         authorizations.append(authorization)
     identities = [(item.prompt_path, item.language_id) for item in authorizations]
-    if len(authorizations) != len(set(authorizations)) or len(identities) != len(
-        set(identities)
+    if len(authorizations) != len(set(authorizations)) or (
+        schema_version == 2 and len(identities) != len(set(identities))
     ):
         raise VerificationProfileError(
             f"{source} requirement transition rules are duplicated or ambiguous"
@@ -704,24 +900,796 @@ def _parse_requirement_transition_authorizations(
     return tuple(authorizations)
 
 
-def _load_requirement_transition_authorizations(
-    root: Path, manifest: UnitManifest
-) -> tuple[_RequirementTransitionAuthorization, ...]:
-    """Accept candidate rules only when protected earlier or exactly bootstrapped."""
-    protected = _parse_requirement_transition_authorizations(
-        read_git_blob(root, manifest.base_ref, ROTATION_POLICY_PATH), "protected"
+def _parse_requirement_transition_retirements(
+    raw: bytes | None, source: str
+) -> tuple[_RequirementTransitionRetirement, ...]:
+    """Parse exact schema-3 retirement records without granting authority."""
+    if raw is None:
+        return ()
+    try:
+        payload = _strict_policy_json(raw, source)
+        schema_version = payload.get("schema_version")
+        if type(schema_version) is not int:
+            raise TypeError
+        if schema_version in {1, 2}:
+            _parse_dormant_policy_envelope(
+                raw, source, allow_legacy_protected=schema_version == 1
+            )
+            _parse_requirement_transition_authorizations(raw, source)
+            return ()
+        rows = payload["requirement_rotation_retirements"]
+        if schema_version != 3 or not isinstance(rows, list):
+            raise TypeError
+    except (json.JSONDecodeError, KeyError, TypeError, UnicodeDecodeError) as exc:
+        raise VerificationProfileError(
+            f"{source} requirement transition retirement policy is malformed"
+        ) from exc
+
+    required_keys = {
+        "prompt_path",
+        "language_id",
+        "from_requirement_id",
+        "to_requirement_id",
+        "policy_path",
+        "base_policy_sha256",
+        "head_policy_sha256",
+        "base_prompt_sha256",
+        "head_prompt_sha256",
+    }
+
+    def parse_authorization(row: Any) -> _RequirementTransitionAuthorization:
+        if (
+            not isinstance(row, dict)
+            or set(row) != required_keys
+            or any(not isinstance(row[key], str) for key in required_keys)
+        ):
+            raise VerificationProfileError(
+                f"{source} requirement transition retirement rule is malformed"
+            )
+        authorization = _RequirementTransitionAuthorization(
+            PurePosixPath(row["prompt_path"]),
+            row["language_id"],
+            row["from_requirement_id"],
+            row["to_requirement_id"],
+            PurePosixPath(row["policy_path"]),
+            _RequirementTransitionBindings(
+                row["base_policy_sha256"],
+                row["head_policy_sha256"],
+                row["base_prompt_sha256"],
+                row["head_prompt_sha256"],
+            ),
+        )
+        if not _valid_requirement_transition(authorization):
+            raise VerificationProfileError(
+                f"{source} requirement transition retirement rule is malformed"
+            )
+        return authorization
+
+    retirements = []
+    for row in rows:
+        if not isinstance(row, dict) or set(row) != {"obsolete", "replacement"}:
+            raise VerificationProfileError(
+                f"{source} requirement transition retirement rule is malformed"
+            )
+        obsolete = parse_authorization(row["obsolete"])
+        replacement = parse_authorization(row["replacement"])
+        if obsolete == replacement or (obsolete.prompt_path, obsolete.language_id) != (
+            replacement.prompt_path,
+            replacement.language_id,
+        ):
+            raise VerificationProfileError(
+                f"{source} requirement transition retirement rule is ambiguous"
+            )
+        retirements.append(_RequirementTransitionRetirement(obsolete, replacement))
+
+    obsolete = [item.obsolete for item in retirements]
+    replacements = [item.replacement for item in retirements]
+    if (
+        len(retirements) > _MAX_REQUIREMENT_TRANSITIONS
+        or len(obsolete) != len(set(obsolete))
+        or len(replacements) != len(set(replacements))
+        or set(obsolete) & set(replacements)
+    ):
+        raise VerificationProfileError(
+            f"{source} requirement transition retirement rules are duplicated or chained"
+        )
+    return tuple(retirements)
+
+
+def _validate_legacy_requirement_transition_rows(payload: dict[str, Any]) -> None:
+    """Validate ignored schema-1 rows so legacy envelopes remain bounded."""
+    rows = payload["requirement_rotations"]
+    required_keys = {
+        "prompt_path",
+        "language_id",
+        "from_requirement_id",
+        "to_requirement_id",
+        "policy_path",
+        "from_policy_sha256",
+        "to_policy_sha256",
+    }
+    if not isinstance(rows, list) or len(rows) > _MAX_REQUIREMENT_TRANSITIONS:
+        raise TypeError
+    identities: list[tuple[PurePosixPath, str]] = []
+    for row in rows:
+        if (
+            not isinstance(row, dict)
+            or set(row) != required_keys
+            or any(not isinstance(row[key], str) for key in required_keys)
+        ):
+            raise TypeError
+        prompt_path = PurePosixPath(row["prompt_path"])
+        language_id = row["language_id"]
+        if (
+            prompt_path.is_absolute()
+            or not prompt_path.parts
+            or ".." in prompt_path.parts
+            or not language_id
+            or language_id.strip() != language_id
+            or row["from_requirement_id"] == row["to_requirement_id"]
+            or _OPAQUE_REQUIREMENT_ID.fullmatch(row["from_requirement_id"]) is None
+            or _OPAQUE_REQUIREMENT_ID.fullmatch(row["to_requirement_id"]) is None
+            or PurePosixPath(row["policy_path"]) != PROFILE_PATH
+            or row["from_policy_sha256"] == row["to_policy_sha256"]
+            or any(
+                re.fullmatch(r"[0-9a-f]{64}", row[key]) is None
+                for key in ("from_policy_sha256", "to_policy_sha256")
+            )
+        ):
+            raise TypeError
+        identities.append((prompt_path, language_id))
+    if len(identities) != len(set(identities)):
+        raise TypeError
+
+
+def _parse_dormant_policy_envelope(
+    raw: bytes | None, source: str, *, allow_legacy_protected: bool = False
+) -> tuple[_PolicyRotationAuthorization, ...]:
+    """Parse active authority while allowing only protected bootstrap sources."""
+    if raw is None and allow_legacy_protected:
+        return ()
+    try:
+        payload = _strict_policy_json(raw, source) if raw is not None else None
+        if payload is None:
+            raise TypeError
+        schema_version = payload.get("schema_version")
+        expected_keys = {
+            "schema_version",
+            "rotations",
+            "requirement_rotations",
+        }
+        if allow_legacy_protected and schema_version == 1:
+            schema_1_keys = {"schema_version", "rotations"}
+            schema_1_keys_with_rows = schema_1_keys | {"requirement_rotations"}
+            if set(payload) not in (schema_1_keys, schema_1_keys_with_rows):
+                raise TypeError
+            expected_keys = set(payload)
+        elif schema_version == 3:
+            expected_keys.add("requirement_rotation_retirements")
+        if (
+            type(schema_version) is not int
+            or set(payload) != expected_keys
+            or schema_version not in ({1, 2, 3} if allow_legacy_protected else {2, 3})
+            or not isinstance(payload["rotations"], list)
+            or (
+                schema_version in {2, 3}
+                and not isinstance(payload["requirement_rotations"], list)
+            )
+        ):
+            raise TypeError
+        if schema_version == 3 and not isinstance(
+            payload["requirement_rotation_retirements"], list
+        ):
+            raise TypeError
+        if schema_version == 1 and "requirement_rotations" in payload:
+            _validate_legacy_requirement_transition_rows(payload)
+    except (json.JSONDecodeError, KeyError, TypeError, UnicodeDecodeError) as exc:
+        raise VerificationProfileError(
+            f"{source} requirement transition policy envelope is malformed"
+        ) from exc
+
+    authorizations: list[_PolicyRotationAuthorization] = []
+    for row in payload["rotations"]:
+        if (
+            not isinstance(row, dict)
+            or set(row)
+            != {
+                "obligation_id",
+                "validator_id",
+                "from_config_digest",
+                "policy_path",
+            }
+            or any(not isinstance(value, str) for value in row.values())
+        ):
+            raise VerificationProfileError(
+                f"{source} profile rotation rule is malformed"
+            )
+        authorization = _PolicyRotationAuthorization(
+            row["obligation_id"],
+            row["validator_id"],
+            row["from_config_digest"],
+            PurePosixPath(row["policy_path"]),
+        )
+        if authorization != _PolicyRotationAuthorization(
+            _HUMAN_OBLIGATION_ID,
+            _HUMAN_VALIDATOR_ID,
+            _PLACEHOLDER_POLICY_DIGEST,
+            TRUST_POLICY_PATH,
+        ):
+            raise VerificationProfileError(
+                f"{source} profile rotation rule is not authorized"
+            )
+        authorizations.append(authorization)
+    if len(authorizations) != len(set(authorizations)):
+        raise VerificationProfileError(
+            f"{source} profile rotation rules are duplicated"
+        )
+    return tuple(authorizations)
+
+
+def _validate_dormant_policy_installation(
+    protected_raw: bytes | None, candidate_raw: bytes | None
+) -> None:
+    """Keep every existing non-requirement authority while adding future rows."""
+    protected = _parse_dormant_policy_envelope(
+        protected_raw, "protected", allow_legacy_protected=True
     )
-    candidate = _parse_requirement_transition_authorizations(
-        read_git_blob(root, manifest.head_ref, ROTATION_POLICY_PATH), "candidate"
+    candidate = _parse_dormant_policy_envelope(candidate_raw, "candidate")
+    if candidate != protected:
+        raise VerificationProfileError(
+            "candidate dormant requirement transition changes protected "
+            "profile rotation authority"
+        )
+
+
+def _candidate_authorization_is_strictly_dormant(
+    manifest: UnitManifest,
+    base: Mapping[UnitId, _ProfileInput],
+    head: Mapping[UnitId, _ProfileInput],
+    policies: tuple[bytes | None, bytes | None],
+    prompts: tuple[bytes | None, bytes | None],
+    authorization: _RequirementTransitionAuthorization,
+) -> bool:
+    """Accept a future rule only while every protected source byte is unchanged."""
+    unit_id = UnitId(
+        manifest.repository_id,
+        authorization.prompt_path,
+        authorization.language_id,
+    )
+    protected = base.get(unit_id)
+    candidate = head.get(unit_id)
+    if protected is None or protected != candidate:
+        return False
+
+    bindings = authorization.bindings
+    if (
+        policies[0] is None
+        or policies[0] != policies[1]
+        or prompts[0] is None
+        or prompts[0] != prompts[1]
+        or _sha256(policies[0]) != bindings.base_policy_sha256
+        or _sha256(prompts[0]) != bindings.base_prompt_sha256
+        or authorization.from_requirement_id
+        != f"CONTRACT-SHA256:{bindings.base_prompt_sha256}"
+        or authorization.to_requirement_id
+        != f"CONTRACT-SHA256:{bindings.head_prompt_sha256}"
+        or bindings.base_prompt_sha256 == bindings.head_prompt_sha256
+        or bindings.base_policy_sha256 == bindings.head_policy_sha256
+        or protected.requirements != (authorization.from_requirement_id,)
+        or _prompt_requirements(prompts[0]) != (authorization.from_requirement_id,)
+    ):
+        return False
+
+    human = next(
+        (
+            obligation
+            for obligation in protected.obligations
+            if obligation.obligation_id == _HUMAN_OBLIGATION_ID
+        ),
+        None,
+    )
+    return bool(
+        human is not None
+        and human.kind == "human-attestation"
+        and human.validator_id == _HUMAN_VALIDATOR_ID
+        and human.requirement_ids == (authorization.from_requirement_id,)
+        and human.required
+    )
+
+
+def _authorization_is_consumed_at_current_state(
+    manifest: UnitManifest,
+    base: Mapping[UnitId, _ProfileInput],
+    head: Mapping[UnitId, _ProfileInput],
+    prompts: tuple[bytes | None, bytes | None],
+    authorization: _RequirementTransitionAuthorization,
+) -> bool:
+    """Permit advancing an identity only after its protected rule was consumed."""
+    unit_id = UnitId(
+        manifest.repository_id,
+        authorization.prompt_path,
+        authorization.language_id,
+    )
+    protected = base.get(unit_id)
+    candidate = head.get(unit_id)
+    if (
+        protected is None
+        or protected != candidate
+        or protected.requirements != (authorization.to_requirement_id,)
+        or prompts[0] is None
+        or prompts[0] != prompts[1]
+        or _sha256(prompts[0]) != authorization.bindings.head_prompt_sha256
+        or _prompt_requirements(prompts[0]) != (authorization.to_requirement_id,)
+    ):
+        return False
+    human = next(
+        (
+            obligation
+            for obligation in protected.obligations
+            if obligation.obligation_id == _HUMAN_OBLIGATION_ID
+        ),
+        None,
+    )
+    return bool(
+        human is not None
+        and human.kind == "human-attestation"
+        and human.validator_id == _HUMAN_VALIDATOR_ID
+        and human.requirement_ids == (authorization.to_requirement_id,)
+        and human.required
+    )
+
+
+def _active_requirement_transition_authorizations(
+    authorizations: tuple[_RequirementTransitionAuthorization, ...],
+    retirements: tuple[_RequirementTransitionRetirement, ...],
+    source: str,
+) -> tuple[_RequirementTransitionAuthorization, ...]:
+    """Return the unretired rows after validating immutable history links."""
+    rows = set(authorizations)
+    retired = {item.obsolete for item in retirements}
+    replacements = {item.replacement for item in retirements}
+    if not retired <= rows or not replacements <= rows:
+        raise VerificationProfileError(
+            f"{source} requirement transition retirement does not name exact rows"
+        )
+    active = tuple(item for item in authorizations if item not in retired)
+    identities = [(item.prompt_path, item.language_id) for item in active]
+    if len(identities) != len(set(identities)):
+        raise VerificationProfileError(
+            f"{source} active requirement transition rules are ambiguous"
+        )
+    return active
+
+
+def _retirement_is_provably_unreachable_dormant(
+    manifest: UnitManifest,
+    base: Mapping[UnitId, _ProfileInput],
+    head: Mapping[UnitId, _ProfileInput],
+    policies: tuple[bytes | None, bytes | None],
+    prompts: tuple[bytes | None, bytes | None],
+    authorization: _RequirementTransitionAuthorization,
+) -> bool:
+    """Accept only a dormant row whose whole-policy bindings cannot be reached."""
+    unit_id = UnitId(
+        manifest.repository_id,
+        authorization.prompt_path,
+        authorization.language_id,
+    )
+    protected = base.get(unit_id)
+    candidate = head.get(unit_id)
+    bindings = authorization.bindings
+    if (
+        protected is None
+        or protected != candidate
+        or policies[0] is None
+        or policies[0] != policies[1]
+        or prompts[0] is None
+        or prompts[0] != prompts[1]
+        or _sha256(policies[0])
+        in {bindings.base_policy_sha256, bindings.head_policy_sha256}
+        or _sha256(prompts[0]) != bindings.base_prompt_sha256
+        or protected.requirements != (authorization.from_requirement_id,)
+        or _prompt_requirements(prompts[0]) != (authorization.from_requirement_id,)
+    ):
+        return False
+    human = next(
+        (
+            obligation
+            for obligation in protected.obligations
+            if obligation.obligation_id == _HUMAN_OBLIGATION_ID
+        ),
+        None,
+    )
+    return bool(
+        human is not None
+        and human.kind == "human-attestation"
+        and human.validator_id == _HUMAN_VALIDATOR_ID
+        and human.requirement_ids == (authorization.from_requirement_id,)
+        and human.required
+    )
+
+
+def _validate_retirement_history_representation(
+    protected_raw: bytes | None,
+    candidate_raw: bytes | None,
+) -> None:
+    """Require every protected row and retirement token to remain byte-identical."""
+    protected_rows, protected_retirements = _raw_requirement_transition_history(
+        protected_raw, "protected"
+    )
+    candidate_rows, candidate_retirements = _raw_requirement_transition_history(
+        candidate_raw, "candidate"
+    )
+    if (
+        candidate_rows[: len(protected_rows)] != protected_rows
+        or candidate_retirements[: len(protected_retirements)] != protected_retirements
+    ):
+        raise VerificationProfileError(
+            "candidate retirement history rewrites protected representation"
+        )
+
+
+def _validate_schema_2_history_representation(
+    protected_raw: bytes | None,
+    candidate_raw: bytes | None,
+    protected_rows: tuple[_RequirementTransitionAuthorization, ...],
+    candidate_rows: tuple[_RequirementTransitionAuthorization, ...],
+) -> None:
+    """Keep surviving schema-2 row tokens exact and ahead of new rows."""
+    if (
+        protected_raw is not None
+        and candidate_raw is not None
+        and (
+            hashlib.sha256(protected_raw).hexdigest(),
+            hashlib.sha256(candidate_raw).hexdigest(),
+        )
+        == _LEGACY_PDD_1989_SCHEMA_2_HISTORY
+    ):
+        return
+    protected_tokens, _ = _raw_requirement_transition_history(
+        protected_raw, "protected"
+    )
+    candidate_tokens, _ = _raw_requirement_transition_history(
+        candidate_raw, "candidate"
+    )
+    candidate_set = set(candidate_rows)
+    surviving_history = tuple(
+        (row, token)
+        for row, token in zip(protected_rows, protected_tokens, strict=True)
+        if row in candidate_set
+    )
+    candidate_prefix = tuple(zip(candidate_rows, candidate_tokens, strict=True))[
+        : len(surviving_history)
+    ]
+    if candidate_prefix != surviving_history:
+        raise VerificationProfileError(
+            "candidate schema-2 history rewrites protected representation"
+        )
+
+
+def _policy_schema_version(raw: bytes | None, source: str) -> int | None:
+    """Return the already-validated policy schema without normalizing its bytes."""
+    if raw is None:
+        return None
+    try:
+        schema_version = _strict_policy_json(raw, source)["schema_version"]
+        if type(schema_version) is not int:
+            raise TypeError
+    except (json.JSONDecodeError, KeyError, TypeError, UnicodeDecodeError) as exc:
+        raise VerificationProfileError(
+            f"{source} requirement transition policy is malformed"
+        ) from exc
+    return schema_version
+
+
+def _managed_prompt_byte_changes(
+    root: Path,
+    manifest: UnitManifest,
+    approved_aliases: Mapping[PurePosixPath, PurePosixPath],
+) -> set[PurePosixPath]:
+    """Return changed canonical managed prompts using the manifest blob inventory."""
+    candidates = {
+        item.candidate_id.artifact_relpath: item for item in manifest.candidates
+    }
+    changed = set()
+    for unit_id in manifest.expected_managed:
+        prompt_path = _canonical_prompt_path(unit_id.prompt_relpath, approved_aliases)
+        candidate = candidates.get(prompt_path)
+        if candidate is not None and candidate.base_object_id is not None:
+            if candidate.base_object_id != candidate.head_object_id:
+                changed.add(prompt_path)
+            continue
+        base_prompt = read_git_blob(root, manifest.base_ref, prompt_path)
+        head_prompt = read_git_blob(root, manifest.head_ref, prompt_path)
+        if base_prompt is None or head_prompt is None or base_prompt != head_prompt:
+            changed.add(prompt_path)
+    return changed
+
+
+def _validate_retirement_managed_prompt_bytes(
+    root: Path,
+    manifest: UnitManifest,
+    approved_aliases: Mapping[PurePosixPath, PurePosixPath],
+) -> None:
+    """Keep every canonical managed prompt byte-identical during retirement Phase A."""
+    changed = _managed_prompt_byte_changes(root, manifest, approved_aliases)
+    if changed:
+        raise VerificationProfileError(
+            "candidate retirement changes managed prompt bytes: "
+            f"{sorted(changed)[0]}"
+        )
+
+
+def _validate_new_authorization_managed_prompt_bytes(
+    root: Path,
+    manifest: UnitManifest,
+    approved_aliases: Mapping[PurePosixPath, PurePosixPath],
+    allowed_changes: set[PurePosixPath],
+) -> None:
+    """Keep every managed prompt unchanged while installing future authority."""
+    changed = _managed_prompt_byte_changes(root, manifest, approved_aliases)
+    unauthorized = changed - allowed_changes
+    if unauthorized:
+        raise VerificationProfileError(
+            "candidate authority-only change modifies managed prompt bytes: "
+            f"{sorted(unauthorized)[0]}"
+        )
+
+
+def _validate_consumed_managed_prompt_bytes(
+    root: Path,
+    manifest: UnitManifest,
+    approved_aliases: Mapping[PurePosixPath, PurePosixPath],
+    authorizations: tuple[_RequirementTransitionAuthorization, ...],
+    updates: Mapping[UnitId, _ProfileInput],
+) -> None:
+    """Limit Phase B prompt drift to exact protected rows consumed in this candidate."""
+    consumed = {
+        _canonical_prompt_path(authorization.prompt_path, approved_aliases)
+        for authorization in authorizations
+        if UnitId(
+            manifest.repository_id,
+            authorization.prompt_path,
+            authorization.language_id,
+        )
+        in updates
+    }
+    unauthorized = (
+        _managed_prompt_byte_changes(root, manifest, approved_aliases) - consumed
+    )
+    if unauthorized:
+        raise VerificationProfileError(
+            "candidate requirement transition changes unmanaged prompt bytes: "
+            f"{sorted(unauthorized)[0]}"
+        )
+
+
+def _validate_candidate_retirements(
+    root: Path,
+    manifest: UnitManifest,
+    approved_aliases: Mapping[PurePosixPath, PurePosixPath],
+    base: Mapping[UnitId, _ProfileInput],
+    head: Mapping[UnitId, _ProfileInput],
+    policies: tuple[bytes | None, bytes | None],
+    prompts: Mapping[PurePosixPath, tuple[bytes | None, bytes | None]],
+    protected_rows: tuple[_RequirementTransitionAuthorization, ...],
+    protected_retirements: tuple[_RequirementTransitionRetirement, ...],
+    candidate_rows: tuple[_RequirementTransitionAuthorization, ...],
+    candidate_retirements: tuple[_RequirementTransitionRetirement, ...],
+    protected_active: tuple[_RequirementTransitionAuthorization, ...],
+    protected_policy: bytes | None,
+    candidate_policy: bytes | None,
+) -> None:
+    """Validate append-only retirement/reissue of unreachable protected rows."""
+    protected_schema = _policy_schema_version(protected_policy, "protected")
+    candidate_schema = _policy_schema_version(candidate_policy, "candidate")
+    if protected_schema == 2 and candidate_schema == 2:
+        _validate_schema_2_history_representation(
+            protected_policy,
+            candidate_policy,
+            protected_rows,
+            candidate_rows,
+        )
+    if protected_schema != 3 and candidate_schema != 3:
+        return
+    if (
+        len(candidate_rows) < len(protected_rows)
+        or candidate_rows[: len(protected_rows)] != protected_rows
+        or candidate_retirements[: len(protected_retirements)] != protected_retirements
+    ):
+        raise VerificationProfileError(
+            "candidate retirement history is not append-only"
+        )
+    if protected_schema == 3 and candidate_schema != 3:
+        raise VerificationProfileError(
+            "candidate cannot remove protected schema-3 retirement history"
+        )
+    _validate_retirement_history_representation(protected_policy, candidate_policy)
+    new_retirements = candidate_retirements[len(protected_retirements) :]
+    if candidate_schema == 3 and protected_schema != 3 and not new_retirements:
+        raise VerificationProfileError(
+            "candidate schema-3 requirement transition policy requires a "
+            "retirement/reissue record"
+        )
+    if new_retirements:
+        _validate_retirement_managed_prompt_bytes(root, manifest, approved_aliases)
+    for retirement in new_retirements:
+        if (
+            retirement.obsolete not in protected_active
+            or retirement.replacement in protected_rows
+            or retirement.replacement not in candidate_rows
+            or not _retirement_is_provably_unreachable_dormant(
+                manifest,
+                base,
+                head,
+                policies,
+                prompts[retirement.obsolete.prompt_path],
+                retirement.obsolete,
+            )
+            or not _candidate_authorization_is_strictly_dormant(
+                manifest,
+                base,
+                head,
+                policies,
+                prompts[retirement.replacement.prompt_path],
+                retirement.replacement,
+            )
+        ):
+            raise VerificationProfileError(
+                "candidate retirement lacks an exact unreachable protected row "
+                "and dormant replacement"
+            )
+
+
+def _load_requirement_transition_authorizations(
+    root: Path,
+    manifest: UnitManifest,
+    base: Mapping[UnitId, _ProfileInput] | None = None,
+    head: Mapping[UnitId, _ProfileInput] | None = None,
+    approved_aliases: Mapping[PurePosixPath, PurePosixPath] | None = None,
+) -> tuple[
+    tuple[_RequirementTransitionAuthorization, ...],
+    dict[PurePosixPath, tuple[bytes | None, bytes | None]],
+    tuple[_RequirementTransitionAuthorization, ...],
+]:
+    """Return protected/candidate rules and candidate-added dormant rows.
+
+    ``base`` and ``head`` are supplied by the production loader so prompt blobs
+    can be evaluated once and reused. Optional empty mappings preserve the
+    fail-closed two-argument boundary used by protected bootstrap-policy tests.
+    The public loader enforces managed-prompt isolation for returned additions.
+    """
+    base = {} if base is None else base
+    head = {} if head is None else head
+    approved_aliases = {} if approved_aliases is None else approved_aliases
+    protected_policy = read_git_blob(root, manifest.base_ref, ROTATION_POLICY_PATH)
+    candidate_policy = read_git_blob(root, manifest.head_ref, ROTATION_POLICY_PATH)
+    protected_rows = _parse_requirement_transition_authorizations(
+        protected_policy, "protected"
+    )
+    candidate_rows = _parse_requirement_transition_authorizations(
+        candidate_policy, "candidate"
+    )
+    protected_retirements = _parse_requirement_transition_retirements(
+        protected_policy, "protected"
+    )
+    candidate_retirements = _parse_requirement_transition_retirements(
+        candidate_policy, "candidate"
+    )
+    protected = _active_requirement_transition_authorizations(
+        protected_rows, protected_retirements, "protected"
+    )
+    candidate = _active_requirement_transition_authorizations(
+        candidate_rows, candidate_retirements, "candidate"
     )
     authority = set(protected)
     if manifest.repository_id == _PDD_REPOSITORY_ID:
         authority.update(_BOOTSTRAP_REQUIREMENT_TRANSITIONS)
-    if any(item not in authority for item in candidate):
-        raise VerificationProfileError(
-            "candidate requirement transition lacks protected authorization"
+    policies = (
+        read_git_blob(root, manifest.base_ref, PROFILE_PATH),
+        read_git_blob(root, manifest.head_ref, PROFILE_PATH),
+    )
+    prompt_paths = {item.prompt_path for item in (*protected_rows, *candidate_rows)}
+    prompts = {
+        prompt_path: (
+            read_git_blob(
+                root,
+                manifest.base_ref,
+                _canonical_prompt_path(prompt_path, approved_aliases),
+            ),
+            read_git_blob(
+                root,
+                manifest.head_ref,
+                _canonical_prompt_path(prompt_path, approved_aliases),
+            ),
         )
-    return candidate
+        for prompt_path in prompt_paths
+    }
+    protected_by_identity = {
+        (item.prompt_path, item.language_id): item for item in protected
+    }
+    _validate_candidate_retirements(
+        root,
+        manifest,
+        approved_aliases,
+        base,
+        head,
+        policies,
+        prompts,
+        protected_rows,
+        protected_retirements,
+        candidate_rows,
+        candidate_retirements,
+        protected,
+        protected_policy,
+        candidate_policy,
+    )
+    legacy_pdd1989_reconciliation = (
+        protected_policy is not None
+        and candidate_policy is not None
+        and policies[0] is not None
+        and policies[1] is not None
+        and (
+            hashlib.sha256(protected_policy).hexdigest(),
+            hashlib.sha256(candidate_policy).hexdigest(),
+        )
+        == _LEGACY_PDD_1989_SCHEMA_2_HISTORY
+        and (
+            hashlib.sha256(policies[0]).hexdigest(),
+            hashlib.sha256(policies[1]).hexdigest(),
+        )
+        == _LEGACY_PDD_1989_PROFILE_BYTES
+    )
+    retired_by_candidate = {item.obsolete for item in candidate_retirements}
+    new_authorizations = tuple(item for item in candidate if item not in protected)
+    if legacy_pdd1989_reconciliation:
+        # The exact historical pair both installed and consumed its authority
+        # before Phase-A isolation existed; validate it as consumption below.
+        new_authorizations = ()
+    for item in candidate:
+        if item in authority:
+            if (
+                item in _BOOTSTRAP_REQUIREMENT_TRANSITIONS
+                and item not in protected
+                and policies[0] != policies[1]
+                and not legacy_pdd1989_reconciliation
+            ):
+                raise VerificationProfileError(
+                    "candidate legacy bootstrap requirement transition changes "
+                    "protected verification-profile bytes"
+                )
+            continue
+        prompt_pair = prompts[item.prompt_path]
+        prior = protected_by_identity.get((item.prompt_path, item.language_id))
+        if not _candidate_authorization_is_strictly_dormant(
+            manifest, base, head, policies, prompt_pair, item
+        ):
+            raise VerificationProfileError(
+                "candidate requirement transition lacks protected authorization"
+            )
+        if (
+            prior is not None
+            and prior not in retired_by_candidate
+            and not _authorization_is_consumed_at_current_state(
+                manifest, base, head, prompt_pair, prior
+            )
+        ):
+            raise VerificationProfileError(
+                "candidate replaced unconsumed protected requirement transition"
+            )
+    candidate_authority = set(candidate_rows)
+    for item in protected:
+        if item in candidate_authority or legacy_pdd1989_reconciliation:
+            continue
+        if not _authorization_is_consumed_at_current_state(
+            manifest, base, head, prompts[item.prompt_path], item
+        ):
+            raise VerificationProfileError(
+                "candidate removed unconsumed protected requirement transition"
+            )
+    if candidate_policy != protected_policy:
+        _validate_dormant_policy_installation(protected_policy, candidate_policy)
+    return candidate, prompts, new_authorizations
 
 
 def _transition_bytes_match(
@@ -769,9 +1737,20 @@ def _expected_requirement_update(
     ):
         return None, "requirement transition is partial or mismatched"
     assert human is not None
-    obligations[_HUMAN_OBLIGATION_ID] = replace(
-        human, requirement_ids=(authorization.to_requirement_id,)
-    )
+    obligations = {
+        obligation_id: replace(
+            obligation,
+            requirement_ids=tuple(
+                (
+                    authorization.to_requirement_id
+                    if requirement_id == authorization.from_requirement_id
+                    else requirement_id
+                )
+                for requirement_id in obligation.requirement_ids
+            ),
+        )
+        for obligation_id, obligation in obligations.items()
+    }
     expected = _ProfileInput(
         (authorization.to_requirement_id,), tuple(sorted(obligations.values()))
     )
@@ -843,14 +1822,7 @@ def _evaluate_requirement_authorization(
         # Existing profile accounting owns missing/candidate-only units. A
         # dormant transition must not duplicate those stable reasons or counts.
         return unit_id, None, None
-    prompts = (
-        read_git_blob(
-            context.root, context.manifest.base_ref, authorization.prompt_path
-        ),
-        read_git_blob(
-            context.root, context.manifest.head_ref, authorization.prompt_path
-        ),
-    )
+    prompts = context.prompts[authorization.prompt_path]
     bindings = authorization.bindings
     stationary = protected == candidate and (
         _matches_unchanged_requirement_state(protected, prompts, authorization)
@@ -895,6 +1867,7 @@ def _authorized_requirement_updates(
     base: dict[UnitId, _ProfileInput],
     head: dict[UnitId, _ProfileInput],
     authorizations: tuple[_RequirementTransitionAuthorization, ...],
+    prompts: Mapping[PurePosixPath, tuple[bytes | None, bytes | None]],
 ) -> tuple[dict[UnitId, _ProfileInput], list[str]]:
     """Authorize only exact opaque requirement and human mapping replacements."""
     updates: dict[UnitId, _ProfileInput] = {}
@@ -903,7 +1876,9 @@ def _authorized_requirement_updates(
         read_git_blob(root, manifest.base_ref, PROFILE_PATH),
         read_git_blob(root, manifest.head_ref, PROFILE_PATH),
     )
-    context = _RequirementTransitionContext(root, manifest, base, head, policies)
+    context = _RequirementTransitionContext(
+        root, manifest, base, head, policies, prompts
+    )
     for authorization in authorizations:
         unit_id, result, reason = _evaluate_requirement_authorization(
             context, authorization
@@ -1145,15 +2120,43 @@ def load_verification_profiles(root: Path, manifest: UnitManifest) -> ProfileSet
         root, manifest.head_ref, manifest.repository_id, approved_aliases
     )
     invalid.extend(loaded_invalid)
+    (
+        requirement_authorizations,
+        requirement_prompts,
+        new_requirement_authorizations,
+    ) = (
+        _load_requirement_transition_authorizations(
+            root, manifest, base, head, approved_aliases
+        )
+    )
+    profile_additions = _authorized_profile_additions(root, manifest, base, head)
+    if new_requirement_authorizations:
+        _validate_new_authorization_managed_prompt_bytes(
+            root,
+            manifest,
+            approved_aliases,
+            {
+                _canonical_prompt_path(unit_id.prompt_relpath, approved_aliases)
+                for unit_id in profile_additions
+            },
+        )
     requirement_updates, requirement_invalid = _authorized_requirement_updates(
         root,
         manifest,
         base,
         head,
-        _load_requirement_transition_authorizations(root, manifest),
+        requirement_authorizations,
+        requirement_prompts,
     )
+    if requirement_updates:
+        _validate_consumed_managed_prompt_bytes(
+            root,
+            manifest,
+            approved_aliases,
+            requirement_authorizations,
+            requirement_updates,
+        )
     invalid.extend(requirement_invalid)
-    profile_additions = _authorized_profile_additions(root, manifest, base, head)
     requirement_updates = {**profile_additions, **requirement_updates}
     authorized_updates, rotation_invalid = _authorized_rotation_updates(
         root,

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -141,6 +141,23 @@ CI_DETECT_REQUIREMENT_ROTATION = {
         "f0d873e5505d40035d3c7364fd3961b5602d21519ec9be2049c2f38b16239712"
     ),
 }
+LEGACY_SCHEMA_1_REQUIREMENT_ROTATION = {
+    "prompt_path": "pdd/prompts/ci_detect_changed_modules_python.prompt",
+    "language_id": "python",
+    "from_requirement_id": (
+        "CONTRACT-SHA256:ef30764861a3080d2fb093ca747f86a3f46bba733a0cdc6a5634efc1b36a73a2"
+    ),
+    "to_requirement_id": (
+        "CONTRACT-SHA256:2d5d65f695fc6c8cd2f3e82f5c5d2a55ad3eb30fc4791b2a1d94ff8465ab6d10"
+    ),
+    "policy_path": ".pdd/verification-profiles.json",
+    "from_policy_sha256": (
+        "ffd867088a7c9a92840130ffd9db9eb8f279e611a02afe501d02855ebb03930f"
+    ),
+    "to_policy_sha256": (
+        "8a957dfa94fdc78ec9d1eb5ea6dfb0a08ff2452928a8b9f6a4dbd5368cb25f53"
+    ),
+}
 
 
 def _git(root: Path, *args: str) -> None:
@@ -370,6 +387,267 @@ def test_committed_rotations_equal_exact_bootstrap_authority() -> None:
         assert row["base_policy_sha256"] != row["head_policy_sha256"]
 
 
+@pytest.mark.parametrize("protected_source", ("schema-1", "schema-1-old-row", "absent"))
+def test_exact_bootstrap_row_installs_from_legacy_protected_source(
+    monkeypatch, protected_source: str
+) -> None:
+    """The exact in-code trust root can perform the first schema-2 install."""
+    policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
+    authorization = verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS[
+        0
+    ]  # pylint: disable=protected-access
+    rotations = policy["rotations"] if protected_source != "absent" else []
+    protected_payload = {"schema_version": 1, "rotations": rotations}
+    if protected_source == "schema-1-old-row":
+        protected_payload["requirement_rotations"] = [
+            LEGACY_SCHEMA_1_REQUIREMENT_ROTATION
+        ]
+    protected = (
+        None if protected_source == "absent" else json.dumps(protected_payload).encode()
+    )
+    candidate = json.dumps(
+        {
+            "schema_version": 2,
+            "rotations": rotations,
+            "requirement_rotations": [_requirement_authorization_row(authorization)],
+        }
+    ).encode()
+
+    def protected_read(_root: Path, ref: str, path: PurePosixPath) -> bytes | None:
+        if path != verification.ROTATION_POLICY_PATH:
+            return None
+        return protected if ref == "protected" else candidate
+
+    monkeypatch.setattr(verification, "read_git_blob", protected_read)
+    manifest = SimpleNamespace(
+        repository_id=REPOSITORY_ID,
+        base_ref="protected",
+        head_ref="candidate",
+    )
+
+    authorizations, _prompts, _new_authorizations = (
+        verification._load_requirement_transition_authorizations(  # pylint: disable=protected-access
+            ROOT, manifest
+        )
+    )
+    assert authorizations == (authorization,)
+
+
+@pytest.mark.parametrize("profile_source", ("absent", "schema-1"))
+def test_exact_bootstrap_row_rejects_profile_byte_mutation(
+    monkeypatch, profile_source: str
+) -> None:
+    """A legacy bootstrap cannot install while profile bytes drift."""
+    authorization = verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS[
+        0
+    ]  # pylint: disable=protected-access
+    candidate = json.dumps(
+        {
+            "schema_version": 2,
+            "rotations": [],
+            "requirement_rotations": [_requirement_authorization_row(authorization)],
+        }
+    ).encode()
+    protected_profile = (
+        None
+        if profile_source == "absent"
+        else b'{"schema_version":1,"profiles":[]}\n'
+    )
+    candidate_profile = b'{\n  "schema_version": 1, "profiles": []\n}\n'
+
+    def protected_read(_root: Path, ref: str, path: PurePosixPath) -> bytes | None:
+        if path == verification.ROTATION_POLICY_PATH:
+            return None if ref == "protected" else candidate
+        if path == PROFILE_REL_PATH:
+            return protected_profile if ref == "protected" else candidate_profile
+        return None
+
+    monkeypatch.setattr(verification, "read_git_blob", protected_read)
+    manifest = SimpleNamespace(
+        repository_id=REPOSITORY_ID,
+        base_ref="protected",
+        head_ref="candidate",
+    )
+
+    with pytest.raises(
+        verification.VerificationProfileError,
+        match="changes protected verification-profile bytes",
+    ):
+        verification._load_requirement_transition_authorizations(  # pylint: disable=protected-access
+            ROOT, manifest
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation", ("malformed-row", "non-list-rows", "extra-envelope-key")
+)
+def test_legacy_schema_1_bootstrap_rejects_malformed_envelope(
+    monkeypatch, mutation: str
+) -> None:
+    """Historical rows are ignored as authority only after strict parsing."""
+    policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
+    authorization = verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS[
+        0
+    ]  # pylint: disable=protected-access
+    protected_payload = {
+        "schema_version": 1,
+        "rotations": policy["rotations"],
+        "requirement_rotations": [dict(LEGACY_SCHEMA_1_REQUIREMENT_ROTATION)],
+    }
+    if mutation == "malformed-row":
+        protected_payload["requirement_rotations"][0].pop("language_id")
+    elif mutation == "non-list-rows":
+        protected_payload["requirement_rotations"] = {}
+    else:
+        protected_payload["candidate_authority"] = []
+    protected = json.dumps(protected_payload).encode()
+    candidate = json.dumps(
+        {
+            "schema_version": 2,
+            "rotations": policy["rotations"],
+            "requirement_rotations": [_requirement_authorization_row(authorization)],
+        }
+    ).encode()
+
+    def protected_read(_root: Path, ref: str, path: PurePosixPath) -> bytes | None:
+        if path != verification.ROTATION_POLICY_PATH:
+            return None
+        return protected if ref == "protected" else candidate
+
+    monkeypatch.setattr(verification, "read_git_blob", protected_read)
+    manifest = SimpleNamespace(
+        repository_id=REPOSITORY_ID,
+        base_ref="protected",
+        head_ref="candidate",
+    )
+
+    with pytest.raises(verification.VerificationProfileError, match="protected"):
+        verification._load_requirement_transition_authorizations(  # pylint: disable=protected-access
+            ROOT, manifest
+        )
+
+
+@pytest.mark.parametrize("mutation", ("non-list-rotations", "malformed-row"))
+def test_stationary_schema_1_policy_is_validated_before_early_return(
+    monkeypatch, mutation: str
+) -> None:
+    """Equal legacy bytes cannot bypass structural validation by staying stationary."""
+    payload = {"schema_version": 1, "rotations": []}
+    if mutation == "non-list-rotations":
+        payload["rotations"] = {}
+    else:
+        payload["requirement_rotations"] = [{"prompt_path": "missing-fields"}]
+    raw = json.dumps(payload).encode()
+
+    monkeypatch.setattr(
+        verification,
+        "read_git_blob",
+        lambda _root, _ref, path: (
+            raw if path == verification.ROTATION_POLICY_PATH else None
+        ),
+    )
+    manifest = SimpleNamespace(
+        repository_id=REPOSITORY_ID,
+        base_ref="protected",
+        head_ref="candidate",
+    )
+
+    with pytest.raises(verification.VerificationProfileError, match="protected"):
+        verification._load_requirement_transition_authorizations(  # pylint: disable=protected-access
+            ROOT, manifest
+        )
+
+
+@pytest.mark.parametrize("schema_version", (True, 1.0, "1", False, 2.0))
+def test_rotation_policy_parsers_reject_non_exact_integer_schema_versions(
+    monkeypatch, schema_version
+) -> None:
+    """Every policy parser rejects bools and non-integer schema encodings."""
+    schema_2 = json.dumps(
+        {
+            "schema_version": schema_version,
+            "rotations": [],
+            "requirement_rotations": [],
+        }
+    ).encode()
+    schema_3 = json.dumps(
+        {
+            "schema_version": schema_version,
+            "rotations": [],
+            "requirement_rotations": [],
+            "requirement_rotation_retirements": [],
+        }
+    ).encode()
+
+    with pytest.raises(verification.VerificationProfileError):
+        verification._parse_requirement_transition_authorizations(  # pylint: disable=protected-access
+            schema_2, "candidate"
+        )
+    with pytest.raises(verification.VerificationProfileError):
+        verification._parse_requirement_transition_retirements(  # pylint: disable=protected-access
+            schema_3, "candidate"
+        )
+    with pytest.raises(verification.VerificationProfileError):
+        verification._parse_dormant_policy_envelope(  # pylint: disable=protected-access
+            schema_2, "candidate"
+        )
+    monkeypatch.setattr(
+        verification,
+        "read_git_blob",
+        lambda _root, _ref, _path: schema_2,
+    )
+    with pytest.raises(verification.VerificationProfileError):
+        verification._load_rotation_authorizations(  # pylint: disable=protected-access
+            ROOT, "protected"
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation", ("remove-schema-1", "replace-schema-1", "add-to-absent")
+)
+def test_bootstrap_install_cannot_change_active_rotation_authority(
+    monkeypatch, mutation: str
+) -> None:
+    """Legacy bootstrap changes only the envelope, never active authority."""
+    policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
+    authorization = verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS[
+        0
+    ]  # pylint: disable=protected-access
+    rotations = policy["rotations"]
+    protected = (
+        None
+        if mutation == "add-to-absent"
+        else json.dumps({"schema_version": 1, "rotations": rotations}).encode()
+    )
+    candidate_rotations = rotations if mutation == "add-to-absent" else []
+    if mutation == "replace-schema-1":
+        candidate_rotations = [dict(rotations[0], validator_id="candidate-validator")]
+    candidate = json.dumps(
+        {
+            "schema_version": 2,
+            "rotations": candidate_rotations,
+            "requirement_rotations": [_requirement_authorization_row(authorization)],
+        }
+    ).encode()
+
+    def protected_read(_root: Path, ref: str, path: PurePosixPath) -> bytes | None:
+        if path != verification.ROTATION_POLICY_PATH:
+            return None
+        return protected if ref == "protected" else candidate
+
+    monkeypatch.setattr(verification, "read_git_blob", protected_read)
+    manifest = SimpleNamespace(
+        repository_id=REPOSITORY_ID,
+        base_ref="protected",
+        head_ref="candidate",
+    )
+
+    with pytest.raises(verification.VerificationProfileError, match="candidate"):
+        verification._load_requirement_transition_authorizations(  # pylint: disable=protected-access
+            ROOT, manifest
+        )
+
+
 def test_pdd1989_transitions_cover_the_actual_merged_base() -> None:
     """The #1989 transition table must load a complete exact-base profile set."""
     manifest = build_unit_manifest(ROOT, base_ref=PDD_1989_ACTUAL_BASE, head_ref="HEAD")
@@ -415,8 +693,6 @@ def test_current_profile_rotation_matches_current_prompt_and_profile_rows() -> N
             if item["validator_id"] == "threshold-ed25519"
         )
         assert human["requirement_ids"] == [expected_requirement]
-
-
 @pytest.mark.parametrize(
     "field,replacement",
     (
@@ -658,6 +934,7 @@ def test_exact_bootstrap_profile_addition_is_authorized(monkeypatch) -> None:
         "wrong-repository",
         "wrong-policy",
         "wrong-prompt",
+        "wrong-requirement",
         "altered-profile",
         "base-existing",
         "not-expected",
@@ -675,6 +952,23 @@ def test_bootstrap_profile_addition_fails_closed(monkeypatch, mutation: str) -> 
         blobs[("candidate", PROFILE_REL_PATH)] = b"different policy\n"
     elif mutation == "wrong-prompt":
         blobs[("candidate", unit_id.prompt_relpath)] = b"different prompt\n"
+    elif mutation == "wrong-requirement":
+        prompt_path, language_id, _requirement_id, policy_digest, prompt_digest = (
+            verification._BOOTSTRAP_PROFILE_ADDITIONS[0]  # pylint: disable=protected-access
+        )
+        monkeypatch.setattr(
+            verification,
+            "_BOOTSTRAP_PROFILE_ADDITIONS",
+            (
+                (
+                    prompt_path,
+                    language_id,
+                    f"CONTRACT-SHA256:{'0' * 64}",
+                    policy_digest,
+                    prompt_digest,
+                ),
+            ),
+        )
     elif mutation == "altered-profile":
         head[unit_id] = verification._ProfileInput(  # pylint: disable=protected-access
             profile.requirements, ()

--- a/tests/test_sync_core_verification_profiles.py
+++ b/tests/test_sync_core_verification_profiles.py
@@ -149,6 +149,15 @@ def _rotation_authorization() -> dict:
     }
 
 
+def _empty_requirement_policy() -> dict:
+    """Build the protected schema-2 envelope before future rows are installed."""
+    return {
+        "schema_version": 2,
+        "rotations": _rotation_authorization()["rotations"],
+        "requirement_rotations": [],
+    }
+
+
 def _requirement_transition(
     root: Path, target_prompt: str, candidate_profile: dict | None = None
 ) -> tuple[dict, dict]:
@@ -199,7 +208,6 @@ def _repository(tmp_path: Path) -> Path:
     (root / "prompts/widget_python.prompt").write_text("REQ-1: Build widget\n")
     return root
 
-
 def _manifest(root: Path, base: str, head: str):
     return build_unit_manifest(root, base_ref=base, head_ref=head)
 
@@ -238,8 +246,6 @@ def test_candidate_cannot_delete_protected_obligation(tmp_path) -> None:
     assert any(
         "removed protected obligation" in item for item in profiles.invalid_reasons
     )
-
-
 def test_candidate_cannot_remap_protected_validator(tmp_path) -> None:
     """Candidate policy cannot remap a protected validator."""
     root = _repository(tmp_path)
@@ -328,8 +334,980 @@ def test_protected_requirement_transition_is_valid_while_dormant(tmp_path) -> No
     assert profiles.coverage == 1.0
 
 
-def test_exact_requirement_transition_updates_human_mapping(tmp_path) -> None:
-    """Exact Git-bound prompt and human requirement replacement is accepted."""
+def test_candidate_can_install_strictly_dormant_requirement_authorization(
+    tmp_path,
+) -> None:
+    """A candidate may install exact future authority without consuming it."""
+    root = _repository(tmp_path)
+    prompt = root / "prompts/widget_python.prompt"
+    prompt.write_text("Opaque contract version one\n")
+    profile_path = root / ".pdd/verification-profiles.json"
+    profile_path.write_text(json.dumps(_human_profile(root, "threshold-ed25519-v1")))
+    policy, _candidate_profile = _requirement_transition(
+        root, "Opaque contract version two\n"
+    )
+    rotation_path = root / ".pdd/verification-profile-rotations.json"
+    rotation_path.write_text(json.dumps(_empty_requirement_policy()))
+    base = _commit(root, "protected source bytes")
+
+    rotation_path.write_text(json.dumps(policy))
+    head = _commit(root, "install dormant transition authority")
+
+    profiles = load_verification_profiles(root, _manifest(root, base, head))
+    assert not profiles.invalid_reasons
+    assert profiles.coverage == 1.0
+
+
+def test_dormant_schema_2_admission_rejects_unrelated_managed_prompt_drift(
+    tmp_path,
+) -> None:
+    """Ordinary Phase A cannot carry explicit-REQ drift in another managed prompt."""
+    root = _repository(tmp_path)
+    prompt = root / "prompts/widget_python.prompt"
+    prompt.write_text("Opaque contract version one\n")
+    other_path = "prompts/other_python.prompt"
+    other = root / other_path
+    other.write_text("REQ-OTHER: Protected requirement\n")
+    profile_path = root / ".pdd/verification-profiles.json"
+    profile = _human_profile(root, "threshold-ed25519-v1")
+    other_row = _human_row(other_path, other.read_bytes())
+    other_row["required_requirement_ids"] = ["REQ-OTHER"]
+    other_row["obligations"][0]["requirement_ids"] = ["REQ-OTHER"]
+    profile["profiles"].append(other_row)
+    profile_path.write_text(json.dumps(profile))
+    policy, _candidate_profile = _requirement_transition(
+        root, "Opaque contract version two\n"
+    )
+    rotation_path = root / ".pdd/verification-profile-rotations.json"
+    rotation_path.write_text(json.dumps(_empty_requirement_policy()))
+    base = _commit(root, "protect ordinary Phase A source")
+
+    other.write_text("REQ-OTHER: Drift without identifier change\n")
+    rotation_path.write_text(json.dumps(policy))
+    head = _commit(root, "install authority with unrelated prompt drift")
+
+    with pytest.raises(VerificationProfileError, match="authority-only change"):
+        load_verification_profiles(root, _manifest(root, base, head))
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "remove-rotations",
+        "replace-rotations",
+        "malformed-rotation",
+        "schema-substitution",
+        "envelope-substitution",
+    ],
+)
+def test_candidate_dormant_authorization_preserves_policy_envelope(
+    tmp_path, mutation
+) -> None:
+    """Installing future rows cannot replace the protected authority envelope."""
+    root = _repository(tmp_path)
+    prompt = root / "prompts/widget_python.prompt"
+    prompt.write_text("Opaque contract version one\n")
+    profile_path = root / ".pdd/verification-profiles.json"
+    profile_path.write_text(json.dumps(_human_profile(root, "threshold-ed25519-v1")))
+    policy, _candidate_profile = _requirement_transition(
+        root, "Opaque contract version two\n"
+    )
+    rotation_path = root / ".pdd/verification-profile-rotations.json"
+    rotation_path.write_text(json.dumps(_empty_requirement_policy()))
+    base = _commit(root, "protected policy envelope")
+
+    if mutation == "remove-rotations":
+        policy["rotations"] = []
+    elif mutation == "replace-rotations":
+        policy["rotations"][0]["validator_id"] = "candidate-validator"
+    elif mutation == "malformed-rotation":
+        policy["rotations"] = [{"obligation_id": "threshold-human-attestation"}]
+    elif mutation == "schema-substitution":
+        policy["schema_version"] = 1
+    else:
+        policy["candidate_authority"] = []
+    rotation_path.write_text(json.dumps(policy))
+    head = _commit(root, f"attempt dormant install with {mutation}")
+
+    with pytest.raises(VerificationProfileError, match="candidate"):
+        load_verification_profiles(root, _manifest(root, base, head))
+
+
+def test_candidate_can_replace_consumed_rule_with_next_dormant_authorization(
+    tmp_path,
+) -> None:
+    """A consumed protected identity may advance to its next dormant transition."""
+    root = _repository(tmp_path)
+    prompt_path = "prompts/widget_python.prompt"
+    prompt = root / prompt_path
+    old_prompt = b"Opaque contract version zero\n"
+    current_prompt = b"Opaque contract version one\n"
+    future_prompt = b"Opaque contract version two\n"
+    prompt.write_bytes(current_prompt)
+    profile_path = root / ".pdd/verification-profiles.json"
+    old_profile = json.dumps(
+        {"profiles": [_human_row(prompt_path, old_prompt)]}
+    ).encode()
+    current_profile = json.dumps(
+        {"profiles": [_human_row(prompt_path, current_prompt)]}
+    ).encode()
+    future_profile = json.dumps(
+        {"profiles": [_human_row(prompt_path, future_prompt)]}
+    ).encode()
+    profile_path.write_bytes(current_profile)
+    policy_path = root / ".pdd/verification-profile-rotations.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "rotations": _rotation_authorization()["rotations"],
+                "requirement_rotations": [
+                    _requirement_rule(
+                        prompt_path,
+                        old_prompt,
+                        current_prompt,
+                        old_profile,
+                        current_profile,
+                    )
+                ],
+            }
+        )
+    )
+    base = _commit(root, "protected consumed transition")
+
+    policy_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "rotations": _rotation_authorization()["rotations"],
+                "requirement_rotations": [
+                    _requirement_rule(
+                        prompt_path,
+                        current_prompt,
+                        future_prompt,
+                        current_profile,
+                        future_profile,
+                    )
+                ],
+            }
+        )
+    )
+    head = _commit(root, "replace consumed authority with next dormant rule")
+
+    profiles = load_verification_profiles(root, _manifest(root, base, head))
+    assert not profiles.invalid_reasons
+    assert profiles.coverage == 1.0
+
+
+def test_consumed_rule_replacement_preserves_surviving_protected_row(tmp_path) -> None:
+    """A consumed row may be replaced only after exact surviving history."""
+    root = _repository(tmp_path)
+    widget_path = "prompts/widget_python.prompt"
+    gadget_path = "prompts/gadget_python.prompt"
+    widget_v0 = b"Widget contract version zero\n"
+    widget_v1 = b"Widget contract version one\n"
+    widget_v2 = b"Widget contract version two\n"
+    gadget_v1 = b"Gadget contract version one\n"
+    gadget_v2 = b"Gadget contract version two\n"
+    (root / widget_path).write_bytes(widget_v1)
+    (root / gadget_path).write_bytes(gadget_v1)
+    profile_path = root / ".pdd/verification-profiles.json"
+    old_profile = json.dumps(
+        {
+            "profiles": [
+                _human_row(widget_path, widget_v0),
+                _human_row(gadget_path, gadget_v1),
+            ]
+        }
+    ).encode()
+    current_profile = json.dumps(
+        {
+            "profiles": [
+                _human_row(widget_path, widget_v1),
+                _human_row(gadget_path, gadget_v1),
+            ]
+        }
+    ).encode()
+    widget_future_profile = json.dumps(
+        {
+            "profiles": [
+                _human_row(widget_path, widget_v2),
+                _human_row(gadget_path, gadget_v1),
+            ]
+        }
+    ).encode()
+    gadget_future_profile = json.dumps(
+        {
+            "profiles": [
+                _human_row(widget_path, widget_v1),
+                _human_row(gadget_path, gadget_v2),
+            ]
+        }
+    ).encode()
+    profile_path.write_bytes(current_profile)
+    consumed = _requirement_rule(
+        widget_path, widget_v0, widget_v1, old_profile, current_profile
+    )
+    surviving = _requirement_rule(
+        gadget_path, gadget_v1, gadget_v2, current_profile, gadget_future_profile
+    )
+    replacement = _requirement_rule(
+        widget_path, widget_v1, widget_v2, current_profile, widget_future_profile
+    )
+    policy_path = root / ".pdd/verification-profile-rotations.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "rotations": _rotation_authorization()["rotations"],
+                "requirement_rotations": [consumed, surviving],
+            }
+        )
+    )
+    base = _commit(root, "protect consumed and surviving transitions")
+
+    policy_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "rotations": _rotation_authorization()["rotations"],
+                "requirement_rotations": [surviving, replacement],
+            }
+        )
+    )
+    head = _commit(root, "replace consumed transition after surviving history")
+
+    profiles = load_verification_profiles(root, _manifest(root, base, head))
+    assert not profiles.invalid_reasons
+    assert profiles.coverage == 1.0
+
+
+def test_dormant_schema_2_admission_rejects_prepend_before_protected_row(
+    tmp_path,
+) -> None:
+    """Phase A additions follow exact protected row history."""
+    root = _repository(tmp_path)
+    widget_path = "prompts/widget_python.prompt"
+    gadget_path = "prompts/gadget_python.prompt"
+    widget_v1 = b"Widget contract version one\n"
+    widget_v2 = b"Widget contract version two\n"
+    gadget_v1 = b"Gadget contract version one\n"
+    gadget_v2 = b"Gadget contract version two\n"
+    (root / widget_path).write_bytes(widget_v1)
+    (root / gadget_path).write_bytes(gadget_v1)
+    profile_path = root / ".pdd/verification-profiles.json"
+    current_profile = json.dumps(
+        {
+            "profiles": [
+                _human_row(widget_path, widget_v1),
+                _human_row(gadget_path, gadget_v1),
+            ]
+        }
+    ).encode()
+    widget_future_profile = json.dumps(
+        {
+            "profiles": [
+                _human_row(widget_path, widget_v2),
+                _human_row(gadget_path, gadget_v1),
+            ]
+        }
+    ).encode()
+    gadget_future_profile = json.dumps(
+        {
+            "profiles": [
+                _human_row(widget_path, widget_v1),
+                _human_row(gadget_path, gadget_v2),
+            ]
+        }
+    ).encode()
+    profile_path.write_bytes(current_profile)
+    protected = _requirement_rule(
+        widget_path, widget_v1, widget_v2, current_profile, widget_future_profile
+    )
+    addition = _requirement_rule(
+        gadget_path, gadget_v1, gadget_v2, current_profile, gadget_future_profile
+    )
+    policy_path = root / ".pdd/verification-profile-rotations.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "rotations": _rotation_authorization()["rotations"],
+                "requirement_rotations": [protected],
+            }
+        )
+    )
+    base = _commit(root, "protect existing transition history")
+
+    policy_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "rotations": _rotation_authorization()["rotations"],
+                "requirement_rotations": [addition, protected],
+            }
+        )
+    )
+    head = _commit(root, "prepend dormant transition")
+
+    with pytest.raises(VerificationProfileError, match="protected representation"):
+        load_verification_profiles(root, _manifest(root, base, head))
+
+
+@pytest.mark.parametrize("mutation", ["key-order", "escaping", "path-lexeme"])
+def test_dormant_schema_2_admission_rejects_protected_row_rewrite(
+    tmp_path, mutation
+) -> None:
+    """Semantic equivalence cannot rewrite an unconsumed protected row token."""
+    root = _repository(tmp_path)
+    prompt_path = "prompts/widget_python.prompt"
+    current_prompt = b"Opaque contract version one\n"
+    future_prompt = b"Opaque contract version two\n"
+    (root / prompt_path).write_bytes(current_prompt)
+    profile_path = root / ".pdd/verification-profiles.json"
+    current_profile = json.dumps(
+        {"profiles": [_human_row(prompt_path, current_prompt)]}
+    ).encode()
+    future_profile = json.dumps(
+        {"profiles": [_human_row(prompt_path, future_prompt)]}
+    ).encode()
+    profile_path.write_bytes(current_profile)
+    row = _requirement_rule(
+        prompt_path, current_prompt, future_prompt, current_profile, future_profile
+    )
+    policy_path = root / ".pdd/verification-profile-rotations.json"
+    protected_policy = {
+        "schema_version": 2,
+        "rotations": _rotation_authorization()["rotations"],
+        "requirement_rotations": [row],
+    }
+    policy_path.write_text(json.dumps(protected_policy))
+    base = _commit(root, "protect exact row representation")
+
+    rewritten = dict(reversed(tuple(row.items()))) if mutation == "key-order" else row
+    candidate_raw = json.dumps(
+        {
+            "schema_version": 2,
+            "rotations": _rotation_authorization()["rotations"],
+            "requirement_rotations": [rewritten],
+        }
+    )
+    if mutation == "escaping":
+        candidate_raw = candidate_raw.replace(
+            '"prompts/widget_python.prompt"', '"prompts\\/widget_python.prompt"'
+        )
+    elif mutation == "path-lexeme":
+        candidate_raw = candidate_raw.replace(
+            '"prompts/widget_python.prompt"', '"prompts//widget_python.prompt"'
+        )
+    policy_path.write_text(candidate_raw)
+    head = _commit(root, f"rewrite protected row via {mutation}")
+
+    with pytest.raises(VerificationProfileError, match="protected representation"):
+        load_verification_profiles(root, _manifest(root, base, head))
+
+
+@pytest.mark.parametrize("mutation", ["replace", "remove"])
+def test_candidate_cannot_revoke_unconsumed_requirement_authorization(
+    tmp_path, mutation
+) -> None:
+    """A candidate cannot revoke manager-reviewed authority before consumption."""
+    root = _repository(tmp_path)
+    prompt_path = "prompts/widget_python.prompt"
+    current_prompt = b"Opaque contract version one\n"
+    first_future_prompt = b"Opaque contract version two\n"
+    replacement_future_prompt = b"Opaque contract version three\n"
+    (root / prompt_path).write_bytes(current_prompt)
+    profile_path = root / ".pdd/verification-profiles.json"
+    current_profile = json.dumps(
+        {"profiles": [_human_row(prompt_path, current_prompt)]}
+    ).encode()
+    first_future_profile = json.dumps(
+        {"profiles": [_human_row(prompt_path, first_future_prompt)]}
+    ).encode()
+    replacement_future_profile = json.dumps(
+        {"profiles": [_human_row(prompt_path, replacement_future_prompt)]}
+    ).encode()
+    profile_path.write_bytes(current_profile)
+    policy_path = root / ".pdd/verification-profile-rotations.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "rotations": _rotation_authorization()["rotations"],
+                "requirement_rotations": [
+                    _requirement_rule(
+                        prompt_path,
+                        current_prompt,
+                        first_future_prompt,
+                        current_profile,
+                        first_future_profile,
+                    )
+                ],
+            }
+        )
+    )
+    base = _commit(root, "protect unconsumed transition")
+
+    replacement = (
+        [
+            _requirement_rule(
+                prompt_path,
+                current_prompt,
+                replacement_future_prompt,
+                current_profile,
+                replacement_future_profile,
+            )
+        ]
+        if mutation == "replace"
+        else []
+    )
+    policy_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "rotations": _rotation_authorization()["rotations"],
+                "requirement_rotations": replacement,
+            }
+        )
+    )
+    head = _commit(root, f"attempt to {mutation} unconsumed authority")
+
+    with pytest.raises(VerificationProfileError, match="unconsumed protected"):
+        load_verification_profiles(root, _manifest(root, base, head))
+
+
+def _stale_authority_sequence(
+    tmp_path: Path,
+    *,
+    include_unrelated: bool = False,
+    unrelated_alias: bool = False,
+):
+    """Build the #1790-first shape that leaves #2058 authority unreachable."""
+    root = _repository(tmp_path)
+    widget_path = "prompts/widget_python.prompt"
+    gadget_path = "prompts/gadget_python.prompt"
+    widget_v1, widget_v2, widget_v3 = (
+        b"Widget contract version one\n",
+        b"Widget contract version two\n",
+        b"Widget contract version three\n",
+    )
+    gadget_v1, gadget_v2 = (
+        b"Gadget contract version one\n",
+        b"Gadget contract version two\n",
+    )
+    unrelated_path = "prompts/unrelated_python.prompt"
+    unrelated_target = PurePosixPath("canonical-prompts/unrelated_python.prompt")
+    unrelated_v1 = b"REQ-UNRELATED: Preserve this explicit requirement\n"
+    (root / widget_path).write_bytes(widget_v1)
+    (root / gadget_path).write_bytes(gadget_v1)
+    if include_unrelated and unrelated_alias:
+        target = root / unrelated_target
+        target.parent.mkdir()
+        target.write_bytes(unrelated_v1)
+        (root / unrelated_path).symlink_to("../canonical-prompts/unrelated_python.prompt")
+        (root / ".pdd/sync-aliases.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "aliases": [
+                        {
+                            "alias_path": unrelated_path,
+                            "canonical_path": unrelated_target.as_posix(),
+                        }
+                    ],
+                }
+            )
+        )
+    elif include_unrelated:
+        (root / unrelated_path).write_bytes(unrelated_v1)
+    profile_path = root / ".pdd/verification-profiles.json"
+    unrelated_rows = []
+    if include_unrelated:
+        unrelated_row = _human_row(unrelated_path, unrelated_v1)
+        unrelated_row["required_requirement_ids"] = ["REQ-UNRELATED"]
+        unrelated_row["obligations"][0]["requirement_ids"] = ["REQ-UNRELATED"]
+        unrelated_rows = [unrelated_row]
+    profile_v0 = json.dumps(
+        {
+            "profiles": [
+                _human_row(widget_path, widget_v1),
+                _human_row(gadget_path, gadget_v1),
+                *unrelated_rows,
+            ]
+        }
+    ).encode()
+    profile_v1 = json.dumps(
+        {
+            "profiles": [
+                _human_row(widget_path, widget_v2),
+                _human_row(gadget_path, gadget_v1),
+                *unrelated_rows,
+            ]
+        }
+    ).encode()
+    profile_v2 = json.dumps(
+        {
+            "profiles": [
+                _human_row(widget_path, widget_v1),
+                _human_row(gadget_path, gadget_v2),
+                *unrelated_rows,
+            ]
+        }
+    ).encode()
+    profile_v3 = json.dumps(
+        {
+            "profiles": [
+                _human_row(widget_path, widget_v2),
+                _human_row(gadget_path, gadget_v2),
+                *unrelated_rows,
+            ]
+        }
+    ).encode()
+    profile_v4 = json.dumps(
+        {
+            "profiles": [
+                _human_row(widget_path, widget_v3),
+                _human_row(gadget_path, gadget_v1),
+                *unrelated_rows,
+            ]
+        }
+    ).encode()
+    profile_path.write_bytes(profile_v0)
+    first = _requirement_rule(widget_path, widget_v1, widget_v2, profile_v0, profile_v1)
+    stale = _requirement_rule(gadget_path, gadget_v1, gadget_v2, profile_v0, profile_v2)
+    policy_path = root / ".pdd/verification-profile-rotations.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "rotations": _rotation_authorization()["rotations"],
+                "requirement_rotations": [first, stale],
+            }
+        )
+    )
+    authority_base = _commit(root, "protect #1790 and #2058 dormant authority")
+
+    (root / widget_path).write_bytes(widget_v2)
+    profile_path.write_bytes(profile_v1)
+    stale_base = _commit(root, "consume #1790 first")
+    replacement = _requirement_rule(
+        gadget_path, gadget_v1, gadget_v2, profile_v1, profile_v3
+    )
+    next_widget = _requirement_rule(
+        widget_path, widget_v2, widget_v3, profile_v1, profile_v4
+    )
+    return SimpleNamespace(
+        root=root,
+        authority_base=authority_base,
+        stale_base=stale_base,
+        policy_path=policy_path,
+        profile_path=profile_path,
+        first=first,
+        stale=stale,
+        replacement=replacement,
+        next_widget=next_widget,
+        profile_v0=profile_v0,
+        profile_v1=profile_v1,
+        profile_v3=profile_v3,
+        widget_v1=widget_v1,
+        gadget_v2=gadget_v2,
+        unrelated_path=unrelated_path,
+        unrelated_target=unrelated_target,
+    )
+
+
+def _retirement_policy(state, *, retirements=None, rows=None) -> dict:
+    """Render one schema-3 append-only retirement candidate."""
+    if rows is None:
+        rows = [state.first, state.stale, state.replacement]
+    if retirements is None:
+        retirements = [{"obsolete": state.stale, "replacement": state.replacement}]
+    return {
+        "schema_version": 3,
+        "rotations": _rotation_authorization()["rotations"],
+        "requirement_rotations": rows,
+        "requirement_rotation_retirements": retirements,
+    }
+
+
+def _empty_schema_3_policy(state, *, rows=None) -> dict:
+    """Render an invalid schema-3 upgrade without a retirement/reissue record."""
+    if rows is None:
+        rows = [state.first, state.stale]
+    return _retirement_policy(state, rows=rows, retirements=[])
+
+
+def test_retire_unreachable_2058_authority_after_1790_consumes_first(tmp_path) -> None:
+    """A protected stale row stays visible while fresh authority is reissued."""
+    state = _stale_authority_sequence(tmp_path)
+    state.policy_path.write_text(json.dumps(_retirement_policy(state)))
+    reissue = _commit(state.root, "retire stale #2058 authority and reissue it")
+
+    profiles = load_verification_profiles(
+        state.root, _manifest(state.root, state.stale_base, reissue)
+    )
+    assert not profiles.invalid_reasons
+
+    (state.root / "prompts/gadget_python.prompt").write_bytes(state.gadget_v2)
+    state.profile_path.write_bytes(state.profile_v3)
+    consumed = _commit(state.root, "consume fresh #2058 authority")
+    profiles = load_verification_profiles(
+        state.root, _manifest(state.root, reissue, consumed)
+    )
+    assert not profiles.invalid_reasons
+    policy = json.loads(state.policy_path.read_text())
+    assert policy["requirement_rotations"][:2] == [state.first, state.stale]
+    assert policy["requirement_rotation_retirements"] == [
+        {"obsolete": state.stale, "replacement": state.replacement}
+    ]
+
+
+def test_schema_3_upgrade_with_empty_retirements_rejects_rewritten_history(tmp_path) -> None:
+    """A schema-3 upgrade cannot reformat a protected schema-2 authorization row."""
+    state = _stale_authority_sequence(tmp_path)
+    state.policy_path.write_text(
+        json.dumps(
+            _empty_schema_3_policy(
+                state, rows=[dict(reversed(state.first.items())), state.stale]
+            )
+        )
+    )
+    candidate = _commit(state.root, "rewrite history during empty schema-3 upgrade")
+
+    with pytest.raises(VerificationProfileError, match="rewrites protected representation"):
+        load_verification_profiles(
+            state.root, _manifest(state.root, state.stale_base, candidate)
+        )
+
+
+def test_schema_3_upgrade_with_empty_retirements_is_rejected(tmp_path) -> None:
+    """Schema 2 cannot enter schema 3 until it appends a valid retirement/reissue."""
+    state = _stale_authority_sequence(tmp_path)
+    state.policy_path.write_text(json.dumps(_empty_schema_3_policy(state)))
+    candidate = _commit(state.root, "attempt empty schema-3 upgrade")
+
+    with pytest.raises(VerificationProfileError, match="requires a retirement/reissue"):
+        load_verification_profiles(
+            state.root, _manifest(state.root, state.stale_base, candidate)
+        )
+
+
+def test_schema_3_history_rejects_rewrite_without_new_retirement(tmp_path) -> None:
+    """Protected schema-3 rows stay token-identical in later stationary candidates."""
+    state = _stale_authority_sequence(tmp_path)
+    state.policy_path.write_text(json.dumps(_retirement_policy(state)))
+    protected = _commit(state.root, "protect retirement history")
+    policy = json.loads(state.policy_path.read_text())
+    policy["requirement_rotations"][0] = dict(reversed(state.first.items()))
+    state.policy_path.write_text(json.dumps(policy))
+    candidate = _commit(state.root, "rewrite stationary schema-3 history")
+
+    with pytest.raises(VerificationProfileError, match="rewrites protected representation"):
+        load_verification_profiles(state.root, _manifest(state.root, protected, candidate))
+
+
+def test_schema_3_phase_b_consumption_keeps_stationary_history(tmp_path) -> None:
+    """A later Phase B still consumes the protected schema-3 replacement row."""
+    state = _stale_authority_sequence(tmp_path)
+    state.policy_path.write_text(json.dumps(_retirement_policy(state)))
+    protected = _commit(state.root, "protect retirement history")
+
+    (state.root / "prompts/gadget_python.prompt").write_bytes(state.gadget_v2)
+    state.profile_path.write_bytes(state.profile_v3)
+    candidate = _commit(state.root, "consume protected schema-3 authority")
+
+    profiles = load_verification_profiles(state.root, _manifest(state.root, protected, candidate))
+    assert not profiles.invalid_reasons
+
+
+@pytest.mark.parametrize("mutation", ["consume", "profile-bytes", "prompt-bytes"])
+def test_retirement_reissue_rejects_same_candidate_byte_changes(
+    tmp_path, mutation
+) -> None:
+    """Retirement Phase A cannot consume replacement authority or change bytes."""
+    state = _stale_authority_sequence(tmp_path)
+    if mutation == "consume":
+        (state.root / "prompts/gadget_python.prompt").write_bytes(state.gadget_v2)
+        state.profile_path.write_bytes(state.profile_v3)
+    elif mutation == "profile-bytes":
+        state.profile_path.write_bytes(
+            json.dumps(json.loads(state.profile_v1), indent=2).encode()
+        )
+    else:
+        (state.root / "prompts/gadget_python.prompt").write_text("unbound mutation\n")
+    state.policy_path.write_text(json.dumps(_retirement_policy(state)))
+    candidate = _commit(state.root, f"invalid retirement {mutation}")
+
+    with pytest.raises(VerificationProfileError, match="candidate retirement"):
+        load_verification_profiles(
+            state.root, _manifest(state.root, state.stale_base, candidate)
+        )
+
+
+def test_retirement_reissue_rejects_unrelated_managed_prompt_byte_drift(tmp_path) -> None:
+    """Retirement Phase A binds every expected prompt, not only its target row."""
+    state = _stale_authority_sequence(tmp_path, include_unrelated=True)
+    (state.root / state.unrelated_path).write_bytes(
+        b"REQ-UNRELATED: Same identifier, changed protected bytes\n"
+    )
+    state.policy_path.write_text(json.dumps(_retirement_policy(state)))
+    candidate = _commit(state.root, "change unrelated prompt during retirement")
+
+    with pytest.raises(VerificationProfileError, match="managed prompt bytes"):
+        load_verification_profiles(
+            state.root, _manifest(state.root, state.stale_base, candidate)
+        )
+
+
+def test_retirement_reissue_rejects_canonical_file_alias_target_drift(tmp_path) -> None:
+    """An unchanged alias blob cannot hide canonical prompt drift in Phase A."""
+    state = _stale_authority_sequence(
+        tmp_path, include_unrelated=True, unrelated_alias=True
+    )
+    alias_before = (state.root / state.unrelated_path).readlink()
+    (state.root / state.unrelated_target).write_bytes(
+        b"REQ-UNRELATED: Changed canonical target bytes\n"
+    )
+    assert (state.root / state.unrelated_path).readlink() == alias_before
+    state.policy_path.write_text(json.dumps(_retirement_policy(state)))
+    candidate = _commit(state.root, "change canonical alias target during retirement")
+
+    with pytest.raises(VerificationProfileError, match="managed prompt bytes"):
+        load_verification_profiles(
+            state.root, _manifest(state.root, state.stale_base, candidate)
+        )
+
+
+def test_dormant_schema_2_admission_rejects_canonical_alias_target_drift(
+    tmp_path,
+) -> None:
+    """Ordinary Phase A resolves approved aliases before checking every prompt."""
+    state = _stale_authority_sequence(
+        tmp_path, include_unrelated=True, unrelated_alias=True
+    )
+    alias_before = (state.root / state.unrelated_path).readlink()
+    (state.root / state.unrelated_target).write_bytes(
+        b"REQ-UNRELATED: Drift in canonical target during ordinary Phase A\n"
+    )
+    assert (state.root / state.unrelated_path).readlink() == alias_before
+    state.policy_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "rotations": _rotation_authorization()["rotations"],
+                "requirement_rotations": [state.stale, state.next_widget],
+            }
+        )
+    )
+    candidate = _commit(state.root, "ordinary Phase A canonical alias drift")
+
+    with pytest.raises(VerificationProfileError, match="authority-only change"):
+        load_verification_profiles(
+            state.root, _manifest(state.root, state.stale_base, candidate)
+        )
+
+
+def test_consuming_reissued_authority_rejects_unrelated_managed_prompt_drift(
+    tmp_path,
+) -> None:
+    """Phase B may consume its row but cannot carry another managed prompt change."""
+    state = _stale_authority_sequence(tmp_path, include_unrelated=True)
+    state.policy_path.write_text(json.dumps(_retirement_policy(state)))
+    reissue = _commit(state.root, "protect retirement and fresh authority")
+
+    (state.root / "prompts/gadget_python.prompt").write_bytes(state.gadget_v2)
+    state.profile_path.write_bytes(state.profile_v3)
+    (state.root / state.unrelated_path).write_bytes(
+        b"REQ-UNRELATED: Same requirement, unauthorized byte drift\n"
+    )
+    candidate = _commit(state.root, "consume authority with unrelated drift")
+
+    with pytest.raises(VerificationProfileError, match="unmanaged prompt bytes"):
+        load_verification_profiles(state.root, _manifest(state.root, reissue, candidate))
+
+
+def test_consuming_reissued_authority_allows_unchanged_unrelated_prompts(tmp_path) -> None:
+    """Phase B remains usable when only its exact protected prompt changes."""
+    state = _stale_authority_sequence(tmp_path, include_unrelated=True)
+    state.policy_path.write_text(json.dumps(_retirement_policy(state)))
+    reissue = _commit(state.root, "protect retirement and fresh authority")
+
+    (state.root / "prompts/gadget_python.prompt").write_bytes(state.gadget_v2)
+    state.profile_path.write_bytes(state.profile_v3)
+    candidate = _commit(state.root, "consume fresh authority only")
+
+    profiles = load_verification_profiles(state.root, _manifest(state.root, reissue, candidate))
+    assert not profiles.invalid_reasons
+
+
+@pytest.mark.parametrize("mutation", ["row-order", "row-path", "retirement-order"])
+def test_retirement_history_preserves_protected_json_representation(
+    tmp_path, mutation
+) -> None:
+    """Semantic equality cannot rewrite protected historical JSON tokens."""
+    state = _stale_authority_sequence(tmp_path)
+    policy = _retirement_policy(state)
+    if mutation == "row-order":
+        policy["requirement_rotations"][0] = dict(reversed(state.first.items()))
+        base = state.stale_base
+    elif mutation == "row-path":
+        policy["requirement_rotations"][1] = dict(state.stale)
+        policy["requirement_rotations"][1]["prompt_path"] = (
+            "prompts/./gadget_python.prompt"
+        )
+        policy["requirement_rotation_retirements"][0]["obsolete"] = policy[
+            "requirement_rotations"
+        ][1]
+        base = state.stale_base
+    else:
+        state.policy_path.write_text(json.dumps(policy))
+        protected = _commit(state.root, "protect retirement history")
+        policy["requirement_rotation_retirements"][0] = {
+            "replacement": state.replacement,
+            "obsolete": state.stale,
+        }
+        base = protected
+    state.policy_path.write_text(json.dumps(policy))
+    candidate = _commit(state.root, f"rewrite retirement history {mutation}")
+
+    with pytest.raises(VerificationProfileError, match="rewrites protected representation"):
+        load_verification_profiles(state.root, _manifest(state.root, base, candidate))
+
+
+@pytest.mark.parametrize("location", ["top", "row", "retirement", "obsolete", "replacement"])
+def test_rotation_policy_rejects_duplicate_json_members_at_every_nesting_level(
+    tmp_path, location
+) -> None:
+    """Authority parsing rejects duplicate members before interpreting any row."""
+    state = _stale_authority_sequence(tmp_path)
+    row = json.dumps(state.stale, separators=(",", ":"))
+    duplicate_row = f'{{"prompt_path":"{state.stale["prompt_path"]}",{row[1:]}'
+    retirement = json.dumps(
+        {"obsolete": state.stale, "replacement": state.replacement},
+        separators=(",", ":"),
+    )
+    duplicate_retirement = (
+        f'{{"obsolete":{row},"obsolete":{row},"replacement":{row}}}'
+    )
+    duplicate_obsolete = (
+        f'{{"obsolete":{duplicate_row},"replacement":{row}}}'
+    )
+    duplicate_replacement = (
+        f'{{"obsolete":{row},"replacement":{duplicate_row}}}'
+    )
+    retirement_value = {
+        "retirement": duplicate_retirement,
+        "obsolete": duplicate_obsolete,
+        "replacement": duplicate_replacement,
+    }.get(location, retirement)
+    payload = (
+        f'{{"schema_version":3,"rotations":[],"requirement_rotations":[{row}],'
+        f'"requirement_rotation_retirements":[{retirement_value}]}}'
+    )
+    if location == "top":
+        payload = payload.replace('"schema_version":3,', '"schema_version":3,"schema_version":3,')
+    elif location == "row":
+        payload = (
+            f'{{"schema_version":2,"rotations":[],'
+            f'"requirement_rotations":[{duplicate_row}]}}'
+        )
+
+    with pytest.raises(VerificationProfileError, match="duplicate JSON members"):
+        verification._parse_requirement_transition_authorizations(  # pylint: disable=protected-access
+            payload.encode(), "candidate"
+        )
+
+
+@pytest.mark.parametrize("target", ["live", "consumed"])
+def test_retirement_rejects_live_or_consumed_protected_row(tmp_path, target) -> None:
+    """Only a dormant row with an unreachable policy binding may be retired."""
+    state = _stale_authority_sequence(tmp_path)
+    if target == "live":
+        base = state.authority_base
+        (state.root / "prompts/widget_python.prompt").write_bytes(state.widget_v1)
+        state.profile_path.write_bytes(state.profile_v0)
+        replacement = _requirement_rule(
+            "prompts/gadget_python.prompt",
+            b"Gadget contract version one\n",
+            state.gadget_v2,
+            state.profile_v0,
+            state.profile_v3,
+        )
+        obsolete = state.stale
+    else:
+        base = state.stale_base
+        replacement = state.next_widget
+        obsolete = state.first
+    state.policy_path.write_text(
+        json.dumps(
+            _retirement_policy(
+                state,
+                rows=[state.first, state.stale, replacement],
+                retirements=[{"obsolete": obsolete, "replacement": replacement}],
+            )
+        )
+    )
+    candidate = _commit(state.root, f"attempt to retire {target} row")
+
+    with pytest.raises(VerificationProfileError, match="candidate retirement"):
+        load_verification_profiles(state.root, _manifest(state.root, base, candidate))
+
+
+@pytest.mark.parametrize(
+    "mutation", ["missing", "modified", "duplicate", "fork", "chain", "cycle"]
+)
+def test_retirement_record_rejects_ambiguous_or_nonexact_history(
+    tmp_path, mutation
+) -> None:
+    """Retirement records are exact single links, never deletion or a graph."""
+    state = _stale_authority_sequence(tmp_path)
+    policy = _retirement_policy(state)
+    if mutation == "missing":
+        policy["requirement_rotations"] = [state.first, state.replacement]
+    elif mutation == "modified":
+        policy["requirement_rotation_retirements"][0]["obsolete"] = dict(state.stale)
+        policy["requirement_rotation_retirements"][0]["obsolete"][
+            "head_prompt_sha256"
+        ] = "0" * 64
+    elif mutation == "duplicate":
+        policy["requirement_rotation_retirements"].append(
+            {"obsolete": state.stale, "replacement": state.replacement}
+        )
+    else:
+        alternate = dict(state.replacement)
+        alternate["head_policy_sha256"] = "0" * 64
+        policy["requirement_rotations"].append(alternate)
+        if mutation == "fork":
+            link = {"obsolete": state.stale, "replacement": alternate}
+        elif mutation == "chain":
+            link = {"obsolete": state.replacement, "replacement": alternate}
+        else:
+            link = {"obsolete": state.replacement, "replacement": state.stale}
+        policy["requirement_rotation_retirements"].append(link)
+    state.policy_path.write_text(json.dumps(policy))
+    candidate = _commit(state.root, f"invalid retirement {mutation}")
+
+    with pytest.raises(VerificationProfileError, match="retirement|ambiguous"):
+        load_verification_profiles(
+            state.root, _manifest(state.root, state.stale_base, candidate)
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "profile-bytes",
+        "prompt",
+        "base-policy-binding",
+        "base-prompt-binding",
+        "already-consumed",
+    ],
+)
+def test_candidate_dormant_authorization_rejects_changed_source_state(
+    tmp_path, mutation
+) -> None:
+    """Candidate-added authority cannot accompany or misstate protected source bytes."""
     root = _repository(tmp_path)
     prompt = root / "prompts/widget_python.prompt"
     prompt.write_text("Opaque contract version one\n")
@@ -337,6 +1315,112 @@ def test_exact_requirement_transition_updates_human_mapping(tmp_path) -> None:
     profile_path.write_text(json.dumps(_human_profile(root, "threshold-ed25519-v1")))
     policy, candidate_profile = _requirement_transition(
         root, "Opaque contract version two\n"
+    )
+    rotation_path = root / ".pdd/verification-profile-rotations.json"
+    rotation_path.write_text(json.dumps(_empty_requirement_policy()))
+    base = _commit(root, "protected source bytes")
+
+    if mutation == "profile-bytes":
+        profile_path.write_text(
+            json.dumps(json.loads(profile_path.read_text()), indent=2)
+        )
+    elif mutation == "prompt":
+        prompt.write_text("Unbound prompt mutation\n")
+    elif mutation == "base-policy-binding":
+        row = policy["requirement_rotations"][0]
+        row["base_policy_sha256"] = "0" * 64
+    elif mutation == "base-prompt-binding":
+        row = policy["requirement_rotations"][0]
+        row["base_prompt_sha256"] = "0" * 64
+    else:
+        prompt.write_text("Opaque contract version two\n")
+        profile_path.write_text(json.dumps(candidate_profile))
+    rotation_path.write_text(json.dumps(policy))
+    head = _commit(root, f"attempt dormant authority with {mutation}")
+
+    with pytest.raises(
+        VerificationProfileError,
+        match="candidate requirement transition lacks protected authorization",
+    ):
+        load_verification_profiles(root, _manifest(root, base, head))
+
+
+def test_candidate_dormant_authorization_requires_exact_human_obligation(
+    tmp_path,
+) -> None:
+    """Candidate authority fails closed without the threshold human mapping."""
+    root = _repository(tmp_path)
+    prompt_path = "prompts/widget_python.prompt"
+    current_prompt = b"Opaque contract version one\n"
+    future_prompt = b"Opaque contract version two\n"
+    (root / prompt_path).write_bytes(current_prompt)
+    current_row = _human_row(prompt_path, current_prompt)
+    current_row["obligations"][0]["validator_id"] = "untrusted"
+    future_row = _human_row(prompt_path, future_prompt)
+    current_profile = json.dumps({"profiles": [current_row]}).encode()
+    future_profile = json.dumps({"profiles": [future_row]}).encode()
+    (root / ".pdd/verification-profiles.json").write_bytes(current_profile)
+    policy = {
+        "schema_version": 2,
+        "rotations": _rotation_authorization()["rotations"],
+        "requirement_rotations": [
+            _requirement_rule(
+                prompt_path,
+                current_prompt,
+                future_prompt,
+                current_profile,
+                future_profile,
+            )
+        ],
+    }
+    rotation_path = root / ".pdd/verification-profile-rotations.json"
+    rotation_path.write_text(json.dumps(_empty_requirement_policy()))
+    base = _commit(root, "protected malformed human obligation")
+
+    rotation_path.write_text(json.dumps(policy))
+    head = _commit(root, "attempt authority without threshold human mapping")
+
+    with pytest.raises(
+        VerificationProfileError,
+        match="candidate requirement transition lacks protected authorization",
+    ):
+        load_verification_profiles(root, _manifest(root, base, head))
+
+
+def test_exact_requirement_transition_updates_all_obligation_mappings(
+    tmp_path,
+) -> None:
+    """Exact transition remaps every existing obligation to the new contract."""
+    root = _repository(tmp_path)
+    prompt = root / "prompts/widget_python.prompt"
+    prompt.write_text("Opaque contract version one\n")
+    profile_path = root / ".pdd/verification-profiles.json"
+    protected_profile = _human_profile(root, "threshold-ed25519-v1")
+    protected_requirement = protected_profile["profiles"][0][
+        "required_requirement_ids"
+    ][0]
+    protected_profile["profiles"][0]["obligations"].append(
+        {
+            "obligation_id": "pytest",
+            "kind": "test",
+            "validator_id": "pytest",
+            "validator_config_digest": "pytest-v1",
+            "requirement_ids": [protected_requirement],
+            "artifact_paths": ["tests/test_widget.py"],
+            "required": True,
+        }
+    )
+    profile_path.write_text(json.dumps(protected_profile))
+    target_prompt = b"Opaque contract version two\n"
+    target_requirement = f"CONTRACT-SHA256:{hashlib.sha256(target_prompt).hexdigest()}"
+    candidate_profile = json.loads(json.dumps(protected_profile))
+    candidate_profile["profiles"][0]["required_requirement_ids"] = [target_requirement]
+    for obligation in candidate_profile["profiles"][0]["obligations"]:
+        obligation["requirement_ids"] = [target_requirement]
+    policy, candidate_profile = _requirement_transition(
+        root,
+        target_prompt.decode(),
+        candidate_profile,
     )
     (root / ".pdd/verification-profile-rotations.json").write_text(json.dumps(policy))
     base = _commit(root, "protected transition authority")
@@ -350,7 +1434,10 @@ def test_exact_requirement_transition_updates_human_mapping(tmp_path) -> None:
     assert not profiles.invalid_reasons
     assert profiles.coverage == 1.0
     assert profiles.profiles[0].required_requirement_ids == (requirement,)
-    assert profiles.profiles[0].obligations[0].requirement_ids == (requirement,)
+    assert all(
+        obligation.requirement_ids == (requirement,)
+        for obligation in profiles.profiles[0].obligations
+    )
 
 
 def test_dormant_requirement_transition_survives_unrelated_exact_transition(
@@ -523,7 +1610,7 @@ def test_requirement_transition_rejects_wrong_bound_prompt(tmp_path) -> None:
 
 
 def test_exact_requirement_transition_cannot_remap_validator(tmp_path) -> None:
-    """Exact byte bindings permit only the human requirement-ID replacement."""
+    """Exact byte bindings permit only existing obligation requirement remaps."""
     root = _repository(tmp_path)
     prompt = root / "prompts/widget_python.prompt"
     prompt.write_text("Opaque contract version one\n")
@@ -839,7 +1926,7 @@ def _estimate_updates(monkeypatch, head_profile, head_prompts, head_rotation=Non
         base_ref="protected-base",
         head_ref="candidate-head",
     )
-    authorizations = verification._load_requirement_transition_authorizations(  # pylint: disable=protected-access
+    authorizations, prompts, _new_authorizations = verification._load_requirement_transition_authorizations(  # pylint: disable=protected-access
         ROOT, manifest
     )
     updates, invalid = verification._authorized_requirement_updates(  # pylint: disable=protected-access
@@ -848,6 +1935,7 @@ def _estimate_updates(monkeypatch, head_profile, head_prompts, head_rotation=Non
         _estimate_inputs(PROFILE_FILE.read_bytes()),
         _estimate_inputs(head_profile),
         authorizations,
+        prompts,
     )
     return authorizations, updates, invalid
 
@@ -927,9 +2015,9 @@ def test_estimate_contract_rotations_share_one_exact_profile_transition(
         "wrong-prompt-binding",
         "wrong-policy-binding",
         "cross-unit",
+        "protected-control-deletion",
         "validator-remap",
         "denominator-reduction",
-        "protected-control-deletion",
     ),
 )
 def test_estimate_contract_rotations_reject_substitution(
@@ -1001,6 +2089,7 @@ def test_estimate_contract_rotations_reject_substitution(
         "wrong-prompt-binding",
         "wrong-policy-binding",
         "cross-unit",
+        "protected-control-deletion",
     }:
         _estimate_transition_read(
             monkeypatch,
@@ -1017,8 +2106,10 @@ def test_estimate_contract_rotations_reject_substitution(
         with pytest.raises(
             verification.VerificationProfileError,
             match=(
-                "candidate requirement transition "
+                "candidate (?:requirement transition "
                 "(?:lacks protected authorization|rules are duplicated or ambiguous)"
+                "|removed unconsumed protected requirement transition"
+                "|schema-2 history rewrites protected representation)"
             ),
         ):
             verification._load_requirement_transition_authorizations(  # pylint: disable=protected-access
@@ -1029,7 +2120,7 @@ def test_estimate_contract_rotations_reject_substitution(
     _authorizations, updates, invalid = _estimate_updates(
         monkeypatch, target_profile, target_prompts, head_rotation
     )
-    if substitution in {"protected-control-deletion", "denominator-reduction"}:
+    if substitution == "denominator-reduction":
         assert len(updates) < 2
     else:
         assert invalid


### PR DESCRIPTION
Part of #2093. This PR is a protected-loader prerequisite for the repository-wide manual synchronization; it is not the final prompt/code/architecture/fingerprint consumer PR.

## What this changes

- permits an authority-only Phase A to install exact future requirement-transition rows while prompt and complete verification-profile bytes remain unchanged;
- permits append-only retirement/reissue of an exact protected dormant row only when its complete policy binding is provably unreachable;
- preserves protected authorization and retirement history byte-for-byte, including JSON representation;
- rejects duplicate JSON members, malformed stationary legacy envelopes, non-integer schema encodings, live/consumed retirement, ambiguity, forks/chains/cycles, candidate-local self-authorization, and schema-3 downgrade or empty entry;
- resolves protected aliases to canonical prompt paths and prevents unrelated managed-prompt drift in both Phase A and later Phase B;
- permits only a later candidate, after authority is protected, to consume the exact prepared prompt/profile bytes.

The changed loader, tests, and documentation are explicitly `HUMAN_OWNED`. This prerequisite intentionally changes no prompt, `architecture.json`, `.pddrc`, verification-profile data, generated metadata, or `.pdd/meta` fingerprint.

## Why this lands first

The final repository reconciliation changes protected prompt/profile identities. Candidate-added authority cannot authorize bytes in the same candidate. The authority boundary must become part of protected `main` before a separately reviewed consumer can use it.

The retirement/reissue path also resolves the global verification-profile binding conflict between the already-prepared #1790 and #2058 transitions: after one batch consumes first, the other batch's now-unreachable dormant row can be preserved in history, retired, and reissued against the new exact protected profile bytes.

## Final validation on exact head `691b9955a45fd7dcfc391239b33cc838fc308aba`

Base and merge-base: `88a9a7807ab46f450e35509fb8368549ff9cf8aa`.

- 75 verification-profile tests passed;
- 43 rollout-policy tests passed;
- 24 focused bootstrap cases passed;
- 25 focused retirement, alias, Phase B, and schema cases passed;
- production manifest/profile validation covered 467/467 units with zero violations and 100% profile coverage;
- Ruff, AST/compile, and diff checks passed;
- exact-head GitHub CI: all 11 checks passed;
- full unit rerun: 14,339 passed, 35 skipped, 1 xfailed;
- same Sol-high sole reviewer: `APPROVED`, with no substantive reasons not to merge;
- PDD status: `NOT_APPLICABLE` for this explicitly human-owned loader change;
- reviewer answer to “Should we merge?”: `YES`;
- no staging used.

The first unit attempt hit the same intermittent pre-reporter Vitest failure already reproduced on current `main`; the unchanged harness path is tracked by #2083. The exact-head rerun passed. This residual base-infrastructure risk was disclosed to and accepted by the same Sol-high reviewer.

## Required sequence after this prerequisite

1. Merge this PR only after manager approval.
2. Rebase, re-review, and land #1790.
3. Retire/reissue #2058 authority from the exact post-#1790 protected base, then consume #2058 in its separately reviewed boundary.
4. Rebuild the repository-wide manual-sync authority from that exact `main`; do not reuse stale prepared hashes.
5. Land the separately reviewed Phase A authority-only boundary.
6. Recreate the final manager-facing Phase B manual-sync consumer byte-for-byte, with prompts, code, tests, docs, architecture, verification profiles, and honestly validated fingerprints aligned.

No merge or auto-merge behavior is introduced. Any head-SHA change requires renewed review and CI.
