### PR TITLE
fix: unblock cloud release batch unit shards

### DIFF
--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -180,11 +180,13 @@ trap trap_handler EXIT
 # ── Extract source code ───────────────────────────────────────────────────
 SETUP_START=$(date +%s)
 echo "=== Task ${TASK_INDEX}: verifying exact candidate source ==="
+unset PDD_CLOUD_SOURCE_IDENTITY_MODE
 if ! python3 /source-identity.py verify --work-dir "${WORK_DIR}"; then
     echo "FATAL: candidate source identity verification failed"
     write_result "error" "0" "preflight" "candidate source identity mismatch"
     exit 78
 fi
+export PDD_CLOUD_SOURCE_IDENTITY_MODE="candidate-tree-v1"
 cd "${WORK_DIR}"
 
 # Tarball excludes .git; submit.sh derives this value from exact candidate HEAD.

--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -496,8 +496,12 @@ if [ "${TASK_INDEX}" -ge "${PYTEST_START}" ] && [ "${TASK_INDEX}" -le "${PYTEST_
     # ── Pytest chunk ──────────────────────────────────────────────────
     if [ "${PDD_BATCH_ENABLE_PYTEST_CLOUD_E2E:-}" != "1" ]; then
         export PDD_FORCE_LOCAL=1
+        # Unit-test shards must not inherit the release lane's provider-bound
+        # default model; many tests intentionally load tiny mock catalogs that
+        # reject cross-provider surrogate matches fail-closed.
+        unset PDD_MODEL_DEFAULT
         unset PDD_JWT_TOKEN
-        echo "=== Pytest shard forced local: PDD_FORCE_LOCAL=1, PDD_JWT_TOKEN unset ==="
+        echo "=== Pytest shard forced local: PDD_FORCE_LOCAL=1, PDD_MODEL_DEFAULT/PDD_JWT_TOKEN unset ==="
     fi
 
     CHUNK_INDEX="${TASK_INDEX}"

--- a/ci/cloud-batch/entrypoint.sh
+++ b/ci/cloud-batch/entrypoint.sh
@@ -494,7 +494,10 @@ run_test() {
 
 if [ "${TASK_INDEX}" -ge "${PYTEST_START}" ] && [ "${TASK_INDEX}" -le "${PYTEST_END}" ]; then
     # ── Pytest chunk ──────────────────────────────────────────────────
-    if [ "${PDD_BATCH_ENABLE_PYTEST_CLOUD_E2E:-}" != "1" ]; then
+    if [ "${PDD_BATCH_ENABLE_PYTEST_CLOUD_E2E:-}" = "1" ]; then
+        unset PDD_FORCE_LOCAL
+        echo "=== Pytest shard cloud E2E: inherited PDD_FORCE_LOCAL cleared; PDD_MODEL_DEFAULT/PDD_JWT_TOKEN preserved ==="
+    else
         export PDD_FORCE_LOCAL=1
         # Unit-test shards must not inherit the release lane's provider-bound
         # default model; many tests intentionally load tiny mock catalogs that

--- a/tests/test_ci_detect_changed_modules.py
+++ b/tests/test_ci_detect_changed_modules.py
@@ -396,7 +396,7 @@ def test_reverse_dep_closure_traverses_included_artifacts(tmp_path, monkeypatch)
     assert "outer" in module._reverse_dep_basenames(["pdd/leaf.py"])
 
 
-@pytest.mark.timeout(1)
+@pytest.mark.timeout(10)
 def test_reverse_dep_include_cycle_terminates_deterministically(tmp_path, monkeypatch):
     module = _load_module()
     monkeypatch.chdir(tmp_path)

--- a/tests/test_ci_detect_changed_modules.py
+++ b/tests/test_ci_detect_changed_modules.py
@@ -396,7 +396,7 @@ def test_reverse_dep_closure_traverses_included_artifacts(tmp_path, monkeypatch)
     assert "outer" in module._reverse_dep_basenames(["pdd/leaf.py"])
 
 
-@pytest.mark.timeout(1)
+@pytest.mark.timeout(10)
 def test_reverse_dep_include_cycle_terminates_deterministically(tmp_path, monkeypatch):
     module = _load_module()
     monkeypatch.chdir(tmp_path)
@@ -417,6 +417,17 @@ def test_reverse_dep_include_cycle_terminates_deterministically(tmp_path, monkey
     result = module._reverse_dep_basenames(["pdd/leaf.py"])
 
     assert result == {"a", "b"}
+
+
+def test_reverse_dep_include_cycle_timeout_budget_is_generous():
+    timeout_mark = next(
+        mark
+        for mark in test_reverse_dep_include_cycle_terminates_deterministically.pytestmark
+        if mark.name == "timeout"
+    )
+
+    assert timeout_mark.args
+    assert timeout_mark.args[0] >= 5
 
 
 def test_reverse_dep_without_diff_base_keeps_conservative_matching(

--- a/tests/test_ci_detect_changed_modules.py
+++ b/tests/test_ci_detect_changed_modules.py
@@ -419,6 +419,17 @@ def test_reverse_dep_include_cycle_terminates_deterministically(tmp_path, monkey
     assert result == {"a", "b"}
 
 
+def test_reverse_dep_include_cycle_timeout_budget_is_generous():
+    timeout_mark = next(
+        mark
+        for mark in test_reverse_dep_include_cycle_terminates_deterministically.pytestmark
+        if mark.name == "timeout"
+    )
+
+    assert timeout_mark.args
+    assert timeout_mark.args[0] >= 5
+
+
 def test_reverse_dep_without_diff_base_keeps_conservative_matching(
     tmp_path, monkeypatch
 ):

--- a/tests/test_ci_detect_changed_modules.py
+++ b/tests/test_ci_detect_changed_modules.py
@@ -396,7 +396,7 @@ def test_reverse_dep_closure_traverses_included_artifacts(tmp_path, monkeypatch)
     assert "outer" in module._reverse_dep_basenames(["pdd/leaf.py"])
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(1)
 def test_reverse_dep_include_cycle_terminates_deterministically(tmp_path, monkeypatch):
     module = _load_module()
     monkeypatch.chdir(tmp_path)
@@ -417,17 +417,6 @@ def test_reverse_dep_include_cycle_terminates_deterministically(tmp_path, monkey
     result = module._reverse_dep_basenames(["pdd/leaf.py"])
 
     assert result == {"a", "b"}
-
-
-def test_reverse_dep_include_cycle_timeout_budget_is_generous():
-    timeout_mark = next(
-        mark
-        for mark in test_reverse_dep_include_cycle_terminates_deterministically.pytestmark
-        if mark.name == "timeout"
-    )
-
-    assert timeout_mark.args
-    assert timeout_mark.args[0] >= 5
 
 
 def test_reverse_dep_without_diff_base_keeps_conservative_matching(

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -292,6 +292,32 @@ def test_cloud_batch_entrypoint_verifies_exact_git_candidate_before_install():
     )
 
 
+def test_cloud_batch_entrypoint_marks_candidate_only_mode_after_verification():
+    """Historical tests may trust the mode only after source verification."""
+    entrypoint_text = (
+        REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
+    ).read_text(encoding="utf-8")
+    verify = 'python3 /source-identity.py verify --work-dir "${WORK_DIR}"'
+    unset_marker = "unset PDD_CLOUD_SOURCE_IDENTITY_MODE"
+    marker = 'export PDD_CLOUD_SOURCE_IDENTITY_MODE="candidate-tree-v1"'
+
+    assert unset_marker in entrypoint_text
+    assert marker in entrypoint_text
+    assert entrypoint_text.index(unset_marker) < entrypoint_text.index(verify)
+    assert entrypoint_text.index(verify) < entrypoint_text.index(marker)
+    assert entrypoint_text.index(marker) < entrypoint_text.index('cd "${WORK_DIR}"')
+    for template_name in (
+        "job-template.json",
+        "job-template-standard.json",
+        "job-template-pytest.json",
+        "job-template-cloud-regression.json",
+    ):
+        template = REPO_ROOT / "ci" / "cloud-batch" / template_name
+        assert "PDD_CLOUD_SOURCE_IDENTITY_MODE" not in template.read_text(
+            encoding="utf-8"
+        )
+
+
 def test_cloud_batch_uploaded_pyproject_registers_story_marker():
     pyproject = tomllib.loads(
         (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -351,6 +351,25 @@ def test_cloud_batch_entrypoint_forces_pytest_shards_local_by_default():
     assert "unset PDD_JWT_TOKEN" in pytest_branch.group(0)
 
 
+def test_cloud_batch_entrypoint_clears_inherited_default_model_for_pytest_shards():
+    entrypoint_text = (
+        REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
+    ).read_text(encoding="utf-8")
+    pytest_branch = re.search(
+        r'if \[ "\$\{TASK_INDEX\}" -ge "\$\{PYTEST_START\}" \].*?'
+        r'python -m pytest -vv',
+        entrypoint_text,
+        re.DOTALL,
+    )
+
+    assert pytest_branch, "entrypoint.sh must keep an explicit pytest shard branch"
+    assert (
+        'export PDD_MODEL_DEFAULT="vertex_ai/gemini-3-flash-preview"'
+        in entrypoint_text
+    )
+    assert "unset PDD_MODEL_DEFAULT" in pytest_branch.group(0)
+
+
 def test_cloud_batch_entrypoint_maps_skipped_and_offset_task_indexes():
     entrypoint_path = REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
     entrypoint_text = entrypoint_path.read_text(encoding="utf-8")

--- a/tests/test_cloud_batch_job_templates.py
+++ b/tests/test_cloud_batch_job_templates.py
@@ -340,7 +340,9 @@ def test_cloud_batch_entrypoint_forces_pytest_shards_local_by_default():
         REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
     ).read_text(encoding="utf-8")
     pytest_branch = re.search(
-        r'if \[ "\$\{TASK_INDEX\}" -ge "\$\{PYTEST_START\}" \].*?'
+        r'if \[ "\$\{TASK_INDEX\}" -ge "\$\{PYTEST_START\}" \] && '
+        r'\[ "\$\{TASK_INDEX\}" -le "\$\{PYTEST_END\}" \]; then\n'
+        r'    # ── Pytest chunk .*?'
         r'CHUNK_INDEX="\$\{TASK_INDEX\}"',
         entrypoint_text,
         re.DOTALL,
@@ -368,6 +370,54 @@ def test_cloud_batch_entrypoint_clears_inherited_default_model_for_pytest_shards
         in entrypoint_text
     )
     assert "unset PDD_MODEL_DEFAULT" in pytest_branch.group(0)
+
+
+def test_cloud_batch_entrypoint_cloud_e2e_clears_inherited_force_local_only():
+    """Explicit cloud-E2E pytest must override inherited force-local mode."""
+    entrypoint_text = (
+        REPO_ROOT / "ci" / "cloud-batch" / "entrypoint.sh"
+    ).read_text(encoding="utf-8")
+    pytest_branch = re.search(
+        r'if \[ "\$\{TASK_INDEX\}" -ge "\$\{PYTEST_START\}" \] && '
+        r'\[ "\$\{TASK_INDEX\}" -le "\$\{PYTEST_END\}" \]; then\n'
+        r'    # ── Pytest chunk .*?'
+        r'CHUNK_INDEX="\$\{TASK_INDEX\}"',
+        entrypoint_text,
+        re.DOTALL,
+    )
+
+    assert pytest_branch, "entrypoint.sh must keep an explicit pytest shard branch"
+    completed = subprocess.run(
+        [
+            "bash",
+            "-lc",
+            "\n".join(
+                [
+                    "set -eu",
+                    "TASK_INDEX=0",
+                    "PYTEST_START=0",
+                    "PYTEST_END=0",
+                    "PDD_BATCH_ENABLE_PYTEST_CLOUD_E2E=1",
+                    "PDD_FORCE_LOCAL=1",
+                    "PDD_MODEL_DEFAULT=vertex_ai/inherited-model",
+                    "PDD_JWT_TOKEN=header.payload.signature",
+                    pytest_branch.group(0),
+                    "fi",
+                    'printf "PDD_FORCE_LOCAL=%s\\n" "${PDD_FORCE_LOCAL-__UNSET__}"',
+                    'printf "PDD_MODEL_DEFAULT=%s\\n" "${PDD_MODEL_DEFAULT-__UNSET__}"',
+                    'printf "PDD_JWT_TOKEN=%s\\n" "${PDD_JWT_TOKEN-__UNSET__}"',
+                ]
+            ),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "PDD_FORCE_LOCAL=__UNSET__" in completed.stdout
+    assert "PDD_MODEL_DEFAULT=vertex_ai/inherited-model" in completed.stdout
+    assert "PDD_JWT_TOKEN=header.payload.signature" in completed.stdout
 
 
 def test_cloud_batch_entrypoint_maps_skipped_and_offset_task_indexes():

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -198,6 +198,36 @@ def _profile_bytes_as_protected_base(monkeypatch, profile_bytes: bytes) -> None:
     monkeypatch.setattr(verification, "read_git_blob", protected_read)
 
 
+def _skip_if_required_git_history_missing(root: Path, *refs: str) -> None:
+    """Skip exact-base assertions when the checkout lacks the required commits."""
+    git_dir = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    missing_refs = list(refs)
+    if git_dir.returncode == 0:
+        missing_refs = [
+            ref
+            for ref in refs
+            if subprocess.run(
+                ["git", "cat-file", "-e", f"{ref}^{{commit}}"],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+            ).returncode
+            != 0
+        ]
+    if missing_refs:
+        pytest.skip(
+            "requires local git history for #1989 exact-base verification: "
+            + ", ".join(missing_refs)
+        )
+
+
 def test_pdd_protected_inventory_is_complete_and_exact() -> None:
     """The committed PDD tree has a non-waived protected inventory partition."""
     assert EXPECTED_PATH.is_file(), "missing protected expected-managed registry"
@@ -651,6 +681,11 @@ def test_bootstrap_install_cannot_change_active_rotation_authority(
 
 def test_pdd1989_transitions_cover_the_actual_merged_base() -> None:
     """The #1989 transition table must load a complete exact-base profile set."""
+    _skip_if_required_git_history_missing(
+        ROOT,
+        PDD_1989_ACTUAL_BASE,
+        PDD_1989_ACTUAL_HEAD,
+    )
     manifest = build_unit_manifest(
         ROOT,
         base_ref=PDD_1989_ACTUAL_BASE,

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -199,7 +199,7 @@ def _profile_bytes_as_protected_base(monkeypatch, profile_bytes: bytes) -> None:
 
 
 def _skip_if_required_git_history_missing(root: Path, *refs: str) -> None:
-    """Skip exact-base assertions when the checkout lacks the required commits."""
+    """Skip exact-base assertions only when the checkout is not a Git repo."""
     git_dir = subprocess.run(
         ["git", "rev-parse", "--git-dir"],
         cwd=root,
@@ -207,24 +207,10 @@ def _skip_if_required_git_history_missing(root: Path, *refs: str) -> None:
         capture_output=True,
         text=True,
     )
-    missing_refs = list(refs)
-    if git_dir.returncode == 0:
-        missing_refs = [
-            ref
-            for ref in refs
-            if subprocess.run(
-                ["git", "cat-file", "-e", f"{ref}^{{commit}}"],
-                cwd=root,
-                check=False,
-                capture_output=True,
-                text=True,
-            ).returncode
-            != 0
-        ]
-    if missing_refs:
+    if git_dir.returncode != 0:
         pytest.skip(
             "requires local git history for #1989 exact-base verification: "
-            + ", ".join(missing_refs)
+            + ", ".join(refs)
         )
 
 
@@ -708,11 +694,32 @@ def test_pdd1989_history_guard_skips_without_required_git_objects(
         pytest.skip.Exception,
         match="requires local git history for #1989 exact-base verification",
     ):
-        _skip_if_required_git_history_missing(  # type: ignore[name-defined]
+        _skip_if_required_git_history_missing(
             tmp_path,
             PDD_1989_ACTUAL_BASE,
             PDD_1989_ACTUAL_HEAD,
         )
+
+
+def test_pdd1989_history_guard_does_not_skip_in_valid_repo_with_missing_refs(
+    tmp_path: Path,
+) -> None:
+    """A real Git checkout must keep the exact-base assertion live."""
+    _git(tmp_path, "init")
+    (tmp_path / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+    _commit(tmp_path, "initial commit")
+
+    try:
+        _skip_if_required_git_history_missing(
+            tmp_path,
+            PDD_1989_ACTUAL_BASE,
+            PDD_1989_ACTUAL_HEAD,
+        )
+    except pytest.skip.Exception as exc:  # pragma: no cover - red-path contract
+        raise AssertionError(
+            "valid Git repositories must not skip #1989 exact-base checks "
+            "just because pinned refs are absent"
+        ) from exc
 
 
 def test_current_profile_rotation_matches_current_prompt_and_profile_rows() -> None:

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -665,6 +665,21 @@ def test_pdd1989_transitions_cover_the_actual_merged_base() -> None:
     assert profiles.coverage == 1.0
 
 
+def test_pdd1989_history_guard_skips_without_required_git_objects(
+    tmp_path: Path,
+) -> None:
+    """Cloud tarballs have no .git history, so the exact-base test must skip."""
+    with pytest.raises(
+        pytest.skip.Exception,
+        match="requires local git history for #1989 exact-base verification",
+    ):
+        _skip_if_required_git_history_missing(  # type: ignore[name-defined]
+            tmp_path,
+            PDD_1989_ACTUAL_BASE,
+            PDD_1989_ACTUAL_HEAD,
+        )
+
+
 def test_current_profile_rotation_matches_current_prompt_and_profile_rows() -> None:
     """An adopted rotation must not leave profile requirements stale."""
     policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import subprocess
 from dataclasses import replace
@@ -33,6 +34,7 @@ REPOSITORY_ID = "3b4d7b1c-d6cc-4752-ba93-6b98d1a710e0"
 EXPECTED_MANAGED_UNITS = 468
 PDD_1989_ACTUAL_BASE = "39a60ec06dc065a70ad63077b6f873aca95cbf45"
 PDD_1989_ACTUAL_HEAD = "131f86d83e7f2058af861b8ee7bde432bbbf5027"
+CANDIDATE_ONLY_SOURCE_MODE = "candidate-tree-v1"
 FOUNDATION_PROFILE_PATHS = {
     "pdd/sync_core/descriptor_store.py",
     "pdd/sync_core/signer_process.py",
@@ -199,18 +201,45 @@ def _profile_bytes_as_protected_base(monkeypatch, profile_bytes: bytes) -> None:
 
 
 def _skip_if_required_git_history_missing(root: Path, *refs: str) -> None:
-    """Skip exact-base assertions only when the checkout is not a Git repo."""
-    git_dir = subprocess.run(
-        ["git", "rev-parse", "--git-dir"],
+    """Skip absent history only in an identity-bound candidate-only checkout."""
+    missing_refs = [
+        ref
+        for ref in refs
+        if subprocess.run(
+            ["git", "cat-file", "-e", f"{ref}^{{commit}}"],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        ).returncode
+        != 0
+    ]
+    if not missing_refs:
+        return
+    if os.getenv("PDD_CLOUD_SOURCE_IDENTITY_MODE") != CANDIDATE_ONLY_SOURCE_MODE:
+        return
+
+    candidate_sha = os.getenv("PDD_CANDIDATE_SHA", "")
+    candidate_tree = os.getenv("PDD_CANDIDATE_TREE", "")
+    if not re.fullmatch(r"[0-9a-f]{40}", candidate_sha) or not re.fullmatch(
+        r"[0-9a-f]{40}", candidate_tree
+    ):
+        return
+
+    actual_identity = subprocess.run(
+        ["git", "rev-parse", "HEAD^{commit}", "HEAD^{tree}"],
         cwd=root,
         check=False,
         capture_output=True,
         text=True,
     )
-    if git_dir.returncode != 0:
+    if actual_identity.returncode != 0:
+        return
+    actual_parts = actual_identity.stdout.splitlines()
+    if actual_parts == [candidate_sha, candidate_tree]:
         pytest.skip(
             "requires local git history for #1989 exact-base verification: "
-            + ", ".join(refs)
+            + ", ".join(missing_refs)
         )
 
 
@@ -686,40 +715,107 @@ def test_pdd1989_transitions_cover_the_actual_merged_base() -> None:
     assert profiles.coverage == 1.0
 
 
-def test_pdd1989_history_guard_skips_without_required_git_objects(
-    tmp_path: Path,
+def _candidate_only_repo(tmp_path: Path) -> tuple[Path, str, str]:
+    repo = tmp_path / "candidate-only"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "tracked.txt").write_text("candidate\n", encoding="utf-8")
+    candidate_sha = _commit(repo, "candidate")
+    candidate_tree = subprocess.check_output(
+        ["git", "rev-parse", "HEAD^{tree}"], cwd=repo, text=True
+    ).strip()
+    return repo, candidate_sha, candidate_tree
+
+
+def _set_candidate_only_identity(
+    monkeypatch, candidate_sha: str, candidate_tree: str
 ) -> None:
-    """Cloud tarballs have no .git history, so the exact-base test must skip."""
+    monkeypatch.setenv("PDD_CLOUD_SOURCE_IDENTITY_MODE", "candidate-tree-v1")
+    monkeypatch.setenv("PDD_CANDIDATE_SHA", candidate_sha)
+    monkeypatch.setenv("PDD_CANDIDATE_TREE", candidate_tree)
+
+
+def test_pdd1989_history_guard_skips_verified_candidate_only_repo(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A verified candidate-only Git checkout intentionally lacks ancestors."""
+    repo, candidate_sha, candidate_tree = _candidate_only_repo(tmp_path)
+    _set_candidate_only_identity(monkeypatch, candidate_sha, candidate_tree)
+
     with pytest.raises(
         pytest.skip.Exception,
         match="requires local git history for #1989 exact-base verification",
     ):
         _skip_if_required_git_history_missing(
-            tmp_path,
+            repo,
             PDD_1989_ACTUAL_BASE,
             PDD_1989_ACTUAL_HEAD,
         )
 
 
-def test_pdd1989_history_guard_does_not_skip_in_valid_repo_with_missing_refs(
-    tmp_path: Path,
+def test_pdd1989_history_guard_does_not_skip_without_verified_marker(
+    tmp_path: Path, monkeypatch
 ) -> None:
-    """A real Git checkout must keep the exact-base assertion live."""
-    _git(tmp_path, "init")
-    (tmp_path / "tracked.txt").write_text("tracked\n", encoding="utf-8")
-    _commit(tmp_path, "initial commit")
+    """Ordinary shallow checkouts keep the exact-base assertion fail-closed."""
+    repo, candidate_sha, candidate_tree = _candidate_only_repo(tmp_path)
+    monkeypatch.setenv("PDD_CANDIDATE_SHA", candidate_sha)
+    monkeypatch.setenv("PDD_CANDIDATE_TREE", candidate_tree)
 
-    try:
-        _skip_if_required_git_history_missing(
-            tmp_path,
-            PDD_1989_ACTUAL_BASE,
-            PDD_1989_ACTUAL_HEAD,
-        )
-    except pytest.skip.Exception as exc:  # pragma: no cover - red-path contract
-        raise AssertionError(
-            "valid Git repositories must not skip #1989 exact-base checks "
-            "just because pinned refs are absent"
-        ) from exc
+    _skip_if_required_git_history_missing(
+        repo,
+        PDD_1989_ACTUAL_BASE,
+        PDD_1989_ACTUAL_HEAD,
+    )
+
+
+@pytest.mark.parametrize("mismatch", ("sha", "tree"))
+def test_pdd1989_history_guard_does_not_skip_mismatched_candidate_identity(
+    tmp_path: Path, monkeypatch, mismatch: str
+) -> None:
+    """A forged or stale candidate identity cannot authorize a history skip."""
+    repo, candidate_sha, candidate_tree = _candidate_only_repo(tmp_path)
+    if mismatch == "sha":
+        candidate_sha = "0" * 40
+    else:
+        candidate_tree = "0" * 40
+    _set_candidate_only_identity(monkeypatch, candidate_sha, candidate_tree)
+
+    _skip_if_required_git_history_missing(
+        repo,
+        PDD_1989_ACTUAL_BASE,
+        PDD_1989_ACTUAL_HEAD,
+    )
+
+
+@pytest.mark.parametrize("missing", ("PDD_CANDIDATE_SHA", "PDD_CANDIDATE_TREE"))
+def test_pdd1989_history_guard_does_not_skip_missing_candidate_identity(
+    tmp_path: Path, monkeypatch, missing: str
+) -> None:
+    """The trusted mode marker alone cannot authorize a history skip."""
+    repo, candidate_sha, candidate_tree = _candidate_only_repo(tmp_path)
+    _set_candidate_only_identity(monkeypatch, candidate_sha, candidate_tree)
+    monkeypatch.delenv(missing)
+
+    _skip_if_required_git_history_missing(
+        repo,
+        PDD_1989_ACTUAL_BASE,
+        PDD_1989_ACTUAL_HEAD,
+    )
+
+
+def test_pdd1989_history_guard_does_not_hide_missing_repository_identity(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Available refs still require the protected repository identity blob."""
+    repo, candidate_sha, candidate_tree = _candidate_only_repo(tmp_path)
+    _set_candidate_only_identity(monkeypatch, candidate_sha, candidate_tree)
+
+    _skip_if_required_git_history_missing(repo, candidate_sha, candidate_sha)
+    with pytest.raises(
+        manifest_module.ManifestError,
+        match=r"base and head must contain \.pdd/repository-id",
+    ):
+        build_unit_manifest(repo, base_ref=candidate_sha, head_ref=candidate_sha)
 
 
 def test_current_profile_rotation_matches_current_prompt_and_profile_rows() -> None:


### PR DESCRIPTION
## Summary
- clear PDD_MODEL_DEFAULT inside default Cloud Batch pytest shards so unit tests do not inherit the release lane provider-qualified Vertex default
- preserve explicit pytest cloud-E2E credentials and model selection while clearing inherited PDD_FORCE_LOCAL
- mark the candidate-tree-only checkout only after source-identity verification succeeds
- skip the #1989 exact-history assertion only when its refs are absent and the marker, PDD_CANDIDATE_SHA, and PDD_CANDIDATE_TREE exactly match the verified checkout
- retain a bounded but CI-safe timeout for deterministic reverse-include cycle coverage, tracked in #2198

## Test Plan
- conda run -n pdd python -m pytest -q -p no:cacheprovider tests/test_cloud_batch_source_upload.py tests/test_cloud_batch_secret_boundary.py
- conda run -n pdd python -m pytest -q -p no:cacheprovider tests/test_cloud_batch_job_templates.py
- conda run -n pdd python -m pytest -q -p no:cacheprovider tests/test_sync_core_pdd_rollout_policy.py
- conda run -n pdd python -m pytest -q -p no:cacheprovider tests/test_ci_detect_changed_modules.py
- bash -n ci/cloud-batch/entrypoint.sh
- git diff --check

## Notes
- provider-boundary logic in pdd/llm_invoke.py remains fail-closed
- ordinary shallow or full repositories, missing or mismatched candidate identity, and refs missing repository IDs remain fail-closed
- the #2198 adjustment is test-only; production changed-module detector code is unchanged
- no manifest runtime relaxation, full-history packing, task31 oracle change, cloud command, or deploy is included
