### PR TITLE
fix(build): close no-isolation dev requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ packages = ["pdd", "pdd.commands", "pdd.core", "pdd.server", "pdd.server.routes"
 
 [project.optional-dependencies]
 dev = [
+    "setuptools>=64",
+    "setuptools-scm>=8",
+    "wheel",
     "pytest-cov",
     "pytest-testmon",
     "pytest-xdist",

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,4 +57,6 @@ pytest-mock
 pytest-testmon
 pytest-timeout
 pytest-xdist
+setuptools-scm>=8
 twine
+wheel

--- a/tests/test_sync_core_runner_vitest.py
+++ b/tests/test_sync_core_runner_vitest.py
@@ -609,6 +609,17 @@ def test_vitest_environment_rejects_ambient_coordinator_nondumpable_marker(
     assert "PDD_FRAMEWORK_COORDINATOR_NONDUMPABLE" not in _vitest_environment(tmp_path)
 
 
+def test_dev_extra_covers_no_isolation_build_requirements() -> None:
+    """The CI dev environment can build the wheel without network isolation."""
+    repository = Path(__file__).resolve().parents[1]
+    pyproject = tomllib.loads((repository / "pyproject.toml").read_text(encoding="utf-8"))
+    build_requirements = set(pyproject["build-system"]["requires"])
+    dev_requirements = set(pyproject["project"]["optional-dependencies"]["dev"])
+
+    missing = build_requirements - dev_requirements
+    assert not missing, f"dev extra is missing build requirements: {sorted(missing)}"
+
+
 def test_vitest_authority_wheel_is_source_only(tmp_path: Path) -> None:
     """The universal checker wheel carries C source, never a host native addon."""
     repository = Path(__file__).resolve().parents[1]
@@ -622,19 +633,18 @@ def test_vitest_authority_wheel_is_source_only(tmp_path: Path) -> None:
         ),
     )
     output = tmp_path / "dist"
-    subprocess.run(
+    completed = subprocess.run(
         [
             sys.executable,
             "-m",
             "build",
             "--no-isolation",
-            "--skip-dependency-check",
             "--wheel",
             "--outdir",
             str(output),
         ],
         cwd=source,
-        check=True,
+        check=False,
         env=os.environ
         | {
             "PIP_NO_INDEX": "1",
@@ -642,6 +652,11 @@ def test_vitest_authority_wheel_is_source_only(tmp_path: Path) -> None:
         },
         capture_output=True,
         text=True,
+    )
+    assert completed.returncode == 0, (
+        f"source-only wheel build failed (exit {completed.returncode})\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
     )
     wheels = tuple(output.glob("*.whl"))
     assert len(wheels) == 1


### PR DESCRIPTION
## Summary

- add a generalized contract that every exact `[build-system].requires` entry is present in the dev extra
- exercise the source-only wheel test with the real offline `--no-isolation` dependency check and captured diagnostics
- add only `setuptools>=64`, `setuptools-scm>=8`, and `wheel` to `.[dev]`
- retain the merged #2164 signed authority/compiler/runner behavior and the full installed-wheel native/checker identity assertions

This is the minimal current-`main` follow-up to #2164 and #2178. The root cause exposed by the hosted failure was an incomplete CI development environment: `python -m build --no-isolation` requires the build-system closure to already be installed, while the test previously bypassed that contract with `--skip-dependency-check`.

Hosted failure evidence: https://github.com/promptdriven/pdd/actions/runs/29621166029 (failed head `89f3ebb339574fba0a086aa1a33e82b635491a8f`).

## TDD evidence

RED was committed and pushed separately as `bbd478322`: the generalized contract failed with exactly:

```
dev extra is missing build requirements: ['setuptools-scm>=8', 'setuptools>=64', 'wheel']
```

GREEN is `5b548a084` and changes only the dev extra.

## Validation

- fresh Python 3.12.11 venv: `pip install -e '.[dev]' pytest-timeout`
- fresh venv + `PIP_NO_INDEX=1`: generalized closure and source-only installed-wheel identity tests: 2 passed
- focused offline wheel/native/header/signed identity tests: 28 passed, 1 skipped (platform-specific)
- `compileall -q pdd` and `py_compile tests/test_sync_core_runner_vitest.py`
- `python -m pdd --help`
- pyproject semantic exact-delta assertion: dev extra only; build-system/runtime unchanged
- changed-line pylint: no findings
- `git diff --check`

No runtime dependencies, build-system requirements, native code, runner/policy code, or workflows are changed.