### PR TITLE
fix(sync): exercise native Vitest authority tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ dev = [
     "pytest-asyncio",
     "pytest-timeout",
     "build",
+    "setuptools-scm>=8",
     "twine"
 ]
 

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -535,6 +535,14 @@ def test_vitest_authority_wheel_is_source_only(tmp_path: Path) -> None:
     assert not any(name.endswith(".node") for name in names)
 
 
+def test_vitest_authority_wheel_build_tooling_is_available_without_isolation() -> None:
+    """Keep the source-only wheel smoke test's build requirements explicit."""
+    repository = Path(__file__).resolve().parents[1]
+    project = tomllib.loads((repository / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert "setuptools-scm>=8" in project["project"]["optional-dependencies"]["dev"]
+
+
 def test_vitest_coordinator_addon_rejects_unsupported_platform(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -264,9 +264,10 @@ def _controlled_supervisor(
         "test_vitest_coordinator_precompile_requires_phase_bound_header_attestation",
         "test_vitest_coordinator_precompile_rechecks_phase_attestation_without_rehash",
     )
+    test_name = request.node.originalname or request.node.name
     if (
         not request.node.name.startswith("test_real_vitest_runs_copied_entrypoint")
-        and request.node.name not in native_authority_tests
+        and test_name not in native_authority_tests
     ):
         # The production authority deliberately rejects unsupported platforms
         # and requires a real Node distribution. Most adapter contracts use a
@@ -336,7 +337,7 @@ def _run_trusted_reporter_source(
     reporter = tmp_path / "trusted-reporter.mjs"
     driver = tmp_path / "reporter-driver.mjs"
     identity = os.fstat(write_fd)
-    phase = _prepared_vitest_phase(tmp_path)
+    phase = _prepared_vitest_phase(tmp_path, use_system_node_headers=True)
     addon = runner_module._load_vitest_coordinator_addon(
         tmp_path, phase.headers, phase_toolchain=phase
     )
@@ -1736,12 +1737,15 @@ def test_vitest_coordinator_precompile_rechecks_phase_attestation_without_rehash
                 added.write_text("#define PDD_INJECTED 1\n", encoding="utf-8")
                 added.chmod(0o444)
                 phase.headers.chmod(0o555)
+                assert added.is_file()
             elif mutation == "deleted":
                 phase.headers.chmod(0o755)
                 header.unlink()
                 phase.headers.chmod(0o555)
+                assert not header.exists()
             elif mutation == "mode":
                 header.chmod(0o644)
+                assert stat.S_IMODE(header.lstat().st_mode) == 0o644
             elif mutation == "owner":
                 provenance = phase.header_provenance[0]
                 phase = replace(
@@ -1751,8 +1755,10 @@ def test_vitest_coordinator_precompile_rechecks_phase_attestation_without_rehash
                         *phase.header_provenance[1:],
                     ),
                 )
+                assert phase.header_provenance[0].owner != header.lstat().st_uid
             elif mutation == "ancestor":
                 phase.controller.chmod(0o720)
+                assert stat.S_IMODE(phase.controller.lstat().st_mode) == 0o720
             elif mutation == "symlink":
                 replacement = tmp_path / "replacement.h"
                 replacement.write_text("#define PDD_INJECTED 1\n", encoding="utf-8")
@@ -1760,6 +1766,7 @@ def test_vitest_coordinator_precompile_rechecks_phase_attestation_without_rehash
                 header.unlink()
                 header.symlink_to(replacement)
                 phase.headers.chmod(0o555)
+                assert header.is_symlink()
             elif mutation == "inode":
                 original = header.read_bytes()
                 phase.headers.chmod(0o755)
@@ -1767,6 +1774,11 @@ def test_vitest_coordinator_precompile_rechecks_phase_attestation_without_rehash
                 header.write_bytes(original)
                 header.chmod(0o444)
                 phase.headers.chmod(0o555)
+                expected = next(
+                    item for item in phase.header_provenance
+                    if item.relative_path == PurePosixPath("node_api.h")
+                )
+                assert header.lstat().st_ino != expected.inode
 
             if mutation == "baseline":
                 addon = runner_module._load_vitest_coordinator_addon(


### PR DESCRIPTION
## Summary

Follow-up to #2164 for the hosted-only gate failures.

- preserves production coordinator authority code and source-only wheel rules; changes only the test harness and build-test dependency declaration.
- uses pytest `originalname` so parametrized native-addon negative tests no longer receive the text placeholder.
- gives Linux reporter tests real selected-Node headers, while retaining platform skips.
- makes the no-rehash attestation test assert each staged/attestation mutation happened.
- declares the existing `setuptools-scm>=8` build-system requirement in the dev extra used by the no-isolation wheel smoke.

## Root cause

The exact #2164 hosted run `29614087280` failed because the fixture compared parameterized `request.node.name` (for example `[wrong-identity]`) to an unparameterized allow-list, causing Node to load `portable test authority` and report `file too short`; reporter tests compiled the fake descriptor headers; and wheel smoke invoked `build --no-isolation` without the dynamic-version build dependency in the dev environment. The separate protected-ownership prerequisite for the three tracked paths is intentionally excluded: it must merge first and cannot self-authorize in this PR.

## Evidence

- Red before fix: `test_vitest_authority_wheel_build_tooling_is_available_without_isolation` failed; committed separately as `416804d02`.
- Green after fix: 5 targeted tests passed (wheel tooling, source-only wheel, phase-bound attestation, candidate aliases, no-rehash mutations).
- `compileall`, `py_compile`, `python -m pdd --help`, and `git diff --check` passed.
- Local macOS skips Linux-only live addon execution; next hosted Linux run is required for reporter/native artifact confirmation.

## Non-goals

No production authority relaxation, policy self-authorization, CI timeout change, merge, deploy, release, or tag.