### PR TITLE
[NON-MERGE VALIDATION] #2108 trusted runtime evidence layer

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -434,6 +434,7 @@ jobs:
         run: |
           pytest -q \
             tests/test_sync_core_runner_playwright.py::test_real_playwright_1_55_config_suffixes_collect_and_use_config_dir \
+            tests/test_sync_core_runner_playwright.py::test_real_playwright_product_import_cannot_forge_reporter_observation \
             tests/test_sync_core_supervisor.py::test_real_linux_authenticated_termination_and_cleanup \
             tests/test_sync_core_supervisor.py::test_real_linux_adapter_environment_handoff[pytest] \
             tests/test_sync_core_supervisor.py::test_real_linux_adapter_environment_handoff[vitest] \

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -434,7 +434,7 @@ jobs:
         run: |
           pytest -q \
             tests/test_sync_core_runner_playwright.py::test_real_playwright_1_55_config_suffixes_collect_and_use_config_dir \
-            tests/test_sync_core_runner_playwright.py::test_real_playwright_product_import_cannot_see_reporter_observation \
+            tests/test_sync_core_runner_playwright.py::test_playwright_product_import_forgery_is_rejected_before_hosted_execution \
             tests/test_sync_core_supervisor.py::test_real_linux_authenticated_termination_and_cleanup \
             tests/test_sync_core_supervisor.py::test_real_linux_adapter_environment_handoff[pytest] \
             tests/test_sync_core_supervisor.py::test_real_linux_adapter_environment_handoff[vitest] \

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -434,7 +434,7 @@ jobs:
         run: |
           pytest -q \
             tests/test_sync_core_runner_playwright.py::test_real_playwright_1_55_config_suffixes_collect_and_use_config_dir \
-            tests/test_sync_core_runner_playwright.py::test_real_playwright_product_import_cannot_forge_reporter_observation \
+            tests/test_sync_core_runner_playwright.py::test_real_playwright_product_import_cannot_see_reporter_observation \
             tests/test_sync_core_supervisor.py::test_real_linux_authenticated_termination_and_cleanup \
             tests/test_sync_core_supervisor.py::test_real_linux_adapter_environment_handoff[pytest] \
             tests/test_sync_core_supervisor.py::test_real_linux_adapter_environment_handoff[vitest] \

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -1920,7 +1920,8 @@ def _playwright_support_closure(
                     raise ValueError(
                         f"Playwright runtime resource path is missing: {resolved}"
                     )
-                pending.append((resolved, owners, False))
+                if resolved not in product_paths:
+                    pending.append((resolved, owners, False))
             mapped_bare: set[PurePosixPath] = set()
             package_manifests: set[PurePosixPath] = set()
             unbound_bare: set[str] = set()

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -69,7 +69,8 @@ _IN_PROCESS_FRAMEWORK_ADAPTERS = frozenset(
     {"pytest", "jest", "vitest", "playwright"}
 )
 _VITEST_SUPERVISOR_LIMITS = SupervisorLimits(
-    max_memory_bytes=4 * 1024 * 1024 * 1024
+    max_memory_bytes=4 * 1024 * 1024 * 1024,
+    max_virtual_memory_bytes=4 * 1024 * 1024 * 1024,
 )
 PYTEST_CONFIG_PATHS = (
     PurePosixPath("pytest.ini"),

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -70,7 +70,6 @@ _IN_PROCESS_FRAMEWORK_ADAPTERS = frozenset(
 )
 _VITEST_SUPERVISOR_LIMITS = SupervisorLimits(
     max_memory_bytes=4 * 1024 * 1024 * 1024,
-    max_virtual_memory_bytes=4 * 1024 * 1024 * 1024,
 )
 PYTEST_CONFIG_PATHS = (
     PurePosixPath("pytest.ini"),

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -2189,6 +2189,16 @@ def _playwright_source_syntax(
         if node.type in {"import_statement", "export_statement"}:
             source_node = node.child_by_field_name("source")
             if source_node is None and node.type == "import_statement":
+                require_clause = next(
+                    (
+                        child for child in node.named_children
+                        if child.type == "import_require_clause"
+                    ),
+                    None,
+                )
+                if require_clause is not None:
+                    source_node = require_clause.child_by_field_name("source")
+            if source_node is None and node.type == "import_statement":
                 source_node = next(
                     (child for child in node.named_children if child.type == "string"), None
                 )

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -1857,31 +1857,39 @@ def _playwright_support_closure(
     product_paths = frozenset(code_under_test_paths)
     all_owners = frozenset(test_paths)
     pending = [
-        (item, all_owners) for item in _playwright_static_config(
+        (item, all_owners, True) for item in _playwright_static_config(
             config_path,
             config_source,
             commonjs=_playwright_config_is_commonjs(root, ref, config_path),
         )
-    ] + [(item, frozenset({item})) for item in test_paths]
-    visited: dict[PurePosixPath, frozenset[PurePosixPath]] = {}
+    ] + [(item, frozenset({item}), True) for item in test_paths]
+    visited: dict[
+        tuple[PurePosixPath, bool], frozenset[PurePosixPath]
+    ] = {}
     snapshot_owners: set[PurePosixPath] = set()
     while pending:
-        path, owners = pending.pop()
-        known_owners = visited.get(path, frozenset())
+        path, owners, node_executable = pending.pop()
+        visit_key = (path, node_executable)
+        known_owners = visited.get(visit_key, frozenset())
         new_owners = owners - known_owners
         if not new_owners:
             continue
-        visited[path] = known_owners | owners
+        visited[visit_key] = known_owners | owners
         path, source = _read_javascript_support_blob(root, ref, path)
         if source is None:
             raise ValueError(f"Playwright local support path is missing: {path.as_posix()}")
+        if node_executable and path in product_paths:
+            raise ValueError(
+                "Playwright Node closure imports declared product: "
+                + path.as_posix()
+            )
         mode = read_git_mode(root, ref, path)
         if mode not in {"100644", "100755"}:
             raise ValueError(
                 f"Playwright closure member must be a regular non-symlink file: {path}"
             )
         paths.add(path)
-        if path.suffix == ".json":
+        if not node_executable or path.suffix == ".json":
             continue
         if path.suffix not in _PLAYWRIGHT_EXECUTABLE_SUFFIXES:
             raise ValueError(
@@ -1900,8 +1908,7 @@ def _playwright_support_closure(
                 resolved, imported_source = _read_javascript_support_blob(root, ref, normalized)
                 if imported_source is None:
                     raise ValueError(f"Playwright local support path is missing: {resolved}")
-                if resolved not in product_paths:
-                    pending.append((resolved, owners))
+                pending.append((resolved, owners, True))
             for resource in resources:
                 normalized = _normalize_repo_relative_path(PurePosixPath(resource))
                 if normalized is None:
@@ -1913,7 +1920,7 @@ def _playwright_support_closure(
                     raise ValueError(
                         f"Playwright runtime resource path is missing: {resolved}"
                     )
-                pending.append((resolved, owners))
+                pending.append((resolved, owners, False))
             mapped_bare: set[PurePosixPath] = set()
             package_manifests: set[PurePosixPath] = set()
             unbound_bare: set[str] = set()
@@ -1933,8 +1940,7 @@ def _playwright_support_closure(
                 )
             paths.update(package_manifests)
             for mapped in mapped_bare:
-                if mapped not in product_paths:
-                    pending.append((mapped, owners))
+                pending.append((mapped, owners, True))
             if has_snapshot:
                 snapshot_owners.update(owners)
     paths.update(_playwright_tree_trust_manifests(root, ref))

--- a/pdd/sync_core/supervisor.py
+++ b/pdd/sync_core/supervisor.py
@@ -3246,6 +3246,21 @@ def _sandbox_command(
                     }))
                     return
                 previous_authority = copied_binding_proof(previous[1], destination)
+                redundant_trusted_runtime = (
+                    option == "--ro-bind"
+                    and previous[0] == "--ro-bind"
+                    and previous[2] == "declared_readable"
+                    and category == "trusted_runtime"
+                    and previous_authority is not None
+                    and previous_authority[0] in consumed_proofs
+                    and previous_authority[1].protected_source == resolved_source
+                    and previous_authority[1].destination == destination
+                )
+                if redundant_trusted_runtime:
+                    # Inference already retained and recorded the immutable
+                    # descriptor copy. The trusted ELF closure names the exact
+                    # same protected bytes and therefore adds no new mount.
+                    return
                 current_authority = copied_binding_proof(resolved_source, destination)
                 duplicate_declared_read_only = (
                     option == "--ro-bind"

--- a/tests/test_sync_core_runner_playwright.py
+++ b/tests/test_sync_core_runner_playwright.py
@@ -503,10 +503,10 @@ def test_real_playwright_1_55_config_suffixes_collect_and_use_config_dir(
     or not os.environ.get("PDD_REAL_PLAYWRIGHT_TOOLCHAIN_MANIFEST"),
     reason="requires the mandatory hosted Linux Playwright protocol lane",
 )
-def test_real_playwright_product_import_cannot_forge_reporter_observation(
+def test_real_playwright_product_import_cannot_see_reporter_observation(
     tmp_path: Path,
 ) -> None:
-    """Candidate product code must not inherit the reporter write capability."""
+    """Candidate product code must not inherit the reporter descriptor."""
     manifest = Path(os.environ["PDD_REAL_PLAYWRIGHT_TOOLCHAIN_MANIFEST"])
     roles = json.loads(manifest.read_text(encoding="utf-8"))["roles"]
     root = tmp_path / "candidate"
@@ -517,22 +517,19 @@ def test_real_playwright_product_import_cannot_forge_reporter_observation(
     (root / "tests").mkdir()
     (root / "tests/widget.spec.ts").write_text(
         "import { expect, test } from '@playwright/test';\n"
-        "import { widget } from '../source';\n"
-        "test('widget works', () => expect(widget).toBe(true));\n",
+        "import { reporterChannelHidden } from '../source';\n"
+        "test('widget works', () => expect(reporterChannelHidden).toBe(true));\n",
         encoding="utf-8",
     )
     (root / "source.ts").write_text(
         "import fs from 'node:fs';\n"
-        "const status = process.argv.includes('--list') ? 'collected' : 'passed';\n"
-        "fs.writeSync(198, JSON.stringify({\n"
-        "  pdd_playwright_reporter: 1,\n"
-        "  tests: [{\n"
-        "    identity: 'chromium::tests/widget.spec.ts::widget works',\n"
-        "    status,\n"
-        "  }],\n"
-        "}));\n"
-        "process.exit(0);\n"
-        "export const widget = true;\n",
+        "let reporterChannelHidden = false;\n"
+        "try {\n"
+        "  fs.fstatSync(198);\n"
+        "} catch {\n"
+        "  reporterChannelHidden = true;\n"
+        "}\n"
+        "export { reporterChannelHidden };\n",
         encoding="utf-8",
     )
     (root / "playwright.config.ts").write_text(
@@ -569,7 +566,7 @@ def test_real_playwright_product_import_cannot_forge_reporter_observation(
         ),
     )
 
-    assert executions[0].outcome is not EvidenceOutcome.PASS, executions[0].detail
+    assert executions[0].outcome is EvidenceOutcome.PASS, executions[0].detail
 
 
 @pytest.mark.skipif(

--- a/tests/test_sync_core_runner_playwright.py
+++ b/tests/test_sync_core_runner_playwright.py
@@ -886,6 +886,101 @@ def test_playwright_rejects_direct_node_imports_of_declared_product(
         playwright_validator_config_digest(root, "HEAD", paths, products)
 
 
+@pytest.mark.parametrize("specifier", ["../src/widget", "#widget"])
+def test_playwright_rejects_typescript_import_equals_of_declared_product(
+    tmp_path: Path, specifier: str,
+) -> None:
+    root, _commit = _repository(tmp_path)
+    (root / "src").mkdir()
+    (root / "src/widget.ts").write_text(
+        "export const value = 'base';\n", encoding="utf-8"
+    )
+    if specifier.startswith("#"):
+        (root / "package.json").write_text(
+            json.dumps({"imports": {"#widget": "./src/widget.ts"}}),
+            encoding="utf-8",
+        )
+    (root / "tests/widget.spec.ts").write_text(
+        "import { expect, test } from '@playwright/test';\n"
+        f"import widget = require('{specifier}');\n"
+        "test('widget works', () => expect(widget.value).toBeTruthy());\n",
+        encoding="utf-8",
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "TypeScript import-equals product")
+
+    with pytest.raises(ValueError, match="declared product"):
+        playwright_validator_config_digest(
+            root,
+            "HEAD",
+            (PurePosixPath("tests/widget.spec.ts"),),
+            (PurePosixPath("src/widget.ts"),),
+        )
+
+
+def test_playwright_rejects_transitive_import_equals_of_declared_product(
+    tmp_path: Path,
+) -> None:
+    root, _commit = _repository(tmp_path)
+    (root / "src").mkdir()
+    (root / "src/widget.ts").write_text(
+        "export const value = 'base';\n", encoding="utf-8"
+    )
+    (root / "tests/helper.ts").write_text(
+        "import widget = require('../src/widget');\n"
+        "export const value = widget.value;\n",
+        encoding="utf-8",
+    )
+    (root / "tests/widget.spec.ts").write_text(
+        "import { expect, test } from '@playwright/test';\n"
+        "import { value } from './helper';\n"
+        "test('widget works', () => expect(value).toBeTruthy());\n",
+        encoding="utf-8",
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "transitive import-equals product")
+
+    with pytest.raises(ValueError, match="declared product"):
+        playwright_validator_config_digest(
+            root,
+            "HEAD",
+            (PurePosixPath("tests/widget.spec.ts"),),
+            (PurePosixPath("src/widget.ts"),),
+        )
+
+
+@pytest.mark.parametrize("specifier", ["./src/widget", "#widget"])
+def test_playwright_rejects_import_equals_in_config(
+    tmp_path: Path, specifier: str,
+) -> None:
+    root, _commit = _repository(
+        tmp_path,
+        config=(
+            f"import widget = require('{specifier}');\n"
+            "export default { metadata: { widget: true } };\n"
+        ),
+    )
+    (root / "src").mkdir()
+    (root / "src/widget.ts").write_text(
+        "export const value = 'base';\n", encoding="utf-8"
+    )
+    if specifier.startswith("#"):
+        (root / "package.json").write_text(
+            json.dumps({"imports": {"#widget": "./src/widget.ts"}}),
+            encoding="utf-8",
+        )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "config import-equals product")
+
+    with pytest.raises(ValueError, match="config"):
+        playwright_validator_config_digest(
+            root,
+            "HEAD",
+            (PurePosixPath("tests/widget.spec.ts"),),
+            (PurePosixPath("src/widget.ts"),),
+        )
+
+
 def test_playwright_rejects_transitive_support_import_of_declared_product(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_sync_core_runner_playwright.py
+++ b/tests/test_sync_core_runner_playwright.py
@@ -498,6 +498,82 @@ def test_real_playwright_1_55_config_suffixes_collect_and_use_config_dir(
 
 @pytest.mark.skipif(
     not sys.platform.startswith("linux")
+    or not shutil.which("bwrap")
+    or not os.environ.get("PDD_RUN_REAL_PLAYWRIGHT")
+    or not os.environ.get("PDD_REAL_PLAYWRIGHT_TOOLCHAIN_MANIFEST"),
+    reason="requires the mandatory hosted Linux Playwright protocol lane",
+)
+def test_real_playwright_product_import_cannot_forge_reporter_observation(
+    tmp_path: Path,
+) -> None:
+    """Candidate product code must not inherit the reporter write capability."""
+    manifest = Path(os.environ["PDD_REAL_PLAYWRIGHT_TOOLCHAIN_MANIFEST"])
+    roles = json.loads(manifest.read_text(encoding="utf-8"))["roles"]
+    root = tmp_path / "candidate"
+    root.mkdir()
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "runner@example.com")
+    _git(root, "config", "user.name", "Runner Test")
+    (root / "tests").mkdir()
+    (root / "tests/widget.spec.ts").write_text(
+        "import { expect, test } from '@playwright/test';\n"
+        "import { widget } from '../source';\n"
+        "test('widget works', () => expect(widget).toBe(true));\n",
+        encoding="utf-8",
+    )
+    (root / "source.ts").write_text(
+        "import fs from 'node:fs';\n"
+        "const status = process.argv.includes('--list') ? 'collected' : 'passed';\n"
+        "fs.writeSync(198, JSON.stringify({\n"
+        "  pdd_playwright_reporter: 1,\n"
+        "  tests: [{\n"
+        "    identity: 'chromium::tests/widget.spec.ts::widget works',\n"
+        "    status,\n"
+        "  }],\n"
+        "}));\n"
+        "process.exit(0);\n"
+        "export const widget = true;\n",
+        encoding="utf-8",
+    )
+    (root / "playwright.config.ts").write_text(
+        "export default { testDir: './tests', projects: [{ name: 'chromium' }] };\n",
+        encoding="utf-8",
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "adversarial product import")
+    commit = _git(root, "rev-parse", "HEAD")
+    paths = (PurePosixPath("tests/widget.spec.ts"),)
+    product_paths = (PurePosixPath("source.ts"),)
+    obligation = VerificationObligation(
+        "playwright-forgery", "test", "playwright",
+        playwright_validator_config_digest(root, commit, paths, product_paths),
+        ("REQ-1",), paths, code_under_test_paths=product_paths,
+    )
+    profile = VerificationProfile(
+        UnitId("repo", PurePosixPath("prompts/widget_ts.prompt"), "typescript"),
+        (obligation,), ("REQ-1",), "profile-v1",
+    )
+
+    _envelope, executions = run_profile(
+        root,
+        profile,
+        RunBinding("snapshot", commit, commit),
+        AttestationIssue(
+            AttestationSigner("trusted-ci", b"w" * 32), "id", "nonce",
+            datetime(2026, 7, 16, tzinfo=timezone.utc),
+        ),
+        RunnerConfig(
+            timeout_seconds=60,
+            playwright_command=(roles["launcher"], roles["entrypoint"]),
+            playwright_toolchain_manifest=manifest,
+        ),
+    )
+
+    assert executions[0].outcome is not EvidenceOutcome.PASS, executions[0].detail
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux")
     or not os.environ.get("PDD_RUN_REAL_PLAYWRIGHT")
     or not os.environ.get("PDD_REAL_PLAYWRIGHT_TOOLCHAIN_MANIFEST"),
     reason="requires the mandatory hosted Linux Playwright protocol lane",

--- a/tests/test_sync_core_runner_playwright.py
+++ b/tests/test_sync_core_runner_playwright.py
@@ -985,12 +985,24 @@ def test_playwright_allows_declared_product_only_as_browser_resource(
     _git(root, "add", ".")
     _git(root, "commit", "-q", "-m", "browser product resource")
 
-    assert playwright_validator_config_digest(
+    before = playwright_validator_config_digest(
         root,
         "HEAD",
         (PurePosixPath("tests/widget.spec.ts"),),
         (PurePosixPath("src/widget.js"),),
     )
+    (root / "src/widget.js").write_text(
+        "window.widgetReady = 'candidate';\n", encoding="utf-8"
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "change browser product resource")
+
+    assert playwright_validator_config_digest(
+        root,
+        "HEAD",
+        (PurePosixPath("tests/widget.spec.ts"),),
+        (PurePosixPath("src/widget.js"),),
+    ) == before
 
 
 def test_playwright_receiver_schema_accepts_representative_suite(tmp_path: Path) -> None:

--- a/tests/test_sync_core_runner_playwright.py
+++ b/tests/test_sync_core_runner_playwright.py
@@ -496,19 +496,10 @@ def test_real_playwright_1_55_config_suffixes_collect_and_use_config_dir(
     assert dict(envelope.binding.adapter_identities)["playwright"]
 
 
-@pytest.mark.skipif(
-    not sys.platform.startswith("linux")
-    or not shutil.which("bwrap")
-    or not os.environ.get("PDD_RUN_REAL_PLAYWRIGHT")
-    or not os.environ.get("PDD_REAL_PLAYWRIGHT_TOOLCHAIN_MANIFEST"),
-    reason="requires the mandatory hosted Linux Playwright protocol lane",
-)
-def test_real_playwright_product_import_cannot_see_reporter_observation(
+def test_playwright_product_import_forgery_is_rejected_before_hosted_execution(
     tmp_path: Path,
 ) -> None:
-    """Candidate product code must not inherit the reporter descriptor."""
-    manifest = Path(os.environ["PDD_REAL_PLAYWRIGHT_TOOLCHAIN_MANIFEST"])
-    roles = json.loads(manifest.read_text(encoding="utf-8"))["roles"]
+    """A Node-imported product must be rejected before it can forge evidence."""
     root = tmp_path / "candidate"
     root.mkdir()
     _git(root, "init", "-q")
@@ -517,23 +508,25 @@ def test_real_playwright_product_import_cannot_see_reporter_observation(
     (root / "tests").mkdir()
     (root / "tests/widget.spec.ts").write_text(
         "import { expect, test } from '@playwright/test';\n"
-        "import { reporterChannelHidden } from '../source';\n"
-        "test('widget works', () => expect(reporterChannelHidden).toBe(true));\n",
+        "import { widget } from '../source';\n"
+        "test('widget works', () => expect(widget).toBe(true));\n",
         encoding="utf-8",
     )
     (root / "source.ts").write_text(
         "import fs from 'node:fs';\n"
-        "let reporterChannelHidden = false;\n"
-        "try {\n"
-        "  fs.fstatSync(198);\n"
-        "} catch {\n"
-        "  reporterChannelHidden = true;\n"
-        "}\n"
-        "export { reporterChannelHidden };\n",
+        "fs.writeSync(198, JSON.stringify({\n"
+        "  pdd_playwright_reporter: 1,\n"
+        "  tests: [{\n"
+        "    identity: 'chromium::tests/widget.spec.ts::widget works',\n"
+        "    status: 'passed',\n"
+        "  }],\n"
+        "}));\n"
+        "process.exit(0);\n"
+        "export const widget = true;\n",
         encoding="utf-8",
     )
     (root / "playwright.config.ts").write_text(
-        "export default { testDir: './tests', projects: [{ name: 'chromium' }] };\n",
+        "export default { testDir: './tests' };\n",
         encoding="utf-8",
     )
     _git(root, "add", ".")
@@ -541,32 +534,9 @@ def test_real_playwright_product_import_cannot_see_reporter_observation(
     commit = _git(root, "rev-parse", "HEAD")
     paths = (PurePosixPath("tests/widget.spec.ts"),)
     product_paths = (PurePosixPath("source.ts"),)
-    obligation = VerificationObligation(
-        "playwright-forgery", "test", "playwright",
-        playwright_validator_config_digest(root, commit, paths, product_paths),
-        ("REQ-1",), paths, code_under_test_paths=product_paths,
-    )
-    profile = VerificationProfile(
-        UnitId("repo", PurePosixPath("prompts/widget_ts.prompt"), "typescript"),
-        (obligation,), ("REQ-1",), "profile-v1",
-    )
 
-    _envelope, executions = run_profile(
-        root,
-        profile,
-        RunBinding("snapshot", commit, commit),
-        AttestationIssue(
-            AttestationSigner("trusted-ci", b"w" * 32), "id", "nonce",
-            datetime(2026, 7, 16, tzinfo=timezone.utc),
-        ),
-        RunnerConfig(
-            timeout_seconds=60,
-            playwright_command=(roles["launcher"], roles["entrypoint"]),
-            playwright_toolchain_manifest=manifest,
-        ),
-    )
-
-    assert executions[0].outcome is EvidenceOutcome.PASS, executions[0].detail
+    with pytest.raises(ValueError, match="declared product"):
+        playwright_validator_config_digest(root, commit, paths, product_paths)
 
 
 @pytest.mark.skipif(
@@ -887,8 +857,16 @@ def test_playwright_rejects_symlinked_closure_members(
         )
 
 
-def test_playwright_excludes_declared_product_edges_from_support_digest(
-    tmp_path: Path,
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "import { value } from '../src/widget';\n",
+        "const { value } = require('../src/widget');\n",
+        "const { value } = await import('../src/widget');\n",
+    ],
+)
+def test_playwright_rejects_direct_node_imports_of_declared_product(
+    tmp_path: Path, statement: str,
 ) -> None:
     root, _commit = _repository(tmp_path)
     (root / "src").mkdir()
@@ -896,19 +874,123 @@ def test_playwright_excludes_declared_product_edges_from_support_digest(
     product.write_text("export const value = 'base';\n", encoding="utf-8")
     (root / "tests/widget.spec.ts").write_text(
         "import { expect, test } from '@playwright/test';\n"
-        "import { value } from '../src/widget';\n"
-        "test('widget works', () => expect(value).toBeTruthy());\n",
+        + statement
+        + "test('widget works', () => expect(value).toBeTruthy());\n",
         encoding="utf-8",
     )
     _git(root, "add", ".")
     _git(root, "commit", "-q", "-m", "product import")
     paths = (PurePosixPath("tests/widget.spec.ts"),)
     products = (PurePosixPath("src/widget.ts"),)
-    before = playwright_validator_config_digest(root, "HEAD", paths, products)
-    product.write_text("export const value = 'candidate';\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="declared product"):
+        playwright_validator_config_digest(root, "HEAD", paths, products)
+
+
+def test_playwright_rejects_transitive_support_import_of_declared_product(
+    tmp_path: Path,
+) -> None:
+    root, _commit = _repository(tmp_path)
+    (root / "src").mkdir()
+    (root / "src/widget.ts").write_text(
+        "export const value = 'base';\n", encoding="utf-8"
+    )
+    (root / "tests/helper.ts").write_text(
+        "export { value } from '../src/widget';\n", encoding="utf-8"
+    )
+    (root / "tests/widget.spec.ts").write_text(
+        "import { expect, test } from '@playwright/test';\n"
+        "import { value } from './helper';\n"
+        "test('widget works', () => expect(value).toBeTruthy());\n",
+        encoding="utf-8",
+    )
     _git(root, "add", ".")
-    _git(root, "commit", "-q", "-m", "candidate product change")
-    assert playwright_validator_config_digest(root, "HEAD", paths, products) == before
+    _git(root, "commit", "-q", "-m", "transitive product import")
+
+    with pytest.raises(ValueError, match="declared product"):
+        playwright_validator_config_digest(
+            root,
+            "HEAD",
+            (PurePosixPath("tests/widget.spec.ts"),),
+            (PurePosixPath("src/widget.ts"),),
+        )
+
+
+def test_playwright_rejects_config_import_of_declared_product(tmp_path: Path) -> None:
+    root, _commit = _repository(
+        tmp_path,
+        config="import './src/widget';\nexport default {};\n",
+    )
+    (root / "src").mkdir()
+    (root / "src/widget.ts").write_text(
+        "export const value = 'base';\n", encoding="utf-8"
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "config product import")
+
+    with pytest.raises(ValueError, match="declared product"):
+        playwright_validator_config_digest(
+            root,
+            "HEAD",
+            (PurePosixPath("tests/widget.spec.ts"),),
+            (PurePosixPath("src/widget.ts"),),
+        )
+
+
+def test_playwright_rejects_mapped_bare_import_of_declared_product(
+    tmp_path: Path,
+) -> None:
+    root, _commit = _repository(tmp_path)
+    (root / "src").mkdir()
+    (root / "src/widget.ts").write_text(
+        "export const value = 'base';\n", encoding="utf-8"
+    )
+    (root / "package.json").write_text(
+        json.dumps({"imports": {"#widget": "./src/widget.ts"}}),
+        encoding="utf-8",
+    )
+    (root / "tests/widget.spec.ts").write_text(
+        "import { expect, test } from '@playwright/test';\n"
+        "import { value } from '#widget';\n"
+        "test('widget works', () => expect(value).toBeTruthy());\n",
+        encoding="utf-8",
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "mapped product import")
+
+    with pytest.raises(ValueError, match="declared product"):
+        playwright_validator_config_digest(
+            root,
+            "HEAD",
+            (PurePosixPath("tests/widget.spec.ts"),),
+            (PurePosixPath("src/widget.ts"),),
+        )
+
+
+def test_playwright_allows_declared_product_only_as_browser_resource(
+    tmp_path: Path,
+) -> None:
+    root, _commit = _repository(tmp_path)
+    (root / "src").mkdir()
+    (root / "src/widget.js").write_text(
+        "window.widgetReady = true;\n", encoding="utf-8"
+    )
+    (root / "tests/widget.spec.ts").write_text(
+        "import { expect, test } from '@playwright/test';\n"
+        "test('widget works', async ({ page }) => {\n"
+        "  await page.addInitScript({ path: './src/widget.js' });\n"
+        "  await expect(true).toBeTruthy();\n"
+        "});\n",
+        encoding="utf-8",
+    )
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "browser product resource")
+
+    assert playwright_validator_config_digest(
+        root,
+        "HEAD",
+        (PurePosixPath("tests/widget.spec.ts"),),
+        (PurePosixPath("src/widget.js"),),
+    )
 
 
 def test_playwright_receiver_schema_accepts_representative_suite(tmp_path: Path) -> None:
@@ -3567,13 +3649,15 @@ def test_playwright_reporter_preserves_failure_across_retry_attempts(
     assert identities == (IDENTITY,)
 
 
-def test_playwright_phase_identity_excludes_imported_declared_product(
-    tmp_path: Path,
+def test_playwright_rejects_product_import_before_top_level_side_effect(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     root, _base = _repository(tmp_path)
+    marker = root / "product-executed"
     (root / "source.ts").write_text(
-        "import React from 'react';\n"
-        "export const widget = React.createElement('div');\n",
+        "import fs from 'node:fs';\n"
+        f"fs.writeFileSync({json.dumps(str(marker))}, 'executed');\n"
+        "export const widget = true;\n",
         encoding="utf-8",
     )
     (root / "tests/widget.spec.ts").write_text(
@@ -3585,7 +3669,14 @@ def test_playwright_phase_identity_excludes_imported_declared_product(
     _git(root, "add", ".")
     _git(root, "commit", "-q", "-m", "import declared product")
     head = _git(root, "rev-parse", "HEAD")
+    launches = 0
 
+    def supervised(*_args, **_kwargs):
+        nonlocal launches
+        launches += 1
+        raise AssertionError("rejected product import must not launch Playwright")
+
+    monkeypatch.setattr(runner_module, "run_supervised", supervised)
     _envelope, executions = _run(
         root,
         head,
@@ -3594,7 +3685,10 @@ def test_playwright_phase_identity_excludes_imported_declared_product(
         code_under_test_paths=(PurePosixPath("source.ts"),),
     )
 
-    assert executions[0].outcome is EvidenceOutcome.PASS
+    assert executions[0].outcome is EvidenceOutcome.ERROR
+    assert "declared product" in executions[0].detail
+    assert launches == 0
+    assert not marker.exists()
 
 
 def test_playwright_rejects_symlink_config_before_subprocess_launch(

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -2233,10 +2233,13 @@ def test_vitest_linux_command_binds_wasm_guard(tmp_path: Path, monkeypatch: pyte
     assert observed_limits == [
         SupervisorLimits(
             max_memory_bytes=4 * 1024 * 1024 * 1024,
-            max_virtual_memory_bytes=4 * 1024 * 1024 * 1024,
         )
     ]
     assert SupervisorLimits().max_memory_bytes == 2 * 1024 * 1024 * 1024
+    assert (
+        observed_limits[0].max_virtual_memory_bytes
+        == SupervisorLimits().max_virtual_memory_bytes
+    )
 
 
 def test_mixed_adapter_identities_survive_manifest_removal_and_round_trip(

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -2231,7 +2231,10 @@ def test_vitest_linux_command_binds_wasm_guard(tmp_path: Path, monkeypatch: pyte
         root, config
     ).identity
     assert observed_limits == [
-        SupervisorLimits(max_memory_bytes=4 * 1024 * 1024 * 1024)
+        SupervisorLimits(
+            max_memory_bytes=4 * 1024 * 1024 * 1024,
+            max_virtual_memory_bytes=4 * 1024 * 1024 * 1024,
+        )
     ]
     assert SupervisorLimits().max_memory_bytes == 2 * 1024 * 1024 * 1024
 

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -1468,6 +1468,90 @@ def test_linux_sandbox_reuses_consumed_copied_runtime_for_trusted_closure(
     assert len(plan.launch_payload["immutable_binding_proofs"]) == 1
 
 
+def test_linux_sandbox_rejects_unconsumed_proof_at_trusted_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Trusted closure discovery cannot consume a proof skipped by inference."""
+    protected, copied = _mock_runtime_collision(tmp_path, monkeypatch)
+    proof = _descriptor_runtime_proof(copied, protected)
+    monkeypatch.setattr(
+        "pdd.sync_core.supervisor._runtime_roots", lambda *_args: ()
+    )
+    monkeypatch.setattr(
+        "pdd.sync_core.supervisor._linked_libraries",
+        lambda _executable: (protected,),
+    )
+    monkeypatch.setattr(
+        "pdd.sync_core.supervisor._native_python_runtime_roots",
+        lambda _executable: (),
+    )
+
+    with pytest.raises(RuntimeError, match="conflicting bindings"):
+        _sandbox_command(
+            ["/bin/true"],
+            (tmp_path,),
+            readable_bindings=((copied, protected),),
+            immutable_binding_proofs=(proof,),
+        )
+
+
+def test_linux_sandbox_rejects_changed_protected_source_at_trusted_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Trusted reuse remains bound to the proof's exact protected source."""
+    protected, copied = _mock_runtime_collision(tmp_path, monkeypatch)
+    replacement = tmp_path / "replacement-loader"
+    replacement.write_bytes(protected.read_bytes())
+    proof = _descriptor_runtime_proof(copied, protected)
+    original_resolve = Path.resolve
+    changed = False
+
+    def phase_resolve(path: Path, *args, **kwargs) -> Path:
+        if changed and path == protected:
+            return replacement
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", phase_resolve)
+
+    def changed_closure(_executable: Path) -> tuple[Path, ...]:
+        nonlocal changed
+        changed = True
+        return (protected,)
+
+    monkeypatch.setattr(
+        "pdd.sync_core.supervisor._linked_libraries", changed_closure
+    )
+    monkeypatch.setattr(
+        "pdd.sync_core.supervisor._native_python_runtime_roots",
+        lambda _executable: (),
+    )
+
+    with pytest.raises(RuntimeError, match="conflicting bindings"):
+        _sandbox_command(
+            ["/bin/true"],
+            (tmp_path,),
+            readable_bindings=((copied, protected),),
+            immutable_binding_proofs=(proof,),
+        )
+
+
+def test_linux_sandbox_rejects_consumed_proof_for_non_trusted_category(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only trusted executable closure discovery may reuse the proven bind."""
+    protected, copied = _mock_runtime_collision(tmp_path, monkeypatch)
+    proof = _descriptor_runtime_proof(copied, protected)
+
+    with pytest.raises(RuntimeError, match="conflicting bindings"):
+        _sandbox_command(
+            ["/bin/true"],
+            (tmp_path,),
+            readable_roots=(protected,),
+            readable_bindings=((copied, protected),),
+            immutable_binding_proofs=(proof,),
+        )
+
+
 def test_linux_sandbox_coalesces_descriptor_proven_loader_aliases(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -1465,7 +1465,7 @@ def test_linux_sandbox_reuses_consumed_copied_runtime_for_trusted_closure(
     assert plan.sources.count(copied.resolve()) == 1
     assert plan.sources.count(protected.resolve()) == 0
     assert plan.launch_payload is not None
-    assert len(plan.launch_payload["immutable_binding_proofs"]) == 1
+    assert len(plan.immutable_binding_proofs) == 1
 
 
 def test_linux_sandbox_rejects_unconsumed_proof_at_trusted_runtime(

--- a/tests/test_sync_core_supervisor.py
+++ b/tests/test_sync_core_supervisor.py
@@ -1440,6 +1440,34 @@ def test_linux_sandbox_allows_descriptor_proven_copied_loader_at_inferred_runtim
     )
 
 
+def test_linux_sandbox_reuses_consumed_copied_runtime_for_trusted_closure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A trusted ELF closure may revisit the exact proven inferred runtime."""
+    protected, copied = _mock_runtime_collision(tmp_path, monkeypatch)
+    proof = _descriptor_runtime_proof(copied, protected)
+    monkeypatch.setattr(
+        "pdd.sync_core.supervisor._linked_libraries",
+        lambda _executable: (protected,),
+    )
+    monkeypatch.setattr(
+        "pdd.sync_core.supervisor._native_python_runtime_roots",
+        lambda _executable: (),
+    )
+
+    _argv, plan = _sandbox_command(
+        ["/bin/true"],
+        (tmp_path,),
+        readable_bindings=((copied, protected),),
+        immutable_binding_proofs=(proof,),
+    )
+
+    assert plan.sources.count(copied.resolve()) == 1
+    assert plan.sources.count(protected.resolve()) == 0
+    assert plan.launch_payload is not None
+    assert len(plan.launch_payload["immutable_binding_proofs"]) == 1
+
+
 def test_linux_sandbox_coalesces_descriptor_proven_loader_aliases(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_unit_tests_workflow.py
+++ b/tests/test_unit_tests_workflow.py
@@ -33,6 +33,8 @@ HOSTED_SUPERVISOR_NODE = "tests/test_sync_core_supervisor.py::"
 REQUIRED_HOSTED_NODES = (
     "tests/test_sync_core_runner_playwright.py::"
     "test_real_playwright_1_55_config_suffixes_collect_and_use_config_dir",
+    "tests/test_sync_core_runner_playwright.py::"
+    "test_playwright_product_import_forgery_is_rejected_before_hosted_execution",
     f"{HOSTED_SUPERVISOR_NODE}test_real_linux_authenticated_termination_and_cleanup",
     f"{HOSTED_SUPERVISOR_NODE}test_real_linux_adapter_environment_handoff[pytest]",
     f"{HOSTED_SUPERVISOR_NODE}test_real_linux_adapter_environment_handoff[vitest]",


### PR DESCRIPTION
## NON-MERGE VALIDATION

This temporary PR exists only for review and hosted validation. **Do not merge it.** It validates the exact #2108 semantic layer before any guarded update of the stacked branch.

## Construction

- first parent: updated #2097 `a56215ff097548d40f3710270a038cc01c8c498f`
- second parent: old #2108 `29faf8f5350131ca818cf3e861f230184bfe4d89`
- merge head: `a6de648ba85cd17461a58e9cda6eb82bce59f6c8`
- tree: `c670a234ac66d3a469a0e5daa0611eea8f2b03b9`

The merge was text-clean but semantically audited across all seven changed files. It preserves the newer #1995/#2097 lifecycle, security, and supervisor scenario union while adding #2108's bounded trusted-runtime copy reuse and Playwright product-evidence boundary.

## First-parent deltas

- `.github/workflows/unit-tests.yml`: add the hosted product-import forgery node
- `pdd/sync_core/runner.py`: distinguish Node-executable imports from browser resources, reject declared-product Node imports, and parse TypeScript import-equals edges
- `pdd/sync_core/supervisor.py`: allow only exact, already-consumed copied proof reuse when trusted runtime discovery revisits the same protected source/destination
- `tests/test_sync_core_runner_playwright.py`: replace two older permissive product-edge tests with stricter direct, transitive, mapped, config, import-equals, side-effect, browser-resource, and forgery coverage
- `tests/test_sync_core_runner_vitest.py`: assert the unchanged default virtual-memory boundary
- `tests/test_sync_core_supervisor.py`: add four adversarial trusted-runtime proof-boundary tests
- `tests/test_unit_tests_workflow.py`: bind the new hosted node

There are no retry, deadline, timeout, worker-cap, V8-pool, or threadpool changes.

## Local evidence

- focused Playwright evidence: `8 passed`
- focused runtime/Vitest/workflow: `110 passed`
- full supervisor suite: `349 passed, 48 skipped`
- Vitest + Playwright + lifecycle/security: `515 passed, 31 skipped`
- workflow/profile/rollout/manifest/detector: `244 passed`
- first-parent → merge manifest: clean, no invalid or unaccounted paths
- stable merge HEAD: clean, no invalid or unaccounted paths
- pylint for both touched production modules: `10.00/10`
- compile and `git diff --check`: clean

Related: #1995, #2097, and #2108.
