### PR TITLE
fix(sync): preauthorize Playwright manifest helper

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -27,6 +27,13 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".github/toolchains/playwright_manifest.py",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".github/toolchains/vitest/package-lock.json",
       "role": "human-maintained"
     },

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -78,6 +78,7 @@ LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS = {
     "context/routing_policy_example.py",
 }
 PREAUTHORIZED_CHILD_PATHS = LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS | {
+    ".github/toolchains/playwright_manifest.py",
     ".pdd/meta/agentic_checkup_orchestrator_python_run.json",
     ".pdd/meta/checkup_agentic_artifact_python.json",
     ".pdd/meta/story_regression_python.json",


### PR DESCRIPTION
## Summary

Preauthorize the exact future `.github/toolchains/playwright_manifest.py` path in the protected ownership base. This is the minimal predecessor required by the blocking review finding on #1995; it does not add the helper or change Playwright behavior.

Unblocks #1995.
Reviewer finding: https://github.com/promptdriven/pdd/pull/1995#issuecomment-4999628464

## TDD

- Current-base RED `e302ceb81`: protected absent-child transition rejects the missing exact ownership rule.
- Current-base GREEN `829def335`: add one exact `HUMAN_OWNED`, `preauthorize_absent` rule.
- Restacked cleanly onto current protected main `39a60ec06`; initial pre-restack TDD SHAs remain recorded in the evidence comments.

## Test plan

- `pytest -q tests/test_sync_core_manifest.py tests/test_sync_core_pdd_rollout_policy.py tests/test_ci_detect_changed_modules.py`
- `pylint --disable=C1803 tests/test_sync_core_pdd_rollout_policy.py` (`C1803` is an identical current-main baseline warning)
- `python -m py_compile tests/test_sync_core_pdd_rollout_policy.py`
- `python -m json.tool .pdd/sync-ownership.json`
- Both real detector entry points against `origin/main...HEAD`
- `git diff --check origin/main...HEAD`