### PR TITLE
fix(sync): terminate Vitest after trusted result publication

### DIFF
--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -2932,6 +2932,19 @@ def _vitest_reporter_source(result_fd: int) -> str:
     return f"""import fs from 'node:fs';
 import path from 'node:path';
 const RESULT_FD = {result_fd};
+const coordinatorExit = process.exit.bind(process);
+const writeAll = (value) => {{
+  const buffer = Buffer.from(value);
+  let offset = 0;
+  while (offset < buffer.length) {{
+    const remaining = buffer.length - offset;
+    const written = fs.writeSync(RESULT_FD, buffer, offset, remaining);
+    if (!Number.isSafeInteger(written) || written <= 0 || written > remaining) {{
+      throw new Error('trusted Vitest result write did not advance safely');
+    }}
+    offset += written;
+  }}
+}};
 export default class PddTrustedVitestReporter {{
   constructor() {{ this.tests = []; }}
   onTestCaseResult(test) {{
@@ -2944,7 +2957,8 @@ export default class PddTrustedVitestReporter {{
     }});
   }}
   onTestRunEnd() {{
-    fs.writeSync(RESULT_FD, JSON.stringify({{tests: this.tests}}));
+    writeAll(JSON.stringify({{tests: this.tests}}));
+    coordinatorExit(process.exitCode ?? 0);
   }}
 }}
 """

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -86,6 +86,112 @@ def _controlled_supervisor(
     monkeypatch.setattr("pdd.sync_core.runner.run_supervised", execute)
 
 
+def _run_trusted_reporter_source(
+    tmp_path: Path, driver_source: str
+) -> tuple[subprocess.CompletedProcess[str], bytes]:
+    """Run the generated trusted reporter with a real inherited result pipe."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("requires Node.js")
+    read_fd, write_fd = os.pipe()
+    reporter = tmp_path / "trusted-reporter.mjs"
+    driver = tmp_path / "reporter-driver.mjs"
+    reporter.write_text(
+        runner_module._vitest_reporter_source(write_fd), encoding="utf-8"
+    )
+    driver.write_text(driver_source, encoding="utf-8")
+    try:
+        try:
+            completed = subprocess.run(
+                [node, str(driver), str(reporter)],
+                pass_fds=(write_fd,),
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        finally:
+            os.close(write_fd)
+        result = bytearray()
+        while chunk := os.read(read_fd, 4096):
+            result.extend(chunk)
+    finally:
+        os.close(read_fd)
+    return completed, bytes(result)
+
+
+def test_vitest_reporter_exits_after_publishing_terminal_result(
+    tmp_path: Path,
+) -> None:
+    completed, result = _run_trusted_reporter_source(
+        tmp_path,
+        """import { pathToFileURL } from 'node:url';
+const { default: Reporter } = await import(pathToFileURL(process.argv[2]).href);
+setInterval(() => {}, 1000);
+process.exitCode = 7;
+new Reporter().onTestRunEnd();
+""",
+    )
+
+    assert completed.returncode == 7
+    assert json.loads(result) == {"tests": []}
+
+
+def test_vitest_reporter_completes_partial_result_writes(tmp_path: Path) -> None:
+    completed, result = _run_trusted_reporter_source(
+        tmp_path,
+        """import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+const originalWriteSync = fs.writeSync.bind(fs);
+fs.writeSync = (fd, value, offset = 0, length) => {
+  const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value);
+  const requested = length ?? buffer.length - offset;
+  return originalWriteSync(fd, buffer, offset, Math.min(requested, 3));
+};
+const { default: Reporter } = await import(pathToFileURL(process.argv[2]).href);
+new Reporter().onTestRunEnd();
+""",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(result) == {"tests": []}
+
+
+def test_vitest_reporter_rejects_result_write_without_progress(
+    tmp_path: Path,
+) -> None:
+    completed, result = _run_trusted_reporter_source(
+        tmp_path,
+        """import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+fs.writeSync = () => 0;
+const { default: Reporter } = await import(pathToFileURL(process.argv[2]).href);
+new Reporter().onTestRunEnd();
+""",
+    )
+
+    assert completed.returncode != 0
+    assert result == b""
+
+
+@pytest.mark.parametrize(
+    "test_config",
+    ({"reporters": ["default"]}, {"coverage": {"enabled": True}}),
+    ids=("reporters", "coverage"),
+)
+def test_vitest_config_cannot_replace_or_extend_trusted_reporter(
+    tmp_path: Path, test_config: dict[str, object]
+) -> None:
+    root, commit = _repository(
+        tmp_path, config=json.dumps({"test": test_config})
+    )
+
+    with pytest.raises(ValueError, match="not bound by this adapter"):
+        vitest_validator_config_digest(
+            root, commit, (PurePosixPath("tests/widget.test.ts"),)
+        )
+
+
 @pytest.mark.parametrize(
     "control",
     [

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -36,6 +36,7 @@ from pdd.sync_core.runner import (
     _validator_tree_identity,
     _vitest_command_error,
     _vitest_environment,
+    _vitest_reporter_source,
     _vitest_result,
     jest_validator_config_digest,
     runner_identity_digest,
@@ -96,9 +97,7 @@ def _run_trusted_reporter_source(
     read_fd, write_fd = os.pipe()
     reporter = tmp_path / "trusted-reporter.mjs"
     driver = tmp_path / "reporter-driver.mjs"
-    reporter.write_text(
-        runner_module._vitest_reporter_source(write_fd), encoding="utf-8"
-    )
+    reporter.write_text(_vitest_reporter_source(write_fd), encoding="utf-8")
     driver.write_text(driver_source, encoding="utf-8")
     try:
         try:
@@ -123,6 +122,7 @@ def _run_trusted_reporter_source(
 def test_vitest_reporter_exits_after_publishing_terminal_result(
     tmp_path: Path,
 ) -> None:
+    """A published terminal result must bypass blocked Vitest pool closure."""
     completed, result = _run_trusted_reporter_source(
         tmp_path,
         """import { pathToFileURL } from 'node:url';
@@ -138,6 +138,7 @@ new Reporter().onTestRunEnd();
 
 
 def test_vitest_reporter_completes_partial_result_writes(tmp_path: Path) -> None:
+    """Short writes must not truncate the trusted terminal result."""
     completed, result = _run_trusted_reporter_source(
         tmp_path,
         """import fs from 'node:fs';
@@ -160,6 +161,7 @@ new Reporter().onTestRunEnd();
 def test_vitest_reporter_rejects_result_write_without_progress(
     tmp_path: Path,
 ) -> None:
+    """A stalled synchronous result write must fail closed before exit."""
     completed, result = _run_trusted_reporter_source(
         tmp_path,
         """import fs from 'node:fs';
@@ -182,6 +184,7 @@ new Reporter().onTestRunEnd();
 def test_vitest_config_cannot_replace_or_extend_trusted_reporter(
     tmp_path: Path, test_config: dict[str, object]
 ) -> None:
+    """Candidate config cannot add a reporter or enable coverage hooks."""
     root, commit = _repository(
         tmp_path, config=json.dumps({"test": test_config})
     )


### PR DESCRIPTION
## Summary

- write the complete checker-owned Vitest result through a checked synchronous `writeAll` loop
- bind coordinator `process.exit` when the sole trusted reporter module loads
- exit only after result publication, preserving Vitest's existing nonzero `process.exitCode`
- keep all timeout, retry, adjudication, sandbox, and supervisor cleanup policy unchanged

Fixes #2145.

Related, but explicitly **not closed by this PR**: #2083. That issue's pre-result `reporter=missing; SIGABRT` failure and approved sealed Node 22.22.3/22.23.1 causal A/B remain unresolved. This PR is only the prerequisite post-result shutdown-liveness correction.

## Root cause evidence

Three unchanged-head Package attempts on validation run [29564456678](https://github.com/promptdriven/pdd/actions/runs/29564456678) produced the same typed sequence and timeout:

1. [job 87833848158](https://github.com/promptdriven/pdd/actions/runs/29564456678/job/87833848158): `post-drop-probes,candidate-exec,coordinator-start,result-published`; timeout 30s; all cgroup deltas 0
2. [job 87837179277](https://github.com/promptdriven/pdd/actions/runs/29564456678/job/87837179277): identical typed sequence and outcome
3. [job 87840247129](https://github.com/promptdriven/pdd/actions/runs/29564456678/job/87840247129): identical typed sequence and outcome

Exact Vitest 4.1.10 package source shows `_testRun.end` awaits trusted `onTestRunEnd` before CLI `finally` awaits `ctx.close()`. `ctx.close()` awaits pool closure, while fork-worker graceful stop has a hard-coded 60s stop timeout. PDD's unchanged protected deadline is 30s. Successful typed result publication followed by the 30s deadline therefore localizes the defect to post-report coordinator/pool shutdown, not test execution, collection, or result transport.

## Safety invariants

- candidate config cannot add `reporters` or enable `coverage`; the command supplies exactly one checker-owned reporter
- candidate tests execute in fork workers, separate from the coordinator where exit is bound
- incomplete, zero-progress, or impossible writes throw before exit
- Vitest-set nonzero exit codes remain nonzero
- the supervisor retains ownership of worker/descendant cleanup after coordinator exit

## TDD evidence

At RED commit `18be57336`:

- held post-result interval: timed out after 2s
- forced 3-byte writes: reporter emitted only `{"t`
- zero-progress write: incorrectly returned exit code 0
- reporter/coverage config rejection: passed

At GREEN commit `4d8fdff03`:

- focused lifecycle/transport/config tests: 5 passed
- complete Vitest adapter matrix: 152 passed, 1 skipped
- supervisor matrix: 73 passed, 25 platform skips
- `pylint pdd/sync_core/runner.py`: 10.00/10
- compileall and `git diff --check`: clean

The full Vitest matrix includes the current-main hosted workflow contract tests. The real Linux sandbox and Package lane are intentionally left to this non-draft PR's hosted checks.