### PR TITLE
fix(test): recognize persistent retry exhaustion

### DIFF
--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -76,6 +76,10 @@ _RETRY_EXHAUSTION_PATTERN = re.compile(
     r"\d+(?:st|nd|rd|th)\s+attempt|"
     r"(?:if|when)\s+(?:the\s+)?\d+(?:st|nd|rd|th)\s+attempt\s+"
     r"(?:(?:also|still)\s+)?fail(?:s|ed)?|"
+    r"(?:if|when)\s+(?:the\s+)?(?:connection\s+)?"
+    r"(?:error|exception|failure)\s+(?:still\s+)?"
+    r"(?:persist(?:s|ed)?|remain(?:s|ed)?)\s+after\s+(?:the\s+)?"
+    r"\d+(?:st|nd|rd|th)\s+(?:retry\s+)?attempt|"
     r"once\s+(?:the\s+)?(?:max(?:imum)?\s+)?(?:retry\s+)?attempts?\s+"
     r"(?:is\s+|are\s+)?(?:reached|exhausted)|"
     r"(?:once|when|if)\s+(?:the\s+)?max(?:imum)?\s+number\s+of\s+attempts?\s+"
@@ -93,7 +97,18 @@ _RETRY_EXHAUSTION_PATTERN = re.compile(
 )
 
 _FALLBACK_ACTION_PATTERN = re.compile(
-    r"\b(?:raise|return|log|skip|abort|surface|propagate|fail|error|exception|fallback)\b",
+    r"\b(?:"
+    r"(?:re-?)?rais(?:e|es|ed|ing)|"
+    r"return(?:s|ed|ing)?|"
+    r"log(?:s|ged|ging)?|"
+    r"skip(?:s|ped|ping)?|"
+    r"abort(?:s|ed|ing)?|"
+    r"surfac(?:e|es|ed|ing)|"
+    r"propagat(?:e|es|ed|ing)"
+    r")\b|"
+    r"\buse(?:s|d|ing)?\s+(?:(?:a|the)\s+)?fallback\b|"
+    r"\b(?:fall(?:s|ing)?|fell)\s+back\b|"
+    r"\bfail(?:s|ed|ing)?\s+(?:closed|with\b|the\b)",
     re.IGNORECASE,
 )
 
@@ -417,6 +432,7 @@ class TestDeterministicChangeJudges:
                 "If all 3 attempts fail, the final connection error remains "
                 "available for inspection."
             ),
+            "If all 3 attempts fail, fallback diagnostics remain available.",
         ),
     )
     def test_retry_fallback_judge_rejects_non_fallback_conditions(

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -118,6 +118,11 @@ _NON_EXHAUSTION_PREFIX_PATTERN = re.compile(
 
 _UNTIL_EXHAUSTION_PREFIX_PATTERN = re.compile(r"\buntil\s*$", re.IGNORECASE)
 
+_RETRY_UNTIL_PREFIX_PATTERN = re.compile(
+    r"\bretry(?:ing)?\s+until\s*$",
+    re.IGNORECASE,
+)
+
 _STOP_RETRYING_EXHAUSTION_PATTERN = re.compile(
     r"(?:do\s+not|don['’]t|must\s+not|mustn['’]t)\s+"
     r"(?:retry(?:\s+again)?|continue\s+retrying)",
@@ -125,7 +130,9 @@ _STOP_RETRYING_EXHAUSTION_PATTERN = re.compile(
 )
 
 _CONDITIONAL_UNIT_PATTERN = re.compile(
-    r"^\s*(?:if|when|unless|before|until|for|on|upon|in\s+case|provided\s+that)\b",
+    r"^\s*(?:if|when|unless|before|until|on|upon|in\s+case|provided\s+that|"
+    r"for\s+(?:(?:an?\s+)?(?:invalid|malformed|bad|unsupported|non[- ]?retryable)\b|"
+    r"(?:auth(?:entication|orization)?|validation)\s+(?:failure|error)\b))",
     re.IGNORECASE,
 )
 
@@ -337,7 +344,10 @@ def _is_affirmative_exhaustion_match(text: str, match: re.Match[str]) -> bool:
     if _NON_EXHAUSTION_PREFIX_PATTERN.search(prefix):
         return False
     if _UNTIL_EXHAUSTION_PREFIX_PATTERN.search(prefix):
-        return bool(_RETRY_CONTINUATION_PATTERN.search(prefix))
+        return bool(
+            _RETRY_CONTINUATION_PATTERN.search(prefix)
+            or _RETRY_UNTIL_PREFIX_PATTERN.search(prefix)
+        )
     return True
 
 

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -66,9 +66,15 @@ _RETRY_BOUND_PATTERNS = [
 
 _RETRY_EXHAUSTION_PATTERN = re.compile(
     r"\b(?:"
-    r"exhaust(?:ed|s|ion)?|"
-    r"after\s+all\s+(?:retry\s+)?attempts?|"
-    r"after\s+all\s+retries|"
+    r"(?:all\s+)?(?:retries|(?:retry\s+)?attempts?)\s+"
+    r"(?:(?:is|are|were|have\s+been|has\s+been)\s+)?exhausted|"
+    r"(?:retry|retries|attempts?)\s+exhaustion|"
+    r"after\s+all\s+(?:retry\s+)?attempts?"
+    r"(?:\s+(?:(?:have|has|are|were)\s+)?"
+    r"(?:fail(?:s|ed)?|exhausted))?|"
+    r"after\s+all\s+retries"
+    r"(?:\s+(?:(?:have|has|are|were)\s+)?"
+    r"(?:fail(?:s|ed)?|exhausted))?|"
     r"after\s+\d+\s+(?:failed\s+)?(?:retry\s+)?attempts?|"
     r"all\s+(?:retry\s+)?attempts?\s+"
     r"(?:(?:have|has|are|were)\s+)?fail(?:s|ed)?|"
@@ -90,11 +96,16 @@ _RETRY_EXHAUSTION_PATTERN = re.compile(
     r"(?:is\s+|are\s+|has\s+been\s+)?(?:reached|exceeded|exhausted)|"
     r"(?:retry\s+)?limit\s+(?:is\s+|has\s+been\s+)?(?:reached|exceeded)|"
     r"(?:final|last)\s+(?:retry\s+)?attempt"
-    r"(?:\s+(?:(?:also|still)\s+)?"
-    r"(?:fail(?:s|ed)?|encounters?|raises?|has)\b.{0,80})?|"
+    r"(?:\s+(?:(?:also|still)\s+)?(?:"
+    r"fail(?:s|ed)?(?:\s+with\s+(?:(?:a|an|the)\s+)?"
+    r"(?:connection\s+)?(?:error|exception|failure))?|"
+    r"(?:encounters?|raises?|has)\s+(?:(?:a|an|the)\s+)?"
+    r"(?:connection\s+)?(?:error|exception|failure)))?|"
     r"if\s+(?:it\s+)?still\s+fail(?:s|ed)?|"
     r"when\s+(?:all\s+)?(?:retry\s+)?attempts?\s+fail|"
-    r"stop\s+retrying"
+    r"stop\s+retrying|"
+    r"(?:do\s+not|don['’]t|must\s+not|mustn['’]t)\s+"
+    r"(?:retry(?:\s+again)?|continue\s+retrying)"
     r")\b",
     re.IGNORECASE,
 )
@@ -135,7 +146,7 @@ _SUCCESS_RETURN_PATTERN = re.compile(
 )
 
 _CONNECTIVE_ONLY_PATTERN = re.compile(
-    r"^\s*(?:then|otherwise|as\s+(?:a|the)\s+fallback)?\s*$",
+    r"^\s*(?:then|otherwise|however|but|as\s+(?:a|the)\s+fallback)?\s*$",
     re.IGNORECASE,
 )
 
@@ -148,7 +159,7 @@ _ACTION_INTRO = (
 _DIRECT_ACTION_PATTERNS = tuple(
     re.compile(rf"^\s*{_ACTION_INTRO}{_ACTION_ADVERBS}{body}\s*$", re.IGNORECASE)
     for body in (
-        r"(?:re[- ]?)?raise\b.{0,96}",
+        r"(?:re[- ]?)?rais(?:e|ed)\b.{0,96}",
         r"(?:surface|propagate|abort|skip)\b.{0,96}",
         r"return\b.{0,64}\b(?:error|exception|failure)\b.{0,32}",
         r"log\b.{0,64}\b(?:error|exception|failure)\b.{0,32}",
@@ -159,19 +170,13 @@ _DIRECT_ACTION_PATTERNS = tuple(
         r"allow\b.{1,64}\bto\s+(?:surface|propagate|abort|skip)\b.{0,64}",
     )
 )
-_MODAL_ACTION_PATTERN = re.compile(
+_MODAL_PREFIX_PATTERN = re.compile(
     rf"^\s*{_ACTION_INTRO}(?:(?:the|a|an|this|that)\s+)?"
     rf"(?:[\w`.-]+\s+){{1,8}}"
     rf"(?:(?:must|should|shall|will|would|can|could|may|might)\s+"
     rf"{_ACTION_ADVERBS}(?:be\s+{_ACTION_ADVERBS})?|"
     rf"(?:has|have)\s+to\s+{_ACTION_ADVERBS}|(?:is|are)\s+{_ACTION_ADVERBS})"
-    r"(?:re[- ]?)?rais(?:e|ed)\b.{0,96}$|"
-    rf"^\s*{_ACTION_INTRO}(?:(?:the|a|an|this|that)\s+)?"
-    rf"(?:[\w`.-]+\s+){{1,8}}"
-    rf"(?:(?:must|should|shall|will|would|can|could|may|might)\s+"
-    rf"{_ACTION_ADVERBS}(?:be\s+{_ACTION_ADVERBS})?|"
-    rf"(?:has|have)\s+to\s+{_ACTION_ADVERBS}|(?:is|are)\s+{_ACTION_ADVERBS})"
-    r"(?:surface|propagate|abort|skip|return|log|use|fallback|fail)\b.{0,112}$",
+    r"(?P<action>.+?)\s*$",
     re.IGNORECASE | re.DOTALL,
 )
 
@@ -257,10 +262,14 @@ def _fallback_action_state(text: str) -> tuple[bool, bool]:
     coordinated = re.split(r"\band\b", text, flags=re.IGNORECASE)[-1].strip()
     if coordinated != text:
         candidates.append(coordinated)
+    for candidate in tuple(candidates):
+        modal = _MODAL_PREFIX_PATTERN.fullmatch(candidate)
+        if modal:
+            candidates.append(modal.group("action"))
     affirmative = any(
         pattern.fullmatch(candidate)
         for candidate in candidates
-        for pattern in (*_DIRECT_ACTION_PATTERNS, _MODAL_ACTION_PATTERN)
+        for pattern in _DIRECT_ACTION_PATTERNS
     )
     return affirmative, False
 
@@ -280,9 +289,14 @@ def _inverse_action_state(unit: str) -> tuple[bool, bool]:
 
 def _is_immediate_contradiction(units: tuple[str, ...], index: int) -> bool:
     """Return whether the unit immediately after an action contradicts it."""
-    if index + 1 >= len(units):
+    next_index = index + 1
+    while next_index < len(units) and _CONNECTIVE_ONLY_PATTERN.fullmatch(
+        units[next_index]
+    ):
+        next_index += 1
+    if next_index >= len(units):
         return False
-    _, rejected = _fallback_action_state(units[index + 1])
+    _, rejected = _fallback_action_state(units[next_index])
     return rejected
 
 
@@ -314,7 +328,7 @@ def _judge_retry_fallback(prompt_output: str) -> JudgmentResult:
             if rejected or suffix.strip():
                 continue
             action_index = index + 1
-            if action_index < len(units) and _CONNECTIVE_ONLY_PATTERN.fullmatch(
+            while action_index < len(units) and _CONNECTIVE_ONLY_PATTERN.fullmatch(
                 units[action_index]
             ):
                 action_index += 1
@@ -781,6 +795,43 @@ class TestDeterministicChangeJudges:
         judgment = _judge_retry_fallback(guidance)
 
         assert judgment.passed, judgment.reasoning
+
+    @pytest.mark.parametrize(
+        "guidance",
+        (
+            "After all attempts fail, raise the final error.",
+            "After all retries fail, return an error.",
+            "If the final attempt still encounters a connection error re-raise the exception.",
+            "Do not retry again; raise the final error.",
+            "Do not continue retrying and raise the final error.",
+        ),
+    )
+    def test_retry_fallback_judge_accepts_canonical_exhaustion_forms(
+        self, guidance: str
+    ) -> None:
+        """Canonical stop conditions retain an explicit fallback action."""
+        judgment = _judge_retry_fallback(guidance)
+
+        assert judgment.passed, judgment.reasoning
+
+    @pytest.mark.parametrize(
+        "guidance",
+        (
+            "Retry 3 times. When the user is exhausted, return an error.",
+            "If retries are exhausted, the runner must log request metrics.",
+            "If retries are exhausted, the runner should use the normal result.",
+            "If retries are exhausted. Raise the error. Then, keep retrying.",
+            "If retries are exhausted. Raise the error. Otherwise, continue normally.",
+            "If retries are exhausted. Raise the error. However, keep retrying.",
+        ),
+    )
+    def test_retry_fallback_judge_rejects_unrelated_or_deferred_actions(
+        self, guidance: str
+    ) -> None:
+        """Unrelated subjects and connective-hidden contradictions are rejected."""
+        judgment = _judge_retry_fallback(guidance)
+
+        assert not judgment.passed
 
     @pytest.mark.parametrize("action_before", (False, True))
     @pytest.mark.parametrize("same_clause", (False, True))

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -77,7 +77,9 @@ _RETRY_EXHAUSTION_PATTERN = re.compile(
     r"(?:if|when)\s+[\w\s]+fail(?:s|ed)?\s+on\s+(?:the\s+)?"
     r"\d+(?:st|nd|rd|th)\s+attempt|"
     r"(?:if|when)\s+(?:the\s+)?\d+(?:st|nd|rd|th)\s+attempt\s+"
-    r"(?:(?:also|still)\s+)?fail(?:s|ed)?|"
+    r"(?:(?:also|still)\s+)?fail(?:s|ed)?"
+    r"(?:\s+with\s+(?:(?:a|an|the)\s+)?(?:connection\s+)?"
+    r"(?:error|exception|failure))?|"
     r"(?:if|when)\s+(?:the\s+)?(?:connection\s+)?"
     r"(?:error|exception|failure)\s+(?:still\s+)?"
     r"(?:persist(?:s|ed)?|remain(?:s|ed)?)\s+after\s+(?:the\s+)?"
@@ -87,7 +89,9 @@ _RETRY_EXHAUSTION_PATTERN = re.compile(
     r"(?:once|when|if)\s+(?:the\s+)?max(?:imum)?\s+number\s+of\s+attempts?\s+"
     r"(?:is\s+|are\s+|has\s+been\s+)?(?:reached|exceeded|exhausted)|"
     r"(?:retry\s+)?limit\s+(?:is\s+|has\s+been\s+)?(?:reached|exceeded)|"
-    r"(?:final|last)\s+(?:retry\s+)?attempt|"
+    r"(?:final|last)\s+(?:retry\s+)?attempt"
+    r"(?:\s+(?:(?:also|still)\s+)?"
+    r"(?:fail(?:s|ed)?|encounters?|raises?|has)\b.{0,80})?|"
     r"if\s+(?:it\s+)?still\s+fail(?:s|ed)?|"
     r"when\s+(?:all\s+)?(?:retry\s+)?attempts?\s+fail|"
     r"stop\s+retrying"
@@ -95,54 +99,32 @@ _RETRY_EXHAUSTION_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-_FALLBACK_ACTION_PATTERNS = (
-    re.compile(r"\b(?:re[- ]?)?rais(?:e|es|ed|ing)\b", re.IGNORECASE),
-    re.compile(r"\b(?:surfac|propagat)(?:e|es|ed|ing)\b", re.IGNORECASE),
-    re.compile(r"\b(?:abort|skip)(?:s|ped|ping|ed|ing)?\b", re.IGNORECASE),
-    re.compile(
-        r"\breturn(?:s|ed|ing)?\b.{0,48}\b(?:error|exception|failure)\b",
-        re.IGNORECASE | re.DOTALL,
-    ),
-    re.compile(
-        r"\blog(?:s|ged|ging)?\b.{0,48}\b(?:error|exception|failure)\b",
-        re.IGNORECASE | re.DOTALL,
-    ),
-    re.compile(
-        r"\bfail(?:s|ed|ing)?\s+with\b.{0,48}\b(?:error|exception|failure)\b",
-        re.IGNORECASE | re.DOTALL,
-    ),
-    re.compile(
-        r"\buse(?:s|d|ing)?\b.{1,64}\bas\s+(?:the\s+)?fallback\b",
-        re.IGNORECASE | re.DOTALL,
-    ),
-    re.compile(r"\b(?:fallback|fall\s+back)\s+to\b", re.IGNORECASE),
-    re.compile(r"\bfail(?:s|ed|ing)?\s+closed\b", re.IGNORECASE),
-)
-
-_RETRY_SENTENCE_PATTERN = re.compile(r"[^.!?]+(?:[.!?]+|$)", re.DOTALL)
+_RETRY_UNIT_PATTERN = re.compile(r"[^,;.!?]+(?:[,;.!?]+|$)", re.DOTALL)
 
 _RETRY_CONTINUATION_PATTERN = re.compile(
     r"\b(?:keep(?:s|ing)?|continu(?:e|es|ed|ing)|resum(?:e|es|ed|ing))\s+"
     r"(?:(?:to|with)\s+)?(?:retry(?:ing)?|retries)\b|"
     r"\btry\s+again\b|"
     r"\banother\s+(?:retry\s+)?attempt\b|"
-    r"\bcontinu(?:e|es|ed|ing)\s+(?:processing\s+)?normally\b",
+    r"\b(?:continu(?:e|es|ed|ing)|resum(?:e|es|ed|ing)|proceed(?:s|ed|ing)?)\s+"
+    r"(?:processing\s+)?normally\b",
     re.IGNORECASE,
 )
 
-_NEGATED_FALLBACK_ACTION_PATTERN = re.compile(
+_REJECTED_ACTION_PATTERN = re.compile(
     r"(?:"
-    r"\bunder\s+no\s+circumstances\b.{0,96}|"
+    r"\bunder\s+no\s+circumstances\b|"
     r"\b(?:do|does|did|must|should|shall|will|would|can|could|may|might)\s+"
-    r"not\b.{0,64}|"
-    r"\b(?:mustn|shouldn|shan|won|wouldn|can|couldn|mayn|mightn)['’]t\b.{0,64}|"
-    r"\bcannot\b.{0,64}|"
-    r"\bnot\s+(?:ever\s+|to\s+)?.{0,64}|"
-    r"\bnever\b.{0,64}|"
-    r"\bavoid(?:s|ed|ing)?\b.{0,64}|"
-    r"\bwithout\b.{0,64}|"
-    r"\brefrain(?:s|ed|ing)?\s+from\b.{0,64}"
-    r")$",
+    r"not\b|"
+    r"\b(?:mustn|shouldn|shan|won|wouldn|can|couldn|mayn|mightn)['’]t\b|"
+    r"\bcannot\b|"
+    r"\bnever\b|"
+    r"\bavoid(?:s|ed|ing)?\b|"
+    r"\bwithout\b|"
+    r"\brefrain(?:s|ed|ing)?\s+from\b|"
+    r"\bno\s+(?:error|exception|failure)\b|"
+    r"\b(?:forbidden|prohibited|disallowed|not\s+allowed|not\s+permitted)\b"
+    r")",
     re.IGNORECASE | re.DOTALL,
 )
 
@@ -152,34 +134,64 @@ _SUCCESS_RETURN_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-_ACTION_CONNECTOR_PATTERN = re.compile(r"\b(?:after|once|when)\b", re.IGNORECASE)
-
-_CONDITIONAL_PREFIX_PATTERN = re.compile(
-    r"^\s*(?:if|when|whenever|unless|while)\b", re.IGNORECASE
-)
-
-_ACTION_LEAD_PATTERN = re.compile(
-    r"^[\s,;:\-]*(?:(?:then|otherwise|stop\s+retrying\s+and|"
-    r"as\s+(?:a|the)\s+fallback)"
-    r"[\s,;:\-]*)?(?:"
-    r"allow(?:s|ed|ing)?\b.{0,48}\bto\s+|"
-    r"(?:(?:the|a|an|this|that)\s+)?(?:[\w`.-]+\s+){1,8}"
-    r"(?:(?:must|should|shall|will|would|can|could|may|might)"
-    r"(?:\s+be)?|(?:has|have)\s+to|is|are|be)\s+"
-    r")?$",
-    re.IGNORECASE | re.DOTALL,
-)
-
 _CONNECTIVE_ONLY_PATTERN = re.compile(
-    r"^[\s,;:.!?\-]*(?:(?:then|otherwise|as\s+(?:a|the)\s+fallback)"
-    r"[\s,;:.!?\-]*)?$",
+    r"^\s*(?:then|otherwise|as\s+(?:a|the)\s+fallback)?\s*$",
     re.IGNORECASE,
 )
 
-_CONDITION_TAIL_PATTERN = re.compile(
-    r"^\s*(?:(?:with|from|due\s+to|because\s+of)\b|"
-    r"still\s+(?:encounters?|raises?|has)\b)[^,;]{0,80}[,;]",
+_ACTION_ADVERBS = (
+    r"(?:(?:immediately|gracefully|clearly|explicitly|directly|finally)\s+)*"
+)
+_ACTION_INTRO = (
+    r"(?:(?:then|otherwise|as\s+(?:a|the)\s+fallback|stop\s+retrying\s+and)\s+)?"
+)
+_DIRECT_ACTION_PATTERNS = tuple(
+    re.compile(rf"^\s*{_ACTION_INTRO}{_ACTION_ADVERBS}{body}\s*$", re.IGNORECASE)
+    for body in (
+        r"(?:re[- ]?)?raise\b.{0,96}",
+        r"(?:surface|propagate|abort|skip)\b.{0,96}",
+        r"return\b.{0,64}\b(?:error|exception|failure)\b.{0,32}",
+        r"log\b.{0,64}\b(?:error|exception|failure)\b.{0,32}",
+        r"fail\s+with\b.{0,64}\b(?:error|exception|failure)\b.{0,32}",
+        r"use\b.{1,80}\bas\s+(?:the\s+)?fallback\b.{0,32}",
+        r"(?:fallback|fall\s+back)\s+to\b.{1,80}",
+        r"fail\s+closed\b.{0,64}",
+        r"allow\b.{1,64}\bto\s+(?:surface|propagate|abort|skip)\b.{0,64}",
+    )
+)
+_MODAL_ACTION_PATTERN = re.compile(
+    rf"^\s*{_ACTION_INTRO}(?:(?:the|a|an|this|that)\s+)?"
+    rf"(?:[\w`.-]+\s+){{1,8}}"
+    rf"(?:(?:must|should|shall|will|would|can|could|may|might)\s+"
+    rf"{_ACTION_ADVERBS}(?:be\s+{_ACTION_ADVERBS})?|"
+    rf"(?:has|have)\s+to\s+{_ACTION_ADVERBS}|(?:is|are)\s+{_ACTION_ADVERBS})"
+    r"(?:re[- ]?)?rais(?:e|ed)\b.{0,96}$|"
+    rf"^\s*{_ACTION_INTRO}(?:(?:the|a|an|this|that)\s+)?"
+    rf"(?:[\w`.-]+\s+){{1,8}}"
+    rf"(?:(?:must|should|shall|will|would|can|could|may|might)\s+"
+    rf"{_ACTION_ADVERBS}(?:be\s+{_ACTION_ADVERBS})?|"
+    rf"(?:has|have)\s+to\s+{_ACTION_ADVERBS}|(?:is|are)\s+{_ACTION_ADVERBS})"
+    r"(?:surface|propagate|abort|skip|return|log|use|fallback|fail)\b.{0,112}$",
     re.IGNORECASE | re.DOTALL,
+)
+
+_INVERSE_EXHAUSTION_PATTERN = re.compile(
+    r"^\s*(?:when|once|after)\s+(?:"
+    r"(?:the\s+)?(?:max(?:imum)?\s+)?(?:retry\s+)?(?:attempts?|retries)\s+"
+    r"(?:(?:is|are|have\s+been|has\s+been)\s+)?(?:exhausted|fail(?:s|ed)?)|"
+    r"all\s+(?:\d+\s+)?(?:retry\s+)?(?:attempts?|retries)\s+"
+    r"(?:(?:are|have\s+been)\s+)?(?:exhausted|fail(?:s|ed)?)|"
+    r"(?:the\s+)?(?:retry\s+)?limit\s+"
+    r"(?:(?:is|has\s+been)\s+)?(?:reached|exceeded|exhausted)|"
+    r"(?:the\s+)?max(?:imum)?\s+number\s+of\s+attempts?\s+"
+    r"(?:(?:is|has\s+been)\s+)?(?:reached|exceeded|exhausted)|"
+    r"(?:the\s+)?(?:connection\s+)?(?:error|exception|failure)\s+"
+    r"(?:still\s+)?(?:persists?|remains?)\s+after\s+(?:the\s+)?"
+    r"\d+(?:st|nd|rd|th)\s+(?:retry\s+)?attempt|"
+    r"(?:the\s+)?\d+(?:st|nd|rd|th)\s+(?:retry\s+)?attempt\s+"
+    r"(?:(?:also|still)\s+)?fails?"
+    r")\s*$",
+    re.IGNORECASE,
 )
 
 
@@ -222,105 +234,98 @@ def _judge_retry_bound(prompt_output: str) -> JudgmentResult:
     )
 
 
-def _retry_sentences(prompt_output: str) -> tuple[str, ...]:
-    """Split prose at terminal punctuation while retaining action continuations."""
+def _retry_units(prompt_output: str) -> tuple[str, ...]:
+    """Split prose into ordered comma, semicolon, and sentence units."""
     return tuple(
-        match.group(0).strip()
-        for match in _RETRY_SENTENCE_PATTERN.finditer(prompt_output)
-        if match.group(0).strip()
+        match.group(0).rstrip(" ,;.!?\t\r\n").strip()
+        for match in _RETRY_UNIT_PATTERN.finditer(prompt_output)
+        if match.group(0).rstrip(" ,;.!?\t\r\n").strip()
     )
 
 
 def _fallback_action_state(text: str) -> tuple[bool, bool]:
-    """Classify explicit fallback actions within one ordered text span."""
-    condition_tail = _CONDITION_TAIL_PATTERN.match(text)
-    if condition_tail:
-        text = text[condition_tail.end() :]
+    """Classify one self-contained action unit as affirmative or rejected."""
+    text = text.strip(" ,;:.!?\t\r\n")
     if _RETRY_CONTINUATION_PATTERN.search(text):
         return False, True
     if _SUCCESS_RETURN_PATTERN.search(text):
         return False, True
+    if _REJECTED_ACTION_PATTERN.search(text):
+        return False, True
 
-    actions = sorted(
-        (
-            action
-            for pattern in _FALLBACK_ACTION_PATTERNS
-            for action in pattern.finditer(text)
-        ),
-        key=lambda action: action.start(),
+    candidates = [text]
+    coordinated = re.split(r"\band\b", text, flags=re.IGNORECASE)[-1].strip()
+    if coordinated != text:
+        candidates.append(coordinated)
+    affirmative = any(
+        pattern.fullmatch(candidate)
+        for candidate in candidates
+        for pattern in (*_DIRECT_ACTION_PATTERNS, _MODAL_ACTION_PATTERN)
     )
-    if not actions:
-        return False, False
+    return affirmative, False
 
-    affirmative = False
-    for action in actions:
-        prefix = text[: action.start()]
-        if _NEGATED_FALLBACK_ACTION_PATTERN.search(prefix):
+
+def _inverse_action_state(unit: str) -> tuple[bool, bool]:
+    """Classify only a self-contained ``ACTION when EXHAUSTED`` unit."""
+    connectors = tuple(re.finditer(r"\b(?:when|once|after)\b", unit, re.IGNORECASE))
+    for connector in reversed(connectors):
+        condition = unit[connector.start() :].strip()
+        if not _INVERSE_EXHAUSTION_PATTERN.fullmatch(condition):
             continue
-        if not _ACTION_LEAD_PATTERN.fullmatch(prefix):
-            continue
-        affirmative = True
-
-    return affirmative, not affirmative
-
-
-def _has_action_before_exhaustion(sentence: str, exhaustion: re.Match[str]) -> bool:
-    """Accept explicit ``ACTION when EXHAUSTED`` grammar in one sentence."""
-
-    def has_affirmative_action(action_text: str) -> bool:
+        action_text = unit[: connector.start()].strip()
         action, rejected = _fallback_action_state(action_text)
-        if action and not rejected:
-            return True
-        continuation = re.split(r"\band\b", action_text, flags=re.IGNORECASE)[-1]
-        if continuation == action_text:
-            return False
-        action, rejected = _fallback_action_state(continuation)
-        return action and not rejected
+        return action, rejected
+    return False, False
 
-    prefix = sentence[: exhaustion.start()]
-    if re.match(r"\s*(?:after|once|when)\b", exhaustion.group(), re.IGNORECASE):
-        action_text = prefix.strip(" ,;:-")
-        if not action_text or _CONDITIONAL_PREFIX_PATTERN.match(action_text):
-            return False
-        return has_affirmative_action(action_text)
 
-    connectors = tuple(_ACTION_CONNECTOR_PATTERN.finditer(prefix))
-    if not connectors:
+def _is_immediate_contradiction(units: tuple[str, ...], index: int) -> bool:
+    """Return whether the unit immediately after an action contradicts it."""
+    if index + 1 >= len(units):
         return False
-
-    connector = connectors[-1]
-    action_text = prefix[: connector.start()].strip(" ,;:-")
-    condition_bridge = prefix[connector.end() :]
-    if not action_text or len(condition_bridge) > 80:
-        return False
-    if _CONDITIONAL_PREFIX_PATTERN.match(action_text):
-        return False
-
-    return has_affirmative_action(action_text)
+    _, rejected = _fallback_action_state(units[index + 1])
+    return rejected
 
 
 def _judge_retry_fallback(prompt_output: str) -> JudgmentResult:
     """Check that retry exhaustion has explicit fallback behavior."""
-    sentences = _retry_sentences(prompt_output)
+    units = _retry_units(prompt_output)
     has_exhaustion = False
     has_action = False
-    for index, sentence in enumerate(sentences):
-        for exhaustion in _RETRY_EXHAUSTION_PATTERN.finditer(sentence):
+    for index, unit in enumerate(units):
+        for exhaustion in _RETRY_EXHAUSTION_PATTERN.finditer(unit):
             has_exhaustion = True
-            suffix = sentence[exhaustion.end() :]
+            suffix = unit[exhaustion.end() :]
             action, rejected = _fallback_action_state(suffix)
-            if action and not rejected:
+            if (
+                action
+                and not rejected
+                and not _is_immediate_contradiction(units, index)
+            ):
                 has_action = True
                 break
-            if _has_action_before_exhaustion(sentence, exhaustion):
+            action, rejected = _inverse_action_state(unit)
+            if (
+                action
+                and not rejected
+                and not _is_immediate_contradiction(units, index)
+            ):
                 has_action = True
                 break
-            if rejected or not _CONNECTIVE_ONLY_PATTERN.fullmatch(suffix):
+            if rejected or suffix.strip():
                 continue
-            if index + 1 >= len(sentences):
+            action_index = index + 1
+            if action_index < len(units) and _CONNECTIVE_ONLY_PATTERN.fullmatch(
+                units[action_index]
+            ):
+                action_index += 1
+            if action_index >= len(units):
                 continue
-            action, rejected = _fallback_action_state(sentences[index + 1])
-            if action and not rejected:
+            action, rejected = _fallback_action_state(units[action_index])
+            if (
+                action
+                and not rejected
+                and not _is_immediate_contradiction(units, action_index)
+            ):
                 has_action = True
                 break
         if has_action:
@@ -721,6 +726,96 @@ class TestDeterministicChangeJudges:
         judgment = _judge_retry_fallback(guidance)
 
         assert not judgment.passed
+
+    @pytest.mark.parametrize(
+        "guidance",
+        (
+            "Log parsing error when validation fails; if retries are exhausted, "
+            "keep retrying.",
+            "If retries are exhausted, raising the exception is forbidden.",
+            "Raise no error when retries are exhausted.",
+            "If retries are exhausted, logs indicate an error.",
+            "If retries are exhausted. Raise an error. Keep retrying.",
+            "Log the parsing error when validation fails; if all retry attempts "
+            "are exhausted, keep retrying.",
+            "If all retry attempts are exhausted, raising the exception is forbidden.",
+            "If all retry attempts are exhausted, raising the exception is prohibited.",
+            "Raise no error when all retry attempts are exhausted.",
+            "If all retry attempts are exhausted, logs indicate an error.",
+            "If all retry attempts are exhausted. Raise the final error. Keep retrying.",
+            "If all retry attempts are exhausted, immediately raise no error.",
+            "If all retry attempts are exhausted, raise the final error under no circumstances.",
+            "If all retry attempts are exhausted, raise the final error without surfacing it.",
+            "If all retry attempts are exhausted, raise the final error; continue normally.",
+            "If all retry attempts are exhausted. Raise the final error. Return success.",
+            "If all retry attempts are exhausted. Raise the final error; continue retrying.",
+        ),
+    )
+    def test_retry_fallback_judge_rejects_postposed_negation_and_contradiction(
+        self, guidance: str
+    ) -> None:
+        """Negation and immediate contradictions dominate an apparent action."""
+        judgment = _judge_retry_fallback(guidance)
+
+        assert not judgment.passed
+
+    @pytest.mark.parametrize(
+        "guidance",
+        (
+            "If all retry attempts are exhausted, immediately raise the error.",
+            "If all retry attempts are exhausted, the runner must immediately raise the error.",
+            "If all retry attempts are exhausted, gracefully abort the operation.",
+            "Immediately re-raise the exception when all retry attempts are exhausted.",
+            "The runner must gracefully propagate the error once retries are exhausted.",
+            "Surface a clear error immediately after all retry attempts are exhausted.",
+            "When all retry attempts fail, immediately return an error result.",
+            "When all retry attempts fail, clearly log the final error.",
+            "When the retry limit is reached, gracefully use cached data as the fallback.",
+            "After all retries are exhausted; fall back to cached data.",
+        ),
+    )
+    def test_retry_fallback_judge_accepts_modal_and_adverbial_actions(
+        self, guidance: str
+    ) -> None:
+        """Bounded modal and adverb prefixes preserve affirmative actions."""
+        judgment = _judge_retry_fallback(guidance)
+
+        assert judgment.passed, judgment.reasoning
+
+    @pytest.mark.parametrize("action_before", (False, True))
+    @pytest.mark.parametrize("same_clause", (False, True))
+    @pytest.mark.parametrize("negated", (False, True))
+    @pytest.mark.parametrize("contradiction", (False, True))
+    def test_retry_fallback_clause_state_cross_product(
+        self,
+        action_before: bool,
+        same_clause: bool,
+        negated: bool,
+        contradiction: bool,
+    ) -> None:
+        """Pairing, order, negation, and contradiction define acceptance."""
+        action = (
+            "must not raise the final error"
+            if negated
+            else "must immediately raise the final error"
+        )
+        if same_clause and action_before:
+            guidance = f"The runner {action} when all retry attempts are exhausted."
+        elif same_clause:
+            guidance = f"When all retry attempts are exhausted, the runner {action}."
+        elif action_before:
+            guidance = f"The runner {action}. When all retry attempts are exhausted."
+        else:
+            guidance = f"When all retry attempts are exhausted. The runner {action}."
+        if contradiction:
+            guidance += " Keep retrying."
+
+        judgment = _judge_retry_fallback(guidance)
+
+        expected = (
+            not negated and not contradiction and (same_clause or not action_before)
+        )
+        assert judgment.passed is expected, guidance
 
 
 @pytest.mark.real

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -876,6 +876,8 @@ class TestDeterministicChangeJudges:
             "If retries are exhausted, the runner needs to raise the error.",
             "If retries are exhausted, the runner ought to raise the error.",
             "Keep retrying until all retries are exhausted; then raise the error.",
+            "Retry up to 3 times. Retry until all attempts are exhausted; then raise the error.",
+            "Retry up to 3 times. For safety, do not retry again; raise the error.",
         ),
     )
     def test_retry_fallback_judge_accepts_canonical_exhaustion_forms(

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -433,6 +433,33 @@ class TestDeterministicChangeJudges:
                 "available for inspection."
             ),
             "If all 3 attempts fail, fallback diagnostics remain available.",
+            (
+                "If fetch_data raises a connection error, retry from the "
+                "beginning. Use a maximum of 3 attempts. If the connection "
+                "error persists after the 3rd attempt, keep retrying."
+            ),
+            (
+                "Use a maximum of 3 attempts. If the connection error persists "
+                "after the 3rd attempt, return success."
+            ),
+            (
+                "Use a maximum of 3 attempts. If the connection error persists "
+                "after the 3rd attempt, do not raise it; keep retrying."
+            ),
+            (
+                "Use a maximum of 3 attempts. If the connection error persists "
+                "after the 3rd attempt, avoid raising the exception."
+            ),
+            (
+                "Log each fetch attempt for diagnostics. Use a maximum of 3 "
+                "attempts. If the connection error persists after the 3rd "
+                "attempt, keep retrying."
+            ),
+            (
+                "Use a maximum of 3 attempts. If the connection error persists "
+                "after the 3rd attempt, keep retrying. Separately, log request "
+                "metrics."
+            ),
         ),
     )
     def test_retry_fallback_judge_rejects_non_fallback_conditions(

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -110,6 +110,22 @@ _RETRY_EXHAUSTION_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+_NON_EXHAUSTION_PREFIX_PATTERN = re.compile(
+    r"(?:\bbefore|\bunless|\buntil|\bprior\s+to|\bnot)\s*$",
+    re.IGNORECASE,
+)
+
+_STOP_RETRYING_EXHAUSTION_PATTERN = re.compile(
+    r"(?:do\s+not|don['’]t|must\s+not|mustn['’]t)\s+"
+    r"(?:retry(?:\s+again)?|continue\s+retrying)",
+    re.IGNORECASE,
+)
+
+_CONDITIONAL_UNIT_PATTERN = re.compile(
+    r"^\s*(?:if|when|unless|before|until|provided\s+that)\b",
+    re.IGNORECASE,
+)
+
 _RETRY_UNIT_PATTERN = re.compile(r"[^,;.!?]+(?:[,;.!?]+|$)", re.DOTALL)
 
 _RETRY_CONTINUATION_PATTERN = re.compile(
@@ -173,7 +189,9 @@ _DIRECT_ACTION_PATTERNS = tuple(
 _MODAL_PREFIX_PATTERN = re.compile(
     rf"^\s*{_ACTION_INTRO}(?:(?:the|a|an|this|that)\s+)?"
     rf"(?:[\w`.-]+\s+){{1,8}}"
-    rf"(?:(?:must|should|shall|will|would|can|could|may|might)\s+"
+    rf"(?:(?:is|are)\s+required\s+to\s+{_ACTION_ADVERBS}|"
+    rf"(?:needs?|ought)\s+to\s+{_ACTION_ADVERBS}|"
+    rf"(?:must|should|shall|will|would|can|could|may|might)\s+"
     rf"{_ACTION_ADVERBS}(?:be\s+{_ACTION_ADVERBS})?|"
     rf"(?:has|have)\s+to\s+{_ACTION_ADVERBS}|(?:is|are)\s+{_ACTION_ADVERBS})"
     r"(?P<action>.+?)\s*$",
@@ -300,6 +318,26 @@ def _is_immediate_contradiction(units: tuple[str, ...], index: int) -> bool:
     return rejected
 
 
+def _has_affirmative_exhaustion(text: str) -> bool:
+    """Return whether *text* names exhaustion without negating or preposing it."""
+    return any(
+        not _NON_EXHAUSTION_PREFIX_PATTERN.search(text[: match.start()])
+        and not _STOP_RETRYING_EXHAUSTION_PATTERN.fullmatch(match.group())
+        for match in _RETRY_EXHAUSTION_PATTERN.finditer(text)
+    )
+
+
+def _stop_exhaustion_has_retry_context(
+    units: tuple[str, ...], index: int, unit_prefix: str
+) -> bool:
+    """Reject stop-only guidance inherited from an unrelated conditional branch."""
+    if unit_prefix.strip() and not _has_affirmative_exhaustion(unit_prefix):
+        return False
+    if index == 0 or not _CONDITIONAL_UNIT_PATTERN.match(units[index - 1]):
+        return True
+    return _has_affirmative_exhaustion(units[index - 1])
+
+
 def _judge_retry_fallback(prompt_output: str) -> JudgmentResult:
     """Check that retry exhaustion has explicit fallback behavior."""
     units = _retry_units(prompt_output)
@@ -307,6 +345,13 @@ def _judge_retry_fallback(prompt_output: str) -> JudgmentResult:
     has_action = False
     for index, unit in enumerate(units):
         for exhaustion in _RETRY_EXHAUSTION_PATTERN.finditer(unit):
+            prefix = unit[: exhaustion.start()]
+            if _NON_EXHAUSTION_PREFIX_PATTERN.search(prefix):
+                continue
+            if _STOP_RETRYING_EXHAUSTION_PATTERN.fullmatch(exhaustion.group()) and not (
+                _stop_exhaustion_has_retry_context(units, index, prefix)
+            ):
+                continue
             has_exhaustion = True
             suffix = unit[exhaustion.end() :]
             action, rejected = _fallback_action_state(suffix)

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -381,6 +381,52 @@ class TestDeterministicChangeJudges:
         assert not missing.passed
         assert "exhaust" in missing.reasoning
 
+    @pytest.mark.parametrize(
+        "guidance",
+        (
+            (
+                "The runner must allow for a maximum of 3 attempts. If the "
+                "connection error persists after the 3rd attempt, run_pipeline "
+                "must raise the exception to the user."
+            ),
+            "If the error remains after the 3rd attempt, raise it.",
+            "When the exception persists after the 4th retry attempt, abort.",
+            "When the exception remains after the 4th attempt, surface it.",
+            "If failure persists after the 2nd attempt, return an error result.",
+            "If the failure remains after the 2nd retry attempt, propagate it.",
+        ),
+    )
+    def test_retry_fallback_judge_accepts_persistent_ordinal_failure(
+        self, guidance: str
+    ) -> None:
+        """Persistent failure at the final ordinal attempt is exhaustion."""
+        judgment = _judge_retry_fallback(guidance)
+
+        assert judgment.passed, judgment.reasoning
+
+    @pytest.mark.parametrize(
+        "guidance",
+        (
+            (
+                "If the connection error does not persist after the 3rd "
+                "attempt, return success."
+            ),
+            "If the connection error persists after the 3rd attempt, keep retrying.",
+            "If all 3 attempts fail, keep retrying.",
+            (
+                "If all 3 attempts fail, the final connection error remains "
+                "available for inspection."
+            ),
+        ),
+    )
+    def test_retry_fallback_judge_rejects_non_fallback_conditions(
+        self, guidance: str
+    ) -> None:
+        """Failure state alone, negation, or continued retry is no fallback."""
+        judgment = _judge_retry_fallback(guidance)
+
+        assert not judgment.passed
+
 
 @pytest.mark.real
 class TestCallSiteEnumeration:

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -852,6 +852,7 @@ class TestDeterministicChangeJudges:
             "If retries are exhausted, the runner is required to raise the error.",
             "If retries are exhausted, the runner needs to raise the error.",
             "If retries are exhausted, the runner ought to raise the error.",
+            "Keep retrying until all retries are exhausted; then raise the error.",
         ),
     )
     def test_retry_fallback_judge_accepts_canonical_exhaustion_forms(
@@ -877,6 +878,14 @@ class TestDeterministicChangeJudges:
             "Prior to retry exhaustion, return an error.",
             "Retry 3 times. If authentication fails, do not retry; raise an auth error.",
             "Retry 3 times. If input is invalid, must not retry; raise a validation error.",
+            "Retry 3 times. For invalid input, must not retry; return a validation error.",
+            "Retry 3 times. On auth failure, do not retry; return an auth error.",
+            "Retry 3 times. For invalid input. Then. Must not retry; return an error.",
+            "Except when retries are exhausted, raise the error.",
+            "Fewer than all retries are exhausted, raise the error.",
+            "If retries are exhausted. Raise the error. And then. Keep retrying.",
+            "If retries are exhausted. Raise the error. But then. Keep retrying.",
+            "If retries are exhausted. Raise the error. Nevertheless. Keep retrying.",
         ),
     )
     def test_retry_fallback_judge_rejects_unrelated_or_deferred_actions(

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -70,8 +70,10 @@ _RETRY_EXHAUSTION_PATTERN = re.compile(
     r"after\s+all\s+(?:retry\s+)?attempts?|"
     r"after\s+all\s+retries|"
     r"after\s+\d+\s+(?:failed\s+)?(?:retry\s+)?attempts?|"
-    r"all\s+(?:retry\s+)?attempts?.{0,80}(?:fail|error|exception)|"
-    r"all\s+\d+\s+(?:retry\s+)?attempts?.{0,80}(?:fail|error|exception)|"
+    r"all\s+(?:retry\s+)?attempts?\s+"
+    r"(?:(?:have|has|are|were)\s+)?fail(?:s|ed)?|"
+    r"all\s+\d+\s+(?:retry\s+)?attempts?\s+"
+    r"(?:(?:have|has|are|were)\s+)?fail(?:s|ed)?|"
     r"(?:if|when)\s+[\w\s]+fail(?:s|ed)?\s+on\s+(?:the\s+)?"
     r"\d+(?:st|nd|rd|th)\s+attempt|"
     r"(?:if|when)\s+(?:the\s+)?\d+(?:st|nd|rd|th)\s+attempt\s+"
@@ -87,52 +89,61 @@ _RETRY_EXHAUSTION_PATTERN = re.compile(
     r"(?:retry\s+)?limit\s+(?:is\s+|has\s+been\s+)?(?:reached|exceeded)|"
     r"(?:final|last)\s+(?:retry\s+)?attempt|"
     r"if\s+(?:it\s+)?still\s+fail(?:s|ed)?|"
-    r"still\s+(?:encounter|encounters|raise|raises)\s+"
-    r"(?:a\s+)?(?:connection\s+)?(?:error|exception)|"
-    r"final\s+(?:connection\s+)?(?:error|exception)|"
     r"when\s+(?:all\s+)?(?:retry\s+)?attempts?\s+fail|"
     r"stop\s+retrying"
     r")\b",
     re.IGNORECASE,
 )
 
-_FALLBACK_ACTION_PATTERN = re.compile(
-    r"\b(?:"
-    r"(?:re-?)?rais(?:e|es|ed|ing)|"
-    r"return(?:s|ed|ing)?|"
-    r"log(?:s|ged|ging)?|"
-    r"skip(?:s|ped|ping)?|"
-    r"abort(?:s|ed|ing)?|"
-    r"surfac(?:e|es|ed|ing)|"
-    r"propagat(?:e|es|ed|ing)"
-    r")\b|"
-    r"\buse(?:s|d|ing)?\s+(?:(?:a|the)\s+)?fallback\b|"
-    r"\b(?:fall(?:s|ing)?|fell)\s+back\b|"
-    r"\bfail(?:s|ed|ing)?\s+closed\b",
-    re.IGNORECASE,
+_FALLBACK_ACTION_PATTERNS = (
+    re.compile(r"\b(?:re[- ]?)?rais(?:e|es|ed|ing)\b", re.IGNORECASE),
+    re.compile(r"\b(?:surfac|propagat)(?:e|es|ed|ing)\b", re.IGNORECASE),
+    re.compile(r"\b(?:abort|skip)(?:s|ped|ping|ed|ing)?\b", re.IGNORECASE),
+    re.compile(
+        r"\breturn(?:s|ed|ing)?\b.{0,48}\b(?:error|exception|failure)\b",
+        re.IGNORECASE | re.DOTALL,
+    ),
+    re.compile(
+        r"\blog(?:s|ged|ging)?\b.{0,48}\b(?:error|exception|failure)\b",
+        re.IGNORECASE | re.DOTALL,
+    ),
+    re.compile(
+        r"\bfail(?:s|ed|ing)?\s+with\b.{0,48}\b(?:error|exception|failure)\b",
+        re.IGNORECASE | re.DOTALL,
+    ),
+    re.compile(
+        r"\buse(?:s|d|ing)?\b.{1,64}\bas\s+(?:the\s+)?fallback\b",
+        re.IGNORECASE | re.DOTALL,
+    ),
+    re.compile(r"\b(?:fallback|fall\s+back)\s+to\b", re.IGNORECASE),
+    re.compile(r"\bfail(?:s|ed|ing)?\s+closed\b", re.IGNORECASE),
 )
 
-_RETRY_CLAUSE_PATTERN = re.compile(r"[^,;.!?]+(?:[,;.!?]+|$)", re.DOTALL)
+_RETRY_SENTENCE_PATTERN = re.compile(r"[^.!?]+(?:[.!?]+|$)", re.DOTALL)
 
 _RETRY_CONTINUATION_PATTERN = re.compile(
     r"\b(?:keep(?:s|ing)?|continu(?:e|es|ed|ing)|resum(?:e|es|ed|ing))\s+"
     r"(?:(?:to|with)\s+)?(?:retry(?:ing)?|retries)\b|"
     r"\btry\s+again\b|"
-    r"\banother\s+(?:retry\s+)?attempt\b",
+    r"\banother\s+(?:retry\s+)?attempt\b|"
+    r"\bcontinu(?:e|es|ed|ing)\s+(?:processing\s+)?normally\b",
     re.IGNORECASE,
 )
 
 _NEGATED_FALLBACK_ACTION_PATTERN = re.compile(
     r"(?:"
+    r"\bunder\s+no\s+circumstances\b.{0,96}|"
     r"\b(?:do|does|did|must|should|shall|will|would|can|could|may|might)\s+"
-    r"not\s+(?:ever\s+|to\s+)?|"
-    r"\bnot\s+(?:ever\s+|to\s+)?|"
-    r"\bnever\s+|"
-    r"\bavoid(?:s|ed|ing)?\s+|"
-    r"\bwithout\s+|"
-    r"\brefrain(?:s|ed|ing)?\s+from\s+"
+    r"not\b.{0,64}|"
+    r"\b(?:mustn|shouldn|shan|won|wouldn|can|couldn|mayn|mightn)['’]t\b.{0,64}|"
+    r"\bcannot\b.{0,64}|"
+    r"\bnot\s+(?:ever\s+|to\s+)?.{0,64}|"
+    r"\bnever\b.{0,64}|"
+    r"\bavoid(?:s|ed|ing)?\b.{0,64}|"
+    r"\bwithout\b.{0,64}|"
+    r"\brefrain(?:s|ed|ing)?\s+from\b.{0,64}"
     r")$",
-    re.IGNORECASE,
+    re.IGNORECASE | re.DOTALL,
 )
 
 _SUCCESS_RETURN_PATTERN = re.compile(
@@ -141,10 +152,34 @@ _SUCCESS_RETURN_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-_UNRELATED_ACTION_PREFIX_PATTERN = re.compile(
-    r"^\s*(?:separately|independently|elsewhere|unrelated(?:ly)?|"
-    r"for\s+diagnostics(?:\s+only)?)\b",
+_ACTION_CONNECTOR_PATTERN = re.compile(r"\b(?:after|once|when)\b", re.IGNORECASE)
+
+_CONDITIONAL_PREFIX_PATTERN = re.compile(
+    r"^\s*(?:if|when|whenever|unless|while)\b", re.IGNORECASE
+)
+
+_ACTION_LEAD_PATTERN = re.compile(
+    r"^[\s,;:\-]*(?:(?:then|otherwise|stop\s+retrying\s+and|"
+    r"as\s+(?:a|the)\s+fallback)"
+    r"[\s,;:\-]*)?(?:"
+    r"allow(?:s|ed|ing)?\b.{0,48}\bto\s+|"
+    r"(?:(?:the|a|an|this|that)\s+)?(?:[\w`.-]+\s+){1,8}"
+    r"(?:(?:must|should|shall|will|would|can|could|may|might)"
+    r"(?:\s+be)?|(?:has|have)\s+to|is|are|be)\s+"
+    r")?$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_CONNECTIVE_ONLY_PATTERN = re.compile(
+    r"^[\s,;:.!?\-]*(?:(?:then|otherwise|as\s+(?:a|the)\s+fallback)"
+    r"[\s,;:.!?\-]*)?$",
     re.IGNORECASE,
+)
+
+_CONDITION_TAIL_PATTERN = re.compile(
+    r"^\s*(?:(?:with|from|due\s+to|because\s+of)\b|"
+    r"still\s+(?:encounters?|raises?|has)\b)[^,;]{0,80}[,;]",
+    re.IGNORECASE | re.DOTALL,
 )
 
 
@@ -187,57 +222,108 @@ def _judge_retry_bound(prompt_output: str) -> JudgmentResult:
     )
 
 
-def _retry_clauses(prompt_output: str) -> tuple[str, ...]:
-    """Split prose into bounded clauses without losing fallback punctuation."""
+def _retry_sentences(prompt_output: str) -> tuple[str, ...]:
+    """Split prose at terminal punctuation while retaining action continuations."""
     return tuple(
         match.group(0).strip()
-        for match in _RETRY_CLAUSE_PATTERN.finditer(prompt_output)
+        for match in _RETRY_SENTENCE_PATTERN.finditer(prompt_output)
         if match.group(0).strip()
     )
 
 
-def _fallback_action_state(clause: str) -> tuple[bool, bool]:
-    """Return whether a clause has an affirmative action or rejects fallback."""
-    if _RETRY_CONTINUATION_PATTERN.search(clause):
+def _fallback_action_state(text: str) -> tuple[bool, bool]:
+    """Classify explicit fallback actions within one ordered text span."""
+    condition_tail = _CONDITION_TAIL_PATTERN.match(text)
+    if condition_tail:
+        text = text[condition_tail.end() :]
+    if _RETRY_CONTINUATION_PATTERN.search(text):
         return False, True
-    if _UNRELATED_ACTION_PREFIX_PATTERN.search(clause):
+    if _SUCCESS_RETURN_PATTERN.search(text):
         return False, True
 
+    actions = sorted(
+        (
+            action
+            for pattern in _FALLBACK_ACTION_PATTERNS
+            for action in pattern.finditer(text)
+        ),
+        key=lambda action: action.start(),
+    )
+    if not actions:
+        return False, False
+
     affirmative = False
-    rejected = False
-    for action in _FALLBACK_ACTION_PATTERN.finditer(clause):
-        prefix = clause[max(0, action.start() - 48) : action.start()]
+    for action in actions:
+        prefix = text[: action.start()]
         if _NEGATED_FALLBACK_ACTION_PATTERN.search(prefix):
-            rejected = True
             continue
-        if _SUCCESS_RETURN_PATTERN.match(clause, action.start()):
-            rejected = True
+        if not _ACTION_LEAD_PATTERN.fullmatch(prefix):
             continue
         affirmative = True
 
-    if rejected:
-        return False, True
-    return affirmative, False
+    return affirmative, not affirmative
+
+
+def _has_action_before_exhaustion(sentence: str, exhaustion: re.Match[str]) -> bool:
+    """Accept explicit ``ACTION when EXHAUSTED`` grammar in one sentence."""
+
+    def has_affirmative_action(action_text: str) -> bool:
+        action, rejected = _fallback_action_state(action_text)
+        if action and not rejected:
+            return True
+        continuation = re.split(r"\band\b", action_text, flags=re.IGNORECASE)[-1]
+        if continuation == action_text:
+            return False
+        action, rejected = _fallback_action_state(continuation)
+        return action and not rejected
+
+    prefix = sentence[: exhaustion.start()]
+    if re.match(r"\s*(?:after|once|when)\b", exhaustion.group(), re.IGNORECASE):
+        action_text = prefix.strip(" ,;:-")
+        if not action_text or _CONDITIONAL_PREFIX_PATTERN.match(action_text):
+            return False
+        return has_affirmative_action(action_text)
+
+    connectors = tuple(_ACTION_CONNECTOR_PATTERN.finditer(prefix))
+    if not connectors:
+        return False
+
+    connector = connectors[-1]
+    action_text = prefix[: connector.start()].strip(" ,;:-")
+    condition_bridge = prefix[connector.end() :]
+    if not action_text or len(condition_bridge) > 80:
+        return False
+    if _CONDITIONAL_PREFIX_PATTERN.match(action_text):
+        return False
+
+    return has_affirmative_action(action_text)
 
 
 def _judge_retry_fallback(prompt_output: str) -> JudgmentResult:
     """Check that retry exhaustion has explicit fallback behavior."""
-    clauses = _retry_clauses(prompt_output)
+    sentences = _retry_sentences(prompt_output)
     has_exhaustion = False
     has_action = False
-    for index, clause in enumerate(clauses):
-        if not _RETRY_EXHAUSTION_PATTERN.search(clause):
-            continue
-        has_exhaustion = True
-        action, rejected = _fallback_action_state(clause)
-        if action and not rejected:
-            has_action = True
-            break
-        if rejected or index + 1 >= len(clauses):
-            continue
-        action, rejected = _fallback_action_state(clauses[index + 1])
-        if action and not rejected:
-            has_action = True
+    for index, sentence in enumerate(sentences):
+        for exhaustion in _RETRY_EXHAUSTION_PATTERN.finditer(sentence):
+            has_exhaustion = True
+            suffix = sentence[exhaustion.end() :]
+            action, rejected = _fallback_action_state(suffix)
+            if action and not rejected:
+                has_action = True
+                break
+            if _has_action_before_exhaustion(sentence, exhaustion):
+                has_action = True
+                break
+            if rejected or not _CONNECTIVE_ONLY_PATTERN.fullmatch(suffix):
+                continue
+            if index + 1 >= len(sentences):
+                continue
+            action, rejected = _fallback_action_state(sentences[index + 1])
+            if action and not rejected:
+                has_action = True
+                break
+        if has_action:
             break
 
     if has_exhaustion and has_action:
@@ -507,6 +593,33 @@ class TestDeterministicChangeJudges:
     @pytest.mark.parametrize(
         "guidance",
         (
+            "If the error remains after the 3rd attempt; as a fallback, return an error result.",
+            "If the error remains after the 3rd attempt, as a fallback, return an error.",
+            "If the error remains after the 3rd attempt. As a fallback, return an error.",
+            "If all retry attempts are exhausted, fail with a clear error.",
+            "If all retry attempts are exhausted; use cached data as the fallback.",
+            "If all retry attempts are exhausted. Fallback to cached data.",
+            "Raise the final error when retries are exhausted.",
+            "Re-raise the exception when all retry attempts are exhausted!",
+            "Propagate the exception once the maximum retry attempts are exhausted.",
+            "Surface a clear error when all retry attempts fail.",
+            "Abort the operation after all retries are exhausted.",
+            "Skip the record when the retry limit is reached.",
+            "Log the final error when all retry attempts fail.",
+            "Return an error result when retries are exhausted.",
+        ),
+    )
+    def test_retry_fallback_judge_preserves_explicit_fallback_grammar(
+        self, guidance: str
+    ) -> None:
+        """Explicit fallback actions remain valid across punctuation forms."""
+        judgment = _judge_retry_fallback(guidance)
+
+        assert judgment.passed, judgment.reasoning
+
+    @pytest.mark.parametrize(
+        "guidance",
+        (
             (
                 "If the connection error does not persist after the 3rd "
                 "attempt, return success."
@@ -549,6 +662,55 @@ class TestDeterministicChangeJudges:
                 "Use a maximum of 3 attempts. If the connection error persists "
                 "after the 3rd attempt, keep retrying. Separately, log request "
                 "metrics."
+            ),
+            (
+                "If fetch_data raises a connection error and if the connection "
+                "error persists after the 3rd attempt."
+            ),
+            (
+                "If the connection error persists after the 3rd attempt, under "
+                "no circumstances should the runner raise the final error."
+            ),
+            (
+                "If the connection error persists after the 3rd attempt; the "
+                "runner mustn't raise the final error."
+            ),
+            (
+                "If the connection error persists after the 3rd attempt. The "
+                "runner cannot raise the final error."
+            ),
+            (
+                "If the connection error persists after the 3rd attempt, do not "
+                "raise the final error."
+            ),
+            (
+                "If the connection error persists after the 3rd attempt; avoid "
+                "raising the final error."
+            ),
+            (
+                "If the connection error persists after the 3rd attempt. Continue "
+                "without raising the final error."
+            ),
+            (
+                "If the connection error persists after the 3rd attempt. Continue "
+                "processing normally. Record the final error in logs for later "
+                "inspection."
+            ),
+            (
+                "If the connection error persists after the 3rd attempt; continue "
+                "normally, then log request metrics."
+            ),
+            (
+                "If the connection error persists after the 3rd attempt. Return "
+                "success."
+            ),
+            (
+                "If the connection error persists after the 3rd attempt and if "
+                "fetch_data raises another connection error."
+            ),
+            (
+                "If the connection error persists after the 3rd attempt; inspect "
+                "the request metrics; log the final error."
             ),
         ),
     )

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -804,6 +804,9 @@ class TestDeterministicChangeJudges:
             "If the final attempt still encounters a connection error re-raise the exception.",
             "Do not retry again; raise the final error.",
             "Do not continue retrying and raise the final error.",
+            "If retries are exhausted, the runner is required to raise the error.",
+            "If retries are exhausted, the runner needs to raise the error.",
+            "If retries are exhausted, the runner ought to raise the error.",
         ),
     )
     def test_retry_fallback_judge_accepts_canonical_exhaustion_forms(
@@ -823,6 +826,12 @@ class TestDeterministicChangeJudges:
             "If retries are exhausted. Raise the error. Then, keep retrying.",
             "If retries are exhausted. Raise the error. Otherwise, continue normally.",
             "If retries are exhausted. Raise the error. However, keep retrying.",
+            "Before all retries are exhausted, raise the error.",
+            "Unless retries are exhausted, raise the error.",
+            "If not all attempts fail, raise the error.",
+            "Prior to retry exhaustion, return an error.",
+            "Retry 3 times. If authentication fails, do not retry; raise an auth error.",
+            "Retry 3 times. If input is invalid, must not retry; raise a validation error.",
         ),
     )
     def test_retry_fallback_judge_rejects_unrelated_or_deferred_actions(

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -111,9 +111,12 @@ _RETRY_EXHAUSTION_PATTERN = re.compile(
 )
 
 _NON_EXHAUSTION_PREFIX_PATTERN = re.compile(
-    r"(?:\bbefore|\bunless|\buntil|\bprior\s+to|\bnot)\s*$",
+    r"(?:\bbefore|\bunless|\bprior\s+to|\bnot|\bexcept(?:\s+when)?|"
+    r"\b(?:fewer|less)\s+than)\s*$",
     re.IGNORECASE,
 )
+
+_UNTIL_EXHAUSTION_PREFIX_PATTERN = re.compile(r"\buntil\s*$", re.IGNORECASE)
 
 _STOP_RETRYING_EXHAUSTION_PATTERN = re.compile(
     r"(?:do\s+not|don['’]t|must\s+not|mustn['’]t)\s+"
@@ -122,7 +125,7 @@ _STOP_RETRYING_EXHAUSTION_PATTERN = re.compile(
 )
 
 _CONDITIONAL_UNIT_PATTERN = re.compile(
-    r"^\s*(?:if|when|unless|before|until|provided\s+that)\b",
+    r"^\s*(?:if|when|unless|before|until|for|on|upon|in\s+case|provided\s+that)\b",
     re.IGNORECASE,
 )
 
@@ -162,7 +165,8 @@ _SUCCESS_RETURN_PATTERN = re.compile(
 )
 
 _CONNECTIVE_ONLY_PATTERN = re.compile(
-    r"^\s*(?:then|otherwise|however|but|as\s+(?:a|the)\s+fallback)?\s*$",
+    r"^\s*(?:then|(?:and|but)\s+then|otherwise|however|but|nevertheless|"
+    r"as\s+(?:a|the)\s+fallback)?\s*$",
     re.IGNORECASE,
 )
 
@@ -321,10 +325,28 @@ def _is_immediate_contradiction(units: tuple[str, ...], index: int) -> bool:
 def _has_affirmative_exhaustion(text: str) -> bool:
     """Return whether *text* names exhaustion without negating or preposing it."""
     return any(
-        not _NON_EXHAUSTION_PREFIX_PATTERN.search(text[: match.start()])
+        _is_affirmative_exhaustion_match(text, match)
         and not _STOP_RETRYING_EXHAUSTION_PATTERN.fullmatch(match.group())
         for match in _RETRY_EXHAUSTION_PATTERN.finditer(text)
     )
+
+
+def _is_affirmative_exhaustion_match(text: str, match: re.Match[str]) -> bool:
+    """Bind one exhaustion phrase to affirmative local temporal context."""
+    prefix = text[: match.start()]
+    if _NON_EXHAUSTION_PREFIX_PATTERN.search(prefix):
+        return False
+    if _UNTIL_EXHAUSTION_PREFIX_PATTERN.search(prefix):
+        return bool(_RETRY_CONTINUATION_PATTERN.search(prefix))
+    return True
+
+
+def _previous_meaningful_unit(units: tuple[str, ...], index: int) -> str | None:
+    """Return the prior non-connective unit, if one exists."""
+    previous = index - 1
+    while previous >= 0 and _CONNECTIVE_ONLY_PATTERN.fullmatch(units[previous]):
+        previous -= 1
+    return units[previous] if previous >= 0 else None
 
 
 def _stop_exhaustion_has_retry_context(
@@ -333,9 +355,10 @@ def _stop_exhaustion_has_retry_context(
     """Reject stop-only guidance inherited from an unrelated conditional branch."""
     if unit_prefix.strip() and not _has_affirmative_exhaustion(unit_prefix):
         return False
-    if index == 0 or not _CONDITIONAL_UNIT_PATTERN.match(units[index - 1]):
+    previous = _previous_meaningful_unit(units, index)
+    if previous is None or not _CONDITIONAL_UNIT_PATTERN.match(previous):
         return True
-    return _has_affirmative_exhaustion(units[index - 1])
+    return _has_affirmative_exhaustion(previous)
 
 
 def _judge_retry_fallback(prompt_output: str) -> JudgmentResult:
@@ -346,7 +369,7 @@ def _judge_retry_fallback(prompt_output: str) -> JudgmentResult:
     for index, unit in enumerate(units):
         for exhaustion in _RETRY_EXHAUSTION_PATTERN.finditer(unit):
             prefix = unit[: exhaustion.start()]
-            if _NON_EXHAUSTION_PREFIX_PATTERN.search(prefix):
+            if not _is_affirmative_exhaustion_match(unit, exhaustion):
                 continue
             if _STOP_RETRYING_EXHAUSTION_PATTERN.fullmatch(exhaustion.group()) and not (
                 _stop_exhaustion_has_retry_context(units, index, prefix)

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -108,7 +108,42 @@ _FALLBACK_ACTION_PATTERN = re.compile(
     r")\b|"
     r"\buse(?:s|d|ing)?\s+(?:(?:a|the)\s+)?fallback\b|"
     r"\b(?:fall(?:s|ing)?|fell)\s+back\b|"
-    r"\bfail(?:s|ed|ing)?\s+(?:closed|with\b|the\b)",
+    r"\bfail(?:s|ed|ing)?\s+closed\b",
+    re.IGNORECASE,
+)
+
+_RETRY_CLAUSE_PATTERN = re.compile(r"[^,;.!?]+(?:[,;.!?]+|$)", re.DOTALL)
+
+_RETRY_CONTINUATION_PATTERN = re.compile(
+    r"\b(?:keep(?:s|ing)?|continu(?:e|es|ed|ing)|resum(?:e|es|ed|ing))\s+"
+    r"(?:(?:to|with)\s+)?(?:retry(?:ing)?|retries)\b|"
+    r"\btry\s+again\b|"
+    r"\banother\s+(?:retry\s+)?attempt\b",
+    re.IGNORECASE,
+)
+
+_NEGATED_FALLBACK_ACTION_PATTERN = re.compile(
+    r"(?:"
+    r"\b(?:do|does|did|must|should|shall|will|would|can|could|may|might)\s+"
+    r"not\s+(?:ever\s+|to\s+)?|"
+    r"\bnot\s+(?:ever\s+|to\s+)?|"
+    r"\bnever\s+|"
+    r"\bavoid(?:s|ed|ing)?\s+|"
+    r"\bwithout\s+|"
+    r"\brefrain(?:s|ed|ing)?\s+from\s+"
+    r")$",
+    re.IGNORECASE,
+)
+
+_SUCCESS_RETURN_PATTERN = re.compile(
+    r"\breturn(?:s|ed|ing)?\s+(?:(?:a|an|the)\s+)?"
+    r"(?:success(?:ful(?:ly)?)?|ok(?:ay)?|true|normally)\b",
+    re.IGNORECASE,
+)
+
+_UNRELATED_ACTION_PREFIX_PATTERN = re.compile(
+    r"^\s*(?:separately|independently|elsewhere|unrelated(?:ly)?|"
+    r"for\s+diagnostics(?:\s+only)?)\b",
     re.IGNORECASE,
 )
 
@@ -152,10 +187,59 @@ def _judge_retry_bound(prompt_output: str) -> JudgmentResult:
     )
 
 
+def _retry_clauses(prompt_output: str) -> tuple[str, ...]:
+    """Split prose into bounded clauses without losing fallback punctuation."""
+    return tuple(
+        match.group(0).strip()
+        for match in _RETRY_CLAUSE_PATTERN.finditer(prompt_output)
+        if match.group(0).strip()
+    )
+
+
+def _fallback_action_state(clause: str) -> tuple[bool, bool]:
+    """Return whether a clause has an affirmative action or rejects fallback."""
+    if _RETRY_CONTINUATION_PATTERN.search(clause):
+        return False, True
+    if _UNRELATED_ACTION_PREFIX_PATTERN.search(clause):
+        return False, True
+
+    affirmative = False
+    rejected = False
+    for action in _FALLBACK_ACTION_PATTERN.finditer(clause):
+        prefix = clause[max(0, action.start() - 48) : action.start()]
+        if _NEGATED_FALLBACK_ACTION_PATTERN.search(prefix):
+            rejected = True
+            continue
+        if _SUCCESS_RETURN_PATTERN.match(clause, action.start()):
+            rejected = True
+            continue
+        affirmative = True
+
+    if rejected:
+        return False, True
+    return affirmative, False
+
+
 def _judge_retry_fallback(prompt_output: str) -> JudgmentResult:
     """Check that retry exhaustion has explicit fallback behavior."""
-    has_exhaustion = bool(_RETRY_EXHAUSTION_PATTERN.search(prompt_output))
-    has_action = bool(_FALLBACK_ACTION_PATTERN.search(prompt_output))
+    clauses = _retry_clauses(prompt_output)
+    has_exhaustion = False
+    has_action = False
+    for index, clause in enumerate(clauses):
+        if not _RETRY_EXHAUSTION_PATTERN.search(clause):
+            continue
+        has_exhaustion = True
+        action, rejected = _fallback_action_state(clause)
+        if action and not rejected:
+            has_action = True
+            break
+        if rejected or index + 1 >= len(clauses):
+            continue
+        action, rejected = _fallback_action_state(clauses[index + 1])
+        if action and not rejected:
+            has_action = True
+            break
+
     if has_exhaustion and has_action:
         return JudgmentResult(
             passed=True,
@@ -409,6 +493,7 @@ class TestDeterministicChangeJudges:
             "When the exception remains after the 4th attempt, surface it.",
             "If failure persists after the 2nd attempt, return an error result.",
             "If the failure remains after the 2nd retry attempt, propagate it.",
+            "After all retry attempts are exhausted. Raise the final error.",
         ),
     )
     def test_retry_fallback_judge_accepts_persistent_ordinal_failure(
@@ -454,6 +539,11 @@ class TestDeterministicChangeJudges:
                 "Log each fetch attempt for diagnostics. Use a maximum of 3 "
                 "attempts. If the connection error persists after the 3rd "
                 "attempt, keep retrying."
+            ),
+            (
+                "Log each fetch attempt for diagnostics. Use a maximum of 3 "
+                "attempts. If the connection error persists after the 3rd "
+                "attempt."
             ),
             (
                 "Use a maximum of 3 attempts. If the connection error persists "


### PR DESCRIPTION
Closes #2193.

## Root cause

Cloud Batch task 31 for exact candidate `cc97ef23a478fa123a7b9ffc5d7450b4d55b70e7` generated a compliant retry contract: maximum 3 attempts, then raise if the connection error persists after the 3rd attempt. The deterministic release-gate oracle rejected it because its exhaustion grammar did not recognize persistent ordinal failure.

Review exposed the broader root cause: the oracle treated exhaustion and fallback as independent keyword searches. That produced false negatives for valid clause/order/modal forms and false positives for unrelated subjects, negated or pre-exhaustion conditions, unrelated conditional stop branches, non-actions, and connective-hidden contradictions.

Cloud evidence: `gs://pdd-stg-ci-results/run-20260717-203338-cc97ef23a/results/task_31.log` — task result was 1 failed, 489 passed; only `TestRetrySafety` failed.

## Changes

The deterministic test oracle now:

- recognizes bounded affirmative exhaustion forms, persistent ordinal failures, and explicit top-level stop-retrying guidance;
- binds a fallback action to the same clause or immediately following unit;
- strips bounded subject/modal/obligation prefixes and reuses one strict direct-action grammar;
- treats `for` as conditional only for bounded non-retryable input/failure wording, preserving rationale such as `for safety`;
- rejects negation, pre-exhaustion/conditional polarity, unrelated subjects/actions, continued retry/success, and connective-hidden contradictions;
- preserves no-comma final-attempt condition tails without consuming the fallback action.

Only `tests/test_change_call_site_and_retry.py` changes. No runtime CLI, prompt, model catalog, cloud automation, or release source behavior changes.

## TDD and validation

The PR retains separate failing-test and fix commits, including the final bounded correction RED `411007f4f` and GREEN `3d3037255`.

Exact-head local evidence at `3d30372553258f69e5952ef48c1bf9aa2bc6c7cc`:

- deterministic judge class: **126 passed**;
- full module with all real-test environment flags explicitly unset: **126 passed, 2 skipped**;
- frozen 44-case Cloud/prior-review corpus: **0 mismatches**;
- `py_compile`, Black (`--target-version py312`), and `git diff --check`: passed;
- normal 18,530-character performance sentinel: 0.000332s;
- adversarial 11,614-character performance sentinel: 0.204922s.

Independent final review: MERGE with no P1/P2 findings. No paid/real LLM test was run. The authoritative end-to-end gate is a fresh full merged-main Cloud Batch run after all release-blocking PRs merge.

## Risk

Natural-language ambiguity remains a bounded risk in any deterministic oracle. Adversarial tests cover the concrete positive/negative grammar found in cloud evidence and independent review; exact merged-main Unit and full 77-task Cloud Batch remain mandatory before release.
