### PR TITLE
fix(sync): authenticate Vitest timeout topology

### DIFF
--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -55,6 +55,7 @@ from .supervisor import (
     InfrastructureFailurePhase,
     ImmutableBindingProof,
     PlaywrightSnapshotAggregate,
+    ProtectedProcessTopology,
     ScopeSetupFailureReason,
     SnapshotBindingProof,
     SupervisorLimits,
@@ -4491,19 +4492,31 @@ def _vitest_result(
 def _vitest_infrastructure_termination(
     result: subprocess.CompletedProcess[str], timeout_seconds: int,
     *, progress: tuple[object, ...] = (),
+    terminal_frame_present: bool = False,
 ) -> tuple[EvidenceOutcome, str]:
-    """Describe trusted no-reporter termination without trusting stderr prose."""
+    """Describe trusted Vitest termination without trusting stderr prose."""
     termination = getattr(result, "termination", None)
     kind = getattr(getattr(termination, "kind", None), "value", None)
     if kind is None:
         kind = "timeout" if result.returncode == 124 else (
             "signal" if result.returncode < 0 else "exit"
         )
-    fields = ["Vitest infrastructure termination: reporter=missing", f"kind={kind}"]
     trusted_progress: list[str] = []
     for stage in progress[:len(VitestProgressStage)]:
         if isinstance(stage, VitestProgressStage) and stage.value not in trusted_progress:
             trusted_progress.append(stage.value)
+    reporter_entered = VitestProgressStage.COORDINATOR_START.value in trusted_progress
+    terminal_present = (
+        terminal_frame_present is True
+        and VitestProgressStage.RESULT_PUBLISHED.value in trusted_progress
+    )
+    fields = [
+        "Vitest infrastructure termination: reporter=" + (
+            "entered" if reporter_entered else "not-entered"
+        ),
+        "terminal_frame=" + ("present" if terminal_present else "absent"),
+        f"kind={kind}",
+    ]
     if trusted_progress:
         fields.append("trusted_vitest_progress=" + ",".join(trusted_progress))
     if kind in {"exit", "sandbox-error"}:
@@ -4548,6 +4561,9 @@ def _vitest_infrastructure_termination(
                 f"cgroup_memory_oom_kill_delta={telemetry.memory_oom_kill_delta}",
                 f"cgroup_pids_max_delta={telemetry.pids_max_delta}",
             ))
+        topology = termination.pre_kill_process_topology
+        if kind == "timeout" and isinstance(topology, ProtectedProcessTopology):
+            fields.append(f"pre_kill_process_topology={topology.value}")
     diagnostic = result.stderr or result.stdout
     if diagnostic:
         fields.append("diagnostic_sha256=" + hashlib.sha256(
@@ -4908,19 +4924,24 @@ def _run_vitest(
             isinstance(termination, SupervisorTermination)
             and termination.kind is TerminationKind.SANDBOX_ERROR
         ):
+            terminal_frame_present = False
             if (
                 "error" not in drained
                 and not drained.get("overflow")
                 and isinstance(drained.get("data", b""), bytes)
             ):
                 try:
-                    _payload, progress = _parse_vitest_transport(
-                        drained.get("data", b"")
+                    transport = drained.get("data", b"")
+                    _payload, progress = _parse_vitest_transport(transport)
+                    terminal_frame_present = any(
+                        record.startswith(_VITEST_RESULT_PREFIX)
+                        for record in transport.splitlines()
                     )
                 except ValueError:
                     progress = ()
             outcome, detail = _vitest_infrastructure_termination(
                 result, timeout_seconds, progress=progress,
+                terminal_frame_present=terminal_frame_present,
             )
             return RunnerExecution("vitest", outcome, digest, detail), ()
         try:
@@ -4931,8 +4952,11 @@ def _run_vitest(
                     "vitest", EvidenceOutcome.ERROR, digest,
                     "Vitest result transport exceeded byte limit",
                 ), ()
-            output_data, progress = _parse_vitest_transport(
-                drained.get("data", b"")
+            transport = drained.get("data", b"")
+            output_data, progress = _parse_vitest_transport(transport)
+            terminal_frame_present = any(
+                record.startswith(_VITEST_RESULT_PREFIX)
+                for record in transport.splitlines()
             )
             output.write_bytes(output_data)
         except (OSError, ValueError) as exc:
@@ -4949,11 +4973,13 @@ def _run_vitest(
         if termination_kind == "timeout" or result.returncode == 124:
             outcome, detail = _vitest_infrastructure_termination(
                 result, timeout_seconds, progress=progress,
+                terminal_frame_present=terminal_frame_present,
             )
             return RunnerExecution("vitest", outcome, digest, detail), ()
         if result.returncode and not output_data:
             outcome, detail = _vitest_infrastructure_termination(
                 result, timeout_seconds, progress=progress,
+                terminal_frame_present=terminal_frame_present,
             )
             return RunnerExecution("vitest", outcome, digest, detail), ()
         if not output_data:

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -101,9 +101,8 @@ def _supervise_candidate(pid, timeout, cgroup=None):
             raise RuntimeError('pidfd poll returned invalid events')
         timed_out = not events
         if timed_out:
-            if cgroup is None:
-                raise RuntimeError('candidate cgroup is unavailable at timeout')
-            pre_kill_process_topology = _pre_kill_process_topology(cgroup)
+            if cgroup is not None:
+                pre_kill_process_topology = _pre_kill_process_topology(cgroup)
             os.kill(pid, 9)
         waited, status = os.waitpid(pid,0)
         if waited != pid:
@@ -599,6 +598,7 @@ def _expect_descriptor_eof(descriptor: int, deadline: float) -> None:
 
 def _descriptor_result(
     payload: object, nonce: str, aggregate_digest: str, maximum: int,
+    *, require_timeout_topology: bool = True,
 ) -> _DescriptorResult:
     """Validate the complete helper result before forwarding any observation bytes."""
     # Exact built-in types and all result bindings are part of the authority grammar.
@@ -607,7 +607,11 @@ def _descriptor_result(
         "kind", "nonce", "aggregate_digest", "candidate", "stdout", "stderr",
         "observation", "observation_sha256", "observation_size",
     }
-    if type(payload) is not dict or set(payload) != expected:
+    if (
+        type(payload) is not dict
+        or set(payload) != expected
+        or type(require_timeout_topology) is not bool
+    ):
         raise RuntimeError("protected descriptor result is invalid")
     if (
         payload["kind"] != "result"
@@ -638,7 +642,7 @@ def _descriptor_result(
         raise RuntimeError("protected candidate record is invalid")
     candidate_fields = set(candidate_payload)
     standard_fields = {"version", "state", "returncode", "timed_out"}
-    if candidate_payload.get("timed_out") is True:
+    if candidate_payload.get("timed_out") is True and require_timeout_topology:
         if candidate_fields != standard_fields | {"pre_kill_process_topology"}:
             raise RuntimeError("protected candidate record is invalid")
         try:
@@ -2537,7 +2541,7 @@ def _staged_bwrap(
         "     kill_candidate_leaf(); return",
         "  parent_watch=threading.Thread(target=watch_parent,daemon=True); parent_watch.start()",
         " os.write(release_write,b'1'); os.close(release_write)",
-        " result,timed_out,pre_kill_process_topology=_supervise_candidate(pid,limits['timeout'],candidate_cgroup)",
+        " result,timed_out,pre_kill_process_topology=_supervise_candidate(pid,limits['timeout'],candidate_cgroup if standard_anonymous else None)",
         " def nested_status(deadline):",
         "  record=b''",
         "  while len(record)<256:",
@@ -2572,7 +2576,7 @@ def _staged_bwrap(
         "  aggregate_digest=playwright['expected_digest'] if playwright is not None else "
         + repr(_STANDARD_ANONYMOUS_AGGREGATE_DIGEST),
         "  candidate_payload={'version':1,'state':'terminal','returncode':result,'timed_out':timed_out}",
-        "  if timed_out: candidate_payload['pre_kill_process_topology']=pre_kill_process_topology",
+        "  if timed_out and standard_anonymous: candidate_payload['pre_kill_process_topology']=pre_kill_process_topology",
         "  payload={'kind':'result','nonce':observation_nonce,'aggregate_digest':aggregate_digest,'candidate':candidate_payload,'stdout':base64.b64encode(b''.join(candidate_stdout)).decode('ascii'),'stderr':base64.b64encode(b''.join(candidate_stderr)).decode('ascii'),'observation':base64.b64encode(b''.join(observation_chunks)).decode('ascii'),'observation_sha256':hashlib.sha256(b''.join(observation_chunks)).hexdigest(),'observation_size':observation_size}",
         "  protocol_send(payload,limits['protocol'],time.monotonic()+limits['trusted_timeout'])",
         "  acknowledgement=protocol_receive(4096,time.monotonic()+limits['trusted_timeout'])",
@@ -3836,6 +3840,9 @@ def _run_playwright_descriptor_supervised(
             )
             result = _descriptor_result(
                 payload, nonce, expected_aggregate, limits.max_output_bytes,
+                require_timeout_topology=(
+                    playwright_snapshot_aggregate is None
+                ),
             )
             candidate_returncode = result.candidate.returncode
             timed_out = result.candidate.timed_out

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -70,9 +70,24 @@ _BLOCKED_CANDIDATE_ENV_MARKERS = (
 _CANDIDATE_ENV_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 _PIDFD_PROTOCOL_SOURCE = """
-def _supervise_candidate(pid, timeout):
+def _pre_kill_process_topology(cgroup):
+    members = (cgroup / 'cgroup.procs').read_text(encoding='ascii').splitlines()
+    if any(
+        not value.isascii() or not value.isdecimal()
+        or int(value) <= 0 or str(int(value)) != value
+        for value in members
+    ):
+        raise RuntimeError('candidate cgroup membership is invalid')
+    if not members:
+        return 'none'
+    if len(members) == 1:
+        return 'one'
+    return 'multiple'
+
+def _supervise_candidate(pid, timeout, cgroup=None):
     pidfd = None
     reaped = False
+    pre_kill_process_topology = None
     try:
         if not hasattr(os, 'pidfd_open'):
             raise RuntimeError('pidfd_open unavailable')
@@ -86,6 +101,9 @@ def _supervise_candidate(pid, timeout):
             raise RuntimeError('pidfd poll returned invalid events')
         timed_out = not events
         if timed_out:
+            if cgroup is None:
+                raise RuntimeError('candidate cgroup is unavailable at timeout')
+            pre_kill_process_topology = _pre_kill_process_topology(cgroup)
             os.kill(pid, 9)
         waited, status = os.waitpid(pid,0)
         if waited != pid:
@@ -94,6 +112,7 @@ def _supervise_candidate(pid, timeout):
         return (
             124 if timed_out else os.waitstatus_to_exitcode(status),
             timed_out,
+            pre_kill_process_topology,
         )
     finally:
         if pidfd is not None:
@@ -165,6 +184,14 @@ class ScopeSetupFailureReason(str, Enum):
     READY_HANDOFF = "ready-handoff"
 
 
+class ProtectedProcessTopology(str, Enum):
+    """Bounded candidate-cgroup membership immediately before timeout kill."""
+
+    NONE = "none"
+    ONE = "one"
+    MULTIPLE = "multiple"
+
+
 @dataclass(frozen=True)
 class CgroupResourceTelemetry:
     """Trusted deltas from the candidate leaf's kernel event counters."""
@@ -186,6 +213,7 @@ class SupervisorTermination:  # pylint: disable=too-many-instance-attributes
     resource_telemetry: CgroupResourceTelemetry | None = None
     failure_phases: tuple[InfrastructureFailurePhase, ...] = ()
     scope_setup_subreason: ScopeSetupFailureReason | None = None
+    pre_kill_process_topology: ProtectedProcessTopology | None = None
 
 
 class SupervisedCompletedProcess(subprocess.CompletedProcess[str]):  # pylint: disable=too-few-public-methods
@@ -276,6 +304,7 @@ def _termination_evidence(
     timeout_seconds: int,
     resource_limit: str | None,
     resource_telemetry: CgroupResourceTelemetry | None = None,
+    pre_kill_process_topology: ProtectedProcessTopology | None = None,
 ) -> SupervisorTermination:
     """Classify only termination causes observed by the trusted supervisor."""
     if resource_limit is not None:
@@ -289,6 +318,11 @@ def _termination_evidence(
             TerminationKind.TIMEOUT,
             timeout_seconds=timeout_seconds,
             resource_telemetry=resource_telemetry,
+            pre_kill_process_topology=(
+                pre_kill_process_topology
+                if isinstance(pre_kill_process_topology, ProtectedProcessTopology)
+                else None
+            ),
         )
     if returncode < 0:
         return SupervisorTermination(
@@ -433,6 +467,7 @@ class _DescriptorResult:
     stdout: bytes
     stderr: bytes
     observation: bytes
+    pre_kill_process_topology: ProtectedProcessTopology | None = None
 
 
 def _descriptor_frame(payload: dict[str, object], maximum: int) -> bytes:
@@ -598,7 +633,32 @@ def _descriptor_result(
         or hashlib.sha256(observation).hexdigest() != payload["observation_sha256"]
     ):
         raise RuntimeError("protected descriptor result is invalid")
-    return _DescriptorResult(_load_candidate_record_payload(payload["candidate"]), stdout, stderr, observation)
+    candidate_payload = payload["candidate"]
+    if type(candidate_payload) is not dict:  # pylint: disable=unidiomatic-typecheck
+        raise RuntimeError("protected candidate record is invalid")
+    candidate_fields = set(candidate_payload)
+    standard_fields = {"version", "state", "returncode", "timed_out"}
+    if candidate_payload.get("timed_out") is True:
+        if candidate_fields != standard_fields | {"pre_kill_process_topology"}:
+            raise RuntimeError("protected candidate record is invalid")
+        try:
+            topology = ProtectedProcessTopology(
+                candidate_payload["pre_kill_process_topology"]
+            )
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("protected candidate record is invalid") from exc
+        record_payload = {
+            key: candidate_payload[key] for key in standard_fields
+        }
+    else:
+        if candidate_fields != standard_fields:
+            raise RuntimeError("protected candidate record is invalid")
+        topology = None
+        record_payload = candidate_payload
+    return _DescriptorResult(
+        _load_candidate_record_payload(record_payload), stdout, stderr,
+        observation, topology,
+    )
 
 
 def _scope_setup_error_reason(
@@ -2477,7 +2537,7 @@ def _staged_bwrap(
         "     kill_candidate_leaf(); return",
         "  parent_watch=threading.Thread(target=watch_parent,daemon=True); parent_watch.start()",
         " os.write(release_write,b'1'); os.close(release_write)",
-        " result,timed_out=_supervise_candidate(pid,limits['timeout'])",
+        " result,timed_out,pre_kill_process_topology=_supervise_candidate(pid,limits['timeout'],candidate_cgroup)",
         " def nested_status(deadline):",
         "  record=b''",
         "  while len(record)<256:",
@@ -2511,7 +2571,9 @@ def _staged_bwrap(
         "  if sum(validate_tree(path) for path in writable_paths) > limits['writable']: raise RuntimeError('final writable quota exceeded')",
         "  aggregate_digest=playwright['expected_digest'] if playwright is not None else "
         + repr(_STANDARD_ANONYMOUS_AGGREGATE_DIGEST),
-        "  payload={'kind':'result','nonce':observation_nonce,'aggregate_digest':aggregate_digest,'candidate':{'version':1,'state':'terminal','returncode':result,'timed_out':timed_out},'stdout':base64.b64encode(b''.join(candidate_stdout)).decode('ascii'),'stderr':base64.b64encode(b''.join(candidate_stderr)).decode('ascii'),'observation':base64.b64encode(b''.join(observation_chunks)).decode('ascii'),'observation_sha256':hashlib.sha256(b''.join(observation_chunks)).hexdigest(),'observation_size':observation_size}",
+        "  candidate_payload={'version':1,'state':'terminal','returncode':result,'timed_out':timed_out}",
+        "  if timed_out: candidate_payload['pre_kill_process_topology']=pre_kill_process_topology",
+        "  payload={'kind':'result','nonce':observation_nonce,'aggregate_digest':aggregate_digest,'candidate':candidate_payload,'stdout':base64.b64encode(b''.join(candidate_stdout)).decode('ascii'),'stderr':base64.b64encode(b''.join(candidate_stderr)).decode('ascii'),'observation':base64.b64encode(b''.join(observation_chunks)).decode('ascii'),'observation_sha256':hashlib.sha256(b''.join(observation_chunks)).hexdigest(),'observation_size':observation_size}",
         "  protocol_send(payload,limits['protocol'],time.monotonic()+limits['trusted_timeout'])",
         "  acknowledgement=protocol_receive(4096,time.monotonic()+limits['trusted_timeout'])",
         "  expected_ack={'kind':'ack','nonce':observation_nonce,'digest':hashlib.sha256(json.dumps(payload,sort_keys=True,separators=(',',':')).encode('utf-8')).hexdigest()}",
@@ -3886,6 +3948,7 @@ def _run_playwright_descriptor_supervised(
                 timed_out=timed_out, timeout_seconds=timeout,
                 resource_limit=resource_limit,
                 resource_telemetry=resource_telemetry,
+                pre_kill_process_topology=result.pre_kill_process_topology,
             )
         ),
     ), False

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -2578,6 +2578,54 @@ def test_vitest_result_fifo_without_writer_is_distinct_collection_error(
     assert executions[0].detail == "Vitest reporter produced no result"
 
 
+def test_vitest_timeout_never_adjudicates_present_terminal_frame_as_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Strict terminal JSON localizes the hang but cannot erase TIMEOUT."""
+    root, _commit = _repository(tmp_path)
+    result = SupervisedCompletedProcess(
+        ["vitest"], 124, "", "",
+        termination=SupervisorTermination(
+            TerminationKind.TIMEOUT,
+            timeout_seconds=30,
+            resource_telemetry=CgroupResourceTelemetry(0, 0, 0),
+            pre_kill_process_topology=(
+                supervisor_module.ProtectedProcessTopology.MULTIPLE
+            ),
+        ),
+    )
+    stages = (
+        runner_module.VitestProgressStage.POST_DROP_PROBES,
+        runner_module.VitestProgressStage.CANDIDATE_EXEC,
+        runner_module.VitestProgressStage.COORDINATOR_START,
+        runner_module.VitestProgressStage.RESULT_PUBLISHED,
+    )
+    payload = json.dumps({
+        "tests": [{"identity": IDENTITY, "status": "passed"}],
+    }, separators=(",", ":")).encode("utf-8")
+
+    def supervised(_command, *, result_write_fd, **_kwargs):
+        transport = b"".join(
+            runner_module._vitest_progress_frame(stage) for stage in stages
+        ) + runner_module._vitest_result_frame(payload)
+        os.write(result_write_fd, transport)
+        return result, False
+
+    monkeypatch.setattr("pdd.sync_core.runner.run_supervised", supervised)
+
+    execution, identities = _run_vitest(
+        root, (PurePosixPath("tests/widget.test.ts"),), 30,
+        _runner_config(tmp_path, _fake_vitest(tmp_path)),
+    )
+
+    assert execution.outcome is EvidenceOutcome.TIMEOUT
+    assert "reporter=entered" in execution.detail
+    assert "terminal_frame=present" in execution.detail
+    assert "pre_kill_process_topology=multiple" in execution.detail
+    assert "protected Vitest tests passed" not in execution.detail
+    assert not identities
+
+
 def test_vitest_sigabrt_reports_only_trusted_zero_cgroup_deltas(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2609,7 +2657,8 @@ def test_vitest_sigabrt_reports_only_trusted_zero_cgroup_deltas(
 
     assert execution.outcome is EvidenceOutcome.ERROR
     assert execution.detail == (
-        "Vitest infrastructure termination: reporter=missing; kind=signal; "
+        "Vitest infrastructure termination: reporter=not-entered; "
+        "terminal_frame=absent; kind=signal; "
         "signal=SIGABRT; signal_number=6; cgroup_memory_oom_delta=0; "
         "cgroup_memory_oom_kill_delta=0; cgroup_pids_max_delta=0; "
         "diagnostic_sha256=a56506d06ba82ba55af2e5593dab5a2044555b5f75d8389f"
@@ -2656,7 +2705,8 @@ def test_vitest_sandbox_error_reports_only_trusted_phases_and_hashed_diagnostic(
 
     assert execution.outcome is EvidenceOutcome.ERROR
     assert execution.detail == (
-        "Vitest infrastructure termination: reporter=missing; kind=sandbox-error; "
+        "Vitest infrastructure termination: reporter=not-entered; "
+        "terminal_frame=absent; kind=sandbox-error; "
         "exit_code=125; trusted_failure_phases=scope-cleanup,mount-cleanup; "
         "cgroup_memory_oom_delta=0; cgroup_memory_oom_kill_delta=0; "
         "cgroup_pids_max_delta=0; diagnostic_sha256="
@@ -2780,7 +2830,8 @@ def test_vitest_valid_reporter_cannot_hide_cleanup_sandbox_error(
 
     assert execution.outcome is EvidenceOutcome.ERROR
     assert execution.detail == (
-        "Vitest infrastructure termination: reporter=missing; kind=sandbox-error; "
+        "Vitest infrastructure termination: reporter=not-entered; "
+        "terminal_frame=absent; kind=sandbox-error; "
         "exit_code=125; trusted_failure_phases=scope-cleanup,mount-cleanup; "
         "diagnostic_sha256="
         + hashlib.sha256(diagnostic.encode("utf-8")).hexdigest()
@@ -2824,7 +2875,8 @@ def test_vitest_survivor_cannot_hide_process_cleanup_sandbox_error(
 
     assert execution.outcome is EvidenceOutcome.ERROR
     assert execution.detail == (
-        "Vitest infrastructure termination: reporter=missing; kind=sandbox-error; "
+        "Vitest infrastructure termination: reporter=not-entered; "
+        "terminal_frame=absent; kind=sandbox-error; "
         "exit_code=125; trusted_failure_phases=process-cleanup; diagnostic_sha256="
         + hashlib.sha256(diagnostic.encode("utf-8")).hexdigest()
     )
@@ -2872,7 +2924,8 @@ def test_vitest_transport_overflow_cannot_hide_output_drain_sandbox_error(
 
     assert execution.outcome is EvidenceOutcome.ERROR
     assert execution.detail == (
-        "Vitest infrastructure termination: reporter=missing; kind=sandbox-error; "
+        "Vitest infrastructure termination: reporter=not-entered; "
+        "terminal_frame=absent; kind=sandbox-error; "
         "exit_code=125; trusted_failure_phases=output-drain; diagnostic_sha256="
         + hashlib.sha256(diagnostic.encode("utf-8")).hexdigest()
     )
@@ -2897,7 +2950,8 @@ def test_vitest_exit_failure_precedes_empty_fifo_collection_error(
     assert executions[0].outcome is outcome
     if returncode == 1:
         assert executions[0].detail == (
-            "Vitest infrastructure termination: reporter=missing; kind=exit; "
+            "Vitest infrastructure termination: reporter=not-entered; "
+            "terminal_frame=absent; kind=exit; "
             "exit_code=1"
         )
 

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -269,6 +269,90 @@ def test_vitest_timeout_reports_only_allowlisted_progress() -> None:
     assert "secret candidate diagnostic" not in detail
 
 
+@pytest.mark.parametrize(
+    ("topology", "expected"),
+    [
+        (supervisor_module.ProtectedProcessTopology.NONE, "none"),
+        (supervisor_module.ProtectedProcessTopology.ONE, "one"),
+        (supervisor_module.ProtectedProcessTopology.MULTIPLE, "multiple"),
+    ],
+)
+def test_vitest_timeout_reports_terminal_reporter_and_pre_kill_topology(
+    topology: object, expected: str,
+) -> None:
+    """Timeout detail distinguishes lifecycle and trusted process topology."""
+    result = SupervisedCompletedProcess(
+        ["vitest"], 124, "", "candidate prose",
+        termination=SupervisorTermination(
+            TerminationKind.TIMEOUT,
+            timeout_seconds=30,
+            resource_telemetry=CgroupResourceTelemetry(0, 0, 0),
+            pre_kill_process_topology=topology,
+        ),
+    )
+
+    outcome, detail = runner_module._vitest_infrastructure_termination(
+        result,
+        30,
+        progress=(
+            runner_module.VitestProgressStage.POST_DROP_PROBES,
+            runner_module.VitestProgressStage.CANDIDATE_EXEC,
+            runner_module.VitestProgressStage.COORDINATOR_START,
+            runner_module.VitestProgressStage.RESULT_PUBLISHED,
+        ),
+        terminal_frame_present=True,
+    )
+
+    assert outcome is EvidenceOutcome.TIMEOUT
+    assert "reporter=entered" in detail
+    assert "terminal_frame=present" in detail
+    assert f"pre_kill_process_topology={expected}" in detail
+    assert "candidate prose" not in detail
+
+
+def test_vitest_sandbox_termination_reports_absent_terminal_and_reporter() -> None:
+    """A pre-reporter sandbox fault does not claim a terminal reporter frame."""
+    result = SupervisedCompletedProcess(
+        ["vitest"], 125, "", "candidate prose",
+        termination=SupervisorTermination(
+            TerminationKind.SANDBOX_ERROR,
+            exit_code=125,
+            failure_phases=(
+                supervisor_module.InfrastructureFailurePhase.CANDIDATE_EXECUTION,
+            ),
+        ),
+    )
+
+    outcome, detail = runner_module._vitest_infrastructure_termination(
+        result,
+        30,
+        progress=(runner_module.VitestProgressStage.CANDIDATE_EXEC,),
+        terminal_frame_present=False,
+    )
+
+    assert outcome is EvidenceOutcome.ERROR
+    assert "reporter=not-entered" in detail
+    assert "terminal_frame=absent" in detail
+    assert "pre_kill_process_topology" not in detail
+    assert "candidate prose" not in detail
+
+
+def test_vitest_timeout_rejects_non_boolean_terminal_presence() -> None:
+    """Forged caller values cannot claim an authenticated terminal frame."""
+    result = SupervisedCompletedProcess(
+        ["vitest"], 124, "", "",
+        termination=SupervisorTermination(
+            TerminationKind.TIMEOUT, timeout_seconds=30,
+        ),
+    )
+
+    _outcome, detail = runner_module._vitest_infrastructure_termination(
+        result, 30, terminal_frame_present="present",  # type: ignore[arg-type]
+    )
+
+    assert "terminal_frame=absent" in detail
+
+
 UNIT = UnitId("repository-1", PurePosixPath("prompts/widget_ts.prompt"), "typescript")
 IDENTITY = "tests/widget.test.ts::widget works"
 

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -9791,6 +9791,82 @@ def test_candidate_record_parser_fails_closed_for_every_malformed_shape(
         supervisor._load_candidate_record_payload(payload)
 
 
+def test_descriptor_timeout_topology_is_bounded_cgroup_owned_and_pre_kill() -> None:
+    """The root helper classifies its protected leaf before timeout termination."""
+    protocol = supervisor._PIDFD_PROTOCOL_SOURCE
+    helper = inspect.getsource(supervisor._staged_bwrap)
+
+    assert {member.value for member in supervisor.ProtectedProcessTopology} == {
+        "none", "one", "multiple",
+    }
+    assert "cgroup/'cgroup.procs'" in protocol
+    assert protocol.index("pre_kill_process_topology") < protocol.index(
+        "os.kill(pid, 9)"
+    )
+    assert "_supervise_candidate(pid,limits['timeout'],candidate_cgroup)" in helper
+    assert "'pre_kill_process_topology':pre_kill_process_topology" in helper
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        {"version": 1, "state": "terminal", "returncode": 124,
+         "timed_out": True},
+        {"version": 1, "state": "terminal", "returncode": 124,
+         "timed_out": True, "pre_kill_process_topology": "candidate-prose"},
+        {"version": 1, "state": "terminal", "returncode": 0,
+         "timed_out": False, "pre_kill_process_topology": "one"},
+        {"version": 1, "state": "terminal", "returncode": 124,
+         "timed_out": True, "pre_kill_process_topology": "one", "pid": 42},
+    ],
+)
+def test_descriptor_timeout_topology_rejects_missing_forged_and_extra_fields(
+    candidate: dict[str, object],
+) -> None:
+    """Only the helper-authenticated enum can cross the descriptor boundary."""
+    observation = b"{}"
+    payload = {
+        "kind": "result", "nonce": "a" * 64, "aggregate_digest": "b" * 64,
+        "candidate": candidate,
+        "stdout": "", "stderr": "",
+        "observation": base64.b64encode(observation).decode(),
+        "observation_sha256": hashlib.sha256(observation).hexdigest(),
+        "observation_size": len(observation),
+    }
+
+    with pytest.raises(RuntimeError, match="candidate record"):
+        supervisor._descriptor_result(payload, "a" * 64, "b" * 64, 1024)
+
+
+def test_descriptor_timeout_topology_propagates_as_typed_termination_evidence() -> None:
+    """A valid timeout enum remains typed through result and termination evidence."""
+    observation = b"{}"
+    payload = {
+        "kind": "result", "nonce": "a" * 64, "aggregate_digest": "b" * 64,
+        "candidate": {
+            "version": 1, "state": "terminal", "returncode": 124,
+            "timed_out": True, "pre_kill_process_topology": "multiple",
+        },
+        "stdout": "", "stderr": "",
+        "observation": base64.b64encode(observation).decode(),
+        "observation_sha256": hashlib.sha256(observation).hexdigest(),
+        "observation_size": len(observation),
+    }
+
+    result = supervisor._descriptor_result(payload, "a" * 64, "b" * 64, 1024)
+    termination = supervisor._termination_evidence(
+        124, timed_out=True, timeout_seconds=30, resource_limit=None,
+        pre_kill_process_topology=result.pre_kill_process_topology,
+    )
+
+    assert result.pre_kill_process_topology is (
+        supervisor.ProtectedProcessTopology.MULTIPLE
+    )
+    assert termination.pre_kill_process_topology is (
+        supervisor.ProtectedProcessTopology.MULTIPLE
+    )
+
+
 @pytest.mark.parametrize(
     ("program", "expected"),
     [

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -3525,6 +3525,81 @@ def test_generated_pidfd_protocol_real_child_lifecycle(
             pass
 
 
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or not hasattr(os, "pidfd_open"),
+    reason="requires Linux pidfds",
+)
+def test_generated_pidfd_timeout_without_topology_kills_reaps_and_closes() -> None:
+    """Playwright's topology-free timeout remains bounded and leak-free."""
+    protocol = _generated_pidfd_protocol()
+    before = set(os.listdir("/proc/self/fd"))
+    pid = os.fork()
+    if pid == 0:
+        time.sleep(5)
+        os._exit(0)
+    try:
+        assert protocol(pid, .03, None) == (124, True, None)
+        with pytest.raises(ChildProcessError):
+            os.waitpid(pid, os.WNOHANG)
+        assert set(os.listdir("/proc/self/fd")) == before
+    finally:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        try:
+            os.waitpid(pid, 0)
+        except ChildProcessError:
+            pass
+
+
+def test_generated_pidfd_timeout_without_topology_has_bounded_fake_lifecycle() -> None:
+    """Topology-free timeout still closes pidfd and kills/reaps exactly once."""
+    class FakeSystem:
+        def __init__(self) -> None:
+            self.closed: list[int] = []
+            self.killed: list[tuple[int, int]] = []
+            self.reaped = 0
+
+        @staticmethod
+        def pidfd_open(_pid, _flags):
+            return 17
+
+        def close(self, descriptor):
+            self.closed.append(descriptor)
+
+        def kill(self, pid, sig):
+            self.killed.append((pid, sig))
+
+        def waitpid(self, pid, _options):
+            self.reaped += 1
+            return pid, 0
+
+        @staticmethod
+        def waitstatus_to_exitcode(_status):
+            return 0
+
+    class FakePoll:
+        @staticmethod
+        def register(*_args):
+            return None
+
+        @staticmethod
+        def poll(_timeout):
+            return []
+
+    fake_system = FakeSystem()
+    protocol = _generated_pidfd_protocol({
+        "os": fake_system,
+        "select": SimpleNamespace(POLLIN=1, poll=FakePoll),
+    })
+
+    assert protocol(321, 1, None) == (124, True, None)
+    assert fake_system.killed == [(321, signal.SIGKILL)]
+    assert fake_system.reaped == 1
+    assert fake_system.closed == [17]
+
+
 @pytest.mark.parametrize("failure", ["pidfd_open", "poll", "waitpid"])
 def test_generated_pidfd_protocol_errors_reap_once_and_close(
     failure: str,
@@ -9840,11 +9915,69 @@ def test_descriptor_timeout_topology_is_bounded_cgroup_owned_and_pre_kill() -> N
     assert protocol.index("pre_kill_process_topology") < protocol.index(
         "os.kill(pid, 9)"
     )
-    assert "_supervise_candidate(pid,limits['timeout'],candidate_cgroup)" in helper
+    assert (
+        "_supervise_candidate(pid,limits['timeout'],candidate_cgroup "
+        "if standard_anonymous else None)"
+    ) in helper
+    assert (
+        "if timed_out and standard_anonymous: "
+        "candidate_payload['pre_kill_process_topology']="
+        "pre_kill_process_topology"
+    ) in helper
     assert (
         "candidate_payload['pre_kill_process_topology']="
         "pre_kill_process_topology"
     ) in helper
+
+
+def _descriptor_timeout_payload(*, topology: str | None) -> dict[str, object]:
+    """Return one canonical descriptor timeout fixture for protocol tests."""
+    observation = b"{}"
+    candidate: dict[str, object] = {
+        "version": 1, "state": "terminal", "returncode": 124,
+        "timed_out": True,
+    }
+    if topology is not None:
+        candidate["pre_kill_process_topology"] = topology
+    return {
+        "kind": "result", "nonce": "a" * 64, "aggregate_digest": "b" * 64,
+        "candidate": candidate, "stdout": "", "stderr": "",
+        "observation": base64.b64encode(observation).decode(),
+        "observation_sha256": hashlib.sha256(observation).hexdigest(),
+        "observation_size": len(observation),
+    }
+
+
+def test_descriptor_timeout_schema_is_bound_to_trusted_protocol_mode() -> None:
+    """Vitest requires topology while Playwright retains its four-field record."""
+    playwright = supervisor._descriptor_result(
+        _descriptor_timeout_payload(topology=None),
+        "a" * 64, "b" * 64, 1024,
+        require_timeout_topology=False,
+    )
+    assert playwright.candidate.timed_out is True
+    assert playwright.pre_kill_process_topology is None
+
+    with pytest.raises(RuntimeError, match="candidate record"):
+        supervisor._descriptor_result(
+            _descriptor_timeout_payload(topology=None),
+            "a" * 64, "b" * 64, 1024,
+            require_timeout_topology=True,
+        )
+    standard = supervisor._descriptor_result(
+        _descriptor_timeout_payload(topology="one"),
+        "a" * 64, "b" * 64, 1024,
+        require_timeout_topology=True,
+    )
+    assert standard.pre_kill_process_topology is (
+        supervisor.ProtectedProcessTopology.ONE
+    )
+    with pytest.raises(RuntimeError, match="candidate record"):
+        supervisor._descriptor_result(
+            _descriptor_timeout_payload(topology="one"),
+            "a" * 64, "b" * 64, 1024,
+            require_timeout_topology=False,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -3445,6 +3445,38 @@ def _generated_pidfd_protocol(namespace: dict[str, object] | None = None):
     return values["_supervise_candidate"]
 
 
+@pytest.mark.parametrize(
+    ("membership", "expected"),
+    [("", "none"), ("101\n", "one"), ("101\n202\n", "multiple")],
+)
+def test_generated_pre_kill_topology_has_only_three_bounded_categories(
+    tmp_path: Path, membership: str, expected: str,
+) -> None:
+    """Trusted cgroup membership becomes an enum, never a count or PID list."""
+    values = {"os": os, "select": __import__("select"), "math": math}
+    exec(supervisor._PIDFD_PROTOCOL_SOURCE, values)  # pylint: disable=exec-used
+    cgroup = tmp_path / "candidate-cgroup"
+    cgroup.mkdir()
+    (cgroup / "cgroup.procs").write_text(membership, encoding="ascii")
+
+    assert values["_pre_kill_process_topology"](cgroup) == expected
+
+
+@pytest.mark.parametrize("membership", ("01\n", "-1\n", "pid\n"))
+def test_generated_pre_kill_topology_rejects_malformed_membership(
+    tmp_path: Path, membership: str,
+) -> None:
+    """Malformed kernel membership cannot cross the typed evidence boundary."""
+    values = {"os": os, "select": __import__("select"), "math": math}
+    exec(supervisor._PIDFD_PROTOCOL_SOURCE, values)  # pylint: disable=exec-used
+    cgroup = tmp_path / "candidate-cgroup"
+    cgroup.mkdir()
+    (cgroup / "cgroup.procs").write_text(membership, encoding="ascii")
+
+    with pytest.raises(RuntimeError, match="membership is invalid"):
+        values["_pre_kill_process_topology"](cgroup)
+
+
 @pytest.mark.skipif(
     not sys.platform.startswith("linux") or not hasattr(os, "pidfd_open"),
     reason="requires Linux pidfds",
@@ -3452,16 +3484,18 @@ def _generated_pidfd_protocol(namespace: dict[str, object] | None = None):
 @pytest.mark.parametrize(
     ("mode", "expected"),
     [
-        ("zero", (0, False)),
-        ("signal", (-signal.SIGTERM, False)),
-        ("exit124", (124, False)),
-        ("timeout", (124, True)),
+        ("zero", (0, False, None)),
+        ("signal", (-signal.SIGTERM, False, None)),
+        ("exit124", (124, False, None)),
+        ("timeout", (124, True, "one")),
     ],
 )
 def test_generated_pidfd_protocol_real_child_lifecycle(
-    mode: str, expected: tuple[int, bool],
+    tmp_path: Path, mode: str, expected: tuple[int, bool, str | None],
 ) -> None:
     protocol = _generated_pidfd_protocol()
+    cgroup = tmp_path / "candidate-cgroup"
+    cgroup.mkdir()
     before = set(os.listdir("/proc/self/fd"))
     pid = os.fork()
     if pid == 0:
@@ -3473,7 +3507,10 @@ def test_generated_pidfd_protocol_real_child_lifecycle(
             time.sleep(5)
         os._exit(0)
     try:
-        assert protocol(pid, .03 if mode == "timeout" else 2) == expected
+        (cgroup / "cgroup.procs").write_text(str(pid), encoding="ascii")
+        assert protocol(
+            pid, .03 if mode == "timeout" else 2, cgroup
+        ) == expected
         with pytest.raises(ChildProcessError):
             os.waitpid(pid, os.WNOHANG)
         assert set(os.listdir("/proc/self/fd")) == before
@@ -9799,12 +9836,15 @@ def test_descriptor_timeout_topology_is_bounded_cgroup_owned_and_pre_kill() -> N
     assert {member.value for member in supervisor.ProtectedProcessTopology} == {
         "none", "one", "multiple",
     }
-    assert "cgroup/'cgroup.procs'" in protocol
+    assert "cgroup / 'cgroup.procs'" in protocol
     assert protocol.index("pre_kill_process_topology") < protocol.index(
         "os.kill(pid, 9)"
     )
     assert "_supervise_candidate(pid,limits['timeout'],candidate_cgroup)" in helper
-    assert "'pre_kill_process_topology':pre_kill_process_topology" in helper
+    assert (
+        "candidate_payload['pre_kill_process_topology']="
+        "pre_kill_process_topology"
+    ) in helper
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Bounded timeout topology diagnostic

This sub-PR targets #2128 and does not change adjudication. It adds typed evidence required by the exact cap-free #2143 failures.

TDD:
- RED `d5c8da289f1dad59dca2ac2b4f9220cdfef97015`: tests-only contract; collection failed because typed topology did not exist.
- GREEN `08f0852d9528e7af002d5354e1dd7b7a6ddece2e`: exact four-file implementation.

Behavior:
- root-owned helper samples the owned candidate cgroup immediately before timeout kill and emits only `none|one|multiple`;
- timeout records require the enum; non-timeout records reject it;
- runner reports reporter entry only from allowlisted progress and terminal-frame presence only after strict framed parsing;
- TIMEOUT is returned before any JSON semantic adjudication and can never become PASS;
- no PIDs, counts, paths, argv, environment, or candidate prose are exposed.

Non-goals: no retry, timeout/resource increase, reporter reinterpretation, proc/ptrace/FD/preload/Playwright weakening, or causal fix yet.

Local evidence: supervisor 318 passed/48 skipped; non-real Vitest 184 passed/5 skipped; Playwright 264 passed/16 skipped; focused final 18 passed/4 Linux-only skipped; pylint 10/10; compile/diff/clean/live-head guards passed. Independent critical review added full Vitest 185 passed/5 skipped and supervisor adversarial 31 passed/4 Linux skips.

Hosted purpose: observe terminal-frame state and pre-kill candidate topology on the known post-`result-published` timeout, then make the smallest causal correction.