### PR TITLE
fix(sync): preauthorize Vitest coordinator paths

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -6022,6 +6022,13 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/native/vitest_fd_cloexec.c",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "pdd/sync_core/path_policy.py",
       "role": "human-maintained"
     },
@@ -9742,6 +9749,13 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "scripts/build_vitest_fd_cloexec_addon.py",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "scripts/check_deps.py",
       "role": "human-maintained"
     },
@@ -9797,6 +9811,13 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "scripts/sops_release_env.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "setup.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -78,7 +78,15 @@ LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS = {
     "context/prompt_repair_example.py",
     "context/routing_policy_example.py",
 }
-PREAUTHORIZED_CHILD_PATHS = LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS | {
+ISSUE_2083_VITEST_COORDINATOR_PREAUTHORIZED_PATHS = {
+    "pdd/sync_core/native/vitest_fd_cloexec.c",
+    "scripts/build_vitest_fd_cloexec_addon.py",
+    "setup.py",
+}
+PREAUTHORIZED_CHILD_PATHS = (
+    LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS
+    | ISSUE_2083_VITEST_COORDINATOR_PREAUTHORIZED_PATHS
+    | {
     ".github/toolchains/playwright_manifest.py",
     ".pdd/meta/agentic_checkup_orchestrator_python_run.json",
     ".pdd/meta/checkup_agentic_artifact_python.json",
@@ -102,7 +110,8 @@ PREAUTHORIZED_CHILD_PATHS = LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS | {
     "pdd/schemas/story_detection_result.schema.json",
     "pdd/schemas/story_detection_scope.schema.json",
     "tests/test_story_detection_result.py",
-}
+    }
+)
 PREAUTHORIZED_CHILD_OWNERSHIP = {
     "inventory": "HUMAN_OWNED",
     "role": "human-maintained",
@@ -939,6 +948,22 @@ def test_protected_base_pre_authorizes_absent_exact_child_paths(
         )
     assert not manifest.unaccounted_tracked_paths
     assert len(manifest.expected_managed) == baseline_denominator
+
+
+def test_issue_2083_vitest_coordinator_paths_are_exactly_preauthorized() -> None:
+    """The coordinator prerequisite grants no authority beyond three paths."""
+    ownership = json.loads(OWNERSHIP_PATH.read_text(encoding="utf-8"))
+    rules = {row["pattern"]: row for row in ownership["rules"]}
+    assert {
+        path: rules.get(path)
+        for path in ISSUE_2083_VITEST_COORDINATOR_PREAUTHORIZED_PATHS
+    } == {
+        path: {
+            "pattern": path,
+            **PREAUTHORIZED_CHILD_OWNERSHIP,
+        }
+        for path in ISSUE_2083_VITEST_COORDINATOR_PREAUTHORIZED_PATHS
+    }
 
 
 def _bootstrap_head_entry_fixture(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Pre-authorizes only the three absent child paths required by PDD #2164:

- `pdd/sync_core/native/vitest_fd_cloexec.c`
- `scripts/build_vitest_fd_cloexec_addon.py`
- `setup.py`

Each rule is exact, `HUMAN_OWNED`, `human-maintained`, `pdd-maintainers`, and `preauthorize_absent: true`. No wildcard, prefix, addon, runner, Vitest fixture, workflow, cloud, release, or tag change is included.

## Investigation

Followed the prior #2083 preauthorization shape in #2113 / `5344eca`; its one-shot dispatcher rules were intentionally removed later, so this is a separate permanent prerequisite for the reviewed coordinator implementation in #2164.

## TDD evidence

- `b9edae606` added the exact-path policy test; it failed red because all three rules were absent.
- `27e4d03db` adds the three exact policy rows.
- Green: focused exact policy and protected-inventory checks; committed-head absent-child fixture; full rollout-policy module; `git diff --check`.
- Lint: rollout-policy module is clean with the two pre-existing whole-file diagnostics (`too-many-lines`, unrelated `use-implicit-booleaness-not-comparison`) disabled for the validation command.