### PR TITLE
[NON-MERGE VALIDATION] #2097 supervisor scenario union

### DIFF
--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -7763,6 +7763,102 @@ def test_stalled_cleanup_unmounts_before_coordinator_reap_deletes_paths(
         os.fstat(read_fd)
 
 
+def test_stalled_cleanup_unmounts_before_destructive_scope_actions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Authenticated held cleanup finishes before systemd can delete backing paths."""
+    prefix = tmp_path / "pdd-scope-owned"
+    mount = prefix / "binds" / "writable"
+    mount.mkdir(parents=True)
+    namespace = {"link": "mnt:[11]", "inode": 11}
+    coordinator = {
+        "holder_kind": "current", "pid": 999999, "start_time": "100",
+        "namespace": "mnt:[11]", "namespace_inode": 11,
+    }
+    ownership = {
+        "unit": "pdd-validator-scope-order.scope", "cgroup": tmp_path / "cgroup",
+        "control_prefix": prefix, "namespace": namespace,
+        "namespace_holder": coordinator, "coordinator": coordinator,
+        "mount_points": [mount],
+    }
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    coordinator_alive = True
+    mounted = True
+    held_cleanup_complete = False
+    events = []
+
+    monkeypatch.setattr(
+        supervisor, "_trusted_tools",
+        lambda: SimpleNamespace(helper_python=Path("/trusted/python")),
+    )
+
+    def scanner(**_kwargs):
+        records = [coordinator] if coordinator_alive else []
+        return {
+            "watched": records, "identities": records,
+            "current_holders": records, "fd_holders": [],
+            "mount_holders": [], "cgroup_exists": False,
+        }
+
+    def runner(argv, **_kwargs):
+        nonlocal held_cleanup_complete, mounted
+        if "systemctl" in argv and "show" in argv:
+            return SimpleNamespace(returncode=0, stdout="not-found\n", stderr="")
+        if "systemctl" in argv:
+            action = argv[3]
+            events.append(f"scope-{action}")
+            if action == "kill":
+                mounted = False
+                shutil.rmtree(prefix)
+                assert held_cleanup_complete
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if _NSENTER_REVALIDATOR_SOURCE in argv:
+            operation = json.loads(argv[-1])["operation"]
+            assert coordinator_alive
+            assert mount.exists()
+            os.fstat(read_fd)
+            events.append(operation)
+            if operation == "unmount":
+                mounted = False
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            if mounted:
+                return SimpleNamespace(returncode=0, stdout="mounted", stderr="")
+            held_cleanup_complete = True
+            return SimpleNamespace(returncode=0, stdout="absent", stderr="")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    def terminate(pid: int, sent: signal.Signals) -> None:
+        nonlocal coordinator_alive
+        assert pid == coordinator["pid"] and sent == signal.SIGTERM
+        assert held_cleanup_complete and not mounted and not prefix.exists()
+        coordinator_alive = False
+        events.append("coordinator-reaped")
+
+    def waitpid(pid: int, _options: int) -> tuple[int, int]:
+        assert pid == coordinator["pid"]
+        return (0, 0) if coordinator_alive else (pid, 0)
+
+    def parse_diagnostic(raw: str, **_kwargs):
+        return ({"root": {"matches": True}}, (mount,) if raw == "mounted" else ())
+
+    monkeypatch.setattr(os, "kill", terminate)
+    monkeypatch.setattr(os, "waitpid", waitpid)
+    monkeypatch.setattr(
+        sys.modules[__name__], "_parse_held_namespace_diagnostic", parse_diagnostic,
+    )
+
+    assert _fallback_stalled_observation_cleanup(
+        ownership, (read_fd,), runner=runner, scanner=scanner,
+    ) == (-1,)
+    assert events == [
+        "scan", "unmount", "scan", "scope-kill", "scope-stop",
+        "scope-reset-failed", "coordinator-reaped",
+    ]
+    with pytest.raises(OSError):
+        os.fstat(read_fd)
+
+
 def test_exact_blocked_role_snapshot_rejects_running_and_reused_identity() -> None:
     """A running role or PID reuse cannot satisfy blocked-role evidence."""
     roles = [

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -6940,7 +6940,8 @@ def test_fallback_fd_holder_empty_untrusted_scan_keeps_stale_unmounts(
             if payload["operation"] == "unmount":
                 unmounts.append(payload["mount"])
                 return SimpleNamespace(
-                    returncode=1, stdout="", stderr="no mount point specified",
+                    returncode=1, stdout="",
+                    stderr=f"umount: {stale}: no mount point specified.",
                 )
             if mode == "unavailable":
                 return SimpleNamespace(returncode=2, stdout="", stderr="scanner unavailable")
@@ -7071,9 +7072,9 @@ def test_held_namespace_scan_failures_continue_cleanup_and_final_verification(
     (
         ("not mounted", False, True, True),
         ("no such file", False, True, True),
-        ("umount: /p/binds/writable: no mount point specified", False, True, True),
-        ("no mount point specified", False, False, False),
-        ("no mount point specified", True, True, False),
+        ("ambiguous-period", False, True, True),
+        ("ambiguous-period", False, False, False),
+        ("ambiguous-period", True, True, False),
     ),
     ids=("not-mounted", "enoent", "exact-root-empty", "root-mismatch", "nonempty"),
 )
@@ -7123,7 +7124,11 @@ def test_proven_absent_unmount_failures_are_deferred_only_after_later_scan(
             payload = json.loads(argv[-1])
             if payload["operation"] == "scan":
                 return SimpleNamespace(returncode=0, stdout=scan_outputs.pop(0), stderr="")
-            return SimpleNamespace(returncode=1, stdout="", stderr=stderr)
+            unmount_stderr = (
+                f"umount: {target}: no mount point specified."
+                if stderr == "ambiguous-period" else stderr
+            )
+            return SimpleNamespace(returncode=1, stdout="", stderr=unmount_stderr)
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     if succeeds:
@@ -7139,11 +7144,41 @@ def test_proven_absent_unmount_failures_are_deferred_only_after_later_scan(
 
 def test_root_mismatched_scan_is_never_deferred_absence_proof() -> None:
     """A scan from a mismatched root cannot discharge an otherwise stale unmount."""
-    deferred = [(Path("/p/binds/mount"), "not mounted")]
+    deferred = [(Path("/p/binds/mount"), "not mounted", False)]
 
     assert not _deferred_absent_is_proven(deferred, ((), False), None)
     assert _deferred_absent_is_proven(deferred, ((), True), None)
     assert _deferred_absent_is_proven(deferred, ((), False), ())
+
+
+def test_ambiguous_unmount_classification_is_bound_to_exact_mount() -> None:
+    """Only exact C-locale util-linux output for this mount is ambiguous absence."""
+    mount = Path("/p/binds/mount")
+    assert _ambiguous_absent_unmount_diagnostic(
+        "umount: /p/binds/mount: no mount point specified.", mount,
+    )
+    assert _ambiguous_absent_unmount_diagnostic(
+        "umount: /p/binds/mount: no mount point specified", mount,
+    )
+    for diagnostic in (
+        "no mount point specified.",
+        "umount: /p/binds/other: no mount point specified.",
+        "umount: /p/binds/mount: no mount point specified..",
+        "umount: /p/binds/mount: not mounted",
+        "prefix umount: /p/binds/mount: no mount point specified.",
+    ):
+        assert not _ambiguous_absent_unmount_diagnostic(diagnostic, mount)
+
+
+def test_ambiguous_unmount_proof_classification_survives_diagnostic_truncation() -> None:
+    """A long stored diagnostic cannot downgrade root-proof requirements."""
+    mount = Path("/p/binds") / ("x" * 700)
+    diagnostic = f"umount: {mount}: no mount point specified."
+    deferred = [(mount, diagnostic[:512], True)]
+
+    assert not _deferred_absent_is_proven(deferred, None, ())
+    assert not _deferred_absent_is_proven(deferred, ((), False), ())
+    assert _deferred_absent_is_proven(deferred, ((), True), None)
 
 
 def test_fdinfo_mount_id_parser_normalizes_whitespace_and_rejects_ambiguity() -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -7655,6 +7655,93 @@ def test_stalled_cleanup_closes_observer_fds_after_teardown_exception(
         os.fstat(read_fd)
 
 
+def test_stalled_cleanup_unmounts_before_coordinator_reap_deletes_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Held mounts are removed before coordinator cleanup deletes their paths."""
+    prefix = tmp_path / "pdd-scope-owned"
+    mount = prefix / "binds" / "writable"
+    mount.mkdir(parents=True)
+    namespace = {"link": "mnt:[11]", "inode": 11}
+    coordinator = {
+        "holder_kind": "current", "pid": 999999, "start_time": "100",
+        "namespace": "mnt:[11]", "namespace_inode": 11,
+    }
+    ownership = {
+        "unit": "pdd-validator-order.scope", "cgroup": tmp_path / "cgroup",
+        "control_prefix": prefix, "namespace": namespace,
+        "namespace_holder": coordinator, "coordinator": coordinator,
+        "mount_points": [mount],
+    }
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    coordinator_alive = True
+    mounted = True
+    events = []
+
+    monkeypatch.setattr(
+        supervisor, "_trusted_tools",
+        lambda: SimpleNamespace(helper_python=Path("/trusted/python")),
+    )
+
+    def scanner(**_kwargs):
+        records = [coordinator] if coordinator_alive else []
+        return {
+            "watched": records, "identities": records,
+            "current_holders": records, "fd_holders": [],
+            "mount_holders": [], "cgroup_exists": False,
+        }
+
+    def runner(argv, **_kwargs):
+        nonlocal mounted
+        if "systemctl" in argv and "show" in argv:
+            return SimpleNamespace(returncode=0, stdout="not-found\n", stderr="")
+        if _NSENTER_REVALIDATOR_SOURCE in argv:
+            operation = json.loads(argv[-1])["operation"]
+            assert coordinator_alive
+            assert mount.exists()
+            os.fstat(read_fd)
+            events.append(operation)
+            if operation == "unmount":
+                mounted = False
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(
+                returncode=0, stdout="mounted" if mounted else "absent", stderr="",
+            )
+        if "umount" in argv:
+            events.append("plain-unmount-after-reap")
+            return SimpleNamespace(returncode=32, stdout="", stderr="no such file")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def terminate(pid: int, sent: signal.Signals) -> None:
+        nonlocal coordinator_alive
+        assert pid == coordinator["pid"] and sent == signal.SIGTERM
+        assert mounted is False
+        coordinator_alive = False
+        shutil.rmtree(prefix)
+        events.append("coordinator-reaped-paths")
+
+    def waitpid(pid: int, _options: int) -> tuple[int, int]:
+        assert pid == coordinator["pid"]
+        return (0, 0) if coordinator_alive else (pid, 0)
+
+    def parse_diagnostic(raw: str, **_kwargs):
+        return ({"root": {"matches": True}}, (mount,) if raw == "mounted" else ())
+
+    monkeypatch.setattr(os, "kill", terminate)
+    monkeypatch.setattr(os, "waitpid", waitpid)
+    monkeypatch.setattr(
+        sys.modules[__name__], "_parse_held_namespace_diagnostic", parse_diagnostic,
+    )
+
+    assert _fallback_stalled_observation_cleanup(
+        ownership, (read_fd,), runner=runner, scanner=scanner,
+    ) == (-1,)
+    assert events == ["scan", "unmount", "scan", "coordinator-reaped-paths"]
+    with pytest.raises(OSError):
+        os.fstat(read_fd)
+
+
 def test_exact_blocked_role_snapshot_rejects_running_and_reused_identity() -> None:
     """A running role or PID reuse cannot satisfy blocked-role evidence."""
     roles = [

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -6232,7 +6232,12 @@ def _run_root_proc_scanner_cgroup_fault_fixture(
     cgroup.mkdir()
     membership = cgroup / "cgroup.procs"
     membership.write_text("4242\n", encoding="ascii")
-    if fault == "enodev-disappeared":
+    if fault == "empty-disappeared":
+        fault_body = f"""
+        pathlib.Path({str(membership)!r}).unlink()
+        return []
+"""
+    elif fault == "enodev-disappeared":
         fault_body = f"""
         pathlib.Path({str(membership)!r}).unlink()
         pathlib.Path({str(cgroup)!r}).rmdir()
@@ -6292,6 +6297,18 @@ def test_root_proc_scanner_accepts_kernel_confirmed_cgroup_disappearance(
     """An ENODEV followed by exact path absence proves scope removal."""
     completed = _run_root_proc_scanner_cgroup_fault_fixture(
         tmp_path, "enodev-disappeared",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout)["cgroup_exists"] is False
+
+
+def test_root_proc_scanner_accepts_disappeared_membership_files(
+    tmp_path: Path,
+) -> None:
+    """Missing cgroup controls prove teardown even while the directory lingers."""
+    completed = _run_root_proc_scanner_cgroup_fault_fixture(
+        tmp_path, "empty-disappeared",
     )
 
     assert completed.returncode == 0, completed.stderr

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -7859,6 +7859,132 @@ def test_stalled_cleanup_unmounts_before_destructive_scope_actions(
         os.fstat(read_fd)
 
 
+def test_stalled_cleanup_switches_to_captured_fd_holder_after_scope_teardown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Post-scope absence is authenticated through the captured external FD holder."""
+    prefix = tmp_path / "pdd-scope-owned"
+    mount = prefix / "binds" / "writable"
+    mount.mkdir(parents=True)
+    namespace = {"link": "mnt:[11]", "inode": 11}
+    coordinator = {"pid": 777777, "start_time": "100"}
+    current_holder = {
+        "holder_kind": "current", "pid": 999999, "start_time": "101",
+        "namespace": "mnt:[11]", "namespace_inode": 11,
+    }
+    fd_holder = {
+        "holder_kind": "fd", "pid": 888888, "start_time": "102", "fd": 73,
+        "fd_path": "/proc/888888/fd/73", "fd_link": "mnt:[11]", "fd_inode": 11,
+        "root_fd": 74, "root_path": "/proc/888888/fd/74",
+        "root_device": 1, "root_inode": 2, "root_mode": 0o40755,
+        "root_mnt_id": 42, "namespace": "mnt:[11]", "namespace_inode": 11,
+    }
+    ownership = {
+        "unit": "pdd-validator-holder-switch.scope", "cgroup": tmp_path / "cgroup",
+        "control_prefix": prefix, "namespace": namespace,
+        "namespace_holder": fd_holder,
+        "namespace_holders": [current_holder, fd_holder],
+        "coordinator": coordinator, "mount_points": [mount],
+        "external_holders": [fd_holder], "require_fd_only_holder": True,
+    }
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    coordinator_alive = True
+    fd_holder_alive = True
+    current_holder_alive = True
+    scope_torn_down = False
+    mounted = True
+    events = []
+
+    monkeypatch.setattr(
+        supervisor, "_trusted_tools",
+        lambda: SimpleNamespace(helper_python=Path("/trusted/python")),
+    )
+
+    def scanner(**_kwargs):
+        identities = []
+        watched = []
+        if coordinator_alive:
+            identities.append(coordinator)
+            watched.append(coordinator)
+        if current_holder_alive:
+            identities.append(current_holder)
+            watched.append(current_holder)
+        if fd_holder_alive:
+            identities.append(fd_holder)
+            watched.append(fd_holder)
+        return {
+            "watched": watched, "identities": identities,
+            "current_holders": [current_holder] if current_holder_alive else [],
+            "fd_holders": [fd_holder] if fd_holder_alive else [],
+            "mount_holders": [], "cgroup_exists": False,
+        }
+
+    def runner(argv, **_kwargs):
+        nonlocal current_holder_alive, fd_holder_alive, mounted, scope_torn_down
+        if "systemctl" in argv and "show" in argv:
+            return SimpleNamespace(returncode=0, stdout="not-found\n", stderr="")
+        if "systemctl" in argv:
+            events.append(f"scope-{argv[3]}")
+            if argv[3] == "kill":
+                scope_torn_down = True
+                current_holder_alive = False
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if _NSENTER_REVALIDATOR_SOURCE in argv:
+            payload = json.loads(argv[-1])
+            operation = payload["operation"]
+            holder_kind = payload["holder"]["holder_kind"]
+            events.append(f"{holder_kind}-{operation}")
+            os.fstat(read_fd)
+            if operation == "terminate":
+                assert holder_kind == "fd" and scope_torn_down
+                fd_holder_alive = False
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            if holder_kind == "current":
+                assert current_holder_alive and not scope_torn_down
+            else:
+                assert holder_kind == "fd" and fd_holder_alive and scope_torn_down
+            if operation == "unmount":
+                mounted = False
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(
+                returncode=0, stdout="mounted" if mounted else "absent", stderr="",
+            )
+        raise AssertionError(f"unexpected command: {argv}")
+
+    def terminate(pid: int, sent: signal.Signals) -> None:
+        nonlocal coordinator_alive
+        assert pid == coordinator["pid"] and sent == signal.SIGTERM
+        assert scope_torn_down and not current_holder_alive and not mounted
+        coordinator_alive = False
+        events.append("coordinator-reaped")
+
+    def waitpid(pid: int, _options: int) -> tuple[int, int]:
+        if pid == coordinator["pid"]:
+            return (0, 0) if coordinator_alive else (pid, 0)
+        assert pid == fd_holder["pid"]
+        return (0, 0) if fd_holder_alive else (pid, 0)
+
+    def parse_diagnostic(raw: str, **_kwargs):
+        return ({"root": {"matches": True}}, (mount,) if raw == "mounted" else ())
+
+    monkeypatch.setattr(os, "kill", terminate)
+    monkeypatch.setattr(os, "waitpid", waitpid)
+    monkeypatch.setattr(
+        sys.modules[__name__], "_parse_held_namespace_diagnostic", parse_diagnostic,
+    )
+
+    assert _fallback_stalled_observation_cleanup(
+        ownership, (read_fd,), runner=runner, scanner=scanner,
+    ) == (-1,)
+    assert events == [
+        "current-scan", "current-unmount", "scope-kill", "scope-stop",
+        "scope-reset-failed", "fd-scan", "coordinator-reaped", "fd-terminate",
+    ]
+    with pytest.raises(OSError):
+        os.fstat(read_fd)
+
+
 def test_exact_blocked_role_snapshot_rejects_running_and_reused_identity() -> None:
     """A running role or PID reuse cannot satisfy blocked-role evidence."""
     roles = [

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5804,8 +5804,13 @@ def _fallback_stalled_observation_cleanup_impl(
             )
         )
     holders = [] if scan is None else [*scan["current_holders"], *scan["fd_holders"]]
+    eligible_holders = (
+        captured_fd_holders
+        if ownership.get("require_fd_only_holder")
+        else captured_holders
+    )
     namespace_holder = None if scan is None else _select_captured_namespace_holder(
-        scan, captured_holders, namespace,
+        scan, eligible_holders, namespace,
     )
     if holders and namespace_holder is None:
         errors.append("no live namespace holder matches the complete captured identity")
@@ -7977,10 +7982,10 @@ def test_stalled_cleanup_unmounts_before_destructive_scope_actions(
         os.fstat(read_fd)
 
 
-def test_stalled_cleanup_switches_to_captured_fd_holder_after_scope_teardown(
+def test_stalled_cleanup_uses_captured_fd_holder_before_and_after_scope_teardown(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Post-scope absence is authenticated through the captured external FD holder."""
+    """A captured external FD holder authenticates the complete cleanup lifecycle."""
     prefix = tmp_path / "pdd-scope-owned"
     mount = prefix / "binds" / "writable"
     mount.mkdir(parents=True)
@@ -8061,7 +8066,7 @@ def test_stalled_cleanup_switches_to_captured_fd_holder_after_scope_teardown(
             if holder_kind == "current":
                 assert current_holder_alive and not scope_torn_down
             else:
-                assert holder_kind == "fd" and fd_holder_alive and scope_torn_down
+                assert holder_kind == "fd" and fd_holder_alive
             if operation == "unmount":
                 mounted = False
                 return SimpleNamespace(returncode=0, stdout="", stderr="")
@@ -8096,7 +8101,7 @@ def test_stalled_cleanup_switches_to_captured_fd_holder_after_scope_teardown(
         ownership, (read_fd,), runner=runner, scanner=scanner,
     ) == (-1,)
     assert events == [
-        "current-scan", "current-unmount", "scope-kill", "scope-stop",
+        "fd-scan", "fd-unmount", "scope-kill", "scope-stop",
         "scope-reset-failed", "fd-scan", "coordinator-reaped", "fd-terminate",
     ]
     with pytest.raises(OSError):

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -6853,6 +6853,66 @@ def test_fallback_fd_holder_accepts_root_valid_empty_held_inventory(
     assert operations == ["scan", "scan"]
 
 
+def test_fallback_fd_only_cleanup_prefers_captured_fd_holder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FD-only cleanup must not depend on a short-lived current holder."""
+    prefix = tmp_path / "pdd-scope-owned"
+    stale = prefix / "binds" / "stale"
+    fd_holder = _fallback_fd_holder()
+    current_holder = {
+        "holder_kind": "current", "pid": 11, "start_time": "99",
+        "namespace": "mnt:[11]", "namespace_inode": 11,
+    }
+    ownership = {
+        "unit": "pdd-validator-test.scope", "cgroup": tmp_path / "cgroup",
+        "control_prefix": prefix, "namespace": {"link": "mnt:[11]", "inode": 11},
+        "namespace_holder": current_holder,
+        "namespace_holders": [current_holder, fd_holder],
+        "coordinator": {"pid": 1, "start_time": "1"},
+        "mount_points": [stale], "require_fd_only_holder": True,
+    }
+    scans = 0
+    selected_holders = []
+    monkeypatch.setattr(
+        supervisor, "_trusted_tools",
+        lambda: SimpleNamespace(helper_python=Path("/trusted/python")),
+    )
+
+    def scanner(**_kwargs):
+        nonlocal scans
+        scans += 1
+        return {
+            "watched": [], "identities": [], "cgroup_exists": False,
+            "mount_holders": [],
+            "current_holders": [current_holder] if scans == 1 else [],
+            "fd_holders": [fd_holder] if scans <= 2 else [],
+        }
+
+    def runner(argv, **kwargs):
+        if "systemctl" in argv and "show" in argv:
+            return SimpleNamespace(returncode=0, stdout="not-found\n", stderr="")
+        if _NSENTER_REVALIDATOR_SOURCE in argv:
+            payload = json.loads(argv[-1])
+            selected_holders.append(payload["holder"]["holder_kind"])
+            assert payload["holder"] == fd_holder
+            request = json.loads(kwargs["input"])
+            return SimpleNamespace(
+                returncode=0,
+                stdout=_fallback_held_scan_diagnostic(
+                    prefix, tuple(Path(path) for path in request["targets"]),
+                    fd_holder, (), root_matches=True,
+                ),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    assert _fallback_stalled_observation_cleanup(
+        ownership, (), runner=runner, scanner=scanner,
+    ) == ()
+    assert selected_holders == ["fd", "fd"]
+
+
 def test_fallback_fd_holder_unmounts_stacked_nested_held_inventory_exactly(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5632,7 +5632,21 @@ def _hold_validated_descriptor_result(
     return result
 
 
-def _fallback_stalled_observation_cleanup(
+def _close_stalled_observation_fds(
+    owned_fds: tuple[int, ...], errors: list[str] | None = None,
+) -> None:
+    """Close every transferred lifecycle descriptor, recording non-EBADF failures."""
+    for descriptor in owned_fds:
+        if descriptor < 0:
+            continue
+        try:
+            os.close(descriptor)
+        except OSError as exc:
+            if exc.errno != 9 and errors is not None:
+                errors.append(f"close fd {descriptor} failed: {exc}")
+
+
+def _fallback_stalled_observation_cleanup_impl(
     ownership: dict[str, object], owned_fds: tuple[int, ...], *,
     runner=subprocess.run, scanner=_root_proc_scan,
 ) -> tuple[int, ...]:
@@ -5700,7 +5714,7 @@ def _fallback_stalled_observation_cleanup(
             errors.append(f"privileged procfs scan failed: {type(exc).__name__}: {exc}")
             return None
 
-    def teardown_scope_and_coordinator() -> None:
+    def teardown_exact_scope() -> None:
         for action in (
             ["kill", "--kill-whom=all", "--signal=SIGKILL", unit],
             ["stop", unit],
@@ -5718,9 +5732,10 @@ def _fallback_stalled_observation_cleanup(
                     or f"{purpose} returned {completed.returncode}"
                 )
 
+    def terminate_exact_coordinator() -> None:
         # Signal only a procfs-confirmed PID/start-time identity; a reused PID
-        # is untouchable. The lifecycle gate remains held until this outside
-        # coordinator can no longer run its private-namespace cleanup path.
+        # is untouchable. Held mounts are already gone, so coordinator cleanup
+        # can no longer invalidate paths needed by the authenticated unmount.
         scan = scan_owned()
         coordinator_present = scan is not None and any(
             _process_key(record) == expected_coordinator
@@ -5764,17 +5779,7 @@ def _fallback_stalled_observation_cleanup(
         if coordinator_present and not reaped:
             errors.append("captured coordinator could not be reaped before deadline")
 
-    try:
-        teardown_scope_and_coordinator()
-    finally:
-        for descriptor in owned_fds:
-            if descriptor < 0:
-                continue
-            try:
-                os.close(descriptor)
-            except OSError as exc:
-                if exc.errno != 9:
-                    errors.append(f"close fd {descriptor} failed: {exc}")
+    teardown_exact_scope()
 
     # The scanner sees mounts in the privileged private namespace, including binds/*.
     scan = scan_owned()
@@ -5903,6 +5908,7 @@ def _fallback_stalled_observation_cleanup(
             "owned mounts remain in held namespace: "
             + ", ".join(str(path) for path in remaining_held_mounts)
         )
+    terminate_exact_coordinator()
     for holder in ownership.get("external_holders", ()):
         expected = _process_key(holder)
         holder_scan = scanner(
@@ -5944,6 +5950,7 @@ def _fallback_stalled_observation_cleanup(
             reaper.kill()
             reaper.wait(timeout=max(.01, min(5, remaining())))
 
+    _close_stalled_observation_fds(owned_fds, errors)
     verification_deadline = min(deadline, time.monotonic() + 8)
     final_leaks = ["verification did not run"]
     final_authoritative_mounts: tuple[Path, ...] | None = None
@@ -6029,6 +6036,19 @@ def _fallback_stalled_observation_cleanup(
         errors.extend(held_namespace_diagnostics)
         raise AssertionError("; ".join(errors))
     return tuple(-1 for _descriptor in owned_fds)
+
+
+def _fallback_stalled_observation_cleanup(
+    ownership: dict[str, object], owned_fds: tuple[int, ...], *,
+    runner=subprocess.run, scanner=_root_proc_scan,
+) -> tuple[int, ...]:
+    """Close lifecycle descriptors even when fail-closed cleanup raises."""
+    try:
+        return _fallback_stalled_observation_cleanup_impl(
+            ownership, owned_fds, runner=runner, scanner=scanner,
+        )
+    finally:
+        _close_stalled_observation_fds(owned_fds)
 
 
 def _run_stalled_observation_setup(scan, assert_watched, failure_cleanup) -> None:
@@ -7523,9 +7543,10 @@ def test_stalled_observation_setup_failure_preserves_primary_and_reaps_owned_sta
         nonlocal calls, coordinator_scan_observed_open_fd
         calls += 1
         selections.append(selection)
-        if calls == 1:
-            os.fstat(read_fd)
-            coordinator_scan_observed_open_fd = True
+        if calls <= 3:
+            if calls == 1:
+                os.fstat(read_fd)
+                coordinator_scan_observed_open_fd = True
             return {
                 "watched": [coordinator_record], "mount_holders": [],
                 "current_holders": [], "fd_holders": [], "identities": [],

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5571,7 +5571,20 @@ def _deferred_absent_is_proven(
     procfs_absence = final_authoritative_mounts is not None and all(
         mount not in final_authoritative_mounts for mount, _diagnostic in deferred
     )
+    if any(
+        _ambiguous_absent_unmount_diagnostic(diagnostic)
+        for _mount, diagnostic in deferred
+    ):
+        return root_valid_absence
     return root_valid_absence or procfs_absence
+
+
+def _ambiguous_absent_unmount_diagnostic(diagnostic: str) -> bool:
+    """Match only util-linux's exact missing-mountpoint diagnostic shape."""
+    return diagnostic == "no mount point specified" or (
+        diagnostic.startswith("umount: ")
+        and diagnostic.endswith(": no mount point specified")
+    )
 
 
 _BLOCKED_WCHAN_MARKERS = ("sleep", "wait", "pause", "futex")
@@ -5889,7 +5902,10 @@ def _fallback_stalled_observation_cleanup_impl(
         if completed is None or completed.returncode == 0:
             continue
         diagnostic = (completed.stderr or completed.stdout).strip().lower()
-        if "not mounted" in diagnostic or "no such file" in diagnostic:
+        if (
+            "not mounted" in diagnostic or "no such file" in diagnostic
+            or _ambiguous_absent_unmount_diagnostic(diagnostic)
+        ):
             deferred_absent_unmounts.append((mount, diagnostic[:512]))
         else:
             errors.append(diagnostic[:512] or f"cannot unmount {mount}")
@@ -7055,7 +7071,7 @@ def test_held_namespace_scan_failures_continue_cleanup_and_final_verification(
     (
         ("not mounted", False, True, True),
         ("no such file", False, True, True),
-        ("no mount point specified", False, True, True),
+        ("umount: /p/binds/writable: no mount point specified", False, True, True),
         ("no mount point specified", False, False, False),
         ("no mount point specified", True, True, False),
     ),

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5700,60 +5700,40 @@ def _fallback_stalled_observation_cleanup(
             errors.append(f"privileged procfs scan failed: {type(exc).__name__}: {exc}")
             return None
 
-    for descriptor in owned_fds:
-        if descriptor < 0:
-            continue
-        try:
-            os.close(descriptor)
-        except OSError as exc:
-            if exc.errno != 9:
-                errors.append(f"close fd {descriptor} failed: {exc}")
+    def teardown_scope_and_coordinator() -> None:
+        for action in (
+            ["kill", "--kill-whom=all", "--signal=SIGKILL", unit],
+            ["stop", unit],
+            ["reset-failed", unit],
+        ):
+            purpose = f"systemctl {action[0]} exact scope"
+            before = len(errors)
+            completed = command(["sudo", "-n", "systemctl", *action], purpose)
+            if len(errors) != before:
+                unit_action_failures.extend(errors[before:])
+                del errors[before:]
+            elif completed is not None and completed.returncode != 0:
+                unit_action_failures.append(
+                    completed.stderr.strip()
+                    or f"{purpose} returned {completed.returncode}"
+                )
 
-    for action in (
-        ["kill", "--kill-whom=all", "--signal=SIGKILL", unit],
-        ["stop", unit],
-        ["reset-failed", unit],
-    ):
-        purpose = f"systemctl {action[0]} exact scope"
-        before = len(errors)
-        completed = command(["sudo", "-n", "systemctl", *action], purpose)
-        if len(errors) != before:
-            unit_action_failures.extend(errors[before:])
-            del errors[before:]
-        elif completed is not None and completed.returncode != 0:
-            unit_action_failures.append(
-                completed.stderr.strip() or f"{purpose} returned {completed.returncode}"
-            )
-
-    # Signal only a procfs-confirmed PID/start-time identity; a reused PID is untouchable.
-    scan = scan_owned()
-    coordinator_present = scan is not None and any(
-        _process_key(record) == expected_coordinator for record in scan["watched"]
-    )
-    if coordinator_present:
-        try:
-            os.kill(int(coordinator["pid"]), signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-    reap_deadline = min(deadline, time.monotonic() + 5)
-    reaped = False
-    while time.monotonic() < reap_deadline:
-        try:
-            waited, _status = os.waitpid(int(coordinator["pid"]), os.WNOHANG)
-        except ChildProcessError:
-            reaped = True
-            break
-        if waited == int(coordinator["pid"]):
-            reaped = True
-            break
-        time.sleep(.05)
-    if not reaped and coordinator_present:
-        try:
-            os.kill(int(coordinator["pid"]), signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        kill_deadline = min(deadline, time.monotonic() + 5)
-        while time.monotonic() < kill_deadline:
+        # Signal only a procfs-confirmed PID/start-time identity; a reused PID
+        # is untouchable. The lifecycle gate remains held until this outside
+        # coordinator can no longer run its private-namespace cleanup path.
+        scan = scan_owned()
+        coordinator_present = scan is not None and any(
+            _process_key(record) == expected_coordinator
+            for record in scan["watched"]
+        )
+        if coordinator_present:
+            try:
+                os.kill(int(coordinator["pid"]), signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+        reap_deadline = min(deadline, time.monotonic() + 5)
+        reaped = False
+        while time.monotonic() < reap_deadline:
             try:
                 waited, _status = os.waitpid(int(coordinator["pid"]), os.WNOHANG)
             except ChildProcessError:
@@ -5763,8 +5743,38 @@ def _fallback_stalled_observation_cleanup(
                 reaped = True
                 break
             time.sleep(.05)
-    if coordinator_present and not reaped:
-        errors.append("captured coordinator could not be reaped before deadline")
+        if not reaped and coordinator_present:
+            try:
+                os.kill(int(coordinator["pid"]), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            kill_deadline = min(deadline, time.monotonic() + 5)
+            while time.monotonic() < kill_deadline:
+                try:
+                    waited, _status = os.waitpid(
+                        int(coordinator["pid"]), os.WNOHANG,
+                    )
+                except ChildProcessError:
+                    reaped = True
+                    break
+                if waited == int(coordinator["pid"]):
+                    reaped = True
+                    break
+                time.sleep(.05)
+        if coordinator_present and not reaped:
+            errors.append("captured coordinator could not be reaped before deadline")
+
+    try:
+        teardown_scope_and_coordinator()
+    finally:
+        for descriptor in owned_fds:
+            if descriptor < 0:
+                continue
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                if exc.errno != 9:
+                    errors.append(f"close fd {descriptor} failed: {exc}")
 
     # The scanner sees mounts in the privileged private namespace, including binds/*.
     scan = scan_owned()
@@ -7492,11 +7502,10 @@ def test_stalled_observation_setup_failure_preserves_primary_and_reaps_owned_sta
     os.close(write_fd)
     commands = []
     calls = 0
+    coordinator_scan_observed_open_fd = False
 
     def runner(*args, **_kwargs):
         commands.append(args[0])
-        if args[0][2:4] == ["systemctl", "kill"]:
-            os.kill(coordinator, signal.SIGKILL)
         if args[0][2:4] == ["systemctl", "stop"]:
             return SimpleNamespace(returncode=5, stdout="", stderr="already removed")
         if args[0][2:4] == ["systemctl", "show"]:
@@ -7511,10 +7520,12 @@ def test_stalled_observation_setup_failure_preserves_primary_and_reaps_owned_sta
         selection=_RootProcSelection(),
     ):
         del cgroup, namespace, targets, target_prefix
-        nonlocal calls
+        nonlocal calls, coordinator_scan_observed_open_fd
         calls += 1
         selections.append(selection)
         if calls == 1:
+            os.fstat(read_fd)
+            coordinator_scan_observed_open_fd = True
             return {
                 "watched": [coordinator_record], "mount_holders": [],
                 "current_holders": [], "fd_holders": [], "identities": [],
@@ -7557,6 +7568,7 @@ def test_stalled_observation_setup_failure_preserves_primary_and_reaps_owned_sta
 
     with pytest.raises(OSError):
         os.fstat(read_fd)
+    assert coordinator_scan_observed_open_fd
     with pytest.raises(ChildProcessError):
         os.waitpid(coordinator, os.WNOHANG)
     assert selections and selections[0] == _RootProcSelection((coordinator,))
@@ -7609,6 +7621,38 @@ def test_stalled_cleanup_load_state_timeout_fails_closed(tmp_path: Path) -> None
         _fallback_stalled_observation_cleanup(
             ownership, (), runner=runner, scanner=scanner,
         )
+
+
+def test_stalled_cleanup_closes_observer_fds_after_teardown_exception(
+    tmp_path: Path,
+) -> None:
+    """Transferred descriptors close even when exact teardown raises unexpectedly."""
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    ownership = {
+        "unit": "pdd-validator-action-error.scope",
+        "cgroup": tmp_path / "cgroup",
+        "control_prefix": tmp_path / "pdd-scope-owned",
+        "namespace": {"link": "mnt:[1]", "inode": 1},
+        "namespace_holder": {
+            "holder_kind": "current", "pid": 999999,
+            "start_time": "100", "namespace": "mnt:[1]",
+            "namespace_inode": 1,
+        },
+        "coordinator": {"pid": 999999, "start_time": "100"},
+        "mount_points": [],
+    }
+
+    def runner(_argv, **_kwargs):
+        os.fstat(read_fd)
+        raise RuntimeError("injected teardown failure")
+
+    with pytest.raises(RuntimeError, match="injected teardown failure"):
+        _fallback_stalled_observation_cleanup(
+            ownership, (read_fd,), runner=runner,
+        )
+    with pytest.raises(OSError):
+        os.fstat(read_fd)
 
 
 def test_exact_blocked_role_snapshot_rejects_running_and_reused_identity() -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5779,8 +5779,6 @@ def _fallback_stalled_observation_cleanup_impl(
         if coordinator_present and not reaped:
             errors.append("captured coordinator could not be reaped before deadline")
 
-    teardown_exact_scope()
-
     # The scanner sees mounts in the privileged private namespace, including binds/*.
     scan = scan_owned()
     if scan is not None:
@@ -5908,6 +5906,7 @@ def _fallback_stalled_observation_cleanup_impl(
             "owned mounts remain in held namespace: "
             + ", ".join(str(path) for path in remaining_held_mounts)
         )
+    teardown_exact_scope()
     terminate_exact_coordinator()
     for holder in ownership.get("external_holders", ()):
         expected = _process_key(holder)
@@ -7594,11 +7593,12 @@ def test_stalled_observation_setup_failure_preserves_primary_and_reaps_owned_sta
         os.waitpid(coordinator, os.WNOHANG)
     assert selections and selections[0] == _RootProcSelection((coordinator,))
     assert commands == [
+        ["sudo", "-n", "umount",
+         str(tmp_path / "pdd-scope-owned" / "binds" / "nested")],
         ["sudo", "-n", "systemctl", "kill", "--kill-whom=all",
          "--signal=SIGKILL", "pdd-validator-test.scope"],
         ["sudo", "-n", "systemctl", "stop", "pdd-validator-test.scope"],
         ["sudo", "-n", "systemctl", "reset-failed", "pdd-validator-test.scope"],
-        ["sudo", "-n", "umount", str(tmp_path / "pdd-scope-owned" / "binds" / "nested")],
         ["sudo", "-n", "systemctl", "show", "pdd-validator-test.scope",
          "--property=LoadState", "--value"],
     ]

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -4009,6 +4009,29 @@ def cgroup_pids(path):
         try:
             files=list(root.rglob('cgroup.procs'))
             if not files:
+                try:
+                    root.lstat()
+                except FileNotFoundError:
+                    return False,set()
+                except OSError as verify_error:
+                    fail(f'verify empty cgroup scan: {root}: '
+                         f'{type(verify_error).__name__}: {verify_error}')
+                controls=('cgroup.procs','cgroup.threads',
+                          'cgroup.events','cgroup.type')
+                controls_gone=True
+                for name in controls:
+                    control=root/name
+                    try:
+                        control.lstat()
+                    except FileNotFoundError:
+                        continue
+                    except OSError as verify_error:
+                        fail(f'verify cgroup control: {control}: '
+                             f'{type(verify_error).__name__}: {verify_error}')
+                    controls_gone=False
+                    break
+                if controls_gone:
+                    return False,set()
                 fail(f'cgroup has no membership files: {root}')
             for membership in files:
                 values=membership.read_text(encoding='ascii').split()
@@ -6234,6 +6257,24 @@ def _run_root_proc_scanner_cgroup_fault_fixture(
     membership.write_text("4242\n", encoding="ascii")
     if fault == "empty-disappeared":
         fault_body = f"""
+        pathlib.Path({str(membership)!r}).unlink(missing_ok=True)
+        return []
+"""
+    elif fault == "empty-live-procs":
+        fault_body = """
+        return []
+"""
+    elif fault == "empty-live-threads":
+        threads = cgroup / "cgroup.threads"
+        threads.write_text("4242\n", encoding="ascii")
+        fault_body = f"""
+        pathlib.Path({str(membership)!r}).unlink()
+        return []
+"""
+    elif fault == "empty-live-events":
+        events = cgroup / "cgroup.events"
+        events.write_text("populated 0\n", encoding="ascii")
+        fault_body = f"""
         pathlib.Path({str(membership)!r}).unlink()
         return []
 """
@@ -6318,6 +6359,9 @@ def test_root_proc_scanner_accepts_disappeared_membership_files(
 @pytest.mark.parametrize(
     ("fault", "diagnostic"),
     (
+        ("empty-live-procs", "cgroup has no membership files"),
+        ("empty-live-threads", "cgroup has no membership files"),
+        ("empty-live-events", "cgroup has no membership files"),
         ("enodev-surviving", "OSError: [Errno 19] cgroup remains"),
         ("permission-disappeared", "PermissionError: [Errno 13] cgroup denied"),
         ("io-disappeared", "OSError: [Errno 5] cgroup I/O failure"),

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5669,6 +5669,14 @@ def _fallback_stalled_observation_cleanup_impl(
     if holder_records is None:
         holder_records = (ownership["namespace_holder"],)
     captured_holders = tuple(holder_records)
+    external_holder_keys = {
+        _holder_key(holder) for holder in ownership.get("external_holders", ())
+    }
+    captured_external_fd_holders = tuple(
+        holder for holder in captured_holders
+        if holder.get("holder_kind") == "fd"
+        and _holder_key(holder) in external_holder_keys
+    )
     unit_action_failures = []
 
     def remaining() -> float:
@@ -5862,15 +5870,6 @@ def _fallback_stalled_observation_cleanup_impl(
     held_mounts = None if held_scan is None else held_scan[0]
     if held_mounts is not None:
         captured_mounts.update(held_mounts)
-    if ownership.get("require_fd_only_holder") and (
-        namespace_holder is None
-        or namespace_holder.get("holder_kind") != "fd"
-        or scan is None
-        or scan["current_holders"]
-        or held_scan is None
-        or not held_scan[1]
-    ):
-        errors.append("exact FD-only namespace mount ownership was not preserved")
     deferred_absent_unmounts = []
     unmount_mounts = (
         held_mounts if held_scan is not None and held_scan[1] else captured_mounts
@@ -5899,14 +5898,35 @@ def _fallback_stalled_observation_cleanup_impl(
         else:
             errors.append(diagnostic[:512] or f"cannot unmount {mount}")
 
-    remaining_scan = holder_mount_scan()
+    if ownership.get("require_fd_only_holder"):
+        teardown_exact_scope()
+        post_scope_scan = scan_owned()
+        namespace_holder = (
+            None if post_scope_scan is None
+            else _select_captured_namespace_holder(
+                post_scope_scan, captured_external_fd_holders, namespace,
+            )
+        )
+        remaining_scan = holder_mount_scan()
+        if (
+            namespace_holder is None
+            or namespace_holder.get("holder_kind") != "fd"
+            or post_scope_scan is None
+            or post_scope_scan["current_holders"]
+            or remaining_scan is None
+            or not remaining_scan[1]
+            or remaining_scan[0]
+        ):
+            errors.append("exact FD-only namespace mount ownership was not preserved")
+    else:
+        remaining_scan = holder_mount_scan()
+        teardown_exact_scope()
     remaining_held_mounts = None if remaining_scan is None else remaining_scan[0]
     if remaining_held_mounts:
         errors.append(
             "owned mounts remain in held namespace: "
             + ", ".join(str(path) for path in remaining_held_mounts)
         )
-    teardown_exact_scope()
     terminate_exact_coordinator()
     for holder in ownership.get("external_holders", ()):
         expected = _process_key(holder)

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -3871,7 +3871,7 @@ def test_real_linux_authenticated_termination_and_cleanup(tmp_path: Path) -> Non
 
 
 _ROOT_PROC_SCANNER_SOURCE = r"""
-import json,os,pathlib,sys
+import errno,json,os,pathlib,sys
 
 payload=json.loads(sys.argv[1])
 proc=pathlib.Path('/proc')
@@ -4028,6 +4028,16 @@ def cgroup_pids(path):
                 continue
             fail(f'read cgroup membership raced twice: {root}: {error}')
         except OSError as error:
+            if error.errno==errno.ENODEV:
+                try:
+                    root.lstat()
+                except FileNotFoundError:
+                    return False,set()
+                except OSError as verify_error:
+                    if verify_error.errno==errno.ENODEV:
+                        return False,set()
+                    fail(f'verify cgroup ENODEV: {root}: '
+                         f'{type(verify_error).__name__}: {verify_error}')
             fail(f'read cgroup membership: {root}: {type(error).__name__}: {error}')
     fail(f'unreachable cgroup scan state: {root}')
 
@@ -6238,6 +6248,12 @@ def _run_root_proc_scanner_cgroup_fault_fixture(
         pathlib.Path({str(cgroup)!r}).rmdir()
         raise PermissionError(errno.EACCES,'cgroup denied',str(root))
 """
+    elif fault == "io-disappeared":
+        fault_body = f"""
+        pathlib.Path({str(membership)!r}).unlink()
+        pathlib.Path({str(cgroup)!r}).rmdir()
+        raise OSError(errno.EIO,'cgroup I/O failure',str(root))
+"""
     elif fault == "malformed":
         membership.write_text("not-a-pid\n", encoding="ascii")
         fault_body = """
@@ -6287,6 +6303,7 @@ def test_root_proc_scanner_accepts_kernel_confirmed_cgroup_disappearance(
     (
         ("enodev-surviving", "OSError: [Errno 19] cgroup remains"),
         ("permission-disappeared", "PermissionError: [Errno 13] cgroup denied"),
+        ("io-disappeared", "OSError: [Errno 5] cgroup I/O failure"),
         ("malformed", "parse cgroup membership"),
     ),
 )

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5669,13 +5669,9 @@ def _fallback_stalled_observation_cleanup_impl(
     if holder_records is None:
         holder_records = (ownership["namespace_holder"],)
     captured_holders = tuple(holder_records)
-    external_holder_keys = {
-        _holder_key(holder) for holder in ownership.get("external_holders", ())
-    }
-    captured_external_fd_holders = tuple(
+    captured_fd_holders = tuple(
         holder for holder in captured_holders
         if holder.get("holder_kind") == "fd"
-        and _holder_key(holder) in external_holder_keys
     )
     unit_action_failures = []
 
@@ -5904,7 +5900,7 @@ def _fallback_stalled_observation_cleanup_impl(
         namespace_holder = (
             None if post_scope_scan is None
             else _select_captured_namespace_holder(
-                post_scope_scan, captured_external_fd_holders, namespace,
+                post_scope_scan, captured_fd_holders, namespace,
             )
         )
         remaining_scan = holder_mount_scan()

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -5558,33 +5558,32 @@ def test_held_namespace_scan_stderr_sanitizer_maps_anchored_nsenter_failures(
 
 
 def _deferred_absent_is_proven(
-    deferred: list[tuple[Path, str]],
+    deferred: list[tuple[Path, str, bool]],
     remaining_scan: tuple[tuple[Path, ...], bool] | None,
     final_authoritative_mounts: tuple[Path, ...] | None,
 ) -> bool:
     """Accept stale-unmount output only with root-valid or final procfs absence."""
     root_valid_absence = (
         remaining_scan is not None and remaining_scan[1] and all(
-            mount not in remaining_scan[0] for mount, _diagnostic in deferred
+            mount not in remaining_scan[0]
+            for mount, _diagnostic, _ambiguous in deferred
         )
     )
     procfs_absence = final_authoritative_mounts is not None and all(
-        mount not in final_authoritative_mounts for mount, _diagnostic in deferred
+        mount not in final_authoritative_mounts
+        for mount, _diagnostic, _ambiguous in deferred
     )
-    if any(
-        _ambiguous_absent_unmount_diagnostic(diagnostic)
-        for _mount, diagnostic in deferred
-    ):
+    if any(ambiguous for _mount, _diagnostic, ambiguous in deferred):
         return root_valid_absence
     return root_valid_absence or procfs_absence
 
 
-def _ambiguous_absent_unmount_diagnostic(diagnostic: str) -> bool:
-    """Match only util-linux's exact missing-mountpoint diagnostic shape."""
-    return diagnostic == "no mount point specified" or (
-        diagnostic.startswith("umount: ")
-        and diagnostic.endswith(": no mount point specified")
-    )
+def _ambiguous_absent_unmount_diagnostic(
+    diagnostic: str, mount: Path,
+) -> bool:
+    """Match only C-locale util-linux output bound to the exact requested mount."""
+    prefix = f"umount: {mount}: no mount point specified"
+    return diagnostic in {prefix, prefix + "."}
 
 
 _BLOCKED_WCHAN_MARKERS = ("sleep", "wait", "pause", "futex")
@@ -5901,12 +5900,19 @@ def _fallback_stalled_observation_cleanup_impl(
         completed = command(argv, f"unmount {mount}")
         if completed is None or completed.returncode == 0:
             continue
-        diagnostic = (completed.stderr or completed.stdout).strip().lower()
+        diagnostic = (completed.stderr or completed.stdout).strip()
+        normalized_diagnostic = diagnostic.lower()
+        ambiguous_absence = _ambiguous_absent_unmount_diagnostic(
+            diagnostic, mount,
+        )
         if (
-            "not mounted" in diagnostic or "no such file" in diagnostic
-            or _ambiguous_absent_unmount_diagnostic(diagnostic)
+            "not mounted" in normalized_diagnostic
+            or "no such file" in normalized_diagnostic
+            or ambiguous_absence
         ):
-            deferred_absent_unmounts.append((mount, diagnostic[:512]))
+            deferred_absent_unmounts.append(
+                (mount, diagnostic[:512], ambiguous_absence)
+            )
         else:
             errors.append(diagnostic[:512] or f"cannot unmount {mount}")
 
@@ -6059,10 +6065,10 @@ def _fallback_stalled_observation_cleanup_impl(
         if not _deferred_absent_is_proven(
             deferred_absent_unmounts, remaining_scan, final_authoritative_mounts,
         ):
-            errors.extend(
-                diagnostic or f"cannot unmount {mount}"
-                for mount, diagnostic in deferred_absent_unmounts
-            )
+                errors.extend(
+                    diagnostic or f"cannot unmount {mount}"
+                    for mount, diagnostic, _ambiguous in deferred_absent_unmounts
+                )
     if errors:
         errors.extend(held_namespace_diagnostics)
         raise AssertionError("; ".join(errors))

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -7051,59 +7051,44 @@ def test_held_namespace_scan_failures_continue_cleanup_and_final_verification(
 
 
 @pytest.mark.parametrize(
-    ("stderr", "succeeds"),
-    (("not mounted", True), ("no such file", True), ("no mount point specified", False)),
+    ("stderr", "later_present", "root_matches", "succeeds"),
+    (
+        ("not mounted", False, True, True),
+        ("no such file", False, True, True),
+        ("no mount point specified", False, True, True),
+        ("no mount point specified", False, False, False),
+        ("no mount point specified", True, True, False),
+    ),
+    ids=("not-mounted", "enoent", "exact-root-empty", "root-mismatch", "nonempty"),
 )
 def test_proven_absent_unmount_failures_are_deferred_only_after_later_scan(
-    tmp_path: Path, stderr: str, succeeds: bool, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path, stderr: str, later_present: bool, root_matches: bool,
+    succeeds: bool, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Only later namespace absence proof can discharge known stale-unmount output."""
     prefix = tmp_path / "pdd-scope-owned"
     target = prefix / "binds" / "writable"
     namespace = {"link": "mnt:[11]", "inode": 11}
-    holder = {
-        "holder_kind": "current", "pid": 22, "start_time": "100",
-        "namespace": "mnt:[11]", "namespace_inode": 11,
-    }
+    holder = _fallback_fd_holder()
     ownership = {
         "unit": "pdd-validator-test.scope", "cgroup": tmp_path / "cgroup",
         "control_prefix": prefix, "namespace": namespace,
         "namespace_holder": holder, "coordinator": {"pid": 1, "start_time": "1"},
-        "mount_points": [target],
+        "mount_points": [target], "require_fd_only_holder": True,
     }
     monkeypatch.setattr(
         supervisor, "_trusted_tools", lambda: SimpleNamespace(helper_python=Path("/trusted/python")),
     )
 
-    def metadata() -> dict[str, object]:
-        return {"status": "ok", "device": 1, "inode": 2, "mode": 0o40700}
-
-    def diagnostic(mounts: list[Path]) -> str:
-        record = {
-            "mount_id": 43, "parent_id": 1, "root": "/", "mount_point": str(target),
-            "major_minor": "0:42", "filesystem": "tmpfs", "source": "tmpfs",
-            "options": {"mount": "rw", "super": "rw"}, "truncated": [],
-        }
-        return json.dumps({
-            "schema": "pdd-held-namespace-diagnostic-v1", "operation": "scan",
-            "prefix": str(prefix), "targets": [str(target)],
-            "mount_namespace": namespace,
-            "root": {"link": "/", "expected": None, "actual": {
-                "device": 1, "inode": 2, "mode": 0o40755, "mount_id": 42,
-            }, "matches": None},
-            "cwd": {"status": "ok", "path": "/"}, "paths": {
-                "prefix": {"path": str(prefix), "exists": True, "lstat": metadata(), "stat": metadata()},
-                "target_count": 1,
-                "targets": [{"path": str(target), "exists": True, "lstat": metadata(), "stat": metadata()}],
-            },
-            "mountinfo": {
-                "mounts": [str(path) for path in mounts], "exact_count": len(mounts),
-                "samples": [record] if mounts else [],
-                "related": [] if mounts else [{**record, "mount_id": 44, "mount_point": "/"}],
-            },
-        }, sort_keys=True)
-
-    scan_outputs = [diagnostic([target]), diagnostic([])]
+    scan_outputs = [
+        _fallback_held_scan_diagnostic(
+            prefix, (target,), holder, (target,), root_matches=True,
+        ),
+        _fallback_held_scan_diagnostic(
+            prefix, (target,), holder, (target,) if later_present else (),
+            root_matches=root_matches,
+        ),
+    ]
     scans = 0
 
     def scanner(**_kwargs):
@@ -7111,8 +7096,8 @@ def test_proven_absent_unmount_failures_are_deferred_only_after_later_scan(
         scans += 1
         return {
             "watched": [], "identities": [], "cgroup_exists": False,
-            "mount_holders": [], "fd_holders": [],
-            "current_holders": [holder] if scans <= 2 else [],
+            "mount_holders": [], "current_holders": [],
+            "fd_holders": [holder] if scans <= 2 else [],
         }
 
     def runner(argv, **_kwargs):

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -6212,6 +6212,94 @@ def test_root_proc_scanner_source_rejects_non_enoent_descriptor_errors(
     ) in completed.stderr
 
 
+def _run_root_proc_scanner_cgroup_fault_fixture(
+    tmp_path: Path, fault: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run the embedded scanner across one deterministic cgroup membership fault."""
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    cgroup = tmp_path / "scope"
+    cgroup.mkdir()
+    membership = cgroup / "cgroup.procs"
+    membership.write_text("4242\n", encoding="ascii")
+    if fault == "enodev-disappeared":
+        fault_body = f"""
+        pathlib.Path({str(membership)!r}).unlink()
+        pathlib.Path({str(cgroup)!r}).rmdir()
+        raise OSError(errno.ENODEV,'cgroup disappeared',str(root))
+"""
+    elif fault == "enodev-surviving":
+        fault_body = """
+        raise OSError(errno.ENODEV,'cgroup remains',str(root))
+"""
+    elif fault == "permission-disappeared":
+        fault_body = f"""
+        pathlib.Path({str(membership)!r}).unlink()
+        pathlib.Path({str(cgroup)!r}).rmdir()
+        raise PermissionError(errno.EACCES,'cgroup denied',str(root))
+"""
+    elif fault == "malformed":
+        membership.write_text("not-a-pid\n", encoding="ascii")
+        fault_body = """
+        return _fixture_rglob(root,pattern)
+"""
+    else:
+        raise ValueError(f"unknown cgroup fixture fault: {fault}")
+    source = _ROOT_PROC_SCANNER_SOURCE.replace(
+        "proc=pathlib.Path('/proc')", f"proc=pathlib.Path({str(proc)!r})",
+    ).replace(
+        "self_pid=os.getpid()",
+        f"""self_pid=os.getpid()
+import errno
+_fixture_rglob=pathlib.Path.rglob
+def fixture_rglob(root,pattern):
+    if root==pathlib.Path({str(cgroup)!r}):
+{fault_body}    return _fixture_rglob(root,pattern)""",
+    ).replace(
+        "files=list(root.rglob('cgroup.procs'))",
+        "files=list(fixture_rglob(root,'cgroup.procs'))",
+    )
+    payload = {
+        "cgroup": str(cgroup), "namespace": None, "targets": [],
+        "target_prefix": "", "watch_pids": [], "scope_only": False,
+        "root_holders": [],
+    }
+    return subprocess.run(
+        [sys.executable, "-I", "-S", "-c", source, json.dumps(payload)],
+        capture_output=True, text=True, check=False, timeout=5,
+    )
+
+
+def test_root_proc_scanner_accepts_kernel_confirmed_cgroup_disappearance(
+    tmp_path: Path,
+) -> None:
+    """An ENODEV followed by exact path absence proves scope removal."""
+    completed = _run_root_proc_scanner_cgroup_fault_fixture(
+        tmp_path, "enodev-disappeared",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout)["cgroup_exists"] is False
+
+
+@pytest.mark.parametrize(
+    ("fault", "diagnostic"),
+    (
+        ("enodev-surviving", "OSError: [Errno 19] cgroup remains"),
+        ("permission-disappeared", "PermissionError: [Errno 13] cgroup denied"),
+        ("malformed", "parse cgroup membership"),
+    ),
+)
+def test_root_proc_scanner_rejects_unproven_cgroup_disappearance(
+    tmp_path: Path, fault: str, diagnostic: str,
+) -> None:
+    """Live paths, permission failures, and malformed scans remain fatal."""
+    completed = _run_root_proc_scanner_cgroup_fault_fixture(tmp_path, fault)
+
+    assert completed.returncode == 2
+    assert diagnostic in completed.stderr
+
+
 def test_held_namespace_child_sources_use_closed_marker_states() -> None:
     """Both standalone child programs declare every parent-accepted marker token."""
     for source, component in (


### PR DESCRIPTION
## NON-MERGE VALIDATION

This temporary PR exists only for review and hosted validation. **Do not merge it.** It validates the exact #2097 test-scenario union before any guarded update of the stacked branches.

## Construction

- first parent: updated #1995 `33e70effba98b23aa187030a5a31bd1a810d30de`
- second parent: old #2097 `5c0b901288ede1ed58f5250055ba2ad43a915bac`
- merge head: `a56215ff097548d40f3710270a038cc01c8c498f`
- tree: `e7c3e81f1e4c6c9cf1d1c91be001fc858cfc2568`

The sole conflict was `tests/test_sync_core_supervisor.py`. Resolution retains the newer #1995 scanner/source semantics and unions #2097's unique cleanup scenarios. There is no production-file delta from the first parent.

## No-test-loss proof

- first parent: 213 supervisor test functions
- merged tree: 220 supervisor test functions
- first-parent functions lost: 0
- #2097-only functions retained: 7
- new ambiguous-unmount parameter scenarios retained: 3
- unique retained scenario total: 10

Retained scenarios:

1. captured FD holder preferred for FD-only cleanup
2. ambiguous unmount accepted with exact empty root proof
3. ambiguous unmount rejected on root mismatch
4. ambiguous unmount rejected when the mount remains present
5. ambiguous diagnostic bound to the exact mount
6. ambiguous proof remains fail-closed after diagnostic truncation
7. observer FDs close after teardown exception
8. unmount precedes coordinator reap/path deletion
9. unmount precedes destructive scope actions
10. captured FD holder authenticates cleanup before and after scope teardown

## Local evidence

- ten unique retained scenarios: `10 passed`
- full supervisor suite: `345 passed, 48 skipped`
- Vitest + Playwright + lifecycle/security: `503 passed, 31 skipped`
- workflow/profile/rollout/manifest/detector: `244 passed`
- first-parent → merge manifest: clean, no invalid or unaccounted paths
- stable merge HEAD: clean, no invalid or unaccounted paths
- `pylint pdd/sync_core/supervisor.py`: `10.00/10`
- compile and `git diff --check`: clean

Related: #1995 and #2097.
