### PR TITLE
ci: add one-shot trusted Vitest pressure diagnostic

### DIFF
--- a/.github/workflows/2083-vitest-pressure-dispatch.yml
+++ b/.github/workflows/2083-vitest-pressure-dispatch.yml
@@ -1,4 +1,11 @@
-name: Issue 2083 trusted Vitest pressure dispatch
+name: TEMPORARY ONE-SHOT issue 2083 trusted Vitest pressure dispatch
+
+# ONE-SHOT REMOVAL CONTRACT:
+# Delete this workflow and tests/test_issue_2083_vitest_pressure_dispatch.py
+# immediately after the first terminal run (success, failure, or cancellation).
+# Then remove both exact preauthorization rules in the protected-base cleanup
+# PR. This dispatcher
+# must not remain available as permanent repository automation.
 
 'on':
   workflow_dispatch:
@@ -217,6 +224,139 @@ jobs:
             --expected-run-id "$GITHUB_RUN_ID" \
             --expected-attempt "$GITHUB_RUN_ATTEMPT"
 
+      - name: Always ensure canonical uploadable evidence
+        id: evidence
+        if: always()
+        env:
+          SEALED_EVIDENCE_DIR: ${{ runner.temp }}/issue-2083-sealed
+          NORMAL_SEAL_OUTCOME: ${{ steps.seal.outcome }}
+          INITIALIZE_OUTCOME: ${{ steps.initialize.outcome }}
+          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
+          SOURCE_OUTCOME: ${{ steps.source.outcome }}
+          PYTHON_OUTCOME: ${{ steps.python.outcome }}
+          NODE_OUTCOME: ${{ steps.node.outcome }}
+          TOOLCHAIN_OUTCOME: ${{ steps.toolchain.outcome }}
+          DEPENDENCIES_OUTCOME: ${{ steps.dependencies.outcome }}
+          SANDBOX_OUTCOME: ${{ steps.sandbox.outcome }}
+          ATTEST_OUTCOME: ${{ steps.attest.outcome }}
+          DIAGNOSTIC_OUTCOME: ${{ steps.diagnostic.outcome }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 -I - <<'PY'
+          import hashlib
+          import json
+          import os
+          import re
+          import shutil
+          from pathlib import Path
+
+          sealed = Path(os.environ["SEALED_EVIDENCE_DIR"])
+          normal_files = {
+              "diagnostic-exit-status.txt",
+              "manifest.json",
+              "results.json",
+              "toolchain-identity.json",
+          }
+
+          def regular_names(root):
+              if not root.is_dir() or root.is_symlink():
+                  return None
+              entries = tuple(root.iterdir())
+              if any(path.is_symlink() or not path.is_file() for path in entries):
+                  return None
+              return {path.name for path in entries}
+
+          if (
+              os.environ["NORMAL_SEAL_OUTCOME"] == "success"
+              and regular_names(sealed) == normal_files
+          ):
+              raise SystemExit(0)
+
+          if sealed.exists():
+              if sealed.is_symlink() or not sealed.is_dir():
+                  sealed.unlink()
+              else:
+                  shutil.rmtree(sealed)
+          sealed.mkdir(mode=0o700)
+
+          allowed = {"success", "failure", "cancelled", "skipped"}
+          stage_environment = {
+              "attest": "ATTEST_OUTCOME",
+              "checkout": "CHECKOUT_OUTCOME",
+              "dependencies": "DEPENDENCIES_OUTCOME",
+              "diagnostic": "DIAGNOSTIC_OUTCOME",
+              "initialize": "INITIALIZE_OUTCOME",
+              "node": "NODE_OUTCOME",
+              "python": "PYTHON_OUTCOME",
+              "sandbox": "SANDBOX_OUTCOME",
+              "seal": "NORMAL_SEAL_OUTCOME",
+              "source": "SOURCE_OUTCOME",
+              "toolchain": "TOOLCHAIN_OUTCOME",
+          }
+          stages = {}
+          for stage, variable in stage_environment.items():
+              outcome = os.environ[variable]
+              if outcome not in allowed:
+                  raise SystemExit(f"invalid controlled stage outcome: {stage}")
+              stages[stage] = {"outcome": outcome}
+
+          subject = os.environ["PDD_ISSUE_2083_SUBJECT_SHA"]
+          source = os.environ["PDD_ISSUE_2083_SOURCE_SHA"]
+          run_id = os.environ["GITHUB_RUN_ID"]
+          attempt_text = os.environ["GITHUB_RUN_ATTEMPT"]
+          if re.fullmatch(r"[0-9a-f]{40}", subject) is None:
+              raise SystemExit("invalid controlled subject SHA")
+          if re.fullmatch(r"[0-9a-f]{40}", source) is None:
+              raise SystemExit("invalid controlled source SHA")
+          if re.fullmatch(r"[A-Za-z0-9._-]{1,128}", run_id) is None:
+              raise SystemExit("invalid controlled run ID")
+          if not attempt_text.isdigit() or int(attempt_text) <= 0:
+              raise SystemExit("invalid controlled run attempt")
+
+          canonical = lambda value: json.dumps(
+              value, separators=(",", ":"), sort_keys=True
+          )
+          status = {
+              "fallback": True,
+              "run_attempt": int(attempt_text),
+              "run_id": run_id,
+              "schema": "pdd-issue-2083-fallback-status-v1",
+              "source_sha": source,
+              "stages": stages,
+              "subject_sha": subject,
+          }
+          status_path = sealed / "fallback-status.json"
+          status_path.write_text(canonical(status), encoding="utf-8")
+          manifest = {
+              "files": {
+                  status_path.name: {
+                      "sha256": hashlib.sha256(status_path.read_bytes()).hexdigest(),
+                      "size": status_path.stat().st_size,
+                  }
+              },
+              "run_attempt": int(attempt_text),
+              "run_id": run_id,
+              "schema": "pdd-issue-2083-fallback-evidence-manifest-v1",
+              "source_sha": source,
+              "subject_sha": subject,
+          }
+          (sealed / "manifest.json").write_text(
+              canonical(manifest), encoding="utf-8"
+          )
+          for path in sealed.iterdir():
+              path.chmod(0o444)
+          sealed.chmod(0o555)
+          PY
+          if test -f "$SEALED_EVIDENCE_DIR/fallback-status.json"; then
+            fallback_used=true
+          else
+            fallback_used=false
+          fi
+          if test -n "${GITHUB_OUTPUT:-}"; then
+            printf 'fallback_used=%s\n' "$fallback_used" >>"$GITHUB_OUTPUT"
+          fi
+
       - name: Always upload sealed diagnostic evidence
         id: upload
         if: always()
@@ -242,6 +382,8 @@ jobs:
           ATTEST_OUTCOME: ${{ steps.attest.outcome }}
           DIAGNOSTIC_OUTCOME: ${{ steps.diagnostic.outcome }}
           SEAL_OUTCOME: ${{ steps.seal.outcome }}
+          EVIDENCE_OUTCOME: ${{ steps.evidence.outcome }}
+          FALLBACK_USED: ${{ steps.evidence.outputs.fallback_used }}
           UPLOAD_OUTCOME: ${{ steps.upload.outcome }}
         run: |
           set -euo pipefail
@@ -255,5 +397,7 @@ jobs:
           test "$SANDBOX_OUTCOME" = success
           test "$ATTEST_OUTCOME" = success
           test "$SEAL_OUTCOME" = success
+          test "$EVIDENCE_OUTCOME" = success
+          test "$FALLBACK_USED" = false
           test "$UPLOAD_OUTCOME" = success
           test "$DIAGNOSTIC_OUTCOME" = success

--- a/.github/workflows/2083-vitest-pressure-dispatch.yml
+++ b/.github/workflows/2083-vitest-pressure-dispatch.yml
@@ -1,0 +1,259 @@
+name: Issue 2083 trusted Vitest pressure dispatch
+
+'on':
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  vitest-pressure-diagnostic:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PDD_ISSUE_2083_SUBJECT_SHA: bd4a250420c3b7aaa50bab6fd73aded271115c71
+      PDD_ISSUE_2083_SOURCE_SHA: 829fb7e2818bb326d31a06cb16bdcb698576b7e6
+      PDD_ISSUE_2083_NODE_VERSION: 22.23.1
+
+    steps:
+      - name: Initialize private evidence directories
+        id: initialize
+        shell: bash
+        run: |
+          set -euo pipefail
+          live="$RUNNER_TEMP/issue-2083-live"
+          sealed="$RUNNER_TEMP/issue-2083-sealed"
+          mkdir -m 700 "$live"
+          {
+            printf 'LIVE_EVIDENCE_DIR=%s\n' "$live"
+            printf 'SEALED_EVIDENCE_DIR=%s\n' "$sealed"
+          } >>"$GITHUB_ENV"
+
+      - name: Check out immutable source
+        id: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: 829fb7e2818bb326d31a06cb16bdcb698576b7e6
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify immutable source bytes
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$PDD_ISSUE_2083_SOURCE_SHA"
+          git merge-base --is-ancestor \
+            "$PDD_ISSUE_2083_SUBJECT_SHA" "$PDD_ISSUE_2083_SOURCE_SHA"
+          mapfile -t changed < <(
+            git diff --name-only \
+              "$PDD_ISSUE_2083_SUBJECT_SHA" "$PDD_ISSUE_2083_SOURCE_SHA" --
+          )
+          expected=(
+            scripts/ci/issue_2083_vitest_barrier.py
+            scripts/ci/run_issue_2083_vitest_pressure.py
+            tests/test_issue_2083_vitest_pressure_diagnostic.py
+          )
+          test "${#changed[@]}" -eq "${#expected[@]}"
+          for index in "${!expected[@]}"; do
+            test "${changed[$index]}" = "${expected[$index]}"
+            test -f "${expected[$index]}"
+            test ! -L "${expected[$index]}"
+          done
+          git diff --check \
+            "$PDD_ISSUE_2083_SUBJECT_SHA" "$PDD_ISSUE_2083_SOURCE_SHA"
+          sha256sum --check --strict <<'EOF'
+          b63e3ce1f2d427ca8588d300b7c85144d23350d46d2cbda6bc1dec8c4b442d02  scripts/ci/issue_2083_vitest_barrier.py
+          1103102193911a8b28588d4efb44eb6a83520c945e94ab7e65c2dfea0d99c469  scripts/ci/run_issue_2083_vitest_pressure.py
+          fb146ad1edbaf3f7fb1267dc7fb0ceee93a94610a9ae1cccfb0f4f2cccfe9e75  tests/test_issue_2083_vitest_pressure_diagnostic.py
+          EOF
+
+      - name: Set up exact Python
+        id: python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: '3.12.13'
+
+      - name: Set up exact failing Node patch
+        id: node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+        with:
+          node-version: '22.23.1'
+          check-latest: false
+
+      - name: Provision exact identity-bound Vitest toolchain
+        id: toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(node --version)" = "v$PDD_ISSUE_2083_NODE_VERSION"
+          test "$(npm --version)" = "10.9.8"
+          toolchain="$RUNNER_TEMP/pdd-vitest-toolchain"
+          mkdir -m 700 "$toolchain"
+          cp .github/toolchains/vitest/package.json "$toolchain/"
+          cp .github/toolchains/vitest/package-lock.json "$toolchain/"
+          npm ci --prefix "$toolchain" --ignore-scripts --no-audit --no-fund
+          TOOLCHAIN="$toolchain" python - <<'PY'
+          import json
+          import os
+          import re
+          import shutil
+          import subprocess
+          from pathlib import Path
+
+          root = Path(os.environ["TOOLCHAIN"]).resolve(strict=True)
+          launcher = Path(shutil.which("node") or "").resolve(strict=True)
+          entrypoint = (root / "node_modules/vitest/vitest.mjs").resolve(strict=True)
+          dependencies = (root / "node_modules").resolve(strict=True)
+          lockfile = (root / "package-lock.json").resolve(strict=True)
+          package = json.loads(
+              (root / "node_modules/vitest/package.json").read_text(encoding="utf-8")
+          )
+          if package.get("version") != "4.1.10":
+              raise SystemExit("unexpected installed Vitest version")
+          linked = subprocess.run(
+              ["ldd", str(launcher)],
+              capture_output=True,
+              text=True,
+              check=True,
+              timeout=30,
+          ).stdout
+          native = sorted({
+              str(Path(match.group(1)).resolve(strict=True))
+              for line in linked.splitlines()
+              if (match := re.search(r"(?:=>\s+)?(/[^ ]+)", line))
+          })
+          if not native:
+              raise SystemExit("Node native runtime closure is empty")
+          manifest = root / "vitest-toolchain.json"
+          manifest.write_text(
+              json.dumps(
+                  {
+                      "roles": {
+                          "dependencies": str(dependencies),
+                          "entrypoint": str(entrypoint),
+                          "launcher": str(launcher),
+                          "lockfile": str(lockfile),
+                          "native_runtime": native,
+                      },
+                      "version": 1,
+                  },
+                  separators=(",", ":"),
+                  sort_keys=True,
+              ),
+              encoding="utf-8",
+          )
+          with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as handle:
+              handle.write(f"PDD_REAL_VITEST_TOOLCHAIN_MANIFEST={manifest}\n")
+          PY
+
+      - name: Install diagnostic dependencies
+        id: dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]" pytest-timeout
+
+      - name: Provision protected Linux sandbox
+        id: sandbox
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes bubblewrap
+          command -v bwrap
+          command -v systemd-run
+          command -v unshare
+          command -v nsenter
+          sudo -n true
+          pytest -q \
+            tests/test_sync_core_supervisor.py::test_sandboxed_python_minimal_smoke \
+            --timeout=60
+
+      - name: Attest exact redacted toolchain identity
+        id: attest
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/ci/run_issue_2083_vitest_pressure.py attest-toolchain \
+            --toolchain-root "$RUNNER_TEMP/pdd-vitest-toolchain" \
+            --runtime-manifest "$PDD_REAL_VITEST_TOOLCHAIN_MANIFEST" \
+            --output "$LIVE_EVIDENCE_DIR/toolchain-identity.json"
+
+      - name: Run bounded protected Vitest pressure matrix
+        id: diagnostic
+        continue-on-error: true
+        shell: bash
+        run: |
+          set +e
+          timeout --signal=TERM --kill-after=30s 900s \
+            python scripts/ci/run_issue_2083_vitest_pressure.py run \
+              --root "$GITHUB_WORKSPACE" \
+              --output "$LIVE_EVIDENCE_DIR/results.json" \
+              --toolchain-identity "$LIVE_EVIDENCE_DIR/toolchain-identity.json"
+          status=$?
+          printf '%s\n' "$status" \
+            >"$LIVE_EVIDENCE_DIR/diagnostic-exit-status.txt"
+          exit "$status"
+
+      - name: Always seal and verify diagnostic evidence
+        id: seal
+        if: >-
+          always() &&
+          steps.attest.outcome == 'success' &&
+          steps.diagnostic.outcome != 'skipped'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/ci/run_issue_2083_vitest_pressure.py seal \
+            --source "$LIVE_EVIDENCE_DIR" \
+            --destination "$SEALED_EVIDENCE_DIR" \
+            --expected-source-sha "$PDD_ISSUE_2083_SOURCE_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --attempt "$GITHUB_RUN_ATTEMPT"
+          python scripts/ci/run_issue_2083_vitest_pressure.py verify-seal \
+            --root "$SEALED_EVIDENCE_DIR" \
+            --expected-source-sha "$PDD_ISSUE_2083_SOURCE_SHA" \
+            --expected-run-id "$GITHUB_RUN_ID" \
+            --expected-attempt "$GITHUB_RUN_ATTEMPT"
+
+      - name: Always upload sealed diagnostic evidence
+        id: upload
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: issue-2083-${{ github.run_id }}-${{ github.run_attempt }}-829fb7e2818bb326d31a06cb16bdcb698576b7e6
+          path: ${{ runner.temp }}/issue-2083-sealed
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Propagate exact diagnostic status
+        if: always()
+        shell: bash
+        env:
+          INITIALIZE_OUTCOME: ${{ steps.initialize.outcome }}
+          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
+          SOURCE_OUTCOME: ${{ steps.source.outcome }}
+          PYTHON_OUTCOME: ${{ steps.python.outcome }}
+          NODE_OUTCOME: ${{ steps.node.outcome }}
+          TOOLCHAIN_OUTCOME: ${{ steps.toolchain.outcome }}
+          DEPENDENCIES_OUTCOME: ${{ steps.dependencies.outcome }}
+          SANDBOX_OUTCOME: ${{ steps.sandbox.outcome }}
+          ATTEST_OUTCOME: ${{ steps.attest.outcome }}
+          DIAGNOSTIC_OUTCOME: ${{ steps.diagnostic.outcome }}
+          SEAL_OUTCOME: ${{ steps.seal.outcome }}
+          UPLOAD_OUTCOME: ${{ steps.upload.outcome }}
+        run: |
+          set -euo pipefail
+          test "$INITIALIZE_OUTCOME" = success
+          test "$CHECKOUT_OUTCOME" = success
+          test "$SOURCE_OUTCOME" = success
+          test "$PYTHON_OUTCOME" = success
+          test "$NODE_OUTCOME" = success
+          test "$TOOLCHAIN_OUTCOME" = success
+          test "$DEPENDENCIES_OUTCOME" = success
+          test "$SANDBOX_OUTCOME" = success
+          test "$ATTEST_OUTCOME" = success
+          test "$SEAL_OUTCOME" = success
+          test "$UPLOAD_OUTCOME" = success
+          test "$DIAGNOSTIC_OUTCOME" = success

--- a/tests/test_issue_2083_vitest_pressure_dispatch.py
+++ b/tests/test_issue_2083_vitest_pressure_dispatch.py
@@ -1,0 +1,137 @@
+"""Contracts for the temporary trusted issue-2083 dispatcher."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/2083-vitest-pressure-dispatch.yml"
+SUBJECT = "bd4a250420c3b7aaa50bab6fd73aded271115c71"
+SOURCE = "829fb7e2818bb326d31a06cb16bdcb698576b7e6"
+SOURCE_FILES = {
+    "scripts/ci/run_issue_2083_vitest_pressure.py":
+        "1103102193911a8b28588d4efb44eb6a83520c945e94ab7e65c2dfea0d99c469",
+    "scripts/ci/issue_2083_vitest_barrier.py":
+        "b63e3ce1f2d427ca8588d300b7c85144d23350d46d2cbda6bc1dec8c4b442d02",
+    "tests/test_issue_2083_vitest_pressure_diagnostic.py":
+        "fb146ad1edbaf3f7fb1267dc7fb0ceee93a94610a9ae1cccfb0f4f2cccfe9e75",
+}
+
+
+def _workflow() -> tuple[dict, str]:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    return yaml.safe_load(text), text
+
+
+def test_dispatcher_is_manual_read_only_and_bounded() -> None:
+    """Only a manual unprivileged job may execute this temporary dispatcher."""
+    workflow, text = _workflow()
+    job = workflow["jobs"]["vitest-pressure-diagnostic"]
+
+    assert workflow["on"] == {"workflow_dispatch": None}
+    assert workflow["permissions"] == {"contents": "read"}
+    assert job["timeout-minutes"] <= 20
+    assert "pull_request" not in workflow["on"]
+    assert "push" not in workflow["on"]
+    assert "secrets." not in text
+    assert "id-token" not in text
+    assert "gcloud" not in text
+    assert re.search(r"\b(?:contents|actions|checks|pull-requests):\s*write\b", text) is None
+
+
+def test_dispatcher_pins_source_actions_and_failing_node_patch() -> None:
+    """All executable inputs must be immutable and reproduce the failing host."""
+    workflow, text = _workflow()
+    job = workflow["jobs"]["vitest-pressure-diagnostic"]
+
+    assert job["env"]["PDD_ISSUE_2083_SUBJECT_SHA"] == SUBJECT
+    assert job["env"]["PDD_ISSUE_2083_SOURCE_SHA"] == SOURCE
+    assert job["env"]["PDD_ISSUE_2083_NODE_VERSION"] == "22.23.1"
+    assert "10.9.8" in text
+    assert "4.1.10" in text
+    for path, digest in SOURCE_FILES.items():
+        assert path in text
+        assert digest in text
+
+    checkout = next(
+        step for step in job["steps"] if step["name"] == "Check out immutable source"
+    )
+    assert checkout["with"]["ref"] == SOURCE
+    assert checkout["with"]["persist-credentials"] is False
+    assert checkout["with"]["fetch-depth"] == 0
+    assert re.fullmatch(r"actions/checkout@[0-9a-f]{40}", checkout["uses"])
+    assert "ref: main" not in text
+    assert "github.head_ref" not in text
+    assert "github.event.pull_request" not in text
+    for step in job["steps"]:
+        if uses := step.get("uses"):
+            assert re.fullmatch(r"actions/[a-z-]+@[0-9a-f]{40}", uses)
+
+
+def test_dispatcher_gates_bytes_and_constructs_bound_toolchain() -> None:
+    """The immutable checkout and runtime roles must be verified before use."""
+    workflow, text = _workflow()
+    steps = workflow["jobs"]["vitest-pressure-diagnostic"]["steps"]
+    names = [step["name"] for step in steps]
+
+    assert "Verify immutable source bytes" in names
+    assert "git merge-base --is-ancestor" in text
+    assert "git diff --name-only" in text
+    assert "git diff --check" in text
+    assert "sha256sum --check" in text
+    assert text.index("Verify immutable source bytes") < text.index(
+        "Install diagnostic dependencies"
+    )
+    assert '"version": 1' in text
+    for role in (
+        "launcher", "entrypoint", "dependencies", "native_runtime", "lockfile",
+    ):
+        assert f'"{role}"' in text
+    assert "separators=(\",\", \":\")" in text
+    assert "sort_keys=True" in text
+    assert "PDD_REAL_VITEST_TOOLCHAIN_MANIFEST" in text
+    assert "attest-toolchain" in text
+    assert "--toolchain-identity" in text
+
+
+def test_dispatcher_seals_uploads_then_propagates_exact_run_status() -> None:
+    """Evidence upload must precede the final exact-status propagation."""
+    workflow, text = _workflow()
+    steps = workflow["jobs"]["vitest-pressure-diagnostic"]["steps"]
+    names = [step["name"] for step in steps]
+    upload_index = names.index("Always upload sealed diagnostic evidence")
+    final_index = names.index("Propagate exact diagnostic status")
+
+    assert "900s" in text
+    assert "--expected-source-sha" in text
+    assert "--expected-run-id" in text
+    assert "--expected-attempt" in text
+    assert upload_index < final_index
+    assert steps[upload_index]["if"] == "always()"
+    assert steps[final_index]["if"] == "always()"
+    assert SOURCE in steps[upload_index]["with"]["name"]
+    assert "${{ github.run_id }}" in steps[upload_index]["with"]["name"]
+    assert "${{ github.run_attempt }}" in steps[upload_index]["with"]["name"]
+    assert steps[upload_index]["with"]["if-no-files-found"] == "error"
+
+
+def test_every_shell_block_parses_as_bash() -> None:
+    """Static validation must cover every shell block in the workflow."""
+    workflow, _ = _workflow()
+    blocks = [
+        step["run"]
+        for step in workflow["jobs"]["vitest-pressure-diagnostic"]["steps"]
+        if "run" in step
+    ]
+
+    assert blocks
+    for block in blocks:
+        result = subprocess.run(
+            ["bash", "-n"], input=block, text=True, capture_output=True, check=False,
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/test_issue_2083_vitest_pressure_dispatch.py
+++ b/tests/test_issue_2083_vitest_pressure_dispatch.py
@@ -139,6 +139,7 @@ def test_early_failure_creates_canonical_redacted_fallback_artifact(
 ) -> None:
     """An early failure must still produce a hashed status-only artifact."""
     fallback = _step("Always ensure canonical uploadable evidence")
+    assert "/usr/bin/python3 -I" in fallback["run"]
     sealed = tmp_path / "sealed"
     environment = os.environ.copy()
     environment.update({

--- a/tests/test_issue_2083_vitest_pressure_dispatch.py
+++ b/tests/test_issue_2083_vitest_pressure_dispatch.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -26,6 +29,15 @@ SOURCE_FILES = {
 def _workflow() -> tuple[dict, str]:
     text = WORKFLOW.read_text(encoding="utf-8")
     return yaml.safe_load(text), text
+
+
+def _step(name: str) -> dict:
+    workflow, _ = _workflow()
+    return next(
+        step
+        for step in workflow["jobs"]["vitest-pressure-diagnostic"]["steps"]
+        if step["name"] == name
+    )
 
 
 def test_dispatcher_is_manual_read_only_and_bounded() -> None:
@@ -104,6 +116,7 @@ def test_dispatcher_seals_uploads_then_propagates_exact_run_status() -> None:
     workflow, text = _workflow()
     steps = workflow["jobs"]["vitest-pressure-diagnostic"]["steps"]
     names = [step["name"] for step in steps]
+    fallback_index = names.index("Always ensure canonical uploadable evidence")
     upload_index = names.index("Always upload sealed diagnostic evidence")
     final_index = names.index("Propagate exact diagnostic status")
 
@@ -111,13 +124,100 @@ def test_dispatcher_seals_uploads_then_propagates_exact_run_status() -> None:
     assert "--expected-source-sha" in text
     assert "--expected-run-id" in text
     assert "--expected-attempt" in text
-    assert upload_index < final_index
+    assert fallback_index < upload_index < final_index
+    assert steps[fallback_index]["if"] == "always()"
     assert steps[upload_index]["if"] == "always()"
     assert steps[final_index]["if"] == "always()"
     assert SOURCE in steps[upload_index]["with"]["name"]
     assert "${{ github.run_id }}" in steps[upload_index]["with"]["name"]
     assert "${{ github.run_attempt }}" in steps[upload_index]["with"]["name"]
     assert steps[upload_index]["with"]["if-no-files-found"] == "error"
+
+
+def test_early_failure_creates_canonical_redacted_fallback_artifact(
+    tmp_path: Path,
+) -> None:
+    """An early failure must still produce a hashed status-only artifact."""
+    fallback = _step("Always ensure canonical uploadable evidence")
+    sealed = tmp_path / "sealed"
+    environment = os.environ.copy()
+    environment.update({
+        "SEALED_EVIDENCE_DIR": str(sealed),
+        "PDD_ISSUE_2083_SUBJECT_SHA": SUBJECT,
+        "PDD_ISSUE_2083_SOURCE_SHA": SOURCE,
+        "GITHUB_RUN_ID": "12345",
+        "GITHUB_RUN_ATTEMPT": "1",
+        "NORMAL_SEAL_OUTCOME": "skipped",
+        "INITIALIZE_OUTCOME": "success",
+        "CHECKOUT_OUTCOME": "failure",
+        "SOURCE_OUTCOME": "skipped",
+        "PYTHON_OUTCOME": "skipped",
+        "NODE_OUTCOME": "skipped",
+        "TOOLCHAIN_OUTCOME": "skipped",
+        "DEPENDENCIES_OUTCOME": "skipped",
+        "SANDBOX_OUTCOME": "skipped",
+        "ATTEST_OUTCOME": "skipped",
+        "DIAGNOSTIC_OUTCOME": "skipped",
+        "UNRELATED_SECRET": "must-not-appear",
+    })
+
+    result = subprocess.run(
+        ["bash"],
+        input=fallback["run"],
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    assert {path.name for path in sealed.iterdir()} == {
+        "fallback-status.json",
+        "manifest.json",
+    }
+
+    status_path = sealed / "fallback-status.json"
+    manifest_path = sealed / "manifest.json"
+    status_raw = status_path.read_text(encoding="utf-8")
+    manifest_raw = manifest_path.read_text(encoding="utf-8")
+    status = json.loads(status_raw)
+    manifest = json.loads(manifest_raw)
+    assert status_raw == json.dumps(status, separators=(",", ":"), sort_keys=True)
+    assert manifest_raw == json.dumps(manifest, separators=(",", ":"), sort_keys=True)
+    assert status["subject_sha"] == SUBJECT
+    assert status["source_sha"] == SOURCE
+    assert status["run_id"] == "12345"
+    assert status["run_attempt"] == 1
+    assert status["fallback"] is True
+    assert set(status["stages"]) == {
+        "attest", "checkout", "dependencies", "diagnostic", "initialize",
+        "node", "python", "sandbox", "seal", "source", "toolchain",
+    }
+    assert all(
+        record == {"outcome": record["outcome"]}
+        and record["outcome"] in {"success", "failure", "cancelled", "skipped"}
+        for record in status["stages"].values()
+    )
+    assert "must-not-appear" not in status_raw + manifest_raw
+    assert str(tmp_path) not in status_raw + manifest_raw
+    assert manifest["files"] == {
+        "fallback-status.json": {
+            "sha256": hashlib.sha256(status_path.read_bytes()).hexdigest(),
+            "size": status_path.stat().st_size,
+        }
+    }
+
+
+def test_dispatcher_tracks_one_shot_removal_contract() -> None:
+    """The temporary dispatcher must explicitly require immediate retirement."""
+    workflow, text = _workflow()
+
+    assert "TEMPORARY ONE-SHOT" in workflow["name"]
+    assert "ONE-SHOT REMOVAL CONTRACT" in text
+    assert "immediately after the first terminal run" in text
+    assert "tests/test_issue_2083_vitest_pressure_dispatch.py" in text
+    assert "remove both exact preauthorization rules" in text
+    assert "must not remain available" in text
 
 
 def test_every_shell_block_parses_as_bash() -> None:


### PR DESCRIPTION
## Summary

Adds a temporary, manually dispatched trusted diagnostic for #2083. It checks out the immutable diagnostic source at exact commit `829fb7e2818bb326d31a06cb16bdcb698576b7e6`, runs the bounded serial/concurrent pressure matrix on a trusted hosted runner, seals canonical evidence, and uploads the artifact before propagating the terminal result.

This is diagnostic infrastructure, not the product fix. It is read-only with respect to production and has no deploy permissions.

## Safety and lifecycle

- `workflow_dispatch` only
- exact source SHA and content hashes are verified before execution
- actions are pinned; toolchain identities are explicit
- early failures emit a canonical redacted fallback artifact and remain red
- successful normal evidence remains byte-for-byte preserved
- run exactly once after merge
- remove this workflow and its test after the first terminal run
- remove the temporary preauthorization rules from #2113 after dispatcher removal

## TDD evidence

Separate commits preserve the test-first history:

- `1740ed281` — RED dispatcher contract
- `28fac85f7` — initial workflow
- `65cf0d109` — RED fallback evidence contract
- `842159d36` — fallback implementation

## Validation

- `pytest -q tests/test_issue_2083_vitest_pressure_dispatch.py tests/test_sync_core_pdd_rollout_policy.py` — 33 passed
- `pylint tests/test_issue_2083_vitest_pressure_dispatch.py` — 10.00/10
- `actionlint .github/workflows/2083-vitest-pressure-dispatch.yml` — passed
- `git diff --check origin/main...HEAD` — passed
- exact two-file diff; clean worktree

Reviewed file hashes after rebase onto #2113 merge `5344eca10346940c9b98cd2a5afe4728a7972566`:

- workflow: `512598f4c1225d199b42033c9312847a26ed82ec5415d891312820107111631b`
- test: `bafcd3bb89c68e21a760d71fd81b9528fe11b2e8ff11a02f9c2de8cbc5bc0b5d`

The prior critical review verdict remains **MERGE**, conditional on #2113 merging first and the patch hashes remaining unchanged; both conditions are satisfied.

Closes no issue; evidence from the one-shot run will determine the root fix for #2083.
