### PR TITLE
merge: integrate main Vitest shutdown into Playwright adapter

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -27,6 +27,12 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".github/toolchains/playwright_manifest.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".github/toolchains/vitest/package-lock.json",
       "role": "human-maintained"
     },

--- a/pdd/agentic_common.py
+++ b/pdd/agentic_common.py
@@ -39,6 +39,10 @@ from pdd.routing_policy import (
     select_config,
 )
 
+# Bind once so retry tests can patch this seam without replacing the
+# process-wide ``time.sleep`` used by unrelated worker threads.
+_retry_sleep: Callable[[float], None] = time.sleep
+
 _steer_logger = logging.getLogger(__name__ + ".steer")
 
 AgenticUsage = Optional[Dict[str, List[Dict[str, Any]]]]
@@ -5365,7 +5369,7 @@ def run_agentic_task(
                                     )
                             if not quiet:
                                 console.print(f"[dim]Single-provider config: retrying in {backoff:.0f}s...[/dim]")
-                            time.sleep(backoff)
+                            _retry_sleep(backoff)
                             continue
                         break
                     else:
@@ -5536,7 +5540,7 @@ def run_agentic_task(
 
                     if verbose:
                         console.print(f"[dim]Waiting {backoff:.1f}s before retry...[/dim]")
-                    time.sleep(backoff)
+                    _retry_sleep(backoff)
 
             # All retries exhausted (or deadline budget exhausted) for this provider
             provider_errors.append(f"{provider}: {last_output[:MAX_ERROR_SNIPPET_LENGTH]}")

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -2932,6 +2932,19 @@ def _vitest_reporter_source(result_fd: int) -> str:
     return f"""import fs from 'node:fs';
 import path from 'node:path';
 const RESULT_FD = {result_fd};
+const coordinatorExit = process.exit.bind(process);
+const writeAll = (value) => {{
+  const buffer = Buffer.from(value);
+  let offset = 0;
+  while (offset < buffer.length) {{
+    const remaining = buffer.length - offset;
+    const written = fs.writeSync(RESULT_FD, buffer, offset, remaining);
+    if (!Number.isSafeInteger(written) || written <= 0 || written > remaining) {{
+      throw new Error('trusted Vitest result write did not advance safely');
+    }}
+    offset += written;
+  }}
+}};
 export default class PddTrustedVitestReporter {{
   constructor() {{ this.tests = []; }}
   onTestCaseResult(test) {{
@@ -2944,7 +2957,8 @@ export default class PddTrustedVitestReporter {{
     }});
   }}
   onTestRunEnd() {{
-    fs.writeSync(RESULT_FD, JSON.stringify({{tests: this.tests}}));
+    writeAll(JSON.stringify({{tests: this.tests}}));
+    coordinatorExit(process.exitCode ?? 0);
   }}
 }}
 """

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -52,10 +52,6 @@ TRUSTED_RUNNER_VERSION = "pdd-trusted-runner-v2"
 _VITEST_SUPERVISOR_LIMITS = SupervisorLimits(
     max_memory_bytes=4 * 1024 * 1024 * 1024
 )
-# Keep Node/Vitest's CPU-derived worker bursts inside the unchanged process ceiling.
-_VITEST_MAX_WORKERS = 1
-_VITEST_V8_POOL_SIZE = 1
-_VITEST_UV_THREADPOOL_SIZE = 1
 PYTEST_CONFIG_PATHS = (
     PurePosixPath("pytest.ini"),
     PurePosixPath("pyproject.toml"),
@@ -2814,23 +2810,14 @@ def _vitest_command(config: RunnerConfig) -> tuple[str, ...] | None:
 
 def _vitest_environment(home: Path) -> dict[str, str]:
     """Return a credential-free, non-ambient environment for Vitest."""
-    environment = untrusted_child_environment(
+    return untrusted_child_environment(
         drop={"PYTHONPATH", "PYTHONHOME", "PDD_PATH"}
     ) | {
         "HOME": str(home),
         "XDG_CONFIG_HOME": str(home / "config"),
         "XDG_CACHE_HOME": str(home / "cache"),
         "NODE_ENV": "test",
-        "UV_THREADPOOL_SIZE": str(_VITEST_UV_THREADPOOL_SIZE),
     }
-    # The protected Linux namespace retains a deliberately large 4 GiB virtual
-    # memory bound.  Node otherwise sizes V8 and libuv pools from the host CPU
-    # count, which can exhaust that bound before Vitest's trusted reporter
-    # starts.  Bind the internal pools as part of the checker-owned launch
-    # contract; do not inherit candidate or ambient Node controls.
-    if sys.platform.startswith("linux"):
-        environment["UV_THREADPOOL_SIZE"] = "1"
-    return environment
 
 
 def _vitest_result(
@@ -3058,15 +3045,12 @@ def _run_vitest(
         reporter.write_text(_vitest_reporter_source(result_fd), encoding="utf-8")
         command = [
             str(phase_toolchain.launcher),
-            f"--v8-pool-size={_VITEST_V8_POOL_SIZE}",
             *( ("--disable-wasm-trap-handler",) if sys.platform.startswith("linux") else () ),
-            *( ("--v8-pool-size=1",) if sys.platform.startswith("linux") else () ),
             str(phase_toolchain.entrypoint),
             "run",
             *(path.as_posix() for path in paths),
             f"--config={root / config_path}",
             f"--reporter={reporter}",
-            f"--maxWorkers={_VITEST_MAX_WORKERS}",
         ]
         digest = hashlib.sha256(json.dumps(command, separators=(",", ":")).encode()).hexdigest()
         before = _validator_tree_identity(root)

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -76,10 +76,6 @@ _IN_PROCESS_FRAMEWORK_ADAPTERS = frozenset(
 _VITEST_SUPERVISOR_LIMITS = SupervisorLimits(
     max_memory_bytes=4 * 1024 * 1024 * 1024,
 )
-# Keep Node/Vitest's CPU-derived worker bursts inside the unchanged process ceiling.
-_VITEST_MAX_WORKERS = 1
-_VITEST_V8_POOL_SIZE = 1
-_VITEST_UV_THREADPOOL_SIZE = 1
 PYTEST_CONFIG_PATHS = (
     PurePosixPath("pytest.ini"),
     PurePosixPath("pyproject.toml"),
@@ -4508,24 +4504,14 @@ def _vitest_command(config: RunnerConfig) -> tuple[str, ...] | None:
 
 def _vitest_environment(home: Path) -> dict[str, str]:
     """Return a credential-free, non-ambient environment for Vitest."""
-    environment = untrusted_child_environment(
+    return untrusted_child_environment(
         drop={"PYTHONPATH", "PYTHONHOME", "PDD_PATH"}
     ) | {
         "HOME": str(home),
         "XDG_CONFIG_HOME": str(home / "config"),
         "XDG_CACHE_HOME": str(home / "cache"),
         "NODE_ENV": "test",
-        "NODE_OPTIONS": f"--v8-pool-size={_VITEST_V8_POOL_SIZE}",
-        "UV_THREADPOOL_SIZE": str(_VITEST_UV_THREADPOOL_SIZE),
     }
-    # The protected Linux namespace retains a deliberately large 4 GiB virtual
-    # memory bound.  Node otherwise sizes V8 and libuv pools from the host CPU
-    # count, which can exhaust that bound before Vitest's trusted reporter
-    # starts.  Bind the internal pools as part of the checker-owned launch
-    # contract; do not inherit candidate or ambient Node controls.
-    if sys.platform.startswith("linux"):
-        environment["UV_THREADPOOL_SIZE"] = "1"
-    return environment
 
 
 def _vitest_path_operand(path: PurePosixPath) -> str:
@@ -4687,6 +4673,19 @@ def _vitest_reporter_source(result_fd: int) -> str:
     return f"""import fs from 'node:fs';
 import path from 'node:path';
 const RESULT_FD = {result_fd};
+const coordinatorExit = process.exit.bind(process);
+const writeAll = (value) => {{
+  const buffer = Buffer.from(value);
+  let offset = 0;
+  while (offset < buffer.length) {{
+    const remaining = buffer.length - offset;
+    const written = fs.writeSync(RESULT_FD, buffer, offset, remaining);
+    if (!Number.isSafeInteger(written) || written <= 0 || written > remaining) {{
+      throw new Error('trusted Vitest result write did not advance safely');
+    }}
+    offset += written;
+  }}
+}};
 export default class PddFrameworkVitestReporter {{
   constructor() {{ this.tests = []; }}
   onTestCaseResult(test) {{
@@ -4699,7 +4698,8 @@ export default class PddFrameworkVitestReporter {{
     }});
   }}
   onTestRunEnd() {{
-    fs.writeSync(RESULT_FD, JSON.stringify({{tests: this.tests}}));
+    writeAll(JSON.stringify({{tests: this.tests}}));
+    coordinatorExit(process.exitCode ?? 0);
   }}
 }}
 """
@@ -4801,13 +4801,11 @@ def _run_vitest(
         reporter.write_text(_vitest_reporter_source(result_fd), encoding="utf-8")
         command = [
             str(phase_toolchain.launcher),
-            f"--v8-pool-size={_VITEST_V8_POOL_SIZE}",
             *( ("--disable-wasm-trap-handler",) if sys.platform.startswith("linux") else () ),
             str(phase_toolchain.entrypoint),
             "run",
             f"--config={root / config_path}",
             f"--reporter={reporter}",
-            f"--maxWorkers={_VITEST_MAX_WORKERS}",
             *(_vitest_path_operand(path) for path in paths),
         ]
         digest = hashlib.sha256(json.dumps(command, separators=(",", ":")).encode()).hexdigest()

--- a/tests/test_agentic_common.py
+++ b/tests/test_agentic_common.py
@@ -5042,7 +5042,7 @@ def test_run_agentic_task_retries_on_failure(mock_shutil_which, mock_subprocess_
 
     mock_subprocess_run.side_effect = [fail_response, fail_response, success_response]
 
-    with patch("pdd.agentic_common.time.sleep"):  # Don't actually sleep
+    with patch("pdd.agentic_common._retry_sleep"):  # Don't actually sleep
         success, msg, cost, provider = run_agentic_task("Do work", tmp_path, max_retries=3)
 
     assert success
@@ -5073,7 +5073,7 @@ def test_run_agentic_task_retry_backoff(mock_shutil_which, mock_subprocess_run, 
 
     mock_subprocess_run.side_effect = [fail_response, fail_response, success_response]
 
-    with patch("pdd.agentic_common.time.sleep") as mock_sleep:
+    with patch("pdd.agentic_common._retry_sleep") as mock_sleep:
         run_agentic_task("Do work", tmp_path, max_retries=3, retry_delay=5)
 
     # Verify exponential backoff: 5s after attempt 1, 10s after attempt 2 (with jitter)
@@ -5108,7 +5108,7 @@ def test_run_agentic_task_moves_to_next_after_max_retries(mock_shutil_which, moc
     # Anthropic fails 3 times (max_retries), then Google succeeds
     mock_subprocess_run.side_effect = [fail_response, fail_response, fail_response, success_response]
 
-    with patch("pdd.agentic_common.time.sleep"):
+    with patch("pdd.agentic_common._retry_sleep"):
         success, msg, cost, provider = run_agentic_task("Do work", tmp_path, max_retries=3)
 
     assert success
@@ -6086,7 +6086,7 @@ class TestAgenticDebugLogging:
         from itertools import count
         time_iter = iter(count(start=1000.0, step=200.0))  # each call advances 200s
         with patch("pdd.agentic_common.time.time", side_effect=lambda: next(time_iter)), \
-             patch("pdd.agentic_common.time.sleep"):
+             patch("pdd.agentic_common._retry_sleep"):
             run_agentic_task(
                 "step prompt",
                 tmp_path,
@@ -6127,7 +6127,7 @@ class TestAgenticDebugLogging:
         fail_resp = MagicMock(returncode=1, stdout="", stderr="500 Internal Server Error")
         mock_subprocess_run.side_effect = [fail_resp, fail_resp, fail_resp]
         # Skip real backoff sleeps so the test is fast
-        with patch("pdd.agentic_common.time.sleep"):
+        with patch("pdd.agentic_common._retry_sleep"):
             run_agentic_task(
                 "step prompt",
                 tmp_path,
@@ -8150,7 +8150,7 @@ def test_deadline_skips_attempt_when_insufficient_time(tmp_path):
     with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "k"}, clear=False), \
          patch("pdd.agentic_common._find_cli_binary", return_value="/usr/bin/claude"), \
          patch("pdd.agentic_common._subprocess_run") as mock_run, \
-         patch("time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         mock_run.return_value = MagicMock(
             returncode=1, stdout="", stderr="fail"
         )
@@ -8171,7 +8171,7 @@ def test_deadline_caps_per_attempt_timeout(mock_env, tmp_path):
     with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "k"}, clear=False), \
          patch("pdd.agentic_common._find_cli_binary", return_value="/usr/bin/claude"), \
          patch("pdd.agentic_common._subprocess_run") as mock_run, \
-         patch("time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=json.dumps({"result": "ok", "total_cost_usd": 0.01}),
@@ -8196,7 +8196,7 @@ def test_no_deadline_preserves_default_timeout(mock_env, tmp_path):
     with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "k"}, clear=False), \
          patch("pdd.agentic_common._find_cli_binary", return_value="/usr/bin/claude"), \
          patch("pdd.agentic_common._subprocess_run") as mock_run, \
-         patch("time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=json.dumps({"result": "ok", "total_cost_usd": 0.01}),
@@ -8222,7 +8222,7 @@ def test_deadline_from_env_used_when_param_not_passed(tmp_path):
     }, clear=False), \
          patch("pdd.agentic_common._find_cli_binary", return_value="/usr/bin/claude"), \
          patch("pdd.agentic_common._subprocess_run") as mock_run, \
-         patch("time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         mock_run.return_value = MagicMock(
             returncode=1, stdout="", stderr="fail"
         )
@@ -8656,7 +8656,7 @@ def test_issue557_full_chain_modern_codex_false_positive(tmp_path):
          patch("pdd.agentic_common.get_agent_provider_preference", return_value=["openai"]), \
          patch("pdd.agentic_common._subprocess_run") as mock_run, \
          patch("pdd.agentic_common._subprocess_run_spooled") as mock_run_spooled, \
-         patch("time.sleep"):  # Skip retry delays
+         patch("pdd.agentic_common._retry_sleep"):  # Skip retry delays
         # Issue #1646: openai routes through the spooled runner.
         mock_run_spooled.side_effect = mock_run
         mock_run.return_value = MagicMock(
@@ -8710,7 +8710,7 @@ def test_codex_turn_completed_usage_parsed_for_cost(tmp_path):
          patch("pdd.agentic_common.get_agent_provider_preference", return_value=["openai"]), \
          patch("pdd.agentic_common._subprocess_run") as mock_run, \
          patch("pdd.agentic_common._subprocess_run_spooled") as mock_run_spooled, \
-         patch("time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         # Issue #1646: openai routes through the spooled runner.
         mock_run_spooled.side_effect = mock_run
         mock_run.return_value = MagicMock(
@@ -10533,7 +10533,7 @@ class TestProviderLimitMarker:
             "pdd.agentic_common.get_available_agents",
             return_value=["anthropic"],
         ), patch(
-            "pdd.agentic_common.time.sleep",
+            "pdd.agentic_common._retry_sleep",
         ), patch(
             "pdd.agentic_common._run_with_provider",
             return_value=(False, "Error: api_error_status: 429 rate limit exceeded", 0.0, "claude-opus-4-8", None),
@@ -10561,7 +10561,7 @@ class TestProviderLimitMarker:
             "pdd.agentic_common.get_available_agents",
             return_value=["anthropic"],
         ), patch(
-            "pdd.agentic_common.time.sleep",
+            "pdd.agentic_common._retry_sleep",
         ), patch(
             "pdd.agentic_common._run_with_provider",
             side_effect=attempts,
@@ -10762,7 +10762,7 @@ def test_false_positive_retries_in_single_provider_config(mock_cwd, mock_env, mo
         MagicMock(returncode=0, stdout=real_response, stderr=""),
     ]
 
-    with patch("pdd.agentic_common.time.sleep") as mock_sleep:
+    with patch("pdd.agentic_common._retry_sleep") as mock_sleep:
         success, msg, cost, provider = run_agentic_task(
             "Fix the bug",
             mock_cwd,
@@ -10818,7 +10818,7 @@ def test_false_positive_falls_through_in_multi_provider_config(mock_cwd, mock_en
         MagicMock(returncode=0, stdout=real_google, stderr=""),
     ]
 
-    with patch("pdd.agentic_common.time.sleep"):
+    with patch("pdd.agentic_common._retry_sleep"):
         success, msg, cost, provider = run_agentic_task(
             "Fix the bug",
             mock_cwd,
@@ -11475,7 +11475,7 @@ def test_issue1232_substantive_output_with_error_substring_not_demoted(
     mock_subprocess.return_value.stderr = ""
 
     with patch("pdd.agentic_common.get_agent_provider_preference", return_value=["openai"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -11529,7 +11529,7 @@ def test_issue1232_multi_provider_does_not_fall_through_for_substantive_openai_o
 
     with patch("pdd.agentic_common.get_agent_provider_preference",
                return_value=["openai", "anthropic"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -11575,7 +11575,7 @@ def test_issue1232_long_output_with_error_substring_still_passes(
     mock_subprocess.return_value.stderr = ""
 
     with patch("pdd.agentic_common.get_agent_provider_preference", return_value=["openai"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -11606,7 +11606,7 @@ def test_issue1232_empty_output_branch_still_detects_false_positive(
     mock_subprocess.return_value.stderr = ""
 
     with patch("pdd.agentic_common.get_agent_provider_preference", return_value=["anthropic"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, _cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -11642,7 +11642,7 @@ def test_issue1232_zero_cost_short_output_branch_still_detects_false_positive(
     mock_subprocess.return_value.stderr = ""
 
     with patch("pdd.agentic_common.get_agent_provider_preference", return_value=["anthropic"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, _cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -11682,7 +11682,7 @@ def test_issue1232_leading_error_prefix_response_still_detects_false_positive(
     mock_subprocess.return_value.stderr = ""
 
     with patch("pdd.agentic_common.get_agent_provider_preference", return_value=["openai"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, _cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -11732,7 +11732,7 @@ def test_issue1232_substantive_finding_starting_with_error_prefix_not_demoted(
     mock_subprocess.return_value.stderr = ""
 
     with patch("pdd.agentic_common.get_agent_provider_preference", return_value=["openai"]), \
-         patch("pdd.agentic_common.time.sleep"):
+         patch("pdd.agentic_common._retry_sleep"):
         success, msg, cost, provider = run_agentic_task(
             "instruction", mock_cwd, max_retries=1
         )
@@ -12415,7 +12415,7 @@ class TestIssue814BillingErrorsPermanent:
 
         mock_subprocess_run.side_effect = [anthropic_failure, google_success]
 
-        with patch("pdd.agentic_common.time.sleep") as sleep_mock:
+        with patch("pdd.agentic_common._retry_sleep") as sleep_mock:
             success, msg, cost, provider = run_agentic_task(
                 "Do work", tmp_path, max_retries=3, retry_delay=5
             )
@@ -12459,7 +12459,7 @@ class TestIssue814BillingErrorsPermanent:
 
         mock_subprocess_run.side_effect = [anthropic_failure, google_success]
 
-        with patch("pdd.agentic_common.time.sleep"):
+        with patch("pdd.agentic_common._retry_sleep"):
             success, *_ = run_agentic_task(
                 "Do work", tmp_path, max_retries=3, retry_delay=5
             )
@@ -12527,7 +12527,7 @@ class TestIssue814BillingErrorsPermanent:
 
         mock_subprocess_run.side_effect = [anthropic_failure, google_success]
 
-        with patch("pdd.agentic_common.time.sleep") as sleep_mock:
+        with patch("pdd.agentic_common._retry_sleep") as sleep_mock:
             success, _output, _cost, provider = run_agentic_task(
                 "Do work", tmp_path, max_retries=3, retry_delay=5, quiet=True
             )
@@ -12614,7 +12614,7 @@ class TestIssue814BillingErrorsPermanent:
         real_console = RealConsole(file=capture, force_terminal=False, no_color=True)
 
         with patch("pdd.agentic_common.console", real_console), \
-                patch("pdd.agentic_common.time.sleep"):
+                patch("pdd.agentic_common._retry_sleep"):
             success, _output, _cost, provider = run_agentic_task(
                 "Do work", tmp_path, max_retries=3, retry_delay=5
             )
@@ -12694,7 +12694,7 @@ class TestIssue814BillingErrorsPermanent:
 
         mock_subprocess_run.side_effect = [anthropic_400, google_success]
 
-        with patch("pdd.agentic_common.time.sleep") as sleep_mock:
+        with patch("pdd.agentic_common._retry_sleep") as sleep_mock:
             success, msg, cost, provider = run_agentic_task(
                 "Do work", tmp_path, max_retries=3, retry_delay=5
             )

--- a/tests/test_e2e_issue_902_provider_fallback.py
+++ b/tests/test_e2e_issue_902_provider_fallback.py
@@ -73,7 +73,7 @@ def orchestrator_mocks_with_real_retry():
     with patch("pdd.agentic_common._subprocess_run") as mock_subprocess, \
          patch("pdd.agentic_common._find_cli_binary") as mock_which, \
          patch("pdd.agentic_common._load_model_data", return_value=None), \
-         patch("pdd.agentic_common.time.sleep") as mock_sleep, \
+         patch("pdd.agentic_common._retry_sleep") as mock_sleep, \
          patch("pdd.agentic_e2e_fix_orchestrator.load_prompt_template") as mock_load, \
          patch("pdd.agentic_e2e_fix_orchestrator.console") as mock_console, \
          patch("pdd.agentic_e2e_fix_orchestrator.load_workflow_state") as mock_load_state, \

--- a/tests/test_issue_902.py
+++ b/tests/test_issue_902.py
@@ -2,6 +2,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 from pathlib import Path
+import threading
 import time
 import random
 import sys
@@ -20,22 +21,29 @@ class TestIssue902(unittest.TestCase):
     
     # --- agentic_common Jitter Test ---
     def test_jitter_is_additive(self):
-        """Requirement: Backoff jitter should be additive to the exponential base."""
+        """A foreign thread cannot contaminate normal-failure retry sleep capture."""
         retry_delay = 10.0
         jitter = 2.5
+        expected = retry_delay * (2 ** 0) + jitter
         with (
             patch(
                 "pdd.agentic_common.get_available_agents",
                 return_value=["anthropic"],
             ),
             patch("pdd.agentic_common._run_with_provider") as mock_run_with_provider,
-            patch("pdd.agentic_common.time.sleep") as mock_sleep,
+            patch("pdd.agentic_common.time.sleep") as shared_sleep,
+            patch("pdd.agentic_common._retry_sleep") as retry_sleep,
             patch(
                 "pdd.agentic_common.random.uniform",
                 return_value=jitter,
             ) as mock_uniform,
         ):
             mock_run_with_provider.return_value = (False, "Error: transient", 0.0, None)
+
+            foreign_thread = threading.Thread(target=time.sleep, args=(5.0,))
+            foreign_thread.start()
+            foreign_thread.join(timeout=1.0)
+            self.assertFalse(foreign_thread.is_alive())
 
             run_agentic_task(
                 instruction="test",
@@ -45,11 +53,47 @@ class TestIssue902(unittest.TestCase):
                 quiet=True,
             )
 
-            self.assertTrue(mock_sleep.called)
+            shared_sleep.assert_any_call(5.0)
+            retry_sleep.assert_called_once_with(expected)
             mock_uniform.assert_called_with(0, retry_delay)
-            first_sleep = mock_sleep.call_args_list[0][0][0]
-            expected = retry_delay * (2 ** 0) + jitter
-            self.assertAlmostEqual(first_sleep, expected)
+
+    def test_false_positive_retry_sleep_is_thread_isolated(self):
+        """A foreign thread cannot contaminate false-positive retry sleep capture."""
+        retry_delay = 10.0
+        jitter = 2.5
+        expected = retry_delay * (2 ** 0) + jitter
+        with (
+            patch(
+                "pdd.agentic_common.get_available_agents",
+                return_value=["anthropic"],
+            ),
+            patch(
+                "pdd.agentic_common._run_with_provider",
+                return_value=(True, "Error: transient provider response", 0.05, None),
+            ),
+            patch("pdd.agentic_common.time.sleep") as shared_sleep,
+            patch("pdd.agentic_common._retry_sleep") as retry_sleep,
+            patch(
+                "pdd.agentic_common.random.uniform",
+                return_value=jitter,
+            ) as mock_uniform,
+        ):
+            foreign_thread = threading.Thread(target=time.sleep, args=(5.0,))
+            foreign_thread.start()
+            foreign_thread.join(timeout=1.0)
+            self.assertFalse(foreign_thread.is_alive())
+
+            run_agentic_task(
+                instruction="test",
+                cwd=Path("."),
+                max_retries=2,
+                retry_delay=retry_delay,
+                quiet=True,
+            )
+
+            shared_sleep.assert_any_call(5.0)
+            retry_sleep.assert_called_once_with(expected)
+            mock_uniform.assert_called_with(0, retry_delay)
 
     # --- agentic_common False Positive Test ---
     @patch("pdd.agentic_common.get_available_agents", return_value=["anthropic"])

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -1067,12 +1067,7 @@ def _toolchain_manifest(tmp_path: Path, entrypoint: Path) -> Path:
     if not launcher.exists():
         launcher.write_text(
             "#!/bin/sh\n"
-            "while [ \"$#\" -gt 0 ]; do\n"
-            "  case \"$1\" in\n"
-            "    --disable-wasm-trap-handler|--v8-pool-size=*) shift ;;\n"
-            "    *) break ;;\n"
-            "  esac\n"
-            "done\n"
+            "[ \"$1\" = \"--disable-wasm-trap-handler\" ] && shift\n"
             f"exec {sys.executable!s} \"$@\"\n",
             encoding="utf-8",
         )
@@ -1959,19 +1954,24 @@ def test_vitest_exit_failure_precedes_empty_fifo_collection_error(
     assert executions[0].outcome is outcome
 
 
-def test_vitest_linux_command_binds_wasm_guard_and_resource_bounds(
+def test_vitest_omits_unproven_worker_caps_without_relaxing_limits(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Linux execution bounds must be trusted controls, not CI-only tuning."""
+    """Discredited worker caps must not weaken the protected Vitest boundary."""
     root, _commit = _repository(tmp_path)
     config = _runner_config(tmp_path, _fake_vitest(tmp_path))
     observed: list[list[str]] = []
     observed_environments: list[dict[str, str]] = []
     observed_limits: list[SupervisorLimits] = []
-    def capture(command, *, result_fifo, result_fd, limits, env, **_kwargs):
+    observed_timeouts: list[int] = []
+
+    def capture(
+        command, *, result_fifo, result_fd, env, limits, timeout, **_kwargs
+    ):
         observed.append(command)
         observed_limits.append(limits)
         observed_environments.append(env)
+        observed_timeouts.append(timeout)
         writer = os.open(result_fifo, os.O_WRONLY)
         try:
             os.write(
@@ -1982,6 +1982,7 @@ def test_vitest_linux_command_binds_wasm_guard_and_resource_bounds(
             os.close(writer)
         return subprocess.CompletedProcess(command, 0, "", ""), False
 
+    monkeypatch.setenv("UV_THREADPOOL_SIZE", "64")
     monkeypatch.setattr(runner_module.sys, "platform", "linux")
     monkeypatch.setattr("pdd.sync_core.runner.run_supervised", capture)
     execution, _identities = _run_vitest(
@@ -1989,21 +1990,33 @@ def test_vitest_linux_command_binds_wasm_guard_and_resource_bounds(
     )
 
     assert execution.outcome is EvidenceOutcome.PASS
-    assert observed[0][1:3] == ["--v8-pool-size=1", "--disable-wasm-trap-handler"]
-    assert observed[0][-1] == "--maxWorkers=1"
-    assert len(observed_environments) == 1
-    assert observed_environments[0]["UV_THREADPOOL_SIZE"] == "1"
+    assert not {
+        name
+        for name in vars(runner_module)
+        if name.startswith("_VITEST_") and name != "_VITEST_SUPERVISOR_LIMITS"
+    }
+    assert not any(value.startswith("--maxWorkers") for value in observed[0])
+    assert not any(value.startswith("--v8-pool-size") for value in observed[0])
+    assert "UV_THREADPOOL_SIZE" not in observed_environments[0]
+    assert observed[0][1] == "--disable-wasm-trap-handler"
+    assert any(value.startswith("--reporter=") for value in observed[0])
+    assert len(observed) == 1
+    assert observed_timeouts == [2]
     assert observed_limits == [
         SupervisorLimits(max_memory_bytes=4 * 1024 * 1024 * 1024)
     ]
-    assert observed_limits[0].max_processes == 128
+    assert observed_limits[0].max_memory_bytes == 4 * 1024 * 1024 * 1024
+    assert observed_limits[0].max_processes == SupervisorLimits().max_processes
+    assert observed_limits[0].max_output_bytes == SupervisorLimits().max_output_bytes
+    assert observed_limits[0].max_cpu_seconds == SupervisorLimits().max_cpu_seconds
+    assert observed_limits[0].max_writable_bytes == SupervisorLimits().max_writable_bytes
     assert SupervisorLimits().max_memory_bytes == 2 * 1024 * 1024 * 1024
 
 
-def test_vitest_linux_resource_bounds_remain_fake_launcher_compatible(
+def test_vitest_linux_wasm_guard_remains_fake_launcher_compatible(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The portable fake launcher accepts the exact trusted Linux Node flags."""
+    """The portable fake launcher accepts the retained Linux wasm guard."""
     root, _commit = _repository(tmp_path)
     monkeypatch.setattr(runner_module.sys, "platform", "linux")
     execution, identities = _run_vitest(

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -36,6 +36,7 @@ from pdd.sync_core.runner import (
     _validator_tree_identity,
     _vitest_command_error,
     _vitest_environment,
+    _vitest_reporter_source,
     _vitest_result,
     jest_validator_config_digest,
     runner_identity_digest,
@@ -84,6 +85,114 @@ def _controlled_supervisor(
         return result, False
 
     monkeypatch.setattr("pdd.sync_core.runner.run_supervised", execute)
+
+
+def _run_trusted_reporter_source(
+    tmp_path: Path, driver_source: str
+) -> tuple[subprocess.CompletedProcess[str], bytes]:
+    """Run the generated trusted reporter with a real inherited result pipe."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("requires Node.js")
+    read_fd, write_fd = os.pipe()
+    reporter = tmp_path / "trusted-reporter.mjs"
+    driver = tmp_path / "reporter-driver.mjs"
+    reporter.write_text(_vitest_reporter_source(write_fd), encoding="utf-8")
+    driver.write_text(driver_source, encoding="utf-8")
+    try:
+        try:
+            completed = subprocess.run(
+                [node, str(driver), str(reporter)],
+                pass_fds=(write_fd,),
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        finally:
+            os.close(write_fd)
+        result = bytearray()
+        while chunk := os.read(read_fd, 4096):
+            result.extend(chunk)
+    finally:
+        os.close(read_fd)
+    return completed, bytes(result)
+
+
+def test_vitest_reporter_exits_after_publishing_terminal_result(
+    tmp_path: Path,
+) -> None:
+    """A published terminal result must bypass blocked Vitest pool closure."""
+    completed, result = _run_trusted_reporter_source(
+        tmp_path,
+        """import { pathToFileURL } from 'node:url';
+const { default: Reporter } = await import(pathToFileURL(process.argv[2]).href);
+setInterval(() => {}, 1000);
+process.exitCode = 7;
+new Reporter().onTestRunEnd();
+""",
+    )
+
+    assert completed.returncode == 7
+    assert json.loads(result) == {"tests": []}
+
+
+def test_vitest_reporter_completes_partial_result_writes(tmp_path: Path) -> None:
+    """Short writes must not truncate the trusted terminal result."""
+    completed, result = _run_trusted_reporter_source(
+        tmp_path,
+        """import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+const originalWriteSync = fs.writeSync.bind(fs);
+fs.writeSync = (fd, value, offset = 0, length) => {
+  const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value);
+  const requested = length ?? buffer.length - offset;
+  return originalWriteSync(fd, buffer, offset, Math.min(requested, 3));
+};
+const { default: Reporter } = await import(pathToFileURL(process.argv[2]).href);
+new Reporter().onTestRunEnd();
+""",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(result) == {"tests": []}
+
+
+def test_vitest_reporter_rejects_result_write_without_progress(
+    tmp_path: Path,
+) -> None:
+    """A stalled synchronous result write must fail closed before exit."""
+    completed, result = _run_trusted_reporter_source(
+        tmp_path,
+        """import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+fs.writeSync = () => 0;
+const { default: Reporter } = await import(pathToFileURL(process.argv[2]).href);
+new Reporter().onTestRunEnd();
+""",
+    )
+
+    assert completed.returncode != 0
+    assert result == b""
+
+
+@pytest.mark.parametrize(
+    "test_config",
+    ({"reporters": ["default"]}, {"coverage": {"enabled": True}}),
+    ids=("reporters", "coverage"),
+)
+def test_vitest_config_cannot_replace_or_extend_trusted_reporter(
+    tmp_path: Path, test_config: dict[str, object]
+) -> None:
+    """Candidate config cannot add a reporter or enable coverage hooks."""
+    root, commit = _repository(
+        tmp_path, config=json.dumps({"test": test_config})
+    )
+
+    with pytest.raises(ValueError, match="not bound by this adapter"):
+        vitest_validator_config_digest(
+            root, commit, (PurePosixPath("tests/widget.test.ts"),)
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -39,6 +39,7 @@ from pdd.sync_core.runner import (
     _validator_tree_identity,
     _vitest_command_error,
     _vitest_environment,
+    _vitest_reporter_source,
     _vitest_result,
     jest_validator_config_digest,
     runner_identity_digest,
@@ -123,6 +124,114 @@ def _controlled_supervisor(
         return result, False
 
     monkeypatch.setattr("pdd.sync_core.runner.run_supervised", execute)
+
+
+def _run_trusted_reporter_source(
+    tmp_path: Path, driver_source: str
+) -> tuple[subprocess.CompletedProcess[str], bytes]:
+    """Run the generated trusted reporter with a real inherited result pipe."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("requires Node.js")
+    read_fd, write_fd = os.pipe()
+    reporter = tmp_path / "trusted-reporter.mjs"
+    driver = tmp_path / "reporter-driver.mjs"
+    reporter.write_text(_vitest_reporter_source(write_fd), encoding="utf-8")
+    driver.write_text(driver_source, encoding="utf-8")
+    try:
+        try:
+            completed = subprocess.run(
+                [node, str(driver), str(reporter)],
+                pass_fds=(write_fd,),
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        finally:
+            os.close(write_fd)
+        result = bytearray()
+        while chunk := os.read(read_fd, 4096):
+            result.extend(chunk)
+    finally:
+        os.close(read_fd)
+    return completed, bytes(result)
+
+
+def test_vitest_reporter_exits_after_publishing_terminal_result(
+    tmp_path: Path,
+) -> None:
+    """A published terminal result must bypass blocked Vitest pool closure."""
+    completed, result = _run_trusted_reporter_source(
+        tmp_path,
+        """import { pathToFileURL } from 'node:url';
+const { default: Reporter } = await import(pathToFileURL(process.argv[2]).href);
+setInterval(() => {}, 1000);
+process.exitCode = 7;
+new Reporter().onTestRunEnd();
+""",
+    )
+
+    assert completed.returncode == 7
+    assert json.loads(result) == {"tests": []}
+
+
+def test_vitest_reporter_completes_partial_result_writes(tmp_path: Path) -> None:
+    """Short writes must not truncate the trusted terminal result."""
+    completed, result = _run_trusted_reporter_source(
+        tmp_path,
+        """import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+const originalWriteSync = fs.writeSync.bind(fs);
+fs.writeSync = (fd, value, offset = 0, length) => {
+  const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value);
+  const requested = length ?? buffer.length - offset;
+  return originalWriteSync(fd, buffer, offset, Math.min(requested, 3));
+};
+const { default: Reporter } = await import(pathToFileURL(process.argv[2]).href);
+new Reporter().onTestRunEnd();
+""",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(result) == {"tests": []}
+
+
+def test_vitest_reporter_rejects_result_write_without_progress(
+    tmp_path: Path,
+) -> None:
+    """A stalled synchronous result write must fail closed before exit."""
+    completed, result = _run_trusted_reporter_source(
+        tmp_path,
+        """import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+fs.writeSync = () => 0;
+const { default: Reporter } = await import(pathToFileURL(process.argv[2]).href);
+new Reporter().onTestRunEnd();
+""",
+    )
+
+    assert completed.returncode != 0
+    assert result == b""
+
+
+@pytest.mark.parametrize(
+    "test_config",
+    ({"reporters": ["default"]}, {"coverage": {"enabled": True}}),
+    ids=("reporters", "coverage"),
+)
+def test_vitest_config_cannot_replace_or_extend_trusted_reporter(
+    tmp_path: Path, test_config: dict[str, object]
+) -> None:
+    """Candidate config cannot add a reporter or enable coverage hooks."""
+    root, commit = _repository(
+        tmp_path, config=json.dumps({"test": test_config})
+    )
+
+    with pytest.raises(ValueError, match="not bound by this adapter"):
+        vitest_validator_config_digest(
+            root, commit, (PurePosixPath("tests/widget.test.ts"),)
+        )
 
 
 @pytest.mark.parametrize(
@@ -1210,12 +1319,10 @@ def _toolchain_manifest(
         )
         launcher.write_text(
             "#!/bin/sh\n"
-            "[ \"$1\" = \"--v8-pool-size=1\" ] || exit 64\n"
-            "shift\n"
             + wasm_guard
             + "entrypoint=$1\n"
             "shift\n"
-            "case \" $* \" in *\" --v8-pool-size=\"*|*\" --disable-wasm-trap-handler \"*) exit 64;; esac\n"
+            "case \" $* \" in *\" --disable-wasm-trap-handler \"*) exit 64;; esac\n"
             + f"exec {sys.executable!s} \"$entrypoint\" \"$@\"\n",
             encoding="utf-8",
         )
@@ -2598,10 +2705,10 @@ def test_vitest_exit_failure_precedes_empty_fifo_collection_error(
         )
 
 
-def test_vitest_command_and_environment_bind_node_pools_without_relaxing_limits(
+def test_vitest_omits_unproven_worker_caps_without_relaxing_limits(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The checker owns every Vitest pool bound at the supervisor boundary."""
+    """Discredited worker caps must not weaken the protected Vitest boundary."""
     root, _commit = _repository(tmp_path)
     config = _runner_config(tmp_path, _fake_vitest(tmp_path))
     observed: list[list[str]] = []
@@ -2645,34 +2752,30 @@ def test_vitest_command_and_environment_bind_node_pools_without_relaxing_limits(
     )
 
     assert execution.outcome is EvidenceOutcome.PASS
-    assert all(
-        type(value) is int and value > 0
-        for value in (
-            runner_module._VITEST_MAX_WORKERS,
-            runner_module._VITEST_V8_POOL_SIZE,
-            runner_module._VITEST_UV_THREADPOOL_SIZE,
-        )
-    )
-    assert observed[0][1:4] == [
-        "--v8-pool-size=1",
+    assert not {
+        name
+        for name in vars(runner_module)
+        if name.startswith("_VITEST_") and name != "_VITEST_SUPERVISOR_LIMITS"
+    }
+    assert not any(value.startswith("--maxWorkers") for value in observed[0])
+    assert not any(value.startswith("--v8-pool-size") for value in observed[0])
+    assert "UV_THREADPOOL_SIZE" not in observed_environments[0]
+    assert "NODE_OPTIONS" not in observed_environments[0]
+    assert observed[0][1:3] == [
         "--disable-wasm-trap-handler",
         str(root / "node_modules/vitest/fake_vitest.py"),
     ]
-    assert observed[0].count("--maxWorkers=1") == 1
-    assert observed[0][4:8] == [
+    assert observed[0][3:6] == [
         "run",
         f"--config={root / 'vitest.config.json'}",
         next(value for value in observed[0] if value.startswith("--reporter=")),
-        "--maxWorkers=1",
     ]
-    assert observed[0][8:] == [
+    assert observed[0][6:] == [
         "./tests/widget.test.ts",
         "./--maxWorkers=64",
         "./--",
         "./--testNamePattern=escape",
     ]
-    assert observed_environments[0]["UV_THREADPOOL_SIZE"] == "1"
-    assert observed_environments[0]["NODE_OPTIONS"] == "--v8-pool-size=1"
     assert "UV_THREADPOOL_SIZE" not in runner_module._playwright_environment(tmp_path, None)
     assert proofs[0][0].descriptor_identity == _load_vitest_toolchain_descriptor(
         root, config
@@ -2685,46 +2788,30 @@ def test_vitest_command_and_environment_bind_node_pools_without_relaxing_limits(
     assert observed_timeouts == [2]
     assert any(value.startswith("--reporter=") for value in observed[0])
     assert observed_limits[0].max_processes == SupervisorLimits().max_processes
-    assert observed_limits[0].max_virtual_memory_bytes == SupervisorLimits().max_virtual_memory_bytes
+    assert observed_limits[0].max_output_bytes == SupervisorLimits().max_output_bytes
+    assert observed_limits[0].max_cpu_seconds == SupervisorLimits().max_cpu_seconds
+    assert observed_limits[0].max_writable_bytes == SupervisorLimits().max_writable_bytes
     assert SupervisorLimits().max_memory_bytes == 2 * 1024 * 1024 * 1024
 
 
-@pytest.mark.parametrize("linux_wasm_guard", [False, True])
-def test_vitest_test_launcher_requires_exact_platform_node_prefix(
-    tmp_path: Path, linux_wasm_guard: bool
+def test_vitest_linux_wasm_guard_remains_fake_launcher_compatible(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The stand-in launcher rejects malformed or misplaced Node-only flags."""
-    entrypoint = tmp_path / "entrypoint.py"
-    entrypoint.write_text("import sys\nprint('entrypoint')\n", encoding="utf-8")
-    manifest = _toolchain_manifest(
-        tmp_path, entrypoint, linux_wasm_guard=linux_wasm_guard
+    """The portable fake launcher accepts the retained Linux wasm guard."""
+    root, _commit = _repository(tmp_path)
+    monkeypatch.setattr(runner_module.sys, "platform", "linux")
+    monkeypatch.setattr(
+        "pdd.sync_core.runner.released_runtime_closure_paths", lambda: ()
     )
-    launcher = Path(json.loads(manifest.read_text(encoding="utf-8"))["roles"]["launcher"])
-    prefix = ["--v8-pool-size=1"] + (
-        ["--disable-wasm-trap-handler"] if linux_wasm_guard else []
-    )
-
-    accepted = subprocess.run(
-        [str(launcher), *prefix, str(entrypoint), "run"],
-        capture_output=True, text=True, check=False,
-    )
-    malformed = subprocess.run(
-        [str(launcher), "--v8-pool-size=64", *prefix[1:], str(entrypoint), "run"],
-        capture_output=True, text=True, check=False,
-    )
-    misplaced = subprocess.run(
-        [str(launcher), *prefix, str(entrypoint), "--v8-pool-size=1", "run"],
-        capture_output=True, text=True, check=False,
-    )
-    misplaced_wasm_guard = subprocess.run(
-        [str(launcher), *prefix, str(entrypoint), "--disable-wasm-trap-handler", "run"],
-        capture_output=True, text=True, check=False,
+    execution, identities = _run_vitest(
+        root,
+        (PurePosixPath("tests/widget.test.ts"),),
+        2,
+        _runner_config(tmp_path, _fake_vitest(tmp_path)),
     )
 
-    assert accepted.returncode == 0
-    assert malformed.returncode == 64
-    assert misplaced.returncode == 64
-    assert misplaced_wasm_guard.returncode == 64
+    assert execution.outcome is EvidenceOutcome.PASS
+    assert identities == (IDENTITY,)
 
 
 def test_mixed_adapter_identities_survive_manifest_removal_and_round_trip(


### PR DESCRIPTION
## Summary

- merge exact current main `6fb98c804f0e9676a10843b79fdd2cfed56f693d` into exact PR #1995 head `1be64ca21c507d3f9798cf879ce3165659ffae8f`
- preserve #1995's Playwright/security adapter and protected Vitest path operands
- carry main's removal of falsified Vitest worker/V8/libuv caps
- carry #2144's checked complete `writeAll` result publication and coordinator termination semantics
- register `.github/toolchains/playwright_manifest.py` in the exact protected ownership inventory

Merge commit: `20c79d1ccf104769016bd95a36606fa9e2b57d1a`

Parents, in order:

1. `1be64ca21c507d3f9798cf879ce3165659ffae8f`
2. `6fb98c804f0e9676a10843b79fdd2cfed56f693d`

This intentionally does not include the later Vitest terminal module-snapshot integration, retries, new caps, or timeout changes.

## Evidence

- Vitest adapter: `171 passed, 2 skipped`
- Playwright adapter + lifecycle/security: `306 passed, 21 skipped`
- workflow/profile/rollout: `173 passed`
- `pylint pdd/sync_core/runner.py`: `10.00/10`
- `py_compile` for touched runner/Vitest/Playwright modules: clean
- `git diff --check`: clean

This integration PR targets the #1995 feature branch and must not be merged directly to `main`.
