### PR TITLE
fix(sync): raise Vitest address-space ceiling

### DIFF
--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -69,7 +69,8 @@ _IN_PROCESS_FRAMEWORK_ADAPTERS = frozenset(
     {"pytest", "jest", "vitest", "playwright"}
 )
 _VITEST_SUPERVISOR_LIMITS = SupervisorLimits(
-    max_memory_bytes=4 * 1024 * 1024 * 1024
+    max_memory_bytes=4 * 1024 * 1024 * 1024,
+    max_virtual_memory_bytes=4 * 1024 * 1024 * 1024,
 )
 PYTEST_CONFIG_PATHS = (
     PurePosixPath("pytest.ini"),

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -2231,7 +2231,10 @@ def test_vitest_linux_command_binds_wasm_guard(tmp_path: Path, monkeypatch: pyte
         root, config
     ).identity
     assert observed_limits == [
-        SupervisorLimits(max_memory_bytes=4 * 1024 * 1024 * 1024)
+        SupervisorLimits(
+            max_memory_bytes=4 * 1024 * 1024 * 1024,
+            max_virtual_memory_bytes=4 * 1024 * 1024 * 1024,
+        )
     ]
     assert SupervisorLimits().max_memory_bytes == 2 * 1024 * 1024 * 1024
 


### PR DESCRIPTION
Exact-head hosted validation PR for 52c27ea4df414dc49c21698c67b36e4f968cca4a. This branch is logically stacked on #2108; it targets main temporarily because full Unit Tests only trigger for main-targeting PRs. After exact hosted validation, restore base to fix/2083-vitest-gate-bounded before merge. Scope: Vitest-only virtual-address ceiling 2 GiB to 4 GiB, physical cap unchanged. Local evidence: 149 passed/1 skipped runner, 9 passed/1 skipped supervisor, broader 482 passed/95 skipped; independent critical-review GO. Fixes #2083.