### PR TITLE
fix(agentic): isolate retry sleep assertions

### DIFF
--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -39,6 +39,10 @@ from pdd.routing_policy import (
     select_config,
 )
 
+# Bind once so retry tests can patch this seam without replacing the
+# process-wide ``time.sleep`` used by unrelated worker threads.
+_retry_sleep: Callable[[float], None] = time.sleep
+
 _steer_logger = logging.getLogger(__name__ + ".steer")
 
 AgenticUsage = Optional[Dict[str, List[Dict[str, Any]]]]
@@ -5365,7 +5369,7 @@ def run_agentic_task(
                                     )
                             if not quiet:
                                 console.print(f"[dim]Single-provider config: retrying in {backoff:.0f}s...[/dim]")
-                            time.sleep(backoff)
+                            _retry_sleep(backoff)
                             continue
                         break
                     else:
@@ -5536,7 +5540,7 @@ def run_agentic_task(
 
                     if verbose:
                         console.print(f"[dim]Waiting {backoff:.1f}s before retry...[/dim]")
-                    time.sleep(backoff)
+                    _retry_sleep(backoff)
 
             # All retries exhausted (or deadline budget exhausted) for this provider
             provider_errors.append(f"{provider}: {last_output[:MAX_ERROR_SNIPPET_LENGTH]}")

--- a/tests/test_agentic_common.py
+++ b/tests/test_agentic_common.py
@@ -5042,7 +5042,7 @@ def test_run_agentic_task_retries_on_failure(mock_shutil_which, mock_subprocess_
 
     mock_subprocess_run.side_effect = [fail_response, fail_response, success_response]
 
-    with patch("pdd.agentic_common.time.sleep"):  # Don't actually sleep
+    with patch("pdd.agentic_common._retry_sleep"):  # Don't actually sleep
         success, msg, cost, provider = run_agentic_task("Do work", tmp_path, max_retries=3)
 
     assert success
@@ -5073,7 +5073,7 @@ def test_run_agentic_task_retry_backoff(mock_shutil_which, mock_subprocess_run, 
 
     mock_subprocess_run.side_effect = [fail_response, fail_response, success_response]
 
-    with patch("pdd.agentic_common.time.sleep") as mock_sleep:
+    with patch("pdd.agentic_common._retry_sleep") as mock_sleep:
         run_agentic_task("Do work", tmp_path, max_retries=3, retry_delay=5)
 
     # Verify exponential backoff: 5s after attempt 1, 10s after attempt 2 (with jitter)
@@ -5108,7 +5108,7 @@ def test_run_agentic_task_moves_to_next_after_max_retries(mock_shutil_which, moc
     # Anthropic fails 3 times (max_retries), then Google succeeds
     mock_subprocess_run.side_effect = [fail_response, fail_response, fail_response, success_response]
 
-    with patch("pdd.agentic_common.time.sleep"):
+    with patch("pdd.agentic_common._retry_sleep"):
         success, msg, cost, provider = run_agentic_task("Do work", tmp_path, max_retries=3)
 
     assert success
@@ -6086,7 +6086,7 @@ class TestAgenticDebugLogging:
         from itertools import count
         time_iter = iter(count(start=1000.0, step=200.0))  # each call advances 200s
         with patch("pdd.agentic_common.time.time", side_effect=lambda: next(time_iter)), \
-             patch("pdd.agentic_common.time.sleep"):
+             patch("pdd.agentic_common._retry_sleep"):
             run_agentic_task(
                 "step prompt",
                 tmp_path,
@@ -6127,7 +6127,7 @@ class TestAgenticDebugLogging:
         fail_resp = MagicMock(returncode=1, stdout="", stderr="500 Internal Server Error")
         mock_subprocess_run.side_effect = [fail_resp, fail_resp, fail_resp]
         # Skip real backoff sleeps so the test is fast
-        with patch("pdd.agentic_common.time.sleep"):
+        with patch("pdd.agentic_common._retry_sleep"):
             run_agentic_task(
                 "step prompt",
                 tmp_path,
@@ -8150,7 +8150,7 @@ def test_deadline_skips_attempt_when_insufficient_time(tmp_path):
     with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "k"}, clear=False), \
          patch("pdd.agentic_common._find_cli_binary", return_value="/usr/bin/claude"), \
          patch("pdd.agentic_common._subprocess_run") as mock_run, \
-         patch("time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         mock_run.return_value = MagicMock(
             returncode=1, stdout="", stderr="fail"
         )
@@ -8171,7 +8171,7 @@ def test_deadline_caps_per_attempt_timeout(mock_env, tmp_path):
     with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "k"}, clear=False), \
          patch("pdd.agentic_common._find_cli_binary", return_value="/usr/bin/claude"), \
          patch("pdd.agentic_common._subprocess_run") as mock_run, \
-         patch("time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=json.dumps({"result": "ok", "total_cost_usd": 0.01}),
@@ -8196,7 +8196,7 @@ def test_no_deadline_preserves_default_timeout(mock_env, tmp_path):
     with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "k"}, clear=False), \
          patch("pdd.agentic_common._find_cli_binary", return_value="/usr/bin/claude"), \
          patch("pdd.agentic_common._subprocess_run") as mock_run, \
-         patch("time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=json.dumps({"result": "ok", "total_cost_usd": 0.01}),
@@ -8222,7 +8222,7 @@ def test_deadline_from_env_used_when_param_not_passed(tmp_path):
     }, clear=False), \
          patch("pdd.agentic_common._find_cli_binary", return_value="/usr/bin/claude"), \
          patch("pdd.agentic_common._subprocess_run") as mock_run, \
-         patch("time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         mock_run.return_value = MagicMock(
             returncode=1, stdout="", stderr="fail"
         )
@@ -8656,7 +8656,7 @@ def test_issue557_full_chain_modern_codex_false_positive(tmp_path):
          patch("pdd.agentic_common.get_agent_provider_preference", return_value=["openai"]), \
          patch("pdd.agentic_common._subprocess_run") as mock_run, \
          patch("pdd.agentic_common._subprocess_run_spooled") as mock_run_spooled, \
-         patch("time.sleep"):  # Skip retry delays
+         patch("pdd.agentic_common._retry_sleep"):  # Skip retry delays
         # Issue #1646: openai routes through the spooled runner.
         mock_run_spooled.side_effect = mock_run
         mock_run.return_value = MagicMock(
@@ -8710,7 +8710,7 @@ def test_codex_turn_completed_usage_parsed_for_cost(tmp_path):
          patch("pdd.agentic_common.get_agent_provider_preference", return_value=["openai"]), \
          patch("pdd.agentic_common._subprocess_run") as mock_run, \
          patch("pdd.agentic_common._subprocess_run_spooled") as mock_run_spooled, \
-         patch("time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         # Issue #1646: openai routes through the spooled runner.
         mock_run_spooled.side_effect = mock_run
         mock_run.return_value = MagicMock(
@@ -10533,7 +10533,7 @@ class TestProviderLimitMarker:
             "pdd.agentic_common.get_available_agents",
             return_value=["anthropic"],
         ), patch(
-            "pdd.agentic_common.time.sleep",
+            "pdd.agentic_common._retry_sleep",
         ), patch(
             "pdd.agentic_common._run_with_provider",
             return_value=(False, "Error: api_error_status: 429 rate limit exceeded", 0.0, "claude-opus-4-8", None),
@@ -10561,7 +10561,7 @@ class TestProviderLimitMarker:
             "pdd.agentic_common.get_available_agents",
             return_value=["anthropic"],
         ), patch(
-            "pdd.agentic_common.time.sleep",
+            "pdd.agentic_common._retry_sleep",
         ), patch(
             "pdd.agentic_common._run_with_provider",
             side_effect=attempts,
@@ -10762,7 +10762,7 @@ def test_false_positive_retries_in_single_provider_config(mock_cwd, mock_env, mo
         MagicMock(returncode=0, stdout=real_response, stderr=""),
     ]
 
-    with patch("pdd.agentic_common.time.sleep") as mock_sleep:
+    with patch("pdd.agentic_common._retry_sleep") as mock_sleep:
         success, msg, cost, provider = run_agentic_task(
             "Fix the bug",
             mock_cwd,
@@ -10818,7 +10818,7 @@ def test_false_positive_falls_through_in_multi_provider_config(mock_cwd, mock_en
         MagicMock(returncode=0, stdout=real_google, stderr=""),
     ]
 
-    with patch("pdd.agentic_common.time.sleep"):
+    with patch("pdd.agentic_common._retry_sleep"):
         success, msg, cost, provider = run_agentic_task(
             "Fix the bug",
             mock_cwd,
@@ -11475,7 +11475,7 @@ def test_issue1232_substantive_output_with_error_substring_not_demoted(
     mock_subprocess.return_value.stderr = ""
 
     with patch("pdd.agentic_common.get_agent_provider_preference", return_value=["openai"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -11529,7 +11529,7 @@ def test_issue1232_multi_provider_does_not_fall_through_for_substantive_openai_o
 
     with patch("pdd.agentic_common.get_agent_provider_preference",
                return_value=["openai", "anthropic"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -11575,7 +11575,7 @@ def test_issue1232_long_output_with_error_substring_still_passes(
     mock_subprocess.return_value.stderr = ""
 
     with patch("pdd.agentic_common.get_agent_provider_preference", return_value=["openai"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -11606,7 +11606,7 @@ def test_issue1232_empty_output_branch_still_detects_false_positive(
     mock_subprocess.return_value.stderr = ""
 
     with patch("pdd.agentic_common.get_agent_provider_preference", return_value=["anthropic"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, _cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -11642,7 +11642,7 @@ def test_issue1232_zero_cost_short_output_branch_still_detects_false_positive(
     mock_subprocess.return_value.stderr = ""
 
     with patch("pdd.agentic_common.get_agent_provider_preference", return_value=["anthropic"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, _cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -11682,7 +11682,7 @@ def test_issue1232_leading_error_prefix_response_still_detects_false_positive(
     mock_subprocess.return_value.stderr = ""
 
     with patch("pdd.agentic_common.get_agent_provider_preference", return_value=["openai"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, _cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -11732,7 +11732,7 @@ def test_issue1232_substantive_finding_starting_with_error_prefix_not_demoted(
     mock_subprocess.return_value.stderr = ""
 
     with patch("pdd.agentic_common.get_agent_provider_preference", return_value=["openai"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -12415,7 +12415,7 @@ class TestIssue814BillingErrorsPermanent:
 
         mock_subprocess_run.side_effect = [anthropic_failure, google_success]
 
-        with patch("pdd.agentic_common.time.sleep") as sleep_mock:
+        with patch("pdd.agentic_common._retry_sleep") as sleep_mock:
             success, msg, cost, provider = run_agentic_task(
                 "Do work", tmp_path, max_retries=3, retry_delay=5
             )
@@ -12459,7 +12459,7 @@ class TestIssue814BillingErrorsPermanent:
 
         mock_subprocess_run.side_effect = [anthropic_failure, google_success]
 
-        with patch("pdd.agentic_common.time.sleep"):
+        with patch("pdd.agentic_common._retry_sleep"):
             success, *_ = run_agentic_task(
                 "Do work", tmp_path, max_retries=3, retry_delay=5
             )
@@ -12527,7 +12527,7 @@ class TestIssue814BillingErrorsPermanent:
 
         mock_subprocess_run.side_effect = [anthropic_failure, google_success]
 
-        with patch("pdd.agentic_common.time.sleep") as sleep_mock:
+        with patch("pdd.agentic_common._retry_sleep") as sleep_mock:
             success, _output, _cost, provider = run_agentic_task(
                 "Do work", tmp_path, max_retries=3, retry_delay=5, quiet=True
             )
@@ -12614,7 +12614,7 @@ class TestIssue814BillingErrorsPermanent:
         real_console = RealConsole(file=capture, force_terminal=False, no_color=True)
 
         with patch("pdd.agentic_common.console", real_console), \
-                patch("pdd.agentic_common.time.sleep"):
+                patch("pdd.agentic_common._retry_sleep"):
             success, _output, _cost, provider = run_agentic_task(
                 "Do work", tmp_path, max_retries=3, retry_delay=5
             )
@@ -12694,7 +12694,7 @@ class TestIssue814BillingErrorsPermanent:
 
         mock_subprocess_run.side_effect = [anthropic_400, google_success]
 
-        with patch("pdd.agentic_common.time.sleep") as sleep_mock:
+        with patch("pdd.agentic_common._retry_sleep") as sleep_mock:
             success, msg, cost, provider = run_agentic_task(
                 "Do work", tmp_path, max_retries=3, retry_delay=5
             )

--- a/tests/test_e2e_issue_902_provider_fallback.py
+++ b/tests/test_e2e_issue_902_provider_fallback.py
@@ -73,7 +73,7 @@ def orchestrator_mocks_with_real_retry():
     with patch("pdd.agentic_common._subprocess_run") as mock_subprocess, \
          patch("pdd.agentic_common._find_cli_binary") as mock_which, \
          patch("pdd.agentic_common._load_model_data", return_value=None), \
-         patch("pdd.agentic_common.time.sleep") as mock_sleep, \
+         patch("pdd.agentic_common._retry_sleep") as mock_sleep, \
          patch("pdd.agentic_e2e_fix_orchestrator.load_prompt_template") as mock_load, \
          patch("pdd.agentic_e2e_fix_orchestrator.console") as mock_console, \
          patch("pdd.agentic_e2e_fix_orchestrator.load_workflow_state") as mock_load_state, \

--- a/tests/test_issue_902.py
+++ b/tests/test_issue_902.py
@@ -32,7 +32,7 @@ class TestIssue902(unittest.TestCase):
             ),
             patch("pdd.agentic_common._run_with_provider") as mock_run_with_provider,
             patch("pdd.agentic_common.time.sleep") as shared_sleep,
-            patch("pdd.agentic_common._retry_sleep", create=True) as retry_sleep,
+            patch("pdd.agentic_common._retry_sleep") as retry_sleep,
             patch(
                 "pdd.agentic_common.random.uniform",
                 return_value=jitter,
@@ -72,7 +72,7 @@ class TestIssue902(unittest.TestCase):
                 return_value=(True, "Error: transient provider response", 0.05, None),
             ),
             patch("pdd.agentic_common.time.sleep") as shared_sleep,
-            patch("pdd.agentic_common._retry_sleep", create=True) as retry_sleep,
+            patch("pdd.agentic_common._retry_sleep") as retry_sleep,
             patch(
                 "pdd.agentic_common.random.uniform",
                 return_value=jitter,

--- a/tests/test_issue_902.py
+++ b/tests/test_issue_902.py
@@ -2,6 +2,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 from pathlib import Path
+import threading
 import time
 import random
 import sys
@@ -20,22 +21,29 @@ class TestIssue902(unittest.TestCase):
     
     # --- agentic_common Jitter Test ---
     def test_jitter_is_additive(self):
-        """Requirement: Backoff jitter should be additive to the exponential base."""
+        """A foreign thread cannot contaminate normal-failure retry sleep capture."""
         retry_delay = 10.0
         jitter = 2.5
+        expected = retry_delay * (2 ** 0) + jitter
         with (
             patch(
                 "pdd.agentic_common.get_available_agents",
                 return_value=["anthropic"],
             ),
             patch("pdd.agentic_common._run_with_provider") as mock_run_with_provider,
-            patch("pdd.agentic_common.time.sleep") as mock_sleep,
+            patch("pdd.agentic_common.time.sleep") as shared_sleep,
+            patch("pdd.agentic_common._retry_sleep", create=True) as retry_sleep,
             patch(
                 "pdd.agentic_common.random.uniform",
                 return_value=jitter,
             ) as mock_uniform,
         ):
             mock_run_with_provider.return_value = (False, "Error: transient", 0.0, None)
+
+            foreign_thread = threading.Thread(target=time.sleep, args=(5.0,))
+            foreign_thread.start()
+            foreign_thread.join(timeout=1.0)
+            self.assertFalse(foreign_thread.is_alive())
 
             run_agentic_task(
                 instruction="test",
@@ -45,11 +53,47 @@ class TestIssue902(unittest.TestCase):
                 quiet=True,
             )
 
-            self.assertTrue(mock_sleep.called)
+            shared_sleep.assert_any_call(5.0)
+            retry_sleep.assert_called_once_with(expected)
             mock_uniform.assert_called_with(0, retry_delay)
-            first_sleep = mock_sleep.call_args_list[0][0][0]
-            expected = retry_delay * (2 ** 0) + jitter
-            self.assertAlmostEqual(first_sleep, expected)
+
+    def test_false_positive_retry_sleep_is_thread_isolated(self):
+        """A foreign thread cannot contaminate false-positive retry sleep capture."""
+        retry_delay = 10.0
+        jitter = 2.5
+        expected = retry_delay * (2 ** 0) + jitter
+        with (
+            patch(
+                "pdd.agentic_common.get_available_agents",
+                return_value=["anthropic"],
+            ),
+            patch(
+                "pdd.agentic_common._run_with_provider",
+                return_value=(True, "Error: transient provider response", 0.05, None),
+            ),
+            patch("pdd.agentic_common.time.sleep") as shared_sleep,
+            patch("pdd.agentic_common._retry_sleep", create=True) as retry_sleep,
+            patch(
+                "pdd.agentic_common.random.uniform",
+                return_value=jitter,
+            ) as mock_uniform,
+        ):
+            foreign_thread = threading.Thread(target=time.sleep, args=(5.0,))
+            foreign_thread.start()
+            foreign_thread.join(timeout=1.0)
+            self.assertFalse(foreign_thread.is_alive())
+
+            run_agentic_task(
+                instruction="test",
+                cwd=Path("."),
+                max_retries=2,
+                retry_delay=retry_delay,
+                quiet=True,
+            )
+
+            shared_sleep.assert_any_call(5.0)
+            retry_sleep.assert_called_once_with(expected)
+            mock_uniform.assert_called_with(0, retry_delay)
 
     # --- agentic_common False Positive Test ---
     @patch("pdd.agentic_common.get_available_agents", return_value=["anthropic"])


### PR DESCRIPTION
## Summary

- bind a private retry-sleep seam once at module import so retry tests no longer replace process-wide `time.sleep`
- route both ordinary-failure and successful-but-false-positive backoff through that seam
- add deterministic foreign-thread regressions and migrate retry-focused patches without changing retry behavior

Closes #2141

## TDD

- RED `c2f9cdd92`: both deterministic paths failed because `_retry_sleep` received zero calls while the shared module mock captured the foreign 5-second sleep
- GREEN `9558ee586`: both retry paths call the isolated seam with the unchanged 12.5-second additive-jitter value

## Test plan

- [x] two focused tests repeated 20 times
- [x] focused xdist run with two workers
- [x] `pytest -q tests/test_issue_902.py tests/test_e2e_issue_902_provider_fallback.py` — 10 passed
- [x] `pytest -q tests/test_agentic_common.py` — 522 passed
- [x] compileall and focused fatal/undefined-name pylint checks
- [x] `git diff --check`

## Non-goals

No change to backoff, jitter, cap, rate-limit floor, deadline accounting, provider selection, quiet behavior, or PR #2139 ownership metadata. No live provider call was run; the mocked E2E provider-fallback test is the closest safe local CLI orchestration boundary.