### PR TITLE
fix(sync): preserve Vitest worker wasm guard

### DIFF
--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -4414,6 +4414,11 @@ def _vitest_environment(home: Path) -> dict[str, str]:
     }
 
 
+def _vitest_path_operand(path: PurePosixPath) -> str:
+    """Render one protected path so Vitest cannot parse it as a control."""
+    return "./" + path.as_posix()
+
+
 def _vitest_result(
     root: Path, output: Path, returncode: int, expected: tuple[str, ...] | None
 ) -> tuple[EvidenceOutcome, str, tuple[str, ...]]:
@@ -4650,9 +4655,14 @@ def _run_vitest(
             *( ("--disable-wasm-trap-handler",) if sys.platform.startswith("linux") else () ),
             str(phase_toolchain.entrypoint),
             "run",
-            *(path.as_posix() for path in paths),
             f"--config={root / config_path}",
             f"--reporter={reporter}",
+            *(
+                ("--execArgv=--disable-wasm-trap-handler",)
+                if sys.platform.startswith("linux")
+                else ()
+            ),
+            *(_vitest_path_operand(path) for path in paths),
         ]
         digest = hashlib.sha256(json.dumps(command, separators=(",", ":")).encode()).hexdigest()
         before = _validator_tree_identity(root)

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -2267,6 +2267,10 @@ def test_vitest_linux_command_binds_wasm_guard(tmp_path: Path, monkeypatch: pyte
 
     assert execution.outcome is EvidenceOutcome.PASS
     assert observed[0][1] == "--disable-wasm-trap-handler"
+    assert observed[0][-2:] == [
+        "--execArgv=--disable-wasm-trap-handler",
+        "./tests/widget.test.ts",
+    ]
     assert proofs[0][0].descriptor_identity == _load_vitest_toolchain_descriptor(
         root, config
     ).identity

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -1700,6 +1700,46 @@ def test_real_vitest_runs_copied_entrypoint_without_candidate_result_access(
     assert executions[0].outcome is EvidenceOutcome.PASS, executions[0].detail
 
 
+@pytest.mark.skipif(
+    not os.environ.get("PDD_REAL_VITEST_TOOLCHAIN_MANIFEST"),
+    reason="requires provisioned real Vitest toolchain",
+)
+def test_real_vitest_worker_inherits_linux_wasm_address_guard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every forked Vitest runtime must retain the coordinator's V8 guard."""
+    manifest = Path(os.environ["PDD_REAL_VITEST_TOOLCHAIN_MANIFEST"])
+    roles = json.loads(manifest.read_text(encoding="utf-8"))["roles"]
+    root, _commit = _repository(tmp_path)
+    (root / "tests/widget.test.ts").write_text(
+        "import fs from 'node:fs';\n"
+        "import { expect, test } from 'vitest';\n"
+        "test('worker retains checker runtime guard', () => {\n"
+        "  expect(process.execArgv).toContain('--disable-wasm-trap-handler');\n"
+        "  expect(() => fs.fstatSync(198)).toThrow();\n"
+        "});\n",
+        encoding="utf-8",
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "probe forked Vitest runtime")
+    monkeypatch.setattr(runner_module.sys, "platform", "linux")
+
+    execution, identities = _run_vitest(
+        root,
+        (PurePosixPath("tests/widget.test.ts"),),
+        30,
+        RunnerConfig(
+            vitest_command=(roles["launcher"], roles["entrypoint"]),
+            vitest_toolchain_manifest=manifest,
+        ),
+    )
+
+    assert execution.outcome is EvidenceOutcome.PASS, execution.detail
+    assert identities == (
+        "tests/widget.test.ts::worker retains checker runtime guard",
+    )
+
+
 @pytest.mark.parametrize(
     ("specifier", "mapping"),
     [


### PR DESCRIPTION
## Root cause

The protected Linux Vitest coordinator starts with `--disable-wasm-trap-handler`, but Vitest 4.1.10 creates fork workers without retaining that checker-owned Node flag. Repeated exact invocations therefore repeatedly start unguarded V8 runtimes under the sandbox address-space policy; the sealed #2083 matrix observed their identical pre-reporter SIGABRT. This patch passes the existing guard through Vitest’s worker `execArgv` and renders protected paths as operands so a dash-leading path cannot become a competing CLI control.

No maxWorkers, retry, timeout, memory/process-limit, gate, or reporter change. FD 198 remains unavailable in the worker.

## TDD

- Immutable subject: `bd4a250420c3b7aaa50bab6fd73aded271115c71`
- Subject RED: `be80ce152` (real Vitest worker fails to retain guard)
- Subject GREEN: `c48227da8`
- Isolated integration base: `0c3568c656dce2c3bda445eb9ce5f597c5a65c70`
- Integration RED/GREEN: `dbd2d0179` / `d8f22f830`

## Validation

- exact standalone Node 22.23.1 + Vitest 4.1.10 worker lifecycle: PASS
- full `tests/test_sync_core_runner_vitest.py`: PASS
- isolated installed-wheel real worker lifecycle: PASS
- `pylint pdd/sync_core/runner.py`: 10.00/10
- py_compile and diff check: PASS

Fixes #2083