### PR TITLE
fix(sync): canonicalize trusted Vitest temp roots

### DIFF
--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -4076,7 +4076,7 @@ def _run_vitest(
     except (OSError, ValueError) as exc:
         return RunnerExecution("vitest", EvidenceOutcome.ERROR, "vitest-config", str(exc)), ()
     with tempfile.TemporaryDirectory(prefix="pdd-trusted-vitest-") as directory:
-        temporary = Path(directory)
+        temporary = Path(directory).resolve(strict=True)
         try:
             _verify_vitest_phase_toolchain(phase_toolchain)
             coordinator_addon = _load_vitest_coordinator_addon(
@@ -4736,7 +4736,7 @@ def _collect_vitest_at_base(
         with tempfile.TemporaryDirectory(
             prefix="pdd-vitest-protected-base-"
         ) as directory:
-            clone = Path(directory) / "repository"
+            clone = Path(directory).resolve(strict=True) / "repository"
             cloned = subprocess.run(
                 ["git", "clone", "-q", "--no-local", "--no-checkout",
                  str(root), str(clone)],
@@ -4774,7 +4774,7 @@ def _run_vitest_at_commit(
     try:
         descriptor = _load_vitest_toolchain_descriptor(root, config)
         with tempfile.TemporaryDirectory(prefix="pdd-vitest-checked-head-") as directory:
-            clone = Path(directory) / "repository"
+            clone = Path(directory).resolve(strict=True) / "repository"
             cloned = subprocess.run(
                 ["git", "clone", "-q", "--no-local", "--no-checkout",
                  str(root), str(clone)],
@@ -5128,7 +5128,7 @@ def _vitest_signing_addon(root: Path, config: RunnerConfig, required: bool):
         return
     descriptor = _load_vitest_toolchain_descriptor(root, config)
     with tempfile.TemporaryDirectory(prefix="pdd-vitest-signing-binding-") as directory:
-        signing_root = Path(directory)
+        signing_root = Path(directory).resolve(strict=True)
         phase_root = signing_root / "phase"
         phase_root.mkdir(mode=0o700)
         phase = _prepare_vitest_toolchain(phase_root, descriptor)

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import tomllib
 import zipfile
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
@@ -2862,6 +2862,57 @@ def test_vitest_passing_collected_test_is_pass(tmp_path: Path) -> None:
     root, commit = _repository(tmp_path)
     _envelope, executions = _run(root, commit, commit, _fake_vitest(tmp_path))
     assert executions[0].outcome is EvidenceOutcome.PASS
+
+
+def test_vitest_phase_canonicalizes_trusted_temporary_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Platform temp aliases are resolved before trusted Vitest staging."""
+    temporary_directory = runner_module.tempfile.TemporaryDirectory
+    aliased_prefixes = {
+        "pdd-vitest-protected-base-",
+        "pdd-vitest-checked-head-",
+        "pdd-trusted-vitest-",
+        "pdd-vitest-signing-binding-",
+    }
+    aliases_created = 0
+
+    @contextmanager
+    def aliased_temporary_directory(*args, **kwargs):
+        nonlocal aliases_created
+        with temporary_directory(*args, **kwargs) as directory:
+            prefix = kwargs.get("prefix", args[0] if args else None)
+            if prefix not in aliased_prefixes:
+                yield directory
+                return
+            alias = tmp_path / f"temporary-alias-{aliases_created}"
+            aliases_created += 1
+            alias.symlink_to(directory, target_is_directory=True)
+            try:
+                yield str(alias)
+            finally:
+                alias.unlink()
+
+    monkeypatch.setattr(
+        runner_module.tempfile, "TemporaryDirectory", aliased_temporary_directory
+    )
+    load_addon = runner_module._load_vitest_coordinator_addon
+
+    def load_addon_from_canonical_staging(staging_directory: Path, *args, **kwargs):
+        assert not staging_directory.is_symlink()
+        return load_addon(staging_directory, *args, **kwargs)
+
+    monkeypatch.setattr(
+        runner_module,
+        "_load_vitest_coordinator_addon",
+        load_addon_from_canonical_staging,
+    )
+    root, commit = _repository(tmp_path)
+
+    _envelope, executions = _run(root, commit, commit, _fake_vitest(tmp_path))
+
+    assert executions[0].outcome is EvidenceOutcome.PASS
+    assert aliases_created == 5
 
 
 def test_vitest_native_authority_identity_changes_signed_binding(


### PR DESCRIPTION
## Summary
- resolve platform temp aliases before constructing trusted Vitest staging paths
- cover protected-base, checked-head, coordinator, and signed-native binding roots
- add a deterministic regression that fails when a trusted staging root remains a symlink

This branch is based directly on current `main` at `d91b07a90`; it does not carry the superseded authority implementation from #2181. Current `main` already contains the wheel dependency-check correction from #2164.

## Evidence
- red on current main (macOS): `Vitest header ancestor is not a regular directory`, including the signed-native binding root
- `python -m pytest -q tests/test_sync_core_runner_vitest.py` — 195 passed, 13 skipped
- dependency-missing runtime: `python -m pytest -q tests/test_sync_core_runner_vitest.py::test_vitest_authority_wheel_is_source_only` — 1 passed
- `git diff --check` — passed

## Risk
Low and localized to canonicalizing `TemporaryDirectory` return paths. Cleanup remains owned by the original context managers.