### PR TITLE
test(sync): attribute namespace revalidator failures

### DIFF
--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -51,6 +51,7 @@ from .types import (
     VerificationProfile,
 )
 from .supervisor import (
+    InfrastructureFailurePhase,
     ImmutableBindingProof,
     PlaywrightSnapshotAggregate,
     SnapshotBindingProof,
@@ -4478,6 +4479,15 @@ def _vitest_infrastructure_termination(
     elif kind == "resource-limit":
         fields.append(f"resource_limit={getattr(termination, 'resource_limit', None) or 'unknown'}")
     if isinstance(termination, SupervisorTermination):
+        phases = tuple(
+            phase.value
+            for phase in termination.failure_phases
+            if isinstance(phase, InfrastructureFailurePhase)
+        )
+        if kind == "sandbox-error" and not phases:
+            phases = (InfrastructureFailurePhase.UNKNOWN.value,)
+        if phases:
+            fields.append("trusted_failure_phases=" + ",".join(phases))
         telemetry = termination.resource_telemetry
         if telemetry is not None:
             fields.extend((

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -51,6 +51,7 @@ from .types import (
     VerificationProfile,
 )
 from .supervisor import (
+    DescriptorPlanFailureStage,
     InfrastructureFailureReason,
     InfrastructureFailurePhase,
     ImmutableBindingProof,
@@ -4494,6 +4495,10 @@ def _vitest_infrastructure_termination(
             if not isinstance(reason, InfrastructureFailureReason):
                 reason = InfrastructureFailureReason.UNKNOWN
             fields.append("trusted_failure_reason=" + reason.value)
+            plan_stage = termination.descriptor_plan_stage
+            if not isinstance(plan_stage, DescriptorPlanFailureStage):
+                plan_stage = DescriptorPlanFailureStage.UNKNOWN
+            fields.append("trusted_descriptor_plan_stage=" + plan_stage.value)
         telemetry = termination.resource_telemetry
         if telemetry is not None:
             fields.extend((

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -51,6 +51,7 @@ from .types import (
     VerificationProfile,
 )
 from .supervisor import (
+    InfrastructureFailureReason,
     InfrastructureFailurePhase,
     ImmutableBindingProof,
     PlaywrightSnapshotAggregate,
@@ -4488,6 +4489,11 @@ def _vitest_infrastructure_termination(
             phases = (InfrastructureFailurePhase.UNKNOWN.value,)
         if phases:
             fields.append("trusted_failure_phases=" + ",".join(phases))
+        if kind == "sandbox-error":
+            reason = termination.failure_reason
+            if not isinstance(reason, InfrastructureFailureReason):
+                reason = InfrastructureFailureReason.UNKNOWN
+            fields.append("trusted_failure_reason=" + reason.value)
         telemetry = termination.resource_telemetry
         if telemetry is not None:
             fields.extend((

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -131,6 +131,22 @@ class TerminationKind(str, Enum):
     SANDBOX_ERROR = "sandbox-error"
 
 
+class InfrastructureFailurePhase(str, Enum):
+    """Allowlisted trusted phase in which sandbox infrastructure failed."""
+
+    UNKNOWN = "unknown"
+    CONSTRUCTION = "construction"
+    LAUNCH = "launch"
+    SCOPE_SETUP = "scope-setup"
+    CANDIDATE_EXECUTION = "candidate-execution"
+    TRUSTED_POSTPROCESSING = "trusted-postprocessing"
+    RESULT_HANDOFF = "result-handoff"
+    SCOPE_CLEANUP = "scope-cleanup"
+    MOUNT_CLEANUP = "mount-cleanup"
+    OUTPUT_DRAIN = "output-drain"
+    PROCESS_CLEANUP = "process-cleanup"
+
+
 @dataclass(frozen=True)
 class CgroupResourceTelemetry:
     """Trusted deltas from the candidate leaf's kernel event counters."""
@@ -150,6 +166,7 @@ class SupervisorTermination:
     timeout_seconds: int | None = None
     resource_limit: str | None = None
     resource_telemetry: CgroupResourceTelemetry | None = None
+    failure_phases: tuple[InfrastructureFailurePhase, ...] = ()
 
 
 class SupervisedCompletedProcess(subprocess.CompletedProcess[str]):  # pylint: disable=too-few-public-methods
@@ -183,13 +200,43 @@ def _supervised_result(
     )
 
 
+def _sandbox_termination(
+    failure_phases: tuple[object, ...],
+    *,
+    resource_telemetry: CgroupResourceTelemetry | None,
+) -> SupervisorTermination:
+    """Return fail-closed evidence containing only trusted phase values."""
+    phases: list[InfrastructureFailurePhase] = []
+    for value in failure_phases:
+        phase = (
+            value
+            if isinstance(value, InfrastructureFailurePhase)
+            else InfrastructureFailurePhase.UNKNOWN
+        )
+        if phase not in phases:
+            phases.append(phase)
+    if not phases:
+        phases.append(InfrastructureFailurePhase.UNKNOWN)
+    return SupervisorTermination(
+        TerminationKind.SANDBOX_ERROR,
+        exit_code=125,
+        resource_telemetry=resource_telemetry,
+        failure_phases=tuple(phases),
+    )
+
+
 def _sandbox_error(
-    command: list[str], detail: str,
+    command: list[str],
+    detail: str,
+    *,
+    failure_phases: tuple[InfrastructureFailurePhase, ...] = (
+        InfrastructureFailurePhase.UNKNOWN,
+    ),
 ) -> tuple[SupervisedCompletedProcess, bool]:
     """Return one typed infrastructure failure for trusted supervisor faults."""
     return _supervised_result(
         command, 125, "", detail,
-        SupervisorTermination(TerminationKind.SANDBOX_ERROR, exit_code=125),
+        _sandbox_termination(failure_phases, resource_telemetry=None),
     ), False
 
 
@@ -3640,18 +3687,38 @@ def run_supervised(
     pids_before: dict[str, int] = {}
     tracked: dict[int, str | None] = {}
     phase = "construction"
+    failure_phases: list[InfrastructureFailurePhase] = []
+
+    phase_values = {
+        "construction": InfrastructureFailurePhase.CONSTRUCTION,
+        "launch-handoff": InfrastructureFailurePhase.LAUNCH,
+        "scope-setup": InfrastructureFailurePhase.SCOPE_SETUP,
+        "candidate-execution": InfrastructureFailurePhase.CANDIDATE_EXECUTION,
+        "trusted-postprocessing": InfrastructureFailurePhase.TRUSTED_POSTPROCESSING,
+        "result-handoff": InfrastructureFailurePhase.RESULT_HANDOFF,
+    }
+
+    def mark_failure(value: InfrastructureFailurePhase | None = None) -> None:
+        trusted = value or phase_values.get(
+            phase, InfrastructureFailurePhase.UNKNOWN
+        )
+        if trusted not in failure_phases:
+            failure_phases.append(trusted)
 
     if result_write_fd is not None:
         try:
             endpoint = os.fstat(result_write_fd)
         except OSError as exc:
             return _sandbox_error(
-                command, f"protected supervisor phase=construction: {exc}"
+                command,
+                f"protected supervisor phase=construction: {exc}",
+                failure_phases=(InfrastructureFailurePhase.CONSTRUCTION,),
             )
         if not stat.S_ISFIFO(endpoint.st_mode) or os.get_inheritable(result_write_fd):
             return _sandbox_error(
                 command,
                 "protected supervisor phase=construction: invalid anonymous observation endpoint",
+                failure_phases=(InfrastructureFailurePhase.CONSTRUCTION,),
             )
 
     def add_diagnostic(value: str) -> None:
@@ -3686,6 +3753,7 @@ def run_supervised(
         if error is None:
             return False
         failed_closed = True
+        mark_failure()
         add_diagnostic(f"protected supervisor phase={phase}: {error}\n")
         return True
 
@@ -3737,7 +3805,9 @@ def run_supervised(
                 _prepare_staging(plan)
             except (OSError, RuntimeError) as exc:
                 return _sandbox_error(
-                    command, f"protected supervisor phase=construction: {exc}"
+                    command,
+                    f"protected supervisor phase=construction: {exc}",
+                    failure_phases=(InfrastructureFailurePhase.CONSTRUCTION,),
                 )
             try:
                 _revalidate_trusted_tools(plan.tools)
@@ -3754,9 +3824,15 @@ def run_supervised(
                         command,
                         "protected supervisor phase=launch: "
                         f"{exc}; cleanup failed: {cleanup_exc}",
+                        failure_phases=(
+                            InfrastructureFailurePhase.LAUNCH,
+                            InfrastructureFailurePhase.MOUNT_CLEANUP,
+                        ),
                     )
                 return _sandbox_error(
-                    command, f"protected supervisor phase=launch: {exc}"
+                    command,
+                    f"protected supervisor phase=launch: {exc}",
+                    failure_phases=(InfrastructureFailurePhase.LAUNCH,),
                 )
 
             assert process.stdin is not None and process.stdout is not None and process.stderr is not None
@@ -3788,6 +3864,7 @@ def run_supervised(
                         raise RuntimeError("protected scope exited before verification")
                     if time.monotonic() >= setup_deadline:
                         failed_closed = True
+                        mark_failure(InfrastructureFailurePhase.SCOPE_SETUP)
                         add_diagnostic(
                             "protected supervisor phase=scope-setup: "
                             "scope construction did not finish\n"
@@ -3810,6 +3887,9 @@ def run_supervised(
                             break
                         if time.monotonic() >= helper_deadline:
                             failed_closed = True
+                            mark_failure(
+                                InfrastructureFailurePhase.CANDIDATE_EXECUTION
+                            )
                             add_diagnostic(
                                 "protected supervisor phase=candidate-execution: "
                                 "protected candidate record did not arrive\n"
@@ -3836,6 +3916,9 @@ def run_supervised(
                                 break
                             if time.monotonic() >= postprocess_deadline:
                                 failed_closed = True
+                                mark_failure(
+                                    InfrastructureFailurePhase.TRUSTED_POSTPROCESSING
+                                )
                                 add_diagnostic(
                                     "protected supervisor trusted postprocessing "
                                     "did not finish\n"
@@ -3878,6 +3961,9 @@ def run_supervised(
                         and not failed_closed
                     ):
                         failed_closed = True
+                        mark_failure(
+                            InfrastructureFailurePhase.CANDIDATE_EXECUTION
+                        )
                         add_diagnostic(
                             "protected supervisor phase=candidate-execution: "
                             "scope produced no protected candidate record\n"
@@ -3887,6 +3973,9 @@ def run_supervised(
                         and not failed_closed
                     ):
                         failed_closed = True
+                        mark_failure(
+                            InfrastructureFailurePhase.TRUSTED_POSTPROCESSING
+                        )
                         add_diagnostic(
                             "protected supervisor phase=trusted-postprocessing: "
                             "scope produced no validated result\n"
@@ -3898,6 +3987,7 @@ def run_supervised(
                         and not failed_closed
                     ):
                         failed_closed = True
+                        mark_failure(InfrastructureFailurePhase.RESULT_HANDOFF)
                         add_diagnostic(
                             "protected supervisor phase=result-handoff: "
                             "candidate used reserved exit status 124\n"
@@ -3909,6 +3999,7 @@ def run_supervised(
                             process.wait(timeout=remaining)
                         except subprocess.TimeoutExpired:
                             failed_closed = True
+                            mark_failure(InfrastructureFailurePhase.RESULT_HANDOFF)
                             add_diagnostic(
                                 "protected supervisor result-handoff did not finish\n"
                             )
@@ -3924,18 +4015,21 @@ def run_supervised(
                         )
                         if process.returncode != expected_helper_exit:
                             failed_closed = True
+                            mark_failure(InfrastructureFailurePhase.RESULT_HANDOFF)
                             add_diagnostic(
                                 "protected supervisor phase=result-handoff: "
                                 "helper exit status mismatch\n"
                             )
                     if (control / "cleanup-error").exists():
                         failed_closed = True
+                        mark_failure(InfrastructureFailurePhase.MOUNT_CLEANUP)
                         add_diagnostic(
                             "protected supervisor phase=mount-cleanup: "
                             "privileged helper cleanup failed\n"
                         )
             except (OSError, ValueError, KeyError, RuntimeError) as exc:
                 failed_closed = True
+                mark_failure()
                 add_diagnostic(f"protected supervisor phase={phase}: {exc}\n")
             finally:
                 if candidate_timed_out:
@@ -3951,6 +4045,7 @@ def run_supervised(
                         process.wait(timeout=_TRUSTED_COMMAND_SECONDS)
                     except subprocess.TimeoutExpired:
                         failed_closed = True
+                        mark_failure(InfrastructureFailurePhase.SCOPE_CLEANUP)
                         add_diagnostic(
                             "protected supervisor phase=scope-cleanup: "
                             "helper did not terminate\n"
@@ -3959,6 +4054,7 @@ def run_supervised(
                     _stop_scope(plan.unit_name, plan.tools)
                 except RuntimeError as exc:
                     failed_closed = True
+                    mark_failure(InfrastructureFailurePhase.SCOPE_CLEANUP)
                     add_diagnostic(f"protected supervisor phase=scope-cleanup: {exc}\n")
                 if process.poll() is None:
                     try:
@@ -3969,6 +4065,7 @@ def run_supervised(
                     process.wait(timeout=_TRUSTED_COMMAND_SECONDS)
                 except subprocess.TimeoutExpired:
                     failed_closed = True
+                    mark_failure(InfrastructureFailurePhase.SCOPE_CLEANUP)
                     add_diagnostic(
                         "protected supervisor phase=scope-cleanup: "
                         "helper did not terminate after scope stop\n"
@@ -3977,12 +4074,14 @@ def run_supervised(
                     _cleanup_staging(plan)
                 except RuntimeError as exc:
                     failed_closed = True
+                    mark_failure(InfrastructureFailurePhase.MOUNT_CLEANUP)
                     add_diagnostic(f"protected supervisor phase=mount-cleanup: {exc}\n")
     finally:
         for output_thread in output_threads:
             output_thread.join(timeout=1)
             if output_thread.is_alive():
                 failed_closed = True
+                mark_failure(InfrastructureFailurePhase.OUTPUT_DRAIN)
                 add_diagnostic("protected supervisor output drain did not finish\n")
         observed = set()
         if process is not None:
@@ -3991,6 +4090,7 @@ def run_supervised(
                 observed.discard(process.pid)
             except RuntimeError as exc:
                 failed_closed = True
+                mark_failure(InfrastructureFailurePhase.PROCESS_CLEANUP)
                 add_diagnostic(f"protected supervisor process cleanup failed: {exc}\n")
         for pid in observed:
             tracked.setdefault(pid, _process_identity(pid))
@@ -3998,6 +4098,7 @@ def run_supervised(
         if descendants:
             surviving = True
             failed_closed = True
+            mark_failure(InfrastructureFailurePhase.PROCESS_CLEANUP)
             for pid in descendants:
                 try:
                     os.kill(pid, signal.SIGKILL)
@@ -4011,6 +4112,7 @@ def run_supervised(
     stderr_bytes += bytes(diagnostics[:remaining])
     if output_overflow:
         failed_closed = True
+        mark_failure(InfrastructureFailurePhase.OUTPUT_DRAIN)
     returncode = 125 if failed_closed else (
         124 if candidate_timed_out else candidate_returncode
     )
@@ -4022,7 +4124,10 @@ def run_supervised(
         stdout_bytes.decode("utf-8", errors="replace"),
         stderr_bytes.decode("utf-8", errors="replace"),
         (
-            SupervisorTermination(TerminationKind.SANDBOX_ERROR, exit_code=125)
+            _sandbox_termination(
+                tuple(failure_phases),
+                resource_telemetry=resource_telemetry,
+            )
             if failed_closed else _termination_evidence(
                 returncode, timed_out=candidate_timed_out, timeout_seconds=timeout,
                 resource_limit=resource_limit,

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -3955,6 +3955,27 @@ def run_supervised(
                 )
             try:
                 _revalidate_trusted_tools(plan.tools)
+            except _InfrastructureFailure as exc:
+                try:
+                    _cleanup_staging(plan)
+                except RuntimeError as cleanup_exc:
+                    return _sandbox_error(
+                        command,
+                        "protected supervisor phase=construction: "
+                        f"{exc}; cleanup failed: {cleanup_exc}",
+                        failure_phases=(
+                            InfrastructureFailurePhase.CONSTRUCTION,
+                            InfrastructureFailurePhase.MOUNT_CLEANUP,
+                        ),
+                        failure_reason=exc.reason,
+                    )
+                return _sandbox_error(
+                    command,
+                    f"protected supervisor phase=construction: {exc}",
+                    failure_phases=(InfrastructureFailurePhase.CONSTRUCTION,),
+                    failure_reason=exc.reason,
+                )
+            try:
                 process = subprocess.Popen(
                     argv, cwd=Path("/"), stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -3459,8 +3459,25 @@ def _run_playwright_descriptor_supervised(
     resource_limit: str | None = None
     resource_telemetry: CgroupResourceTelemetry | None = None
     phase = "construction"
+    failure_phases: list[InfrastructureFailurePhase] = []
     candidate_stdout = b""
     candidate_stderr = b""
+
+    phase_values = {
+        "construction": InfrastructureFailurePhase.CONSTRUCTION,
+        "launch": InfrastructureFailurePhase.LAUNCH,
+        "scope-setup": InfrastructureFailurePhase.SCOPE_SETUP,
+        "candidate-execution": InfrastructureFailurePhase.CANDIDATE_EXECUTION,
+        "trusted-postprocessing": InfrastructureFailurePhase.TRUSTED_POSTPROCESSING,
+        "result-handoff": InfrastructureFailurePhase.RESULT_HANDOFF,
+    }
+
+    def mark_failure(value: InfrastructureFailurePhase | None = None) -> None:
+        trusted = value or phase_values.get(
+            phase, InfrastructureFailurePhase.UNKNOWN
+        )
+        if trusted not in failure_phases:
+            failure_phases.append(trusted)
 
     def add_diagnostic(value: str) -> None:
         remaining = max(0, limits.max_output_bytes - len(diagnostics))
@@ -3580,6 +3597,7 @@ def _run_playwright_descriptor_supervised(
                 raise RuntimeError("protected descriptor helper exit status mismatch")
     except (OSError, RuntimeError, subprocess.TimeoutExpired) as exc:
         failed_closed = True
+        mark_failure()
         add_diagnostic(f"protected supervisor phase={phase}: {exc}\n")
     finally:
         if process is not None and process.poll() is None:
@@ -3592,24 +3610,29 @@ def _run_playwright_descriptor_supervised(
                 _stop_scope(plan.unit_name, plan.tools)
             except RuntimeError as exc:
                 failed_closed = True
+                mark_failure(InfrastructureFailurePhase.SCOPE_CLEANUP)
                 add_diagnostic(f"protected supervisor phase=scope-cleanup: {exc}\n")
         if process is not None:
             try:
                 process.wait(timeout=_TRUSTED_COMMAND_SECONDS)
             except subprocess.TimeoutExpired:
                 failed_closed = True
+                mark_failure(InfrastructureFailurePhase.SCOPE_CLEANUP)
+                mark_failure(InfrastructureFailurePhase.PROCESS_CLEANUP)
                 add_diagnostic("protected supervisor phase=scope-cleanup: helper did not terminate\n")
         if plan is not None:
             try:
                 _cleanup_staging(plan)
             except RuntimeError as exc:
                 failed_closed = True
+                mark_failure(InfrastructureFailurePhase.MOUNT_CLEANUP)
                 add_diagnostic(f"protected supervisor phase=mount-cleanup: {exc}\n")
         for thread in (stderr_reader,):
             if thread is not None:
                 thread.join(timeout=1)
                 if thread.is_alive():
                     failed_closed = True
+                    mark_failure(InfrastructureFailurePhase.OUTPUT_DRAIN)
                     add_diagnostic("protected descriptor transport did not close\n")
     return _supervised_result(
         command,
@@ -3619,7 +3642,10 @@ def _run_playwright_descriptor_supervised(
             "utf-8", errors="replace"
         ),
         (
-            SupervisorTermination(TerminationKind.SANDBOX_ERROR, exit_code=125)
+            _sandbox_termination(
+                tuple(failure_phases),
+                resource_telemetry=resource_telemetry,
+            )
             if failed_closed else _termination_evidence(
                 124 if timed_out else candidate_returncode,
                 timed_out=timed_out, timeout_seconds=timeout,
@@ -3652,6 +3678,7 @@ def run_supervised(
             return _sandbox_error(
                 command,
                 "protected supervisor phase=construction: invalid Playwright descriptor endpoint",
+                failure_phases=(InfrastructureFailurePhase.CONSTRUCTION,),
             )
         return _run_playwright_descriptor_supervised(
             command, cwd=cwd, timeout=timeout, env=env, writable_roots=writable_roots,

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -147,6 +147,29 @@ class InfrastructureFailurePhase(str, Enum):
     PROCESS_CLEANUP = "process-cleanup"
 
 
+class InfrastructureFailureReason(str, Enum):
+    """Allowlisted trusted reason for a sandbox infrastructure failure."""
+
+    UNKNOWN = "unknown"
+    TRUSTED_TOOL_DISCOVERY = "trusted-tool-discovery"
+    TRUSTED_TOOL_IDENTITY = "trusted-tool-identity"
+    TRUSTED_TOOL_REVALIDATION = "trusted-tool-revalidation"
+    RUNTIME_DEPENDENCY_DISCOVERY = "runtime-dependency-discovery"
+    SUDO_PRIVILEGE_PROBE = "sudo-privilege-probe"
+    WRITABLE_ACCOUNTING = "writable-accounting"
+    WRITABLE_QUOTA = "writable-quota"
+    DESCRIPTOR_PLAN_CONSTRUCTION = "descriptor-plan-construction"
+    STAGING_PREPARATION = "staging-preparation"
+
+
+class _InfrastructureFailure(RuntimeError):
+    """Carry one trusted reason without deriving authority from exception text."""
+
+    def __init__(self, reason: InfrastructureFailureReason, detail: str) -> None:
+        super().__init__(detail)
+        self.reason = reason
+
+
 @dataclass(frozen=True)
 class CgroupResourceTelemetry:
     """Trusted deltas from the candidate leaf's kernel event counters."""
@@ -157,6 +180,7 @@ class CgroupResourceTelemetry:
 
 
 @dataclass(frozen=True)
+# pylint: disable-next=too-many-instance-attributes
 class SupervisorTermination:
     """Typed termination evidence retained outside candidate-controlled output."""
 
@@ -167,6 +191,7 @@ class SupervisorTermination:
     resource_limit: str | None = None
     resource_telemetry: CgroupResourceTelemetry | None = None
     failure_phases: tuple[InfrastructureFailurePhase, ...] = ()
+    failure_reason: InfrastructureFailureReason | None = None
 
 
 class SupervisedCompletedProcess(subprocess.CompletedProcess[str]):  # pylint: disable=too-few-public-methods
@@ -204,6 +229,7 @@ def _sandbox_termination(
     failure_phases: tuple[object, ...],
     *,
     resource_telemetry: CgroupResourceTelemetry | None,
+    failure_reason: object = InfrastructureFailureReason.UNKNOWN,
 ) -> SupervisorTermination:
     """Return fail-closed evidence containing only trusted phase values."""
     phases: list[InfrastructureFailurePhase] = []
@@ -217,11 +243,17 @@ def _sandbox_termination(
             phases.append(phase)
     if not phases:
         phases.append(InfrastructureFailurePhase.UNKNOWN)
+    reason = (
+        failure_reason
+        if isinstance(failure_reason, InfrastructureFailureReason)
+        else InfrastructureFailureReason.UNKNOWN
+    )
     return SupervisorTermination(
         TerminationKind.SANDBOX_ERROR,
         exit_code=125,
         resource_telemetry=resource_telemetry,
         failure_phases=tuple(phases),
+        failure_reason=reason,
     )
 
 
@@ -232,11 +264,16 @@ def _sandbox_error(
     failure_phases: tuple[InfrastructureFailurePhase, ...] = (
         InfrastructureFailurePhase.UNKNOWN,
     ),
+    failure_reason: InfrastructureFailureReason = InfrastructureFailureReason.UNKNOWN,
 ) -> tuple[SupervisedCompletedProcess, bool]:
     """Return one typed infrastructure failure for trusted supervisor faults."""
     return _supervised_result(
         command, 125, "", detail,
-        _sandbox_termination(failure_phases, resource_telemetry=None),
+        _sandbox_termination(
+            failure_phases,
+            resource_telemetry=None,
+            failure_reason=failure_reason,
+        ),
     ), False
 
 
@@ -1465,8 +1502,17 @@ def _trusted_executable(name: str) -> _ExecutableIdentity:
     """Resolve one root-owned executable from the fixed trusted PATH."""
     value = shutil.which(name, path=_TRUSTED_ROOT_PATH)
     if value is None:
-        raise RuntimeError(f"protected sandbox requires trusted {name}")
-    return _executable_identity(Path(value))
+        raise _InfrastructureFailure(
+            InfrastructureFailureReason.TRUSTED_TOOL_DISCOVERY,
+            f"protected sandbox requires trusted {name}",
+        )
+    try:
+        return _executable_identity(Path(value))
+    except RuntimeError as exc:
+        raise _InfrastructureFailure(
+            InfrastructureFailureReason.TRUSTED_TOOL_IDENTITY,
+            "protected sandbox trusted tool identity failed",
+        ) from exc
 
 
 def _trusted_helper_python() -> _ExecutableIdentity:
@@ -1498,8 +1544,14 @@ def _trusted_tools() -> _TrustedTools:
 
 def _revalidate_trusted_tools(tools: _TrustedTools) -> None:
     """Revalidate every executable immediately before a privileged transition."""
-    for identity in getattr(tools, "identities", ()):
-        _revalidate_executable(identity)
+    try:
+        for identity in getattr(tools, "identities", ()):
+            _revalidate_executable(identity)
+    except RuntimeError as exc:
+        raise _InfrastructureFailure(
+            InfrastructureFailureReason.TRUSTED_TOOL_REVALIDATION,
+            "protected sandbox trusted tool revalidation failed",
+        ) from exc
 
 
 def _privileged_helper_environment() -> dict[str, str]:
@@ -1516,8 +1568,11 @@ def _linked_libraries(path: Path) -> tuple[Path, ...]:
             ["ldd", str(path)], capture_output=True, text=True, check=False,
             timeout=_TRUSTED_COMMAND_SECONDS,
         )
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError("trusted ldd command timed out") from exc
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise _InfrastructureFailure(
+            InfrastructureFailureReason.RUNTIME_DEPENDENCY_DISCOVERY,
+            "trusted runtime dependency discovery failed",
+        ) from exc
     libraries: set[Path] = set()
     for line in result.stdout.splitlines():
         fields = line.strip().split()
@@ -3069,16 +3124,32 @@ def _sandbox_command(
                 timeout=_TRUSTED_COMMAND_SECONDS,
             )
         except subprocess.TimeoutExpired as exc:
-            raise RuntimeError("trusted sudo probe timed out") from exc
+            raise _InfrastructureFailure(
+                InfrastructureFailureReason.SUDO_PRIVILEGE_PROBE,
+                "trusted sudo probe timed out",
+            ) from exc
         if privilege_probe.returncode != 0:
-            raise RuntimeError("protected sandbox requires privileged bind staging")
+            raise _InfrastructureFailure(
+                InfrastructureFailureReason.SUDO_PRIVILEGE_PROBE,
+                "protected sandbox requires privileged bind staging",
+            )
         workdir = (cwd or Path.cwd()).resolve()
         writable_sources = tuple(
             source for source, _destination in writable_bindings
         ) + writable_roots
-        storage_roots = _writable_storage_roots(writable_sources)
-        if _writable_size(storage_roots) > limits.max_writable_bytes:
-            raise RuntimeError("initial writable quota exceeded")
+        try:
+            storage_roots = _writable_storage_roots(writable_sources)
+            writable_bytes = _writable_size(storage_roots)
+        except RuntimeError as exc:
+            raise _InfrastructureFailure(
+                InfrastructureFailureReason.WRITABLE_ACCOUNTING,
+                "protected writable accounting failed",
+            ) from exc
+        if writable_bytes > limits.max_writable_bytes:
+            raise _InfrastructureFailure(
+                InfrastructureFailureReason.WRITABLE_QUOTA,
+                "initial writable quota exceeded",
+            )
         # Keep the host cgroup namespace while exposing only the candidate leaf
         # below. A namespace rooted at the monitor cannot migrate the child into
         # its sibling candidate leaf; the read-only candidate uid still cannot
@@ -3460,6 +3531,7 @@ def _run_playwright_descriptor_supervised(
     resource_telemetry: CgroupResourceTelemetry | None = None
     phase = "construction"
     failure_phases: list[InfrastructureFailurePhase] = []
+    failure_reason = InfrastructureFailureReason.UNKNOWN
     candidate_stdout = b""
     candidate_stderr = b""
 
@@ -3494,22 +3566,36 @@ def _run_playwright_descriptor_supervised(
             raise RuntimeError("invalid anonymous observation endpoint")
         with tempfile.TemporaryDirectory(prefix="pdd-scope-") as control_value:
             control = Path(control_value)
-            argv, plan = _sandbox_command(
-                command, writable_roots, cwd=cwd, limits=limits,
-                readable_roots=readable_roots, readable_bindings=readable_bindings,
-                immutable_binding_proofs=immutable_binding_proofs,
-                snapshot_binding_proofs=snapshot_binding_proofs,
-                playwright_snapshot_aggregate=playwright_snapshot_aggregate,
-                writable_bindings=writable_bindings, result_write_fd=result_write_fd,
-                result_fd=result_fd, observation_nonce=nonce, candidate_timeout=timeout,
-                unit_name=_scope_unit_name(), control_directory=control,
-                candidate_environment_values=env,
-                candidate_temp_directory=(
-                    temp_directory or writable_roots[0].resolve()
-                ),
-                supervision_token=supervision_token,
-            )
-            _prepare_staging(plan)
+            try:
+                argv, plan = _sandbox_command(
+                    command, writable_roots, cwd=cwd, limits=limits,
+                    readable_roots=readable_roots, readable_bindings=readable_bindings,
+                    immutable_binding_proofs=immutable_binding_proofs,
+                    snapshot_binding_proofs=snapshot_binding_proofs,
+                    playwright_snapshot_aggregate=playwright_snapshot_aggregate,
+                    writable_bindings=writable_bindings, result_write_fd=result_write_fd,
+                    result_fd=result_fd, observation_nonce=nonce, candidate_timeout=timeout,
+                    unit_name=_scope_unit_name(), control_directory=control,
+                    candidate_environment_values=env,
+                    candidate_temp_directory=(
+                        temp_directory or writable_roots[0].resolve()
+                    ),
+                    supervision_token=supervision_token,
+                )
+            except _InfrastructureFailure:
+                raise
+            except (OSError, RuntimeError) as exc:
+                raise _InfrastructureFailure(
+                    InfrastructureFailureReason.DESCRIPTOR_PLAN_CONSTRUCTION,
+                    "protected descriptor plan construction failed",
+                ) from exc
+            try:
+                _prepare_staging(plan)
+            except (OSError, RuntimeError) as exc:
+                raise _InfrastructureFailure(
+                    InfrastructureFailureReason.STAGING_PREPARATION,
+                    "protected staging preparation failed",
+                ) from exc
             _revalidate_trusted_tools(plan.tools)
             phase = "launch"
             process = subprocess.Popen(
@@ -3595,9 +3681,18 @@ def _run_playwright_descriptor_supervised(
             )
             if process.returncode != expected_helper_exit:
                 raise RuntimeError("protected descriptor helper exit status mismatch")
+    except _InfrastructureFailure as exc:
+        failed_closed = True
+        mark_failure()
+        failure_reason = exc.reason
+        add_diagnostic(f"protected supervisor phase={phase}: {exc}\n")
     except (OSError, RuntimeError, subprocess.TimeoutExpired) as exc:
         failed_closed = True
         mark_failure()
+        if phase == "construction":
+            failure_reason = (
+                InfrastructureFailureReason.DESCRIPTOR_PLAN_CONSTRUCTION
+            )
         add_diagnostic(f"protected supervisor phase={phase}: {exc}\n")
     finally:
         if process is not None and process.poll() is None:
@@ -3645,6 +3740,7 @@ def _run_playwright_descriptor_supervised(
             _sandbox_termination(
                 tuple(failure_phases),
                 resource_telemetry=resource_telemetry,
+                failure_reason=failure_reason,
             )
             if failed_closed else _termination_evidence(
                 124 if timed_out else candidate_returncode,
@@ -3679,6 +3775,9 @@ def run_supervised(
                 command,
                 "protected supervisor phase=construction: invalid Playwright descriptor endpoint",
                 failure_phases=(InfrastructureFailurePhase.CONSTRUCTION,),
+                failure_reason=(
+                    InfrastructureFailureReason.DESCRIPTOR_PLAN_CONSTRUCTION
+                ),
             )
         return _run_playwright_descriptor_supervised(
             command, cwd=cwd, timeout=timeout, env=env, writable_roots=writable_roots,
@@ -3829,12 +3928,30 @@ def run_supervised(
                     ),
                     supervision_token=token,
                 )
+            except _InfrastructureFailure as exc:
+                return _sandbox_error(
+                    command,
+                    f"protected supervisor phase=construction: {exc}",
+                    failure_phases=(InfrastructureFailurePhase.CONSTRUCTION,),
+                    failure_reason=exc.reason,
+                )
+            except (OSError, RuntimeError) as exc:
+                return _sandbox_error(
+                    command,
+                    f"protected supervisor phase=construction: {exc}",
+                    failure_phases=(InfrastructureFailurePhase.CONSTRUCTION,),
+                    failure_reason=(
+                        InfrastructureFailureReason.DESCRIPTOR_PLAN_CONSTRUCTION
+                    ),
+                )
+            try:
                 _prepare_staging(plan)
             except (OSError, RuntimeError) as exc:
                 return _sandbox_error(
                     command,
                     f"protected supervisor phase=construction: {exc}",
                     failure_phases=(InfrastructureFailurePhase.CONSTRUCTION,),
+                    failure_reason=InfrastructureFailureReason.STAGING_PREPARATION,
                 )
             try:
                 _revalidate_trusted_tools(plan.tools)

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -19,7 +19,8 @@ import tempfile
 import threading
 import time
 import uuid
-from functools import lru_cache
+from contextvars import ContextVar
+from functools import lru_cache, wraps
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path, PurePosixPath
@@ -162,12 +163,65 @@ class InfrastructureFailureReason(str, Enum):
     STAGING_PREPARATION = "staging-preparation"
 
 
+class DescriptorPlanFailureStage(str, Enum):
+    """Allowlisted trusted stage within descriptor-plan construction."""
+
+    UNKNOWN = "unknown"
+    INPUT_TRANSPORT_VALIDATION = "input-transport-validation"
+    PROOF_VALIDATION = "immutable-snapshot-proof-validation"
+    CANDIDATE_ENVIRONMENT = "candidate-environment"
+    SOURCE_PATH_COLLISION_PLANNING = "source-path-collision-planning"
+    INFERRED_RUNTIME_BINDING = "inferred-runtime-binding"
+    EXECUTABLE_NATIVE_RUNTIME_BINDING = "executable-native-runtime-binding"
+    RESULT_OBSERVATION_BINDING = "result-fifo-observation-binding"
+    HELPER_PAYLOAD_SERIALIZATION = "helper-payload-serialization"
+    DESCRIPTOR_FRAME_SIZE = "descriptor-frame-size"
+
+
 class _InfrastructureFailure(RuntimeError):
     """Carry one trusted reason without deriving authority from exception text."""
 
     def __init__(self, reason: InfrastructureFailureReason, detail: str) -> None:
         super().__init__(detail)
         self.reason = reason
+
+
+class _DescriptorPlanFailure(RuntimeError):
+    """Carry one trusted plan stage without inspecting exception prose."""
+
+    def __init__(
+        self,
+        stage: DescriptorPlanFailureStage,
+        detail: str = "protected descriptor plan construction failed",
+    ) -> None:
+        super().__init__(detail)
+        self.stage = stage
+
+
+_DESCRIPTOR_PLAN_STAGE = ContextVar(
+    "pdd_descriptor_plan_stage",
+    default=DescriptorPlanFailureStage.UNKNOWN,
+)
+
+
+def _classify_descriptor_plan(function):
+    """Convert ordinary plan failures using the explicitly selected stage."""
+    @wraps(function)
+    def classified(*args, **kwargs):
+        token = _DESCRIPTOR_PLAN_STAGE.set(
+            DescriptorPlanFailureStage.INPUT_TRANSPORT_VALIDATION
+        )
+        try:
+            return function(*args, **kwargs)
+        except (_InfrastructureFailure, _DescriptorPlanFailure):
+            raise
+        except (OSError, RuntimeError) as exc:
+            raise _DescriptorPlanFailure(
+                _DESCRIPTOR_PLAN_STAGE.get(), str(exc)
+            ) from exc
+        finally:
+            _DESCRIPTOR_PLAN_STAGE.reset(token)
+    return classified
 
 
 @dataclass(frozen=True)
@@ -192,6 +246,7 @@ class SupervisorTermination:
     resource_telemetry: CgroupResourceTelemetry | None = None
     failure_phases: tuple[InfrastructureFailurePhase, ...] = ()
     failure_reason: InfrastructureFailureReason | None = None
+    descriptor_plan_stage: DescriptorPlanFailureStage | None = None
 
 
 class SupervisedCompletedProcess(subprocess.CompletedProcess[str]):  # pylint: disable=too-few-public-methods
@@ -230,6 +285,7 @@ def _sandbox_termination(
     *,
     resource_telemetry: CgroupResourceTelemetry | None,
     failure_reason: object = InfrastructureFailureReason.UNKNOWN,
+    descriptor_plan_stage: object = DescriptorPlanFailureStage.UNKNOWN,
 ) -> SupervisorTermination:
     """Return fail-closed evidence containing only trusted phase values."""
     phases: list[InfrastructureFailurePhase] = []
@@ -248,12 +304,18 @@ def _sandbox_termination(
         if isinstance(failure_reason, InfrastructureFailureReason)
         else InfrastructureFailureReason.UNKNOWN
     )
+    plan_stage = (
+        descriptor_plan_stage
+        if isinstance(descriptor_plan_stage, DescriptorPlanFailureStage)
+        else DescriptorPlanFailureStage.UNKNOWN
+    )
     return SupervisorTermination(
         TerminationKind.SANDBOX_ERROR,
         exit_code=125,
         resource_telemetry=resource_telemetry,
         failure_phases=tuple(phases),
         failure_reason=reason,
+        descriptor_plan_stage=plan_stage,
     )
 
 
@@ -265,6 +327,7 @@ def _sandbox_error(
         InfrastructureFailurePhase.UNKNOWN,
     ),
     failure_reason: InfrastructureFailureReason = InfrastructureFailureReason.UNKNOWN,
+    descriptor_plan_stage: DescriptorPlanFailureStage = DescriptorPlanFailureStage.UNKNOWN,
 ) -> tuple[SupervisedCompletedProcess, bool]:
     """Return one typed infrastructure failure for trusted supervisor faults."""
     return _supervised_result(
@@ -273,6 +336,7 @@ def _sandbox_error(
             failure_phases,
             resource_telemetry=None,
             failure_reason=failure_reason,
+            descriptor_plan_stage=descriptor_plan_stage,
         ),
     ), False
 
@@ -1982,6 +2046,9 @@ def _staged_bwrap(
 ) -> tuple[list[str], _ScopePlan]:
     """Build one scope-held helper that releases Bubblewrap after verification."""
     # pylint: disable=too-many-locals
+    _DESCRIPTOR_PLAN_STAGE.set(
+        DescriptorPlanFailureStage.HELPER_PAYLOAD_SERIALIZATION
+    )
     unit_name = _validated_scope_unit(unit_name)
     tool_manifest = _canonical_json({
         name: identity.payload() for name, identity in zip(
@@ -2542,6 +2609,7 @@ def _staged_bwrap(
             "output": limits.max_output_bytes,
         },
     }
+    _DESCRIPTOR_PLAN_STAGE.set(DescriptorPlanFailureStage.DESCRIPTOR_FRAME_SIZE)
     _descriptor_frame(launch_payload, _DESCRIPTOR_PROTOCOL_MAX_LAUNCH_BYTES)
     plan = _ScopePlan(
         unit_name, control_directory, helper, tuple(argv), tuple(sources),
@@ -3063,6 +3131,7 @@ def _cleanup_staging(plan: _ScopePlan) -> None:
         raise RuntimeError("protected scope staging cleanup failed: " + "; ".join(errors))
 
 
+@_classify_descriptor_plan
 def _sandbox_command(
     command: list[str], writable_roots: tuple[Path, ...], *, cwd: Path | None = None,
     limits: SupervisorLimits = SupervisorLimits(),
@@ -3167,9 +3236,13 @@ def _sandbox_command(
         proofs: dict[tuple[Path, Path, Path], _ValidatedBindingProof] = {}
         raw_proofs: dict[tuple[Path, Path, Path], ImmutableBindingProof] = {}
         snapshots: dict[tuple[Path, Path], SnapshotBindingProof] = {}
+        _DESCRIPTOR_PLAN_STAGE.set(DescriptorPlanFailureStage.PROOF_VALIDATION)
         aggregate_payload = (
             _validate_playwright_snapshot_aggregate(playwright_snapshot_aggregate)
             if playwright_snapshot_aggregate is not None else None
+        )
+        _DESCRIPTOR_PLAN_STAGE.set(
+            DescriptorPlanFailureStage.INPUT_TRANSPORT_VALIDATION
         )
         if (aggregate_payload is None) != (result_write_fd is None):
             raise RuntimeError("Playwright aggregate and anonymous observation must pair")
@@ -3180,6 +3253,7 @@ def _sandbox_command(
             raise RuntimeError("Playwright observation requires a fresh parent nonce")
         if result_fifo is not None and result_write_fd is not None:
             raise RuntimeError("framework observation transports conflict")
+        _DESCRIPTOR_PLAN_STAGE.set(DescriptorPlanFailureStage.PROOF_VALIDATION)
         for proof in snapshot_binding_proofs:
             _validate_snapshot_binding_proof(proof)
             key = (proof.source.resolve(strict=True), proof.destination)
@@ -3258,7 +3332,9 @@ def _sandbox_command(
                         relative = source.relative_to(root).as_posix() or "."
                         writable_specs.append((token, index, relative))
                         return token, None
-                raise RuntimeError("writable source is outside bounded storage")
+                raise _DescriptorPlanFailure(
+                    DescriptorPlanFailureStage.SOURCE_PATH_COLLISION_PLANNING
+                )
             source_index = len(sources)
             sources.append(source)
             path_tokens.append(token)
@@ -3279,6 +3355,9 @@ def _sandbox_command(
             category: str, defer_mount: bool = False,
         ) -> None:
             destination = destination or source
+            _DESCRIPTOR_PLAN_STAGE.set(
+                DescriptorPlanFailureStage.SOURCE_PATH_COLLISION_PLANNING
+            )
             resolved_source = source.resolve()
             previous = mounted.get(destination)
             if previous is not None and previous[:2] == (option, resolved_source):
@@ -3372,6 +3451,9 @@ def _sandbox_command(
                 "--ro-bind", source.resolve(), destination,
                 category="declared_readable", defer_mount=True,
             )
+        _DESCRIPTOR_PLAN_STAGE.set(
+            DescriptorPlanFailureStage.INFERRED_RUNTIME_BINDING
+        )
         for item in _runtime_roots(command, workdir):
             # A host bind follows symlinks, but the process command and ELF
             # loader retain their original spellings in the new namespace.
@@ -3387,15 +3469,24 @@ def _sandbox_command(
         # ``setpriv`` and the root helper interpreter execute after the
         # namespace root is installed. Bind each exact invoked spelling with
         # only its ELF closure and selected native Python stdlib root.
+        _DESCRIPTOR_PLAN_STAGE.set(
+            DescriptorPlanFailureStage.EXECUTABLE_NATIVE_RUNTIME_BINDING
+        )
         for executable in (tools.setpriv, tools.helper_python):
             for item in (
                 executable, *_linked_libraries(executable),
                 *_native_python_runtime_roots(executable),
             ):
                 bind("--ro-bind", item.resolve(), item, category="trusted_runtime")
+        _DESCRIPTOR_PLAN_STAGE.set(
+            DescriptorPlanFailureStage.SOURCE_PATH_COLLISION_PLANNING
+        )
         for item in readable_roots:
             bind("--ro-bind", item.resolve(), category="readable_root")
         if result_fifo is not None:
+            _DESCRIPTOR_PLAN_STAGE.set(
+                DescriptorPlanFailureStage.RESULT_OBSERVATION_BINDING
+            )
             observation_source = result_fifo.resolve(strict=True)
             if not stat.S_ISFIFO(observation_source.lstat().st_mode):
                 raise RuntimeError("framework observation channel must be a FIFO")
@@ -3422,6 +3513,9 @@ def _sandbox_command(
              "--clear-groups", "--"]
         )
         if candidate_environment_values is not None:
+            _DESCRIPTOR_PLAN_STAGE.set(
+                DescriptorPlanFailureStage.CANDIDATE_ENVIRONMENT
+            )
             if candidate_temp_directory is None or supervision_token is None:
                 raise RuntimeError("protected candidate environment is invalid")
             candidate_environment = _candidate_environment_record(
@@ -3431,10 +3525,16 @@ def _sandbox_command(
             )
         sandboxed = _limited_command(command, limits, candidate_environment)
         if result_fifo is not None:
+            _DESCRIPTOR_PLAN_STAGE.set(
+                DescriptorPlanFailureStage.RESULT_OBSERVATION_BINDING
+            )
             sandboxed = _framework_observation_command(
                 sandboxed, result_fd, _FRAMEWORK_OBSERVATION_PATH
             )
         elif result_write_fd is not None:
+            _DESCRIPTOR_PLAN_STAGE.set(
+                DescriptorPlanFailureStage.RESULT_OBSERVATION_BINDING
+            )
             if playwright_snapshot_aggregate.result_fd != result_fd:
                 raise RuntimeError("Playwright observation descriptor mismatch")
             sandboxed = _anonymous_framework_observation_command(
@@ -3446,11 +3546,15 @@ def _sandbox_command(
             _INNER_STATUS_SUPERVISOR_SOURCE, str(status_fd),
             "@PDD-TERMINATION-TOKEN@", "/sys/fs/cgroup", *drop, *sandboxed,
         ))
+        _DESCRIPTOR_PLAN_STAGE.set(DescriptorPlanFailureStage.PROOF_VALIDATION)
         if consumed_proofs != proofs.keys():
             raise RuntimeError("protected sandbox has unused immutable binding proof")
         if len(accepted_snapshots) != len(snapshots):
             raise RuntimeError("protected sandbox has unused snapshot binding proof")
         aggregate_record = None
+        _DESCRIPTOR_PLAN_STAGE.set(
+            DescriptorPlanFailureStage.HELPER_PAYLOAD_SERIALIZATION
+        )
         if aggregate_payload is not None:
             protocol_members = []
             for member in aggregate_payload["members"]:
@@ -3532,6 +3636,7 @@ def _run_playwright_descriptor_supervised(
     phase = "construction"
     failure_phases: list[InfrastructureFailurePhase] = []
     failure_reason = InfrastructureFailureReason.UNKNOWN
+    descriptor_plan_stage = DescriptorPlanFailureStage.UNKNOWN
     candidate_stdout = b""
     candidate_stderr = b""
 
@@ -3686,6 +3791,12 @@ def _run_playwright_descriptor_supervised(
         mark_failure()
         failure_reason = exc.reason
         add_diagnostic(f"protected supervisor phase={phase}: {exc}\n")
+    except _DescriptorPlanFailure as exc:
+        failed_closed = True
+        mark_failure()
+        failure_reason = InfrastructureFailureReason.DESCRIPTOR_PLAN_CONSTRUCTION
+        descriptor_plan_stage = exc.stage
+        add_diagnostic(f"protected supervisor phase={phase}: {exc}\n")
     except (OSError, RuntimeError, subprocess.TimeoutExpired) as exc:
         failed_closed = True
         mark_failure()
@@ -3741,6 +3852,7 @@ def _run_playwright_descriptor_supervised(
                 tuple(failure_phases),
                 resource_telemetry=resource_telemetry,
                 failure_reason=failure_reason,
+                descriptor_plan_stage=descriptor_plan_stage,
             )
             if failed_closed else _termination_evidence(
                 124 if timed_out else candidate_returncode,
@@ -3777,6 +3889,9 @@ def run_supervised(
                 failure_phases=(InfrastructureFailurePhase.CONSTRUCTION,),
                 failure_reason=(
                     InfrastructureFailureReason.DESCRIPTOR_PLAN_CONSTRUCTION
+                ),
+                descriptor_plan_stage=(
+                    DescriptorPlanFailureStage.INPUT_TRANSPORT_VALIDATION
                 ),
             )
         return _run_playwright_descriptor_supervised(
@@ -3935,6 +4050,16 @@ def run_supervised(
                     failure_phases=(InfrastructureFailurePhase.CONSTRUCTION,),
                     failure_reason=exc.reason,
                 )
+            except _DescriptorPlanFailure as exc:
+                return _sandbox_error(
+                    command,
+                    f"protected supervisor phase=construction: {exc}",
+                    failure_phases=(InfrastructureFailurePhase.CONSTRUCTION,),
+                    failure_reason=(
+                        InfrastructureFailureReason.DESCRIPTOR_PLAN_CONSTRUCTION
+                    ),
+                    descriptor_plan_stage=exc.stage,
+                )
             except (OSError, RuntimeError) as exc:
                 return _sandbox_error(
                     command,
@@ -3943,6 +4068,7 @@ def run_supervised(
                     failure_reason=(
                         InfrastructureFailureReason.DESCRIPTOR_PLAN_CONSTRUCTION
                     ),
+                    descriptor_plan_stage=DescriptorPlanFailureStage.UNKNOWN,
                 )
             try:
                 _prepare_staging(plan)

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -43,6 +43,7 @@ from pdd.sync_core.runner import (
 from pdd.sync_core.evidence_store import attestation_payload, decode_attestation
 from pdd.sync_core.supervisor import (
     CgroupResourceTelemetry,
+    DescriptorPlanFailureStage,
     InfrastructureFailurePhase,
     InfrastructureFailureReason,
     SupervisedCompletedProcess,
@@ -1958,7 +1959,8 @@ def test_vitest_sandbox_error_reports_only_trusted_phases_and_counters(
         125,
         "candidate says trusted_failure_phases=construction",
         "secret=candidate-value; trusted_failure_phases=result-handoff; "
-        "trusted_failure_reason=trusted-tool-identity",
+        "trusted_failure_reason=trusted-tool-identity; "
+        "trusted_descriptor_plan_stage=input-transport-validation",
         termination=SupervisorTermination(
             TerminationKind.SANDBOX_ERROR,
             exit_code=125,
@@ -1967,6 +1969,9 @@ def test_vitest_sandbox_error_reports_only_trusted_phases_and_counters(
                 InfrastructureFailurePhase.MOUNT_CLEANUP,
             ),
             failure_reason=InfrastructureFailureReason.STAGING_PREPARATION,
+            descriptor_plan_stage=(
+                DescriptorPlanFailureStage.HELPER_PAYLOAD_SERIALIZATION
+            ),
             resource_telemetry=CgroupResourceTelemetry(0, 0, 0),
         ),
     )
@@ -1985,6 +1990,10 @@ def test_vitest_sandbox_error_reports_only_trusted_phases_and_counters(
     assert execution.outcome is EvidenceOutcome.ERROR
     assert "trusted_failure_phases=scope-cleanup,mount-cleanup" in execution.detail
     assert "trusted_failure_reason=staging-preparation" in execution.detail
+    assert (
+        "trusted_descriptor_plan_stage=helper-payload-serialization"
+        in execution.detail
+    )
     assert "cgroup_memory_oom_delta=0" in execution.detail
     assert "cgroup_memory_oom_kill_delta=0" in execution.detail
     assert "cgroup_pids_max_delta=0" in execution.detail
@@ -1992,6 +2001,10 @@ def test_vitest_sandbox_error_reports_only_trusted_phases_and_counters(
     assert "trusted_failure_phases=construction" not in execution.detail
     assert "trusted_failure_phases=result-handoff" not in execution.detail
     assert "trusted_failure_reason=trusted-tool-identity" not in execution.detail
+    assert (
+        "trusted_descriptor_plan_stage=input-transport-validation"
+        not in execution.detail
+    )
     assert identities == ()
 
 
@@ -2010,6 +2023,7 @@ def test_vitest_sandbox_error_defaults_untrusted_phase_to_unknown(
             exit_code=125,
             failure_phases=("candidate-spoofed",),  # type: ignore[arg-type]
             failure_reason="candidate-spoofed",  # type: ignore[arg-type]
+            descriptor_plan_stage="candidate-spoofed",  # type: ignore[arg-type]
         ),
     )
     monkeypatch.setattr(
@@ -2026,6 +2040,7 @@ def test_vitest_sandbox_error_defaults_untrusted_phase_to_unknown(
 
     assert "trusted_failure_phases=unknown" in execution.detail
     assert "trusted_failure_reason=unknown" in execution.detail
+    assert "trusted_descriptor_plan_stage=unknown" in execution.detail
     assert "candidate-spoofed" not in execution.detail
 
 

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -44,6 +44,7 @@ from pdd.sync_core.evidence_store import attestation_payload, decode_attestation
 from pdd.sync_core.supervisor import (
     CgroupResourceTelemetry,
     InfrastructureFailurePhase,
+    InfrastructureFailureReason,
     SupervisedCompletedProcess,
     SupervisorLimits,
     SupervisorTermination,
@@ -1956,7 +1957,8 @@ def test_vitest_sandbox_error_reports_only_trusted_phases_and_counters(
         ["vitest"],
         125,
         "candidate says trusted_failure_phases=construction",
-        "secret=candidate-value; trusted_failure_phases=result-handoff",
+        "secret=candidate-value; trusted_failure_phases=result-handoff; "
+        "trusted_failure_reason=trusted-tool-identity",
         termination=SupervisorTermination(
             TerminationKind.SANDBOX_ERROR,
             exit_code=125,
@@ -1964,6 +1966,7 @@ def test_vitest_sandbox_error_reports_only_trusted_phases_and_counters(
                 InfrastructureFailurePhase.SCOPE_CLEANUP,
                 InfrastructureFailurePhase.MOUNT_CLEANUP,
             ),
+            failure_reason=InfrastructureFailureReason.STAGING_PREPARATION,
             resource_telemetry=CgroupResourceTelemetry(0, 0, 0),
         ),
     )
@@ -1981,12 +1984,14 @@ def test_vitest_sandbox_error_reports_only_trusted_phases_and_counters(
 
     assert execution.outcome is EvidenceOutcome.ERROR
     assert "trusted_failure_phases=scope-cleanup,mount-cleanup" in execution.detail
+    assert "trusted_failure_reason=staging-preparation" in execution.detail
     assert "cgroup_memory_oom_delta=0" in execution.detail
     assert "cgroup_memory_oom_kill_delta=0" in execution.detail
     assert "cgroup_pids_max_delta=0" in execution.detail
     assert "candidate-value" not in execution.detail
     assert "trusted_failure_phases=construction" not in execution.detail
     assert "trusted_failure_phases=result-handoff" not in execution.detail
+    assert "trusted_failure_reason=trusted-tool-identity" not in execution.detail
     assert identities == ()
 
 
@@ -2004,6 +2009,7 @@ def test_vitest_sandbox_error_defaults_untrusted_phase_to_unknown(
             TerminationKind.SANDBOX_ERROR,
             exit_code=125,
             failure_phases=("candidate-spoofed",),  # type: ignore[arg-type]
+            failure_reason="candidate-spoofed",  # type: ignore[arg-type]
         ),
     )
     monkeypatch.setattr(
@@ -2019,6 +2025,7 @@ def test_vitest_sandbox_error_defaults_untrusted_phase_to_unknown(
     )
 
     assert "trusted_failure_phases=unknown" in execution.detail
+    assert "trusted_failure_reason=unknown" in execution.detail
     assert "candidate-spoofed" not in execution.detail
 
 

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -43,6 +43,7 @@ from pdd.sync_core.runner import (
 from pdd.sync_core.evidence_store import attestation_payload, decode_attestation
 from pdd.sync_core.supervisor import (
     CgroupResourceTelemetry,
+    InfrastructureFailurePhase,
     SupervisedCompletedProcess,
     SupervisorLimits,
     SupervisorTermination,
@@ -1943,6 +1944,82 @@ def test_vitest_sigabrt_reports_only_trusted_zero_cgroup_deltas(
     assert "candidate stdout" not in execution.detail
     assert "candidate stderr" not in execution.detail
     assert identities == ()
+
+
+def test_vitest_sandbox_error_reports_only_trusted_phases_and_counters(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Candidate diagnostics cannot spoof structured infrastructure evidence."""
+    root, _commit = _repository(tmp_path)
+    result = SupervisedCompletedProcess(
+        ["vitest"],
+        125,
+        "candidate says trusted_failure_phases=construction",
+        "secret=candidate-value; trusted_failure_phases=result-handoff",
+        termination=SupervisorTermination(
+            TerminationKind.SANDBOX_ERROR,
+            exit_code=125,
+            failure_phases=(
+                InfrastructureFailurePhase.SCOPE_CLEANUP,
+                InfrastructureFailurePhase.MOUNT_CLEANUP,
+            ),
+            resource_telemetry=CgroupResourceTelemetry(0, 0, 0),
+        ),
+    )
+    monkeypatch.setattr(
+        "pdd.sync_core.runner.run_supervised",
+        lambda *_args, **_kwargs: (result, False),
+    )
+
+    execution, identities = _run_vitest(
+        root,
+        (PurePosixPath("tests/widget.test.ts"),),
+        30,
+        _runner_config(tmp_path, _fake_vitest(tmp_path)),
+    )
+
+    assert execution.outcome is EvidenceOutcome.ERROR
+    assert "trusted_failure_phases=scope-cleanup,mount-cleanup" in execution.detail
+    assert "cgroup_memory_oom_delta=0" in execution.detail
+    assert "cgroup_memory_oom_kill_delta=0" in execution.detail
+    assert "cgroup_pids_max_delta=0" in execution.detail
+    assert "candidate-value" not in execution.detail
+    assert "trusted_failure_phases=construction" not in execution.detail
+    assert "trusted_failure_phases=result-handoff" not in execution.detail
+    assert identities == ()
+
+
+def test_vitest_sandbox_error_defaults_untrusted_phase_to_unknown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, _commit = _repository(tmp_path)
+    result = SupervisedCompletedProcess(
+        ["vitest"],
+        125,
+        "",
+        "trusted_failure_phases=candidate-spoofed",
+        termination=SupervisorTermination(
+            TerminationKind.SANDBOX_ERROR,
+            exit_code=125,
+            failure_phases=("candidate-spoofed",),  # type: ignore[arg-type]
+        ),
+    )
+    monkeypatch.setattr(
+        "pdd.sync_core.runner.run_supervised",
+        lambda *_args, **_kwargs: (result, False),
+    )
+
+    execution, _identities = _run_vitest(
+        root,
+        (PurePosixPath("tests/widget.test.ts"),),
+        30,
+        _runner_config(tmp_path, _fake_vitest(tmp_path)),
+    )
+
+    assert "trusted_failure_phases=unknown" in execution.detail
+    assert "candidate-spoofed" not in execution.detail
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5618,6 +5618,14 @@ def _fallback_stalled_observation_cleanup_impl(
     if holder_records is None:
         holder_records = (ownership["namespace_holder"],)
     captured_holders = tuple(holder_records)
+    external_holder_keys = {
+        _holder_key(holder) for holder in ownership.get("external_holders", ())
+    }
+    captured_external_fd_holders = tuple(
+        holder for holder in captured_holders
+        if holder.get("holder_kind") == "fd"
+        and _holder_key(holder) in external_holder_keys
+    )
     unit_action_failures = []
 
     def remaining() -> float:
@@ -5811,15 +5819,6 @@ def _fallback_stalled_observation_cleanup_impl(
     held_mounts = None if held_scan is None else held_scan[0]
     if held_mounts is not None:
         captured_mounts.update(held_mounts)
-    if ownership.get("require_fd_only_holder") and (
-        namespace_holder is None
-        or namespace_holder.get("holder_kind") != "fd"
-        or scan is None
-        or scan["current_holders"]
-        or held_scan is None
-        or not held_scan[1]
-    ):
-        errors.append("exact FD-only namespace mount ownership was not preserved")
     deferred_absent_unmounts = []
     unmount_mounts = (
         held_mounts if held_scan is not None and held_scan[1] else captured_mounts
@@ -5848,14 +5847,35 @@ def _fallback_stalled_observation_cleanup_impl(
         else:
             errors.append(diagnostic[:512] or f"cannot unmount {mount}")
 
-    remaining_scan = holder_mount_scan()
+    if ownership.get("require_fd_only_holder"):
+        teardown_exact_scope()
+        post_scope_scan = scan_owned()
+        namespace_holder = (
+            None if post_scope_scan is None
+            else _select_captured_namespace_holder(
+                post_scope_scan, captured_external_fd_holders, namespace,
+            )
+        )
+        remaining_scan = holder_mount_scan()
+        if (
+            namespace_holder is None
+            or namespace_holder.get("holder_kind") != "fd"
+            or post_scope_scan is None
+            or post_scope_scan["current_holders"]
+            or remaining_scan is None
+            or not remaining_scan[1]
+            or remaining_scan[0]
+        ):
+            errors.append("exact FD-only namespace mount ownership was not preserved")
+    else:
+        remaining_scan = holder_mount_scan()
+        teardown_exact_scope()
     remaining_held_mounts = None if remaining_scan is None else remaining_scan[0]
     if remaining_held_mounts:
         errors.append(
             "owned mounts remain in held namespace: "
             + ", ".join(str(path) for path in remaining_held_mounts)
         )
-    teardown_exact_scope()
     terminate_exact_coordinator()
     for holder in ownership.get("external_holders", ()):
         expected = _process_key(holder)

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -7000,59 +7000,44 @@ def test_held_namespace_scan_failures_continue_cleanup_and_final_verification(
 
 
 @pytest.mark.parametrize(
-    ("stderr", "succeeds"),
-    (("not mounted", True), ("no such file", True), ("no mount point specified", False)),
+    ("stderr", "later_present", "root_matches", "succeeds"),
+    (
+        ("not mounted", False, True, True),
+        ("no such file", False, True, True),
+        ("no mount point specified", False, True, True),
+        ("no mount point specified", False, False, False),
+        ("no mount point specified", True, True, False),
+    ),
+    ids=("not-mounted", "enoent", "exact-root-empty", "root-mismatch", "nonempty"),
 )
 def test_proven_absent_unmount_failures_are_deferred_only_after_later_scan(
-    tmp_path: Path, stderr: str, succeeds: bool, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path, stderr: str, later_present: bool, root_matches: bool,
+    succeeds: bool, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Only later namespace absence proof can discharge known stale-unmount output."""
     prefix = tmp_path / "pdd-scope-owned"
     target = prefix / "binds" / "writable"
     namespace = {"link": "mnt:[11]", "inode": 11}
-    holder = {
-        "holder_kind": "current", "pid": 22, "start_time": "100",
-        "namespace": "mnt:[11]", "namespace_inode": 11,
-    }
+    holder = _fallback_fd_holder()
     ownership = {
         "unit": "pdd-validator-test.scope", "cgroup": tmp_path / "cgroup",
         "control_prefix": prefix, "namespace": namespace,
         "namespace_holder": holder, "coordinator": {"pid": 1, "start_time": "1"},
-        "mount_points": [target],
+        "mount_points": [target], "require_fd_only_holder": True,
     }
     monkeypatch.setattr(
         supervisor, "_trusted_tools", lambda: SimpleNamespace(helper_python=Path("/trusted/python")),
     )
 
-    def metadata() -> dict[str, object]:
-        return {"status": "ok", "device": 1, "inode": 2, "mode": 0o40700}
-
-    def diagnostic(mounts: list[Path]) -> str:
-        record = {
-            "mount_id": 43, "parent_id": 1, "root": "/", "mount_point": str(target),
-            "major_minor": "0:42", "filesystem": "tmpfs", "source": "tmpfs",
-            "options": {"mount": "rw", "super": "rw"}, "truncated": [],
-        }
-        return json.dumps({
-            "schema": "pdd-held-namespace-diagnostic-v1", "operation": "scan",
-            "prefix": str(prefix), "targets": [str(target)],
-            "mount_namespace": namespace,
-            "root": {"link": "/", "expected": None, "actual": {
-                "device": 1, "inode": 2, "mode": 0o40755, "mount_id": 42,
-            }, "matches": None},
-            "cwd": {"status": "ok", "path": "/"}, "paths": {
-                "prefix": {"path": str(prefix), "exists": True, "lstat": metadata(), "stat": metadata()},
-                "target_count": 1,
-                "targets": [{"path": str(target), "exists": True, "lstat": metadata(), "stat": metadata()}],
-            },
-            "mountinfo": {
-                "mounts": [str(path) for path in mounts], "exact_count": len(mounts),
-                "samples": [record] if mounts else [],
-                "related": [] if mounts else [{**record, "mount_id": 44, "mount_point": "/"}],
-            },
-        }, sort_keys=True)
-
-    scan_outputs = [diagnostic([target]), diagnostic([])]
+    scan_outputs = [
+        _fallback_held_scan_diagnostic(
+            prefix, (target,), holder, (target,), root_matches=True,
+        ),
+        _fallback_held_scan_diagnostic(
+            prefix, (target,), holder, (target,) if later_present else (),
+            root_matches=root_matches,
+        ),
+    ]
     scans = 0
 
     def scanner(**_kwargs):
@@ -7060,8 +7045,8 @@ def test_proven_absent_unmount_failures_are_deferred_only_after_later_scan(
         scans += 1
         return {
             "watched": [], "identities": [], "cgroup_exists": False,
-            "mount_holders": [], "fd_holders": [],
-            "current_holders": [holder] if scans <= 2 else [],
+            "mount_holders": [], "current_holders": [],
+            "fd_holders": [holder] if scans <= 2 else [],
         }
 
     def runner(argv, **_kwargs):

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5581,7 +5581,21 @@ def _hold_validated_descriptor_result(
     return result
 
 
-def _fallback_stalled_observation_cleanup(
+def _close_stalled_observation_fds(
+    owned_fds: tuple[int, ...], errors: list[str] | None = None,
+) -> None:
+    """Close every transferred lifecycle descriptor, recording non-EBADF failures."""
+    for descriptor in owned_fds:
+        if descriptor < 0:
+            continue
+        try:
+            os.close(descriptor)
+        except OSError as exc:
+            if exc.errno != 9 and errors is not None:
+                errors.append(f"close fd {descriptor} failed: {exc}")
+
+
+def _fallback_stalled_observation_cleanup_impl(
     ownership: dict[str, object], owned_fds: tuple[int, ...], *,
     runner=subprocess.run, scanner=_root_proc_scan,
 ) -> tuple[int, ...]:
@@ -5649,7 +5663,7 @@ def _fallback_stalled_observation_cleanup(
             errors.append(f"privileged procfs scan failed: {type(exc).__name__}: {exc}")
             return None
 
-    def teardown_scope_and_coordinator() -> None:
+    def teardown_exact_scope() -> None:
         for action in (
             ["kill", "--kill-whom=all", "--signal=SIGKILL", unit],
             ["stop", unit],
@@ -5667,9 +5681,10 @@ def _fallback_stalled_observation_cleanup(
                     or f"{purpose} returned {completed.returncode}"
                 )
 
+    def terminate_exact_coordinator() -> None:
         # Signal only a procfs-confirmed PID/start-time identity; a reused PID
-        # is untouchable. The lifecycle gate remains held until this outside
-        # coordinator can no longer run its private-namespace cleanup path.
+        # is untouchable. Held mounts are already gone, so coordinator cleanup
+        # can no longer invalidate paths needed by the authenticated unmount.
         scan = scan_owned()
         coordinator_present = scan is not None and any(
             _process_key(record) == expected_coordinator
@@ -5713,17 +5728,7 @@ def _fallback_stalled_observation_cleanup(
         if coordinator_present and not reaped:
             errors.append("captured coordinator could not be reaped before deadline")
 
-    try:
-        teardown_scope_and_coordinator()
-    finally:
-        for descriptor in owned_fds:
-            if descriptor < 0:
-                continue
-            try:
-                os.close(descriptor)
-            except OSError as exc:
-                if exc.errno != 9:
-                    errors.append(f"close fd {descriptor} failed: {exc}")
+    teardown_exact_scope()
 
     # The scanner sees mounts in the privileged private namespace, including binds/*.
     scan = scan_owned()
@@ -5852,6 +5857,7 @@ def _fallback_stalled_observation_cleanup(
             "owned mounts remain in held namespace: "
             + ", ".join(str(path) for path in remaining_held_mounts)
         )
+    terminate_exact_coordinator()
     for holder in ownership.get("external_holders", ()):
         expected = _process_key(holder)
         holder_scan = scanner(
@@ -5893,6 +5899,7 @@ def _fallback_stalled_observation_cleanup(
             reaper.kill()
             reaper.wait(timeout=max(.01, min(5, remaining())))
 
+    _close_stalled_observation_fds(owned_fds, errors)
     verification_deadline = min(deadline, time.monotonic() + 8)
     final_leaks = ["verification did not run"]
     final_authoritative_mounts: tuple[Path, ...] | None = None
@@ -5978,6 +5985,19 @@ def _fallback_stalled_observation_cleanup(
         errors.extend(held_namespace_diagnostics)
         raise AssertionError("; ".join(errors))
     return tuple(-1 for _descriptor in owned_fds)
+
+
+def _fallback_stalled_observation_cleanup(
+    ownership: dict[str, object], owned_fds: tuple[int, ...], *,
+    runner=subprocess.run, scanner=_root_proc_scan,
+) -> tuple[int, ...]:
+    """Close lifecycle descriptors even when fail-closed cleanup raises."""
+    try:
+        return _fallback_stalled_observation_cleanup_impl(
+            ownership, owned_fds, runner=runner, scanner=scanner,
+        )
+    finally:
+        _close_stalled_observation_fds(owned_fds)
 
 
 def _run_stalled_observation_setup(scan, assert_watched, failure_cleanup) -> None:
@@ -7472,9 +7492,10 @@ def test_stalled_observation_setup_failure_preserves_primary_and_reaps_owned_sta
         nonlocal calls, coordinator_scan_observed_open_fd
         calls += 1
         selections.append(selection)
-        if calls == 1:
-            os.fstat(read_fd)
-            coordinator_scan_observed_open_fd = True
+        if calls <= 3:
+            if calls == 1:
+                os.fstat(read_fd)
+                coordinator_scan_observed_open_fd = True
             return {
                 "watched": [coordinator_record], "mount_holders": [],
                 "current_holders": [], "fd_holders": [], "identities": [],

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -3507,6 +3507,41 @@ def test_construction_plan_and_staging_failures_are_distinct(
     )
 
 
+def test_trusted_tool_revalidation_failure_cleans_staging_and_returns_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleanup = _mock_scope_run(
+        tmp_path, monkeypatch, _terminal_helper(0, False)
+    )
+    monkeypatch.setattr(
+        supervisor,
+        "_revalidate_trusted_tools",
+        lambda _tools: (_ for _ in ()).throw(
+            supervisor._InfrastructureFailure(
+                supervisor.InfrastructureFailureReason.TRUSTED_TOOL_REVALIDATION,
+                "trusted revalidation failed",
+            )
+        ),
+    )
+
+    result, surviving = run_supervised(
+        [sys.executable, "-c", "pass"], cwd=tmp_path, timeout=1, env={},
+        writable_roots=(tmp_path,),
+    )
+
+    assert result.returncode == 125
+    assert result.termination.kind is supervisor.TerminationKind.SANDBOX_ERROR
+    assert result.termination.failure_phases == (
+        supervisor.InfrastructureFailurePhase.CONSTRUCTION,
+    )
+    assert result.termination.failure_reason is (
+        supervisor.InfrastructureFailureReason.TRUSTED_TOOL_REVALIDATION
+    )
+    assert cleanup == ["mounts"]
+    assert surviving is False
+
+
 def test_scope_cleanup_targets_only_validated_unique_unit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -3409,6 +3409,7 @@ def test_sandbox_termination_preserves_only_allowlisted_failure_phases(
         (trusted, "candidate-spoofed-phase"),
         resource_telemetry=None,
         failure_reason="candidate-spoofed-reason",
+        descriptor_plan_stage="candidate-spoofed-stage",
     )
 
     assert termination.kind is supervisor.TerminationKind.SANDBOX_ERROR
@@ -3419,6 +3420,9 @@ def test_sandbox_termination_preserves_only_allowlisted_failure_phases(
     assert (
         termination.failure_reason
         is supervisor.InfrastructureFailureReason.UNKNOWN
+    )
+    assert termination.descriptor_plan_stage is (
+        supervisor.DescriptorPlanFailureStage.UNKNOWN
     )
 
 
@@ -3468,6 +3472,46 @@ def test_construction_failure_preserves_explicit_trusted_reason(
         supervisor.InfrastructureFailurePhase.CONSTRUCTION,
     )
     assert result.termination.failure_reason is reason
+    assert surviving is False
+
+
+@pytest.mark.parametrize(
+    "stage",
+    [
+        supervisor.DescriptorPlanFailureStage.INPUT_TRANSPORT_VALIDATION,
+        supervisor.DescriptorPlanFailureStage.PROOF_VALIDATION,
+        supervisor.DescriptorPlanFailureStage.CANDIDATE_ENVIRONMENT,
+        supervisor.DescriptorPlanFailureStage.SOURCE_PATH_COLLISION_PLANNING,
+        supervisor.DescriptorPlanFailureStage.INFERRED_RUNTIME_BINDING,
+        supervisor.DescriptorPlanFailureStage.EXECUTABLE_NATIVE_RUNTIME_BINDING,
+        supervisor.DescriptorPlanFailureStage.RESULT_OBSERVATION_BINDING,
+        supervisor.DescriptorPlanFailureStage.HELPER_PAYLOAD_SERIALIZATION,
+        supervisor.DescriptorPlanFailureStage.DESCRIPTOR_FRAME_SIZE,
+    ],
+)
+def test_descriptor_plan_failure_preserves_explicit_trusted_stage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stage: supervisor.DescriptorPlanFailureStage,
+) -> None:
+    monkeypatch.setattr(
+        supervisor,
+        "_sandbox_command",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            supervisor._DescriptorPlanFailure(stage)
+        ),
+    )
+
+    result, surviving = run_supervised(
+        [sys.executable, "-c", "pass"], cwd=tmp_path, timeout=1, env={},
+        writable_roots=(tmp_path,),
+    )
+
+    assert result.returncode == 125
+    assert result.termination.failure_reason is (
+        supervisor.InfrastructureFailureReason.DESCRIPTOR_PLAN_CONSTRUCTION
+    )
+    assert result.termination.descriptor_plan_stage is stage
     assert surviving is False
 
 

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -7712,6 +7712,102 @@ def test_stalled_cleanup_unmounts_before_coordinator_reap_deletes_paths(
         os.fstat(read_fd)
 
 
+def test_stalled_cleanup_unmounts_before_destructive_scope_actions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Authenticated held cleanup finishes before systemd can delete backing paths."""
+    prefix = tmp_path / "pdd-scope-owned"
+    mount = prefix / "binds" / "writable"
+    mount.mkdir(parents=True)
+    namespace = {"link": "mnt:[11]", "inode": 11}
+    coordinator = {
+        "holder_kind": "current", "pid": 999999, "start_time": "100",
+        "namespace": "mnt:[11]", "namespace_inode": 11,
+    }
+    ownership = {
+        "unit": "pdd-validator-scope-order.scope", "cgroup": tmp_path / "cgroup",
+        "control_prefix": prefix, "namespace": namespace,
+        "namespace_holder": coordinator, "coordinator": coordinator,
+        "mount_points": [mount],
+    }
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    coordinator_alive = True
+    mounted = True
+    held_cleanup_complete = False
+    events = []
+
+    monkeypatch.setattr(
+        supervisor, "_trusted_tools",
+        lambda: SimpleNamespace(helper_python=Path("/trusted/python")),
+    )
+
+    def scanner(**_kwargs):
+        records = [coordinator] if coordinator_alive else []
+        return {
+            "watched": records, "identities": records,
+            "current_holders": records, "fd_holders": [],
+            "mount_holders": [], "cgroup_exists": False,
+        }
+
+    def runner(argv, **_kwargs):
+        nonlocal held_cleanup_complete, mounted
+        if "systemctl" in argv and "show" in argv:
+            return SimpleNamespace(returncode=0, stdout="not-found\n", stderr="")
+        if "systemctl" in argv:
+            action = argv[3]
+            events.append(f"scope-{action}")
+            if action == "kill":
+                mounted = False
+                shutil.rmtree(prefix)
+                assert held_cleanup_complete
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if _NSENTER_REVALIDATOR_SOURCE in argv:
+            operation = json.loads(argv[-1])["operation"]
+            assert coordinator_alive
+            assert mount.exists()
+            os.fstat(read_fd)
+            events.append(operation)
+            if operation == "unmount":
+                mounted = False
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            if mounted:
+                return SimpleNamespace(returncode=0, stdout="mounted", stderr="")
+            held_cleanup_complete = True
+            return SimpleNamespace(returncode=0, stdout="absent", stderr="")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    def terminate(pid: int, sent: signal.Signals) -> None:
+        nonlocal coordinator_alive
+        assert pid == coordinator["pid"] and sent == signal.SIGTERM
+        assert held_cleanup_complete and not mounted and not prefix.exists()
+        coordinator_alive = False
+        events.append("coordinator-reaped")
+
+    def waitpid(pid: int, _options: int) -> tuple[int, int]:
+        assert pid == coordinator["pid"]
+        return (0, 0) if coordinator_alive else (pid, 0)
+
+    def parse_diagnostic(raw: str, **_kwargs):
+        return ({"root": {"matches": True}}, (mount,) if raw == "mounted" else ())
+
+    monkeypatch.setattr(os, "kill", terminate)
+    monkeypatch.setattr(os, "waitpid", waitpid)
+    monkeypatch.setattr(
+        sys.modules[__name__], "_parse_held_namespace_diagnostic", parse_diagnostic,
+    )
+
+    assert _fallback_stalled_observation_cleanup(
+        ownership, (read_fd,), runner=runner, scanner=scanner,
+    ) == (-1,)
+    assert events == [
+        "scan", "unmount", "scan", "scope-kill", "scope-stop",
+        "scope-reset-failed", "coordinator-reaped",
+    ]
+    with pytest.raises(OSError):
+        os.fstat(read_fd)
+
+
 def test_exact_blocked_role_snapshot_rejects_running_and_reused_identity() -> None:
     """A running role or PID reuse cannot satisfy blocked-role evidence."""
     roles = [

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5507,33 +5507,32 @@ def test_held_namespace_scan_stderr_sanitizer_maps_anchored_nsenter_failures(
 
 
 def _deferred_absent_is_proven(
-    deferred: list[tuple[Path, str]],
+    deferred: list[tuple[Path, str, bool]],
     remaining_scan: tuple[tuple[Path, ...], bool] | None,
     final_authoritative_mounts: tuple[Path, ...] | None,
 ) -> bool:
     """Accept stale-unmount output only with root-valid or final procfs absence."""
     root_valid_absence = (
         remaining_scan is not None and remaining_scan[1] and all(
-            mount not in remaining_scan[0] for mount, _diagnostic in deferred
+            mount not in remaining_scan[0]
+            for mount, _diagnostic, _ambiguous in deferred
         )
     )
     procfs_absence = final_authoritative_mounts is not None and all(
-        mount not in final_authoritative_mounts for mount, _diagnostic in deferred
+        mount not in final_authoritative_mounts
+        for mount, _diagnostic, _ambiguous in deferred
     )
-    if any(
-        _ambiguous_absent_unmount_diagnostic(diagnostic)
-        for _mount, diagnostic in deferred
-    ):
+    if any(ambiguous for _mount, _diagnostic, ambiguous in deferred):
         return root_valid_absence
     return root_valid_absence or procfs_absence
 
 
-def _ambiguous_absent_unmount_diagnostic(diagnostic: str) -> bool:
-    """Match only util-linux's exact missing-mountpoint diagnostic shape."""
-    return diagnostic == "no mount point specified" or (
-        diagnostic.startswith("umount: ")
-        and diagnostic.endswith(": no mount point specified")
-    )
+def _ambiguous_absent_unmount_diagnostic(
+    diagnostic: str, mount: Path,
+) -> bool:
+    """Match only C-locale util-linux output bound to the exact requested mount."""
+    prefix = f"umount: {mount}: no mount point specified"
+    return diagnostic in {prefix, prefix + "."}
 
 
 _BLOCKED_WCHAN_MARKERS = ("sleep", "wait", "pause", "futex")
@@ -5850,12 +5849,19 @@ def _fallback_stalled_observation_cleanup_impl(
         completed = command(argv, f"unmount {mount}")
         if completed is None or completed.returncode == 0:
             continue
-        diagnostic = (completed.stderr or completed.stdout).strip().lower()
+        diagnostic = (completed.stderr or completed.stdout).strip()
+        normalized_diagnostic = diagnostic.lower()
+        ambiguous_absence = _ambiguous_absent_unmount_diagnostic(
+            diagnostic, mount,
+        )
         if (
-            "not mounted" in diagnostic or "no such file" in diagnostic
-            or _ambiguous_absent_unmount_diagnostic(diagnostic)
+            "not mounted" in normalized_diagnostic
+            or "no such file" in normalized_diagnostic
+            or ambiguous_absence
         ):
-            deferred_absent_unmounts.append((mount, diagnostic[:512]))
+            deferred_absent_unmounts.append(
+                (mount, diagnostic[:512], ambiguous_absence)
+            )
         else:
             errors.append(diagnostic[:512] or f"cannot unmount {mount}")
 
@@ -6008,10 +6014,10 @@ def _fallback_stalled_observation_cleanup_impl(
         if not _deferred_absent_is_proven(
             deferred_absent_unmounts, remaining_scan, final_authoritative_mounts,
         ):
-            errors.extend(
-                diagnostic or f"cannot unmount {mount}"
-                for mount, diagnostic in deferred_absent_unmounts
-            )
+                errors.extend(
+                    diagnostic or f"cannot unmount {mount}"
+                    for mount, diagnostic, _ambiguous in deferred_absent_unmounts
+                )
     if errors:
         errors.extend(held_namespace_diagnostics)
         raise AssertionError("; ".join(errors))

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -6889,7 +6889,8 @@ def test_fallback_fd_holder_empty_untrusted_scan_keeps_stale_unmounts(
             if payload["operation"] == "unmount":
                 unmounts.append(payload["mount"])
                 return SimpleNamespace(
-                    returncode=1, stdout="", stderr="no mount point specified",
+                    returncode=1, stdout="",
+                    stderr=f"umount: {stale}: no mount point specified.",
                 )
             if mode == "unavailable":
                 return SimpleNamespace(returncode=2, stdout="", stderr="scanner unavailable")
@@ -7020,9 +7021,9 @@ def test_held_namespace_scan_failures_continue_cleanup_and_final_verification(
     (
         ("not mounted", False, True, True),
         ("no such file", False, True, True),
-        ("umount: /p/binds/writable: no mount point specified", False, True, True),
-        ("no mount point specified", False, False, False),
-        ("no mount point specified", True, True, False),
+        ("ambiguous-period", False, True, True),
+        ("ambiguous-period", False, False, False),
+        ("ambiguous-period", True, True, False),
     ),
     ids=("not-mounted", "enoent", "exact-root-empty", "root-mismatch", "nonempty"),
 )
@@ -7072,7 +7073,11 @@ def test_proven_absent_unmount_failures_are_deferred_only_after_later_scan(
             payload = json.loads(argv[-1])
             if payload["operation"] == "scan":
                 return SimpleNamespace(returncode=0, stdout=scan_outputs.pop(0), stderr="")
-            return SimpleNamespace(returncode=1, stdout="", stderr=stderr)
+            unmount_stderr = (
+                f"umount: {target}: no mount point specified."
+                if stderr == "ambiguous-period" else stderr
+            )
+            return SimpleNamespace(returncode=1, stdout="", stderr=unmount_stderr)
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     if succeeds:
@@ -7088,11 +7093,41 @@ def test_proven_absent_unmount_failures_are_deferred_only_after_later_scan(
 
 def test_root_mismatched_scan_is_never_deferred_absence_proof() -> None:
     """A scan from a mismatched root cannot discharge an otherwise stale unmount."""
-    deferred = [(Path("/p/binds/mount"), "not mounted")]
+    deferred = [(Path("/p/binds/mount"), "not mounted", False)]
 
     assert not _deferred_absent_is_proven(deferred, ((), False), None)
     assert _deferred_absent_is_proven(deferred, ((), True), None)
     assert _deferred_absent_is_proven(deferred, ((), False), ())
+
+
+def test_ambiguous_unmount_classification_is_bound_to_exact_mount() -> None:
+    """Only exact C-locale util-linux output for this mount is ambiguous absence."""
+    mount = Path("/p/binds/mount")
+    assert _ambiguous_absent_unmount_diagnostic(
+        "umount: /p/binds/mount: no mount point specified.", mount,
+    )
+    assert _ambiguous_absent_unmount_diagnostic(
+        "umount: /p/binds/mount: no mount point specified", mount,
+    )
+    for diagnostic in (
+        "no mount point specified.",
+        "umount: /p/binds/other: no mount point specified.",
+        "umount: /p/binds/mount: no mount point specified..",
+        "umount: /p/binds/mount: not mounted",
+        "prefix umount: /p/binds/mount: no mount point specified.",
+    ):
+        assert not _ambiguous_absent_unmount_diagnostic(diagnostic, mount)
+
+
+def test_ambiguous_unmount_proof_classification_survives_diagnostic_truncation() -> None:
+    """A long stored diagnostic cannot downgrade root-proof requirements."""
+    mount = Path("/p/binds") / ("x" * 700)
+    diagnostic = f"umount: {mount}: no mount point specified."
+    deferred = [(mount, diagnostic[:512], True)]
+
+    assert not _deferred_absent_is_proven(deferred, None, ())
+    assert not _deferred_absent_is_proven(deferred, ((), False), ())
+    assert _deferred_absent_is_proven(deferred, ((), True), None)
 
 
 def test_fdinfo_mount_id_parser_normalizes_whitespace_and_rejects_ambiguity() -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5728,8 +5728,6 @@ def _fallback_stalled_observation_cleanup_impl(
         if coordinator_present and not reaped:
             errors.append("captured coordinator could not be reaped before deadline")
 
-    teardown_exact_scope()
-
     # The scanner sees mounts in the privileged private namespace, including binds/*.
     scan = scan_owned()
     if scan is not None:
@@ -5857,6 +5855,7 @@ def _fallback_stalled_observation_cleanup_impl(
             "owned mounts remain in held namespace: "
             + ", ".join(str(path) for path in remaining_held_mounts)
         )
+    teardown_exact_scope()
     terminate_exact_coordinator()
     for holder in ownership.get("external_holders", ()):
         expected = _process_key(holder)
@@ -7543,11 +7542,12 @@ def test_stalled_observation_setup_failure_preserves_primary_and_reaps_owned_sta
         os.waitpid(coordinator, os.WNOHANG)
     assert selections and selections[0] == _RootProcSelection((coordinator,))
     assert commands == [
+        ["sudo", "-n", "umount",
+         str(tmp_path / "pdd-scope-owned" / "binds" / "nested")],
         ["sudo", "-n", "systemctl", "kill", "--kill-whom=all",
          "--signal=SIGKILL", "pdd-validator-test.scope"],
         ["sudo", "-n", "systemctl", "stop", "pdd-validator-test.scope"],
         ["sudo", "-n", "systemctl", "reset-failed", "pdd-validator-test.scope"],
-        ["sudo", "-n", "umount", str(tmp_path / "pdd-scope-owned" / "binds" / "nested")],
         ["sudo", "-n", "systemctl", "show", "pdd-validator-test.scope",
          "--property=LoadState", "--value"],
     ]

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -4668,6 +4668,8 @@ import errno,fcntl,hashlib,json,os,pathlib,signal,sys
 
 COMPONENT='revalidator'
 PHASE='control-parsing'
+OPERATION='unclassified'
+HOLDER_KIND='unclassified'
 EXCEPTION_TOKENS=((json.JSONDecodeError,'jsondecodeerror'),(OSError,'oserror'),
                   (ValueError,'valueerror'),(TypeError,'typeerror'),
                   (KeyError,'keyerror'),(RuntimeError,'runtimeerror'),
@@ -4675,7 +4677,9 @@ EXCEPTION_TOKENS=((json.JSONDecodeError,'jsondecodeerror'),(OSError,'oserror'),
 def uncaught(exception_type,_exception,_traceback):
     token=next(token for expected,token in EXCEPTION_TOKENS
                if issubclass(exception_type,expected))
-    try: os.write(2,('pdd-held-namespace-failure:'+COMPONENT+':'+PHASE+':'+token+'\n').encode('ascii'))
+    marker=('pdd-held-namespace-failure:'+COMPONENT+':'+OPERATION+':'
+            +HOLDER_KIND+':'+PHASE+':'+token+'\n')
+    try: os.write(2,marker.encode('ascii'))
     except OSError: pass
 sys.excepthook=uncaught
 
@@ -4691,6 +4695,10 @@ if sys.argv[1] != json.dumps(payload,sort_keys=True,separators=(',',':')):
     raise SystemExit('diagnostic transport invariant')
 PHASE='holder-validation'
 holder=payload['holder']; namespace=payload['namespace']
+operation=payload.get('operation')
+kind=holder.get('holder_kind') if isinstance(holder,dict) else None
+if operation in ('scan','unmount'): OPERATION=operation
+if kind in ('current','fd'): HOLDER_KIND=kind
 pid=holder.get('pid'); start_time=holder.get('start_time')
 if type(pid) is not int or pid<=0 or type(start_time) is not str:
     raise SystemExit('invalid holder process identity')
@@ -4699,7 +4707,6 @@ try:
     pidfd=os.pidfd_open(pid,0)
 except ProcessLookupError:
     raise SystemExit(0)
-PHASE='namespace-pin'
 proc=pathlib.Path('/proc')/str(pid)
 
 def identity():
@@ -4715,9 +4722,9 @@ def exact_namespace(path):
         raise RuntimeError('holder namespace identity changed')
     return str(path)
 
+PHASE='process-stat'
 if identity()!=start_time:
     raise RuntimeError('holder PID was reused')
-operation=payload.get('operation')
 if operation=='terminate':
     try:
         signal.pidfd_send_signal(pidfd,signal.SIGTERM,None,0)
@@ -4785,15 +4792,16 @@ def inherit_only(*descriptors):
             os.set_inheritable(descriptor,True)
     except OSError:
         transport_failure('invariant')
+PHASE='current-namespace'
 current_path=proc/'ns'/'mnt'
 current_link=os.readlink(current_path); current_inode=current_path.stat().st_ino
 if (current_link!=holder.get('namespace') or
         current_inode!=holder.get('namespace_inode')):
     raise RuntimeError('holder current namespace identity changed')
-kind=holder.get('holder_kind')
 if kind=='current':
     entry=exact_namespace(current_path)
 elif kind=='fd':
+    PHASE='fd-entry'
     fd=holder.get('fd')
     if type(fd) is not int or fd<0:
         raise RuntimeError('invalid namespace descriptor')
@@ -4817,8 +4825,11 @@ else:
     if str(root_path)!=holder.get('root_path'):
         raise RuntimeError('root descriptor identity changed')
     root_entry=str(root_path)
+PHASE='namespace-open'
 namespace_fd=os.open(entry,os.O_RDONLY|os.O_CLOEXEC)
+PHASE='namespace-pin'
 exact_namespace(pathlib.Path('/proc/self/fd')/str(namespace_fd))
+PHASE='root-pin'
 root_fd=os.open(root_entry,getattr(os,'O_PATH',0)|os.O_CLOEXEC)
 root_metadata=os.fstat(root_fd)
 root_info=(pathlib.Path('/proc/self/fdinfo')/str(root_fd)).read_text(encoding='ascii')
@@ -4831,6 +4842,7 @@ if kind=='fd' and (root_metadata.st_dev!=holder.get('root_device') or
         root_metadata.st_mode!=holder.get('root_mode') or
         int(root_mnt_ids[0])!=holder.get('root_mnt_id')):
     raise RuntimeError('root descriptor identity changed')
+PHASE='post-pin-identity'
 if identity()!=start_time:
     raise RuntimeError('holder identity raced after descriptor pinning')
 scan_fd=None
@@ -5531,13 +5543,17 @@ def _parse_held_namespace_diagnostic(
 _HELD_NAMESPACE_SCAN_FAILURE_MARKER_PREFIX = "pdd-held-namespace-failure"
 _HELD_NAMESPACE_SCAN_FAILURE_COMPONENT_PHASES = {
     "revalidator": frozenset({
-        "control-parsing", "holder-validation", "pidfd", "namespace-pin",
-        "root-pin", "scan-transport", "fd-inheritance", "exec",
+        "control-parsing", "holder-validation", "pidfd", "process-stat",
+        "current-namespace", "fd-entry", "namespace-open", "namespace-pin",
+        "root-pin", "post-pin-identity", "scan-transport", "fd-inheritance",
+        "exec",
     }),
     "scanner": frozenset({
         "transport", "payload", "namespace", "root", "mountinfo", "paths", "output",
     }),
 }
+_HELD_NAMESPACE_SCAN_FAILURE_OPERATIONS = frozenset({"scan", "unmount"})
+_HELD_NAMESPACE_SCAN_FAILURE_HOLDER_KINDS = frozenset({"current", "fd"})
 _HELD_NAMESPACE_SCAN_FAILURE_EXCEPTION_CLASSES = frozenset({
     "jsondecodeerror", "oserror", "valueerror", "typeerror", "keyerror",
     "runtimeerror", "exception", "baseexception",
@@ -5551,10 +5567,27 @@ _HELD_NAMESPACE_SCAN_NSENTER_STDERR_CATEGORIES = (
 def _held_namespace_scan_stderr_category(line: str) -> str | None:
     """Classify exact child markers and anchored static nsenter failures."""
     marker = line.split(":")
+    is_closed_revalidator = (
+        len(marker) == 6
+        and marker[0] == _HELD_NAMESPACE_SCAN_FAILURE_MARKER_PREFIX
+        and marker[4] in _HELD_NAMESPACE_SCAN_FAILURE_COMPONENT_PHASES["revalidator"]
+        and marker[5] in _HELD_NAMESPACE_SCAN_FAILURE_EXCEPTION_CLASSES
+    )
+    has_closed_attribution = (
+        len(marker) == 6
+        and marker[2] in _HELD_NAMESPACE_SCAN_FAILURE_OPERATIONS
+        and marker[3] in _HELD_NAMESPACE_SCAN_FAILURE_HOLDER_KINDS
+    )
+    if (
+        marker[1:2] == ["revalidator"]
+        and is_closed_revalidator
+        and has_closed_attribution
+    ):
+        return line
     if (
         len(marker) == 4
         and marker[0] == _HELD_NAMESPACE_SCAN_FAILURE_MARKER_PREFIX
-        and marker[1] in _HELD_NAMESPACE_SCAN_FAILURE_COMPONENT_PHASES
+        and marker[1] == "scanner"
         and marker[2] in _HELD_NAMESPACE_SCAN_FAILURE_COMPONENT_PHASES[marker[1]]
         and marker[3] in _HELD_NAMESPACE_SCAN_FAILURE_EXCEPTION_CLASSES
     ):
@@ -5613,12 +5646,16 @@ def test_held_namespace_scan_child_returncode_category_is_bounded(
 
 
 def _held_namespace_scan_failure_marker(
-    component: str, phase: str, exception_class: str,
+    component: str, phase: str, exception_class: str, *,
+    operation: str | None = None, holder_kind: str | None = None,
 ) -> str:
     """Build one closed child marker for sanitizer contract tests."""
+    attribution = (
+        f":{operation}:{holder_kind}" if component == "revalidator" else ""
+    )
     return (
         f"{_HELD_NAMESPACE_SCAN_FAILURE_MARKER_PREFIX}:"
-        f"{component}:{phase}:{exception_class}"
+        f"{component}{attribution}:{phase}:{exception_class}"
     )
 
 
@@ -5626,6 +5663,7 @@ def test_held_namespace_scan_stderr_sanitizer_classifies_only_exact_markers() ->
     """Only complete closed markers survive alongside dynamic child output."""
     revalidator_marker = _held_namespace_scan_failure_marker(
         "revalidator", "root-pin", "runtimeerror",
+        operation="scan", holder_kind="fd",
     )
     scanner_marker = _held_namespace_scan_failure_marker(
         "scanner", "mountinfo", "oserror",
@@ -5669,6 +5707,9 @@ def test_held_namespace_scan_stderr_sanitizer_rejects_marker_spoofing() -> None:
     stderr = (
         f"attacker says {marker}\n"
         f"{marker} payload=/private/secret\n"
+        "pdd-held-namespace-failure:revalidator:delete:fd:namespace-pin:oserror\n"
+        "pdd-held-namespace-failure:revalidator:scan:path:namespace-pin:oserror\n"
+        "pdd-held-namespace-failure:revalidator:scan:fd:bogus:oserror\n"
         "pdd-held-namespace-failure:scanner:bogus:runtimeerror\n"
         "pdd-held-namespace-failure:bogus:payload:runtimeerror\n"
         "pdd-held-namespace-failure:scanner:payload:bogus\n"
@@ -5683,19 +5724,30 @@ def test_held_namespace_scan_stderr_sanitizer_accepts_only_closed_marker_tokens(
     for component, phases in _HELD_NAMESPACE_SCAN_FAILURE_COMPONENT_PHASES.items():
         for phase in phases:
             for exception_class in _HELD_NAMESPACE_SCAN_FAILURE_EXCEPTION_CLASSES:
-                marker = _held_namespace_scan_failure_marker(
-                    component, phase, exception_class,
+                attributions = (
+                    (
+                        (operation, holder_kind)
+                        for operation in _HELD_NAMESPACE_SCAN_FAILURE_OPERATIONS
+                        for holder_kind in _HELD_NAMESPACE_SCAN_FAILURE_HOLDER_KINDS
+                    ) if component == "revalidator" else ((None, None),)
                 )
-                assert _held_namespace_scan_stderr_category(marker) == marker
+                for operation, holder_kind in attributions:
+                    marker = _held_namespace_scan_failure_marker(
+                        component, phase, exception_class,
+                        operation=operation, holder_kind=holder_kind,
+                    )
+                    assert _held_namespace_scan_stderr_category(marker) == marker
 
 
 def test_held_namespace_scan_stderr_sanitizer_deduplicates_exact_markers() -> None:
     """Exact matching keeps each marker once without overlapping text ambiguity."""
     root_marker = _held_namespace_scan_failure_marker(
         "revalidator", "root-pin", "runtimeerror",
+        operation="unmount", holder_kind="fd",
     )
     namespace_marker = _held_namespace_scan_failure_marker(
         "revalidator", "namespace-pin", "runtimeerror",
+        operation="unmount", holder_kind="fd",
     )
     stderr = (
         f"{root_marker}\n"
@@ -5715,7 +5767,10 @@ def test_held_namespace_scan_stderr_sanitizer_prioritizes_terminal_categories() 
             _held_namespace_scan_failure_marker("scanner", phase, "runtimeerror")
             for phase in sorted(_HELD_NAMESPACE_SCAN_FAILURE_COMPONENT_PHASES["scanner"])
         ),
-        _held_namespace_scan_failure_marker("revalidator", "exec", "oserror"),
+        _held_namespace_scan_failure_marker(
+            "revalidator", "exec", "oserror",
+            operation="scan", holder_kind="current",
+        ),
     )
     stderr = "".join(f"{category}\n" for category in categories)
 
@@ -6421,6 +6476,52 @@ def test_held_namespace_child_sources_use_closed_marker_states() -> None:
             assert f"PHASE='{phase}'" in source
         for exception_class in _HELD_NAMESPACE_SCAN_FAILURE_EXCEPTION_CLASSES:
             assert f"'{exception_class}'" in source
+    for operation in _HELD_NAMESPACE_SCAN_FAILURE_OPERATIONS:
+        assert f"'{operation}'" in _NSENTER_REVALIDATOR_SOURCE
+    for holder_kind in _HELD_NAMESPACE_SCAN_FAILURE_HOLDER_KINDS:
+        assert f"'{holder_kind}'" in _NSENTER_REVALIDATOR_SOURCE
+
+
+@pytest.mark.parametrize("operation", sorted(_HELD_NAMESPACE_SCAN_FAILURE_OPERATIONS))
+@pytest.mark.parametrize("holder_kind", sorted(_HELD_NAMESPACE_SCAN_FAILURE_HOLDER_KINDS))
+def test_nsenter_revalidator_emits_operation_holder_and_process_stat_phase(
+    tmp_path: Path, operation: str, holder_kind: str,
+) -> None:
+    """A deterministic identity fault emits only its closed attributed marker."""
+    pid = 4242
+    proc = tmp_path / "proc" / str(pid)
+    proc.mkdir(parents=True)
+    (proc / "stat").write_text(
+        f"{pid} (fixture) S {' '.join(['0'] * 19 + ['123'])}\n",
+        encoding="ascii",
+    )
+    source = _NSENTER_REVALIDATOR_SOURCE.replace(
+        "pidfd=os.pidfd_open(pid,0)",
+        "pidfd=os.open('/dev/null',os.O_RDONLY)",
+    ).replace(
+        "proc=pathlib.Path('/proc')/str(pid)", f"proc=pathlib.Path({str(proc)!r})",
+    )
+    payload = json.dumps({
+        "holder": {
+            "holder_kind": holder_kind, "pid": pid, "start_time": "124",
+        },
+        "namespace": {"link": "mnt:[1]", "inode": 1},
+        "operation": operation,
+    }, sort_keys=True, separators=(",", ":"))
+
+    completed = subprocess.run(
+        [sys.executable, "-I", "-S", "-c", source, payload],
+        capture_output=True, text=True, check=False, timeout=5,
+    )
+    marker = _held_namespace_scan_failure_marker(
+        "revalidator", "process-stat", "runtimeerror",
+        operation=operation, holder_kind=holder_kind,
+    )
+
+    assert completed.returncode != 0
+    assert completed.stderr == marker + "\n"
+    assert _sanitized_held_namespace_scan_stderr(completed.stderr) == marker
+    assert str(tmp_path) not in completed.stderr
 
 
 def test_held_namespace_child_sources_emit_exact_markers_and_preserve_system_exit() -> None:
@@ -6440,7 +6541,9 @@ def test_held_namespace_child_sources_emit_exact_markers_and_preserve_system_exi
 
     assert revalidator.stderr == _held_namespace_scan_failure_marker(
         "revalidator", "holder-validation", "keyerror",
+        operation="unclassified", holder_kind="unclassified",
     ) + "\n"
+    assert _sanitized_held_namespace_scan_stderr(revalidator.stderr) == "redacted"
     assert scanner.stderr == _held_namespace_scan_failure_marker(
         "scanner", "transport", "runtimeerror",
     ) + "\n"
@@ -7240,7 +7343,8 @@ def test_held_namespace_scan_failures_continue_cleanup_and_final_verification(
                 if failure == "transport":
                     return SimpleNamespace(
                         returncode=2, stdout=b"", stderr=(
-                            b"pdd-held-namespace-failure:revalidator:scan-transport:runtimeerror\n"
+                            b"pdd-held-namespace-failure:revalidator:scan:current:"
+                            b"scan-transport:runtimeerror\n"
                         ),
                     )
                 return SimpleNamespace(returncode=0, stdout="[]", stderr="")
@@ -7267,8 +7371,9 @@ def test_held_namespace_scan_failures_continue_cleanup_and_final_verification(
         assert "held mount namespace scan was malformed" in message
     elif failure == "transport":
         assert (
-            "category=child-nonzero-returncode-2 stderr_tail="
-            "pdd-held-namespace-failure:revalidator:scan-transport:runtimeerror"
+                "category=child-nonzero-returncode-2 stderr_tail="
+                "pdd-held-namespace-failure:revalidator:scan:current:"
+                "scan-transport:runtimeerror"
         ) in message
         assert "terminate" in operations
     else:
@@ -7610,6 +7715,7 @@ def test_namespace_holder_unmount_payload_and_nsenter_argv_are_exact(
         assert rejected.returncode != 0
         assert rejected.stderr == _held_namespace_scan_failure_marker(
             "revalidator", "exec", "runtimeerror",
+            operation="unmount", holder_kind="fd",
         ) + "\n"
         host_root = os.open("/", getattr(os, "O_PATH") | os.O_CLOEXEC)
         try:
@@ -7639,6 +7745,7 @@ def test_namespace_holder_unmount_payload_and_nsenter_argv_are_exact(
             assert rejected.returncode != 0
             assert rejected.stderr == _held_namespace_scan_failure_marker(
                 "revalidator", "root-pin", "runtimeerror",
+                operation="unmount", holder_kind="fd",
             ) + "\n"
         finally:
             os.close(host_root)

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -7808,6 +7808,132 @@ def test_stalled_cleanup_unmounts_before_destructive_scope_actions(
         os.fstat(read_fd)
 
 
+def test_stalled_cleanup_switches_to_captured_fd_holder_after_scope_teardown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Post-scope absence is authenticated through the captured external FD holder."""
+    prefix = tmp_path / "pdd-scope-owned"
+    mount = prefix / "binds" / "writable"
+    mount.mkdir(parents=True)
+    namespace = {"link": "mnt:[11]", "inode": 11}
+    coordinator = {"pid": 777777, "start_time": "100"}
+    current_holder = {
+        "holder_kind": "current", "pid": 999999, "start_time": "101",
+        "namespace": "mnt:[11]", "namespace_inode": 11,
+    }
+    fd_holder = {
+        "holder_kind": "fd", "pid": 888888, "start_time": "102", "fd": 73,
+        "fd_path": "/proc/888888/fd/73", "fd_link": "mnt:[11]", "fd_inode": 11,
+        "root_fd": 74, "root_path": "/proc/888888/fd/74",
+        "root_device": 1, "root_inode": 2, "root_mode": 0o40755,
+        "root_mnt_id": 42, "namespace": "mnt:[11]", "namespace_inode": 11,
+    }
+    ownership = {
+        "unit": "pdd-validator-holder-switch.scope", "cgroup": tmp_path / "cgroup",
+        "control_prefix": prefix, "namespace": namespace,
+        "namespace_holder": fd_holder,
+        "namespace_holders": [current_holder, fd_holder],
+        "coordinator": coordinator, "mount_points": [mount],
+        "external_holders": [fd_holder], "require_fd_only_holder": True,
+    }
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    coordinator_alive = True
+    fd_holder_alive = True
+    current_holder_alive = True
+    scope_torn_down = False
+    mounted = True
+    events = []
+
+    monkeypatch.setattr(
+        supervisor, "_trusted_tools",
+        lambda: SimpleNamespace(helper_python=Path("/trusted/python")),
+    )
+
+    def scanner(**_kwargs):
+        identities = []
+        watched = []
+        if coordinator_alive:
+            identities.append(coordinator)
+            watched.append(coordinator)
+        if current_holder_alive:
+            identities.append(current_holder)
+            watched.append(current_holder)
+        if fd_holder_alive:
+            identities.append(fd_holder)
+            watched.append(fd_holder)
+        return {
+            "watched": watched, "identities": identities,
+            "current_holders": [current_holder] if current_holder_alive else [],
+            "fd_holders": [fd_holder] if fd_holder_alive else [],
+            "mount_holders": [], "cgroup_exists": False,
+        }
+
+    def runner(argv, **_kwargs):
+        nonlocal current_holder_alive, fd_holder_alive, mounted, scope_torn_down
+        if "systemctl" in argv and "show" in argv:
+            return SimpleNamespace(returncode=0, stdout="not-found\n", stderr="")
+        if "systemctl" in argv:
+            events.append(f"scope-{argv[3]}")
+            if argv[3] == "kill":
+                scope_torn_down = True
+                current_holder_alive = False
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if _NSENTER_REVALIDATOR_SOURCE in argv:
+            payload = json.loads(argv[-1])
+            operation = payload["operation"]
+            holder_kind = payload["holder"]["holder_kind"]
+            events.append(f"{holder_kind}-{operation}")
+            os.fstat(read_fd)
+            if operation == "terminate":
+                assert holder_kind == "fd" and scope_torn_down
+                fd_holder_alive = False
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            if holder_kind == "current":
+                assert current_holder_alive and not scope_torn_down
+            else:
+                assert holder_kind == "fd" and fd_holder_alive and scope_torn_down
+            if operation == "unmount":
+                mounted = False
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(
+                returncode=0, stdout="mounted" if mounted else "absent", stderr="",
+            )
+        raise AssertionError(f"unexpected command: {argv}")
+
+    def terminate(pid: int, sent: signal.Signals) -> None:
+        nonlocal coordinator_alive
+        assert pid == coordinator["pid"] and sent == signal.SIGTERM
+        assert scope_torn_down and not current_holder_alive and not mounted
+        coordinator_alive = False
+        events.append("coordinator-reaped")
+
+    def waitpid(pid: int, _options: int) -> tuple[int, int]:
+        if pid == coordinator["pid"]:
+            return (0, 0) if coordinator_alive else (pid, 0)
+        assert pid == fd_holder["pid"]
+        return (0, 0) if fd_holder_alive else (pid, 0)
+
+    def parse_diagnostic(raw: str, **_kwargs):
+        return ({"root": {"matches": True}}, (mount,) if raw == "mounted" else ())
+
+    monkeypatch.setattr(os, "kill", terminate)
+    monkeypatch.setattr(os, "waitpid", waitpid)
+    monkeypatch.setattr(
+        sys.modules[__name__], "_parse_held_namespace_diagnostic", parse_diagnostic,
+    )
+
+    assert _fallback_stalled_observation_cleanup(
+        ownership, (read_fd,), runner=runner, scanner=scanner,
+    ) == (-1,)
+    assert events == [
+        "current-scan", "current-unmount", "scope-kill", "scope-stop",
+        "scope-reset-failed", "fd-scan", "coordinator-reaped", "fd-terminate",
+    ]
+    with pytest.raises(OSError):
+        os.fstat(read_fd)
+
+
 def test_exact_blocked_role_snapshot_rejects_running_and_reused_identity() -> None:
     """A running role or PID reuse cannot satisfy blocked-role evidence."""
     roles = [

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5618,13 +5618,9 @@ def _fallback_stalled_observation_cleanup_impl(
     if holder_records is None:
         holder_records = (ownership["namespace_holder"],)
     captured_holders = tuple(holder_records)
-    external_holder_keys = {
-        _holder_key(holder) for holder in ownership.get("external_holders", ())
-    }
-    captured_external_fd_holders = tuple(
+    captured_fd_holders = tuple(
         holder for holder in captured_holders
         if holder.get("holder_kind") == "fd"
-        and _holder_key(holder) in external_holder_keys
     )
     unit_action_failures = []
 
@@ -5853,7 +5849,7 @@ def _fallback_stalled_observation_cleanup_impl(
         namespace_holder = (
             None if post_scope_scan is None
             else _select_captured_namespace_holder(
-                post_scope_scan, captured_external_fd_holders, namespace,
+                post_scope_scan, captured_fd_holders, namespace,
             )
         )
         remaining_scan = holder_mount_scan()

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -2290,6 +2290,9 @@ def test_launch_descriptor_write_failure_stops_scope_and_cleans_staging(
     assert result.returncode == 125
     assert surviving is False
     assert "phase=launch-handoff: launch write failed" in result.stderr
+    assert result.termination.failure_phases == (
+        supervisor.InfrastructureFailurePhase.LAUNCH,
+    )
     assert cleanup == ["scope", "mounts"]
 
 
@@ -2392,6 +2395,9 @@ def test_scope_setup_deadline_is_not_candidate_timeout(
 
     assert result.returncode == 125
     assert result.termination.kind is supervisor.TerminationKind.SANDBOX_ERROR
+    assert result.termination.failure_phases == (
+        supervisor.InfrastructureFailurePhase.SCOPE_SETUP,
+    )
     assert "phase=scope-setup" in result.stderr
     assert cleanup == ["scope", "mounts"]
     assert surviving is False
@@ -2466,6 +2472,12 @@ def test_helper_exit_must_match_validated_timeout_record(
 
     assert result.returncode == 125
     assert "helper exit" in result.stderr
+    assert result.termination.failure_phases == (
+        supervisor.InfrastructureFailurePhase.RESULT_HANDOFF,
+    )
+    assert result.termination.resource_telemetry == (
+        supervisor.CgroupResourceTelemetry(0, 0, 0)
+    )
 
 
 def test_signaled_candidate_helper_exit_encoding_is_preserved(
@@ -2499,6 +2511,9 @@ def test_helper_timeout_with_cleanup_failure_fails_closed(
     assert result.returncode == 125
     assert result.termination.kind is supervisor.TerminationKind.SANDBOX_ERROR
     assert "scope-cleanup" in result.stderr
+    assert supervisor.InfrastructureFailurePhase.SCOPE_CLEANUP in (
+        result.termination.failure_phases
+    )
 
 
 def test_helper_stall_after_candidate_exit_is_not_timeout(
@@ -2519,6 +2534,9 @@ time.sleep(30)
 
     assert result.returncode == 125
     assert "protected candidate record" in result.stderr
+    assert result.termination.failure_phases == (
+        supervisor.InfrastructureFailurePhase.CANDIDATE_EXECUTION,
+    )
 
 
 @pytest.mark.parametrize("failure", ["pidfd_open", "poll", "waitpid"])
@@ -2622,6 +2640,9 @@ def test_helper_timeout_with_quota_postprocessing_failure_fails_closed(
 
     assert result.returncode == 125
     assert "trusted postprocessing did not finish" in result.stderr
+    assert result.termination.failure_phases == (
+        supervisor.InfrastructureFailurePhase.TRUSTED_POSTPROCESSING,
+    )
 
 
 def test_helper_timeout_with_output_violation_fails_closed(
@@ -3361,6 +3382,50 @@ def test_cgroup_resource_telemetry_rejects_counter_regression() -> None:
             {"max": 0},
             {"max": 0},
         )
+
+
+@pytest.mark.parametrize(
+    "phase",
+    [
+        "construction",
+        "launch",
+        "scope-setup",
+        "candidate-execution",
+        "trusted-postprocessing",
+        "result-handoff",
+        "scope-cleanup",
+        "mount-cleanup",
+        "output-drain",
+        "process-cleanup",
+    ],
+)
+def test_sandbox_termination_preserves_only_allowlisted_failure_phases(
+    phase: str,
+) -> None:
+    """Candidate prose cannot manufacture a trusted infrastructure phase."""
+    trusted = supervisor.InfrastructureFailurePhase(phase)
+
+    termination = supervisor._sandbox_termination(
+        (trusted, "candidate-spoofed-phase"),
+        resource_telemetry=None,
+    )
+
+    assert termination.kind is supervisor.TerminationKind.SANDBOX_ERROR
+    assert termination.failure_phases == (
+        trusted,
+        supervisor.InfrastructureFailurePhase.UNKNOWN,
+    )
+
+
+def test_sandbox_termination_preserves_available_cgroup_telemetry() -> None:
+    telemetry = supervisor.CgroupResourceTelemetry(2, 1, 3)
+
+    termination = supervisor._sandbox_termination(
+        (supervisor.InfrastructureFailurePhase.PROCESS_CLEANUP,),
+        resource_telemetry=telemetry,
+    )
+
+    assert termination.resource_telemetry == telemetry
 
 
 def test_scope_cleanup_targets_only_validated_unique_unit(

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5649,60 +5649,40 @@ def _fallback_stalled_observation_cleanup(
             errors.append(f"privileged procfs scan failed: {type(exc).__name__}: {exc}")
             return None
 
-    for descriptor in owned_fds:
-        if descriptor < 0:
-            continue
-        try:
-            os.close(descriptor)
-        except OSError as exc:
-            if exc.errno != 9:
-                errors.append(f"close fd {descriptor} failed: {exc}")
+    def teardown_scope_and_coordinator() -> None:
+        for action in (
+            ["kill", "--kill-whom=all", "--signal=SIGKILL", unit],
+            ["stop", unit],
+            ["reset-failed", unit],
+        ):
+            purpose = f"systemctl {action[0]} exact scope"
+            before = len(errors)
+            completed = command(["sudo", "-n", "systemctl", *action], purpose)
+            if len(errors) != before:
+                unit_action_failures.extend(errors[before:])
+                del errors[before:]
+            elif completed is not None and completed.returncode != 0:
+                unit_action_failures.append(
+                    completed.stderr.strip()
+                    or f"{purpose} returned {completed.returncode}"
+                )
 
-    for action in (
-        ["kill", "--kill-whom=all", "--signal=SIGKILL", unit],
-        ["stop", unit],
-        ["reset-failed", unit],
-    ):
-        purpose = f"systemctl {action[0]} exact scope"
-        before = len(errors)
-        completed = command(["sudo", "-n", "systemctl", *action], purpose)
-        if len(errors) != before:
-            unit_action_failures.extend(errors[before:])
-            del errors[before:]
-        elif completed is not None and completed.returncode != 0:
-            unit_action_failures.append(
-                completed.stderr.strip() or f"{purpose} returned {completed.returncode}"
-            )
-
-    # Signal only a procfs-confirmed PID/start-time identity; a reused PID is untouchable.
-    scan = scan_owned()
-    coordinator_present = scan is not None and any(
-        _process_key(record) == expected_coordinator for record in scan["watched"]
-    )
-    if coordinator_present:
-        try:
-            os.kill(int(coordinator["pid"]), signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-    reap_deadline = min(deadline, time.monotonic() + 5)
-    reaped = False
-    while time.monotonic() < reap_deadline:
-        try:
-            waited, _status = os.waitpid(int(coordinator["pid"]), os.WNOHANG)
-        except ChildProcessError:
-            reaped = True
-            break
-        if waited == int(coordinator["pid"]):
-            reaped = True
-            break
-        time.sleep(.05)
-    if not reaped and coordinator_present:
-        try:
-            os.kill(int(coordinator["pid"]), signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        kill_deadline = min(deadline, time.monotonic() + 5)
-        while time.monotonic() < kill_deadline:
+        # Signal only a procfs-confirmed PID/start-time identity; a reused PID
+        # is untouchable. The lifecycle gate remains held until this outside
+        # coordinator can no longer run its private-namespace cleanup path.
+        scan = scan_owned()
+        coordinator_present = scan is not None and any(
+            _process_key(record) == expected_coordinator
+            for record in scan["watched"]
+        )
+        if coordinator_present:
+            try:
+                os.kill(int(coordinator["pid"]), signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+        reap_deadline = min(deadline, time.monotonic() + 5)
+        reaped = False
+        while time.monotonic() < reap_deadline:
             try:
                 waited, _status = os.waitpid(int(coordinator["pid"]), os.WNOHANG)
             except ChildProcessError:
@@ -5712,8 +5692,38 @@ def _fallback_stalled_observation_cleanup(
                 reaped = True
                 break
             time.sleep(.05)
-    if coordinator_present and not reaped:
-        errors.append("captured coordinator could not be reaped before deadline")
+        if not reaped and coordinator_present:
+            try:
+                os.kill(int(coordinator["pid"]), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            kill_deadline = min(deadline, time.monotonic() + 5)
+            while time.monotonic() < kill_deadline:
+                try:
+                    waited, _status = os.waitpid(
+                        int(coordinator["pid"]), os.WNOHANG,
+                    )
+                except ChildProcessError:
+                    reaped = True
+                    break
+                if waited == int(coordinator["pid"]):
+                    reaped = True
+                    break
+                time.sleep(.05)
+        if coordinator_present and not reaped:
+            errors.append("captured coordinator could not be reaped before deadline")
+
+    try:
+        teardown_scope_and_coordinator()
+    finally:
+        for descriptor in owned_fds:
+            if descriptor < 0:
+                continue
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                if exc.errno != 9:
+                    errors.append(f"close fd {descriptor} failed: {exc}")
 
     # The scanner sees mounts in the privileged private namespace, including binds/*.
     scan = scan_owned()
@@ -7441,11 +7451,10 @@ def test_stalled_observation_setup_failure_preserves_primary_and_reaps_owned_sta
     os.close(write_fd)
     commands = []
     calls = 0
+    coordinator_scan_observed_open_fd = False
 
     def runner(*args, **_kwargs):
         commands.append(args[0])
-        if args[0][2:4] == ["systemctl", "kill"]:
-            os.kill(coordinator, signal.SIGKILL)
         if args[0][2:4] == ["systemctl", "stop"]:
             return SimpleNamespace(returncode=5, stdout="", stderr="already removed")
         if args[0][2:4] == ["systemctl", "show"]:
@@ -7460,10 +7469,12 @@ def test_stalled_observation_setup_failure_preserves_primary_and_reaps_owned_sta
         selection=_RootProcSelection(),
     ):
         del cgroup, namespace, targets, target_prefix
-        nonlocal calls
+        nonlocal calls, coordinator_scan_observed_open_fd
         calls += 1
         selections.append(selection)
         if calls == 1:
+            os.fstat(read_fd)
+            coordinator_scan_observed_open_fd = True
             return {
                 "watched": [coordinator_record], "mount_holders": [],
                 "current_holders": [], "fd_holders": [], "identities": [],
@@ -7506,6 +7517,7 @@ def test_stalled_observation_setup_failure_preserves_primary_and_reaps_owned_sta
 
     with pytest.raises(OSError):
         os.fstat(read_fd)
+    assert coordinator_scan_observed_open_fd
     with pytest.raises(ChildProcessError):
         os.waitpid(coordinator, os.WNOHANG)
     assert selections and selections[0] == _RootProcSelection((coordinator,))
@@ -7558,6 +7570,38 @@ def test_stalled_cleanup_load_state_timeout_fails_closed(tmp_path: Path) -> None
         _fallback_stalled_observation_cleanup(
             ownership, (), runner=runner, scanner=scanner,
         )
+
+
+def test_stalled_cleanup_closes_observer_fds_after_teardown_exception(
+    tmp_path: Path,
+) -> None:
+    """Transferred descriptors close even when exact teardown raises unexpectedly."""
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    ownership = {
+        "unit": "pdd-validator-action-error.scope",
+        "cgroup": tmp_path / "cgroup",
+        "control_prefix": tmp_path / "pdd-scope-owned",
+        "namespace": {"link": "mnt:[1]", "inode": 1},
+        "namespace_holder": {
+            "holder_kind": "current", "pid": 999999,
+            "start_time": "100", "namespace": "mnt:[1]",
+            "namespace_inode": 1,
+        },
+        "coordinator": {"pid": 999999, "start_time": "100"},
+        "mount_points": [],
+    }
+
+    def runner(_argv, **_kwargs):
+        os.fstat(read_fd)
+        raise RuntimeError("injected teardown failure")
+
+    with pytest.raises(RuntimeError, match="injected teardown failure"):
+        _fallback_stalled_observation_cleanup(
+            ownership, (read_fd,), runner=runner,
+        )
+    with pytest.raises(OSError):
+        os.fstat(read_fd)
 
 
 def test_exact_blocked_role_snapshot_rejects_running_and_reused_identity() -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -7604,6 +7604,93 @@ def test_stalled_cleanup_closes_observer_fds_after_teardown_exception(
         os.fstat(read_fd)
 
 
+def test_stalled_cleanup_unmounts_before_coordinator_reap_deletes_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Held mounts are removed before coordinator cleanup deletes their paths."""
+    prefix = tmp_path / "pdd-scope-owned"
+    mount = prefix / "binds" / "writable"
+    mount.mkdir(parents=True)
+    namespace = {"link": "mnt:[11]", "inode": 11}
+    coordinator = {
+        "holder_kind": "current", "pid": 999999, "start_time": "100",
+        "namespace": "mnt:[11]", "namespace_inode": 11,
+    }
+    ownership = {
+        "unit": "pdd-validator-order.scope", "cgroup": tmp_path / "cgroup",
+        "control_prefix": prefix, "namespace": namespace,
+        "namespace_holder": coordinator, "coordinator": coordinator,
+        "mount_points": [mount],
+    }
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    coordinator_alive = True
+    mounted = True
+    events = []
+
+    monkeypatch.setattr(
+        supervisor, "_trusted_tools",
+        lambda: SimpleNamespace(helper_python=Path("/trusted/python")),
+    )
+
+    def scanner(**_kwargs):
+        records = [coordinator] if coordinator_alive else []
+        return {
+            "watched": records, "identities": records,
+            "current_holders": records, "fd_holders": [],
+            "mount_holders": [], "cgroup_exists": False,
+        }
+
+    def runner(argv, **_kwargs):
+        nonlocal mounted
+        if "systemctl" in argv and "show" in argv:
+            return SimpleNamespace(returncode=0, stdout="not-found\n", stderr="")
+        if _NSENTER_REVALIDATOR_SOURCE in argv:
+            operation = json.loads(argv[-1])["operation"]
+            assert coordinator_alive
+            assert mount.exists()
+            os.fstat(read_fd)
+            events.append(operation)
+            if operation == "unmount":
+                mounted = False
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(
+                returncode=0, stdout="mounted" if mounted else "absent", stderr="",
+            )
+        if "umount" in argv:
+            events.append("plain-unmount-after-reap")
+            return SimpleNamespace(returncode=32, stdout="", stderr="no such file")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def terminate(pid: int, sent: signal.Signals) -> None:
+        nonlocal coordinator_alive
+        assert pid == coordinator["pid"] and sent == signal.SIGTERM
+        assert mounted is False
+        coordinator_alive = False
+        shutil.rmtree(prefix)
+        events.append("coordinator-reaped-paths")
+
+    def waitpid(pid: int, _options: int) -> tuple[int, int]:
+        assert pid == coordinator["pid"]
+        return (0, 0) if coordinator_alive else (pid, 0)
+
+    def parse_diagnostic(raw: str, **_kwargs):
+        return ({"root": {"matches": True}}, (mount,) if raw == "mounted" else ())
+
+    monkeypatch.setattr(os, "kill", terminate)
+    monkeypatch.setattr(os, "waitpid", waitpid)
+    monkeypatch.setattr(
+        sys.modules[__name__], "_parse_held_namespace_diagnostic", parse_diagnostic,
+    )
+
+    assert _fallback_stalled_observation_cleanup(
+        ownership, (read_fd,), runner=runner, scanner=scanner,
+    ) == (-1,)
+    assert events == ["scan", "unmount", "scan", "coordinator-reaped-paths"]
+    with pytest.raises(OSError):
+        os.fstat(read_fd)
+
+
 def test_exact_blocked_role_snapshot_rejects_running_and_reused_identity() -> None:
     """A running role or PID reuse cannot satisfy blocked-role evidence."""
     roles = [

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -3766,6 +3766,9 @@ def test_playwright_construction_failure_is_typed_sandbox_error(tmp_path: Path) 
     )
     assert result.returncode == 125
     assert result.termination.kind is supervisor.TerminationKind.SANDBOX_ERROR
+    assert result.termination.failure_phases == (
+        supervisor.InfrastructureFailurePhase.CONSTRUCTION,
+    )
     assert "phase=construction" in result.stderr
     assert surviving is False
 
@@ -9260,8 +9263,16 @@ def test_playwright_descriptor_transport_timeout_fails_closed(
         supervisor, "_probe_scope",
         lambda _plan, _limits: (cgroup, {"oom": 0, "oom_kill": 0}, {"max": 0}),
     )
-    monkeypatch.setattr(supervisor, "_stop_scope", lambda *_args: None)
-    monkeypatch.setattr(supervisor, "_cleanup_staging", lambda _plan: None)
+    monkeypatch.setattr(
+        supervisor,
+        "_stop_scope",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("scope cleanup failed")),
+    )
+    monkeypatch.setattr(
+        supervisor,
+        "_cleanup_staging",
+        lambda _plan: (_ for _ in ()).throw(RuntimeError("mount cleanup failed")),
+    )
     monkeypatch.setattr(supervisor, "_TRUSTED_POSTPROCESS_SECONDS", .02)
     monkeypatch.setattr(supervisor.os, "urandom", lambda size: b"\xaa" * size)
     read_fd, write_fd = os.pipe()
@@ -9281,11 +9292,19 @@ def test_playwright_descriptor_transport_timeout_fails_closed(
     assert result.returncode == 125
     assert result.termination.kind is supervisor.TerminationKind.SANDBOX_ERROR
     assert "descriptor transport timed out" in result.stderr
+    assert result.termination.failure_phases == (
+        supervisor.InfrastructureFailurePhase.CANDIDATE_EXECUTION,
+        supervisor.InfrastructureFailurePhase.SCOPE_CLEANUP,
+        supervisor.InfrastructureFailurePhase.MOUNT_CLEANUP,
+    )
     assert surviving is False
 
 
+@pytest.mark.parametrize("cleanup_failure", [False, True])
 def test_playwright_descriptor_records_events_before_helper_cleanup(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cleanup_failure: bool,
 ) -> None:
     """Authenticated event deltas remain readable until result handoff is acknowledged."""
     cgroup = tmp_path / "cgroup"
@@ -9329,7 +9348,11 @@ os.unlink(sys.argv[1]);os.unlink(sys.argv[2])
         lambda _plan, _limits: (cgroup, {"oom": 0, "oom_kill": 0}, {"max": 0}),
     )
     monkeypatch.setattr(supervisor, "_stop_scope", lambda *_args: None)
-    monkeypatch.setattr(supervisor, "_cleanup_staging", lambda _plan: None)
+    def cleanup(_plan) -> None:
+        if cleanup_failure:
+            raise RuntimeError("mount cleanup failed")
+
+    monkeypatch.setattr(supervisor, "_cleanup_staging", cleanup)
     monkeypatch.setattr(supervisor.os, "urandom", lambda size: b"\xaa" * size)
     read_fd, write_fd = os.pipe()
     try:
@@ -9346,8 +9369,18 @@ os.unlink(sys.argv[1]);os.unlink(sys.argv[2])
         os.close(read_fd)
         os.close(write_fd)
 
-    assert result.returncode == 0, result.stderr
-    assert result.termination.kind is supervisor.TerminationKind.EXIT
+    assert result.termination.resource_telemetry == (
+        supervisor.CgroupResourceTelemetry(0, 0, 0)
+    )
+    if cleanup_failure:
+        assert result.returncode == 125
+        assert result.termination.kind is supervisor.TerminationKind.SANDBOX_ERROR
+        assert result.termination.failure_phases == (
+            supervisor.InfrastructureFailurePhase.MOUNT_CLEANUP,
+        )
+    else:
+        assert result.returncode == 0, result.stderr
+        assert result.termination.kind is supervisor.TerminationKind.EXIT
     assert surviving is False
 
 

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5520,7 +5520,20 @@ def _deferred_absent_is_proven(
     procfs_absence = final_authoritative_mounts is not None and all(
         mount not in final_authoritative_mounts for mount, _diagnostic in deferred
     )
+    if any(
+        _ambiguous_absent_unmount_diagnostic(diagnostic)
+        for _mount, diagnostic in deferred
+    ):
+        return root_valid_absence
     return root_valid_absence or procfs_absence
+
+
+def _ambiguous_absent_unmount_diagnostic(diagnostic: str) -> bool:
+    """Match only util-linux's exact missing-mountpoint diagnostic shape."""
+    return diagnostic == "no mount point specified" or (
+        diagnostic.startswith("umount: ")
+        and diagnostic.endswith(": no mount point specified")
+    )
 
 
 _BLOCKED_WCHAN_MARKERS = ("sleep", "wait", "pause", "futex")
@@ -5838,7 +5851,10 @@ def _fallback_stalled_observation_cleanup_impl(
         if completed is None or completed.returncode == 0:
             continue
         diagnostic = (completed.stderr or completed.stdout).strip().lower()
-        if "not mounted" in diagnostic or "no such file" in diagnostic:
+        if (
+            "not mounted" in diagnostic or "no such file" in diagnostic
+            or _ambiguous_absent_unmount_diagnostic(diagnostic)
+        ):
             deferred_absent_unmounts.append((mount, diagnostic[:512]))
         else:
             errors.append(diagnostic[:512] or f"cannot unmount {mount}")
@@ -7004,7 +7020,7 @@ def test_held_namespace_scan_failures_continue_cleanup_and_final_verification(
     (
         ("not mounted", False, True, True),
         ("no such file", False, True, True),
-        ("no mount point specified", False, True, True),
+        ("umount: /p/binds/writable: no mount point specified", False, True, True),
         ("no mount point specified", False, False, False),
         ("no mount point specified", True, True, False),
     ),

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -3408,12 +3408,17 @@ def test_sandbox_termination_preserves_only_allowlisted_failure_phases(
     termination = supervisor._sandbox_termination(
         (trusted, "candidate-spoofed-phase"),
         resource_telemetry=None,
+        failure_reason="candidate-spoofed-reason",
     )
 
     assert termination.kind is supervisor.TerminationKind.SANDBOX_ERROR
     assert termination.failure_phases == (
         trusted,
         supervisor.InfrastructureFailurePhase.UNKNOWN,
+    )
+    assert (
+        termination.failure_reason
+        is supervisor.InfrastructureFailureReason.UNKNOWN
     )
 
 
@@ -3426,6 +3431,80 @@ def test_sandbox_termination_preserves_available_cgroup_telemetry() -> None:
     )
 
     assert termination.resource_telemetry == telemetry
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        supervisor.InfrastructureFailureReason.TRUSTED_TOOL_DISCOVERY,
+        supervisor.InfrastructureFailureReason.TRUSTED_TOOL_IDENTITY,
+        supervisor.InfrastructureFailureReason.TRUSTED_TOOL_REVALIDATION,
+        supervisor.InfrastructureFailureReason.RUNTIME_DEPENDENCY_DISCOVERY,
+        supervisor.InfrastructureFailureReason.SUDO_PRIVILEGE_PROBE,
+        supervisor.InfrastructureFailureReason.WRITABLE_ACCOUNTING,
+        supervisor.InfrastructureFailureReason.WRITABLE_QUOTA,
+    ],
+)
+def test_construction_failure_preserves_explicit_trusted_reason(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reason: supervisor.InfrastructureFailureReason,
+) -> None:
+    def fail_construction(*_args, **_kwargs):
+        raise supervisor._InfrastructureFailure(reason, "trusted construction failed")
+
+    monkeypatch.setattr(supervisor, "_sandbox_command", fail_construction)
+
+    result, surviving = run_supervised(
+        [sys.executable, "-c", "pass"],
+        cwd=tmp_path,
+        timeout=1,
+        env={},
+        writable_roots=(tmp_path,),
+    )
+
+    assert result.returncode == 125
+    assert result.termination.failure_phases == (
+        supervisor.InfrastructureFailurePhase.CONSTRUCTION,
+    )
+    assert result.termination.failure_reason is reason
+    assert surviving is False
+
+
+def test_construction_plan_and_staging_failures_are_distinct(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        supervisor,
+        "_sandbox_command",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("candidate-spoofed reason=staging-preparation")
+        ),
+    )
+    plan_result, _surviving = run_supervised(
+        [sys.executable, "-c", "pass"], cwd=tmp_path, timeout=1, env={},
+        writable_roots=(tmp_path,),
+    )
+    assert plan_result.termination.failure_reason is (
+        supervisor.InfrastructureFailureReason.DESCRIPTOR_PLAN_CONSTRUCTION
+    )
+
+    _mock_scope_run(tmp_path, monkeypatch, _terminal_helper(0, False))
+    monkeypatch.setattr(
+        supervisor,
+        "_prepare_staging",
+        lambda _plan: (_ for _ in ()).throw(
+            RuntimeError("candidate-spoofed reason=descriptor-plan-construction")
+        ),
+    )
+    staging_result, _surviving = run_supervised(
+        [sys.executable, "-c", "pass"], cwd=tmp_path, timeout=1, env={},
+        writable_roots=(tmp_path,),
+    )
+    assert staging_result.termination.failure_reason is (
+        supervisor.InfrastructureFailureReason.STAGING_PREPARATION
+    )
 
 
 def test_scope_cleanup_targets_only_validated_unique_unit(
@@ -3518,6 +3597,33 @@ def test_linked_libraries_keeps_loader_alias_and_resolved_path(
     )
 
     assert _linked_libraries(tmp_path / "python") == (target, alias)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        OSError("ldd unavailable"),
+        subprocess.TimeoutExpired(["ldd"], 5),
+    ],
+)
+def test_linked_library_discovery_failure_has_trusted_reason(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+) -> None:
+    monkeypatch.setattr(supervisor.sys, "platform", "linux")
+    monkeypatch.setattr(
+        supervisor.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(error),
+    )
+
+    with pytest.raises(supervisor._InfrastructureFailure) as raised:
+        _linked_libraries(tmp_path / "python")
+
+    assert raised.value.reason is (
+        supervisor.InfrastructureFailureReason.RUNTIME_DEPENDENCY_DISCOVERY
+    )
 
 
 def test_sandbox_library_path_uses_only_measured_loader_directories(

--- a/tests/test_unit_tests_workflow.py
+++ b/tests/test_unit_tests_workflow.py
@@ -102,6 +102,15 @@ def _workflow() -> dict:
     return loaded
 
 
+def test_workflow_loads_after_current_directory_changes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The committed workflow path must not depend on a worker's current directory."""
+    monkeypatch.chdir(tmp_path)
+
+    assert _workflow()["jobs"][LINUX_JOB_ID]["runs-on"] == "ubuntu-latest"
+
+
 def _named_step(job: dict, name: str) -> dict:
     """Return exactly one active, stable-named workflow step."""
     steps = job.get("steps")

--- a/tests/test_unit_tests_workflow.py
+++ b/tests/test_unit_tests_workflow.py
@@ -12,7 +12,9 @@ import pytest
 import yaml
 
 
-WORKFLOW_PATH = Path(".github/workflows/unit-tests.yml")
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "unit-tests.yml"
+)
 SETUP_AND_FOCUSED_SECONDS = 16 * 60 + 37
 BROAD_SUITE_SECONDS = 30 * 60
 FULL_JOB_SECONDS = SETUP_AND_FOCUSED_SECONDS + BROAD_SUITE_SECONDS


### PR DESCRIPTION
## Summary

Diagnostic-only refinement for #2091. Adds closed, bounded operation/holder/subphase attribution to the hosted held-namespace revalidator failure marker so the recurring fd-only lifecycle race can be localized without raw exception data.

## Scope

- changes only `tests/test_sync_core_supervisor.py`
- no production code
- no retry, timeout, outcome, gate, cleanup, or lifecycle behavior change
- scanner marker compatibility retained

## Validation

- full supervisor file: 301 passed, 48 skipped
- targeted attribution suite: 31 passed, 2 skipped
- `py_compile`: pass
- `git diff --check`: pass
- independent critical review: GO, no findings

## Hosted plan

Temporarily target `main` once to obtain exact hosted Linux attribution, then restore this stacked base. Do not merge this diagnostic PR. Closes no issue.