### PR TITLE
fix(sync): remove falsified Vitest worker caps

### DIFF
--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -52,10 +52,6 @@ TRUSTED_RUNNER_VERSION = "pdd-trusted-runner-v2"
 _VITEST_SUPERVISOR_LIMITS = SupervisorLimits(
     max_memory_bytes=4 * 1024 * 1024 * 1024
 )
-# Keep Node/Vitest's CPU-derived worker bursts inside the unchanged process ceiling.
-_VITEST_MAX_WORKERS = 1
-_VITEST_V8_POOL_SIZE = 1
-_VITEST_UV_THREADPOOL_SIZE = 1
 PYTEST_CONFIG_PATHS = (
     PurePosixPath("pytest.ini"),
     PurePosixPath("pyproject.toml"),
@@ -2814,23 +2810,14 @@ def _vitest_command(config: RunnerConfig) -> tuple[str, ...] | None:
 
 def _vitest_environment(home: Path) -> dict[str, str]:
     """Return a credential-free, non-ambient environment for Vitest."""
-    environment = untrusted_child_environment(
+    return untrusted_child_environment(
         drop={"PYTHONPATH", "PYTHONHOME", "PDD_PATH"}
     ) | {
         "HOME": str(home),
         "XDG_CONFIG_HOME": str(home / "config"),
         "XDG_CACHE_HOME": str(home / "cache"),
         "NODE_ENV": "test",
-        "UV_THREADPOOL_SIZE": str(_VITEST_UV_THREADPOOL_SIZE),
     }
-    # The protected Linux namespace retains a deliberately large 4 GiB virtual
-    # memory bound.  Node otherwise sizes V8 and libuv pools from the host CPU
-    # count, which can exhaust that bound before Vitest's trusted reporter
-    # starts.  Bind the internal pools as part of the checker-owned launch
-    # contract; do not inherit candidate or ambient Node controls.
-    if sys.platform.startswith("linux"):
-        environment["UV_THREADPOOL_SIZE"] = "1"
-    return environment
 
 
 def _vitest_result(
@@ -3058,15 +3045,12 @@ def _run_vitest(
         reporter.write_text(_vitest_reporter_source(result_fd), encoding="utf-8")
         command = [
             str(phase_toolchain.launcher),
-            f"--v8-pool-size={_VITEST_V8_POOL_SIZE}",
             *( ("--disable-wasm-trap-handler",) if sys.platform.startswith("linux") else () ),
-            *( ("--v8-pool-size=1",) if sys.platform.startswith("linux") else () ),
             str(phase_toolchain.entrypoint),
             "run",
             *(path.as_posix() for path in paths),
             f"--config={root / config_path}",
             f"--reporter={reporter}",
-            f"--maxWorkers={_VITEST_MAX_WORKERS}",
         ]
         digest = hashlib.sha256(json.dumps(command, separators=(",", ":")).encode()).hexdigest()
         before = _validator_tree_identity(root)

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -1959,19 +1959,24 @@ def test_vitest_exit_failure_precedes_empty_fifo_collection_error(
     assert executions[0].outcome is outcome
 
 
-def test_vitest_linux_command_binds_wasm_guard_and_resource_bounds(
+def test_vitest_omits_unproven_worker_caps_without_relaxing_limits(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Linux execution bounds must be trusted controls, not CI-only tuning."""
+    """Discredited worker caps must not weaken the protected Vitest boundary."""
     root, _commit = _repository(tmp_path)
     config = _runner_config(tmp_path, _fake_vitest(tmp_path))
     observed: list[list[str]] = []
     observed_environments: list[dict[str, str]] = []
     observed_limits: list[SupervisorLimits] = []
-    def capture(command, *, result_fifo, result_fd, limits, env, **_kwargs):
+    observed_timeouts: list[int] = []
+
+    def capture(
+        command, *, result_fifo, result_fd, env, limits, timeout, **_kwargs
+    ):
         observed.append(command)
         observed_limits.append(limits)
         observed_environments.append(env)
+        observed_timeouts.append(timeout)
         writer = os.open(result_fifo, os.O_WRONLY)
         try:
             os.write(
@@ -1982,6 +1987,7 @@ def test_vitest_linux_command_binds_wasm_guard_and_resource_bounds(
             os.close(writer)
         return subprocess.CompletedProcess(command, 0, "", ""), False
 
+    monkeypatch.setenv("UV_THREADPOOL_SIZE", "64")
     monkeypatch.setattr(runner_module.sys, "platform", "linux")
     monkeypatch.setattr("pdd.sync_core.runner.run_supervised", capture)
     execution, _identities = _run_vitest(
@@ -1989,21 +1995,33 @@ def test_vitest_linux_command_binds_wasm_guard_and_resource_bounds(
     )
 
     assert execution.outcome is EvidenceOutcome.PASS
-    assert observed[0][1:3] == ["--v8-pool-size=1", "--disable-wasm-trap-handler"]
-    assert observed[0][-1] == "--maxWorkers=1"
-    assert len(observed_environments) == 1
-    assert observed_environments[0]["UV_THREADPOOL_SIZE"] == "1"
+    assert not {
+        name
+        for name in vars(runner_module)
+        if name.startswith("_VITEST_") and name != "_VITEST_SUPERVISOR_LIMITS"
+    }
+    assert not any(value.startswith("--maxWorkers") for value in observed[0])
+    assert not any(value.startswith("--v8-pool-size") for value in observed[0])
+    assert "UV_THREADPOOL_SIZE" not in observed_environments[0]
+    assert observed[0][1] == "--disable-wasm-trap-handler"
+    assert any(value.startswith("--reporter=") for value in observed[0])
+    assert len(observed) == 1
+    assert observed_timeouts == [2]
     assert observed_limits == [
         SupervisorLimits(max_memory_bytes=4 * 1024 * 1024 * 1024)
     ]
-    assert observed_limits[0].max_processes == 128
+    assert observed_limits[0].max_memory_bytes == 4 * 1024 * 1024 * 1024
+    assert observed_limits[0].max_processes == SupervisorLimits().max_processes
+    assert observed_limits[0].max_output_bytes == SupervisorLimits().max_output_bytes
+    assert observed_limits[0].max_cpu_seconds == SupervisorLimits().max_cpu_seconds
+    assert observed_limits[0].max_writable_bytes == SupervisorLimits().max_writable_bytes
     assert SupervisorLimits().max_memory_bytes == 2 * 1024 * 1024 * 1024
 
 
-def test_vitest_linux_resource_bounds_remain_fake_launcher_compatible(
+def test_vitest_linux_wasm_guard_remains_fake_launcher_compatible(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The portable fake launcher accepts the exact trusted Linux Node flags."""
+    """The portable fake launcher accepts the retained Linux wasm guard."""
     root, _commit = _repository(tmp_path)
     monkeypatch.setattr(runner_module.sys, "platform", "linux")
     execution, identities = _run_vitest(

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -1067,12 +1067,7 @@ def _toolchain_manifest(tmp_path: Path, entrypoint: Path) -> Path:
     if not launcher.exists():
         launcher.write_text(
             "#!/bin/sh\n"
-            "while [ \"$#\" -gt 0 ]; do\n"
-            "  case \"$1\" in\n"
-            "    --disable-wasm-trap-handler|--v8-pool-size=*) shift ;;\n"
-            "    *) break ;;\n"
-            "  esac\n"
-            "done\n"
+            "[ \"$1\" = \"--disable-wasm-trap-handler\" ] && shift\n"
             f"exec {sys.executable!s} \"$@\"\n",
             encoding="utf-8",
         )


### PR DESCRIPTION
## Summary
- remove `--maxWorkers=1`, `--v8-pool-size=1`, and forced `UV_THREADPOOL_SIZE=1`
- retain the 4 GiB physical cap and all default process, VM, output, CPU, writable, timeout, reporter, and single-attempt fail-closed bounds
- add a regression that rejects reintroduction of these falsified scheduling controls

## Evidence
Issue #2083 correction https://github.com/promptdriven/pdd/issues/2083#issuecomment-4996143235 superseded the original cap rationale. Exact integration run https://github.com/promptdriven/pdd/actions/runs/29558119369 restored the caps alongside the required secure forks/preload path and changed the prior setup failure into a 30-second candidate timeout with zero cgroup OOM/OOM-kill/pids-max deltas. Installed-wheel Playwright still passed 7/7 and 838 focused protected-runner tests passed.

## PR loop
- RED `2c3b5e173c3454b9171d4eb37e9ea40e93e683c3`
- GREEN `68a6a50c41835a508b55cf00ee0f39bd9a1b2add`
- Vitest: 146 passed, 1 hosted-Linux skip
- Jest focus: 4 passed
- runner pylint: 10/10
- compile/diff clean

Closes no issue; #2083 remains open for the separate Node lifecycle SIGABRT investigation. No retry, timeout increase, reporter reinterpretation, or sandbox weakening.