### PR TITLE
chore(ci): preauthorize one-shot issue 2083 rlimit A/B paths

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -39,6 +39,13 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".github/workflows/2083-vitest-rlimit-ab-dispatch.yml",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".github/workflows/auto-heal.yml",
       "role": "human-maintained"
     },
@@ -12576,6 +12583,13 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_issue_1872_reproduction.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_issue_2083_vitest_rlimit_ab_dispatch.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -71,7 +71,16 @@ LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS = {
     "context/prompt_repair_example.py",
     "context/routing_policy_example.py",
 }
-PREAUTHORIZED_CHILD_PATHS = LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS | {
+# One-shot issue-2083 authorization: remove these exact rules after the
+# temporary A/B dispatcher and its contract are removed from the protected base.
+ISSUE_2083_RLIMIT_AB_ONE_SHOT_PREAUTHORIZED_PATHS = {
+    ".github/workflows/2083-vitest-rlimit-ab-dispatch.yml",
+    "tests/test_issue_2083_vitest_rlimit_ab_dispatch.py",
+}
+PREAUTHORIZED_CHILD_PATHS = (
+    LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS
+    | ISSUE_2083_RLIMIT_AB_ONE_SHOT_PREAUTHORIZED_PATHS
+    | {
     ".pdd/meta/agentic_checkup_orchestrator_python_run.json",
     ".pdd/meta/checkup_agentic_artifact_python.json",
     ".pdd/meta/story_regression_python.json",
@@ -87,14 +96,24 @@ PREAUTHORIZED_CHILD_PATHS = LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS | {
     "tests/test_cloud_global_dry_run.py",
     "tests/test_continuous_sync_path_policy.py",
     "pdd/sync_core/human_attestation.py",
-    "tests/test_sync_core_human_attestation.py",
-}
+        "tests/test_sync_core_human_attestation.py",
+    }
+)
 PREAUTHORIZED_CHILD_OWNERSHIP = {
     "inventory": "HUMAN_OWNED",
     "role": "human-maintained",
     "owner": "pdd-maintainers",
     "preauthorize_absent": True,
 }
+
+
+def _preauthorized_child_content(path: str) -> str:
+    """Return minimally valid content for each protected child path kind."""
+    if path.startswith(".github/workflows/"):
+        return "name: preauthorized child\n'on': workflow_dispatch\njobs: {}\n"
+    return "# preauthorized child path\n"
+
+
 CI_DETECT_REQUIREMENT_ROTATION = {
     "prompt_path": "pdd/prompts/ci_detect_changed_modules_python.prompt",
     "language_id": "python",
@@ -828,7 +847,7 @@ def test_protected_base_pre_authorizes_absent_exact_child_paths(
     for path in PREAUTHORIZED_CHILD_PATHS:
         child_path = root / path
         child_path.parent.mkdir(parents=True, exist_ok=True)
-        child_path.write_text("# preauthorized child path\n", encoding="utf-8")
+        child_path.write_text(_preauthorized_child_content(path), encoding="utf-8")
         # Some protected generated metadata paths are intentionally ignored in
         # ordinary development but remain valid exact rollout candidates.
         _git(root, "add", "-f", path)

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -81,21 +81,21 @@ PREAUTHORIZED_CHILD_PATHS = (
     LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS
     | ISSUE_2083_RLIMIT_AB_ONE_SHOT_PREAUTHORIZED_PATHS
     | {
-    ".pdd/meta/agentic_checkup_orchestrator_python_run.json",
-    ".pdd/meta/checkup_agentic_artifact_python.json",
-    ".pdd/meta/story_regression_python.json",
-    "ci/cloud-batch/cloud-regression-runner.py",
-    "context/checkup_agentic_artifact_example.py",
-    "tests/test_checkup_agentic_artifact.py",
-    "tests/test_cloud_batch_cloud_regression_runner.py",
-    "tests/test_unit_tests_workflow.py",
-    "tests/test_ci_drift_heal_example_contract.py",
-    "tests/test_sync_core_runner_jest.py",
-    "tests/test_sync_core_runner_vitest.py",
-    "tests/test_sync_core_runner_playwright.py",
-    "tests/test_cloud_global_dry_run.py",
-    "tests/test_continuous_sync_path_policy.py",
-    "pdd/sync_core/human_attestation.py",
+        ".pdd/meta/agentic_checkup_orchestrator_python_run.json",
+        ".pdd/meta/checkup_agentic_artifact_python.json",
+        ".pdd/meta/story_regression_python.json",
+        "ci/cloud-batch/cloud-regression-runner.py",
+        "context/checkup_agentic_artifact_example.py",
+        "tests/test_checkup_agentic_artifact.py",
+        "tests/test_cloud_batch_cloud_regression_runner.py",
+        "tests/test_unit_tests_workflow.py",
+        "tests/test_ci_drift_heal_example_contract.py",
+        "tests/test_sync_core_runner_jest.py",
+        "tests/test_sync_core_runner_vitest.py",
+        "tests/test_sync_core_runner_playwright.py",
+        "tests/test_cloud_global_dry_run.py",
+        "tests/test_continuous_sync_path_policy.py",
+        "pdd/sync_core/human_attestation.py",
         "tests/test_sync_core_human_attestation.py",
     }
 )
@@ -110,8 +110,27 @@ PREAUTHORIZED_CHILD_OWNERSHIP = {
 def _preauthorized_child_content(path: str) -> str:
     """Return minimally valid content for each protected child path kind."""
     if path.startswith(".github/workflows/"):
-        return "name: preauthorized child\n'on': workflow_dispatch\njobs: {}\n"
+        return (
+            "name: preauthorized child\n"
+            "'on': workflow_dispatch\n"
+            "jobs:\n"
+            "  noop:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: ':'\n"
+        )
     return "# preauthorized child path\n"
+
+
+def test_preauthorized_workflow_fixture_has_one_inert_job() -> None:
+    """The synthetic protected workflow remains valid and side-effect free."""
+    content = _preauthorized_child_content(
+        ".github/workflows/2083-vitest-rlimit-ab-dispatch.yml"
+    )
+    assert content.count("runs-on:") == 1
+    assert content.count("- run:") == 1
+    assert "runs-on: ubuntu-latest" in content
+    assert "- run: ':'" in content
 
 
 CI_DETECT_REQUIREMENT_ROTATION = {
@@ -861,7 +880,11 @@ def test_protected_base_pre_authorizes_absent_exact_child_paths(
     }
     assert set(records) == PREAUTHORIZED_CHILD_PATHS
     for path, record in records.items():
-        assert record.inventory.value == "HUMAN_OWNED"
+        assert record.inventory.value == "HUMAN_OWNED", (
+            path,
+            record,
+            manifest.invalid_reasons,
+        )
         assert record.candidate_id.role == "human-maintained"
         assert not record.in_base and record.in_head
         assert record.ownership_provenance == (


### PR DESCRIPTION
## Summary

- preauthorize only the absent one-shot issue #2083 RLIMIT A/B dispatcher workflow path
- preauthorize only its exact protected-base contract-test path
- keep the prior pressure diagnostic workflow, test, and authorization rules removed

This is the protected-base authorization prerequisite only. It does not add or run the dispatcher, create cloud work, or change production behavior. These exact rules will be removed with the one-shot dispatcher cleanup.

## Test plan

- `/opt/homebrew/Caskroom/miniforge/base/envs/pdd/bin/python -m pytest -q tests/test_sync_core_pdd_rollout_policy.py` — 27 passed
- extracted inert workflow fixture passes `actionlint`
- `.pdd/sync-ownership.json` parses and contains exactly the two intended absent-path rules
- `git diff --check`

## Review evidence

Independent review GO for exact head `56212fcb3e621c54aa19af2be7264dfcaa3bd575`; no authority expansion or wildcard rules found.

Relates to #2083.
