### PR TITLE
fix(sync): revert unsupported Vitest address-space exception

### DIFF
--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -70,7 +70,6 @@ _IN_PROCESS_FRAMEWORK_ADAPTERS = frozenset(
 )
 _VITEST_SUPERVISOR_LIMITS = SupervisorLimits(
     max_memory_bytes=4 * 1024 * 1024 * 1024,
-    max_virtual_memory_bytes=4 * 1024 * 1024 * 1024,
 )
 PYTEST_CONFIG_PATHS = (
     PurePosixPath("pytest.ini"),

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -2233,10 +2233,13 @@ def test_vitest_linux_command_binds_wasm_guard(tmp_path: Path, monkeypatch: pyte
     assert observed_limits == [
         SupervisorLimits(
             max_memory_bytes=4 * 1024 * 1024 * 1024,
-            max_virtual_memory_bytes=4 * 1024 * 1024 * 1024,
         )
     ]
     assert SupervisorLimits().max_memory_bytes == 2 * 1024 * 1024 * 1024
+    assert (
+        observed_limits[0].max_virtual_memory_bytes
+        == SupervisorLimits().max_virtual_memory_bytes
+    )
 
 
 def test_mixed_adapter_identities_survive_manifest_removal_and_round_trip(


### PR DESCRIPTION
Closes #2125. Related: #2083, #2121, #2123.

## Why

#2121 set a Vitest-specific 4 GiB virtual-address ceiling solely as the claimed #2083 fix. Hosted Linux still reproduces the identical `bb513a…` SIGABRT at its merged base, the trusted private diagnostic contains no address-space/resource failure, and controlled 2/4/8 GiB outcomes do not track the ceiling. The branch is non-releaseable with this evidence-disproven exception silently retained.

This rollback deliberately does **not** claim to fix #2083. It removes only the unsupported virtual-address override and restores the inherited bounded supervisor default. The Vitest 4 GiB physical-memory cap, fail-closed missing-reporter classification, cgroup telemetry, process/output/time limits, no-retry behavior, and all gates remain unchanged.

## TDD evidence

- RED `1f477fd75`: `test_vitest_linux_command_binds_wasm_guard` failed with the exact 4 GiB-vs-default virtual-limit mismatch; pushed separately before GREEN.
- GREEN `d2f3cd387`: removes only the special `max_virtual_memory_bytes` override.
- targeted regression: 1 passed
- full `tests/test_sync_core_runner_vitest.py`: 149 passed, 1 skipped
- production pylint `pdd/sync_core/runner.py`: 10.00/10
- `py_compile` and `git diff --check`: passed

The full test-file pylint score remains its pre-existing 9.77/10 due unrelated baseline diagnostics; no new diagnostic was introduced.