### PR TITLE
fix(story): skip nested pytest for empty test trees

### DIFF
--- a/.pdd/verification-profiles.json
+++ b/.pdd/verification-profiles.json
@@ -9627,7 +9627,7 @@
       "prompt_path": "pdd/prompts/story_regression_python.prompt",
       "language_id": "python",
       "required_requirement_ids": [
-        "CONTRACT-SHA256:88ba7a932f444bb1b91e17429ca8c211742fadc8457b96d71b648b2529785d4f"
+        "CONTRACT-SHA256:fbd4c2c6592bcb6950868a6b57691a66c2c3cd16d0ffd4a39abf3081ba613931"
       ],
       "obligations": [
         {
@@ -9636,7 +9636,7 @@
           "validator_id": "threshold-ed25519",
           "validator_config_digest": "threshold-ed25519-v1",
           "requirement_ids": [
-            "CONTRACT-SHA256:88ba7a932f444bb1b91e17429ca8c211742fadc8457b96d71b648b2529785d4f"
+            "CONTRACT-SHA256:fbd4c2c6592bcb6950868a6b57691a66c2c3cd16d0ffd4a39abf3081ba613931"
           ],
           "artifact_paths": [
             "pdd/prompts/story_regression_python.prompt"

--- a/pdd/prompts/story_regression_python.prompt
+++ b/pdd/prompts/story_regression_python.prompt
@@ -41,7 +41,12 @@ public `story_id` helper so both systems share one identity space.
    e.g. `pytest.main(["--collect-only", "-q", str(tests_dir)], plugins=[collector])`
    with a `pytest_collection_modifyitems` hook that records `item.nodeid` against
    the story ids read from `item.iter_markers(name="story")`. Scope collection to
-   the `tests/` tree. Treat every nested `pytest.main` call as an isolated module
+   the `tests/` tree. An absent tests path, or an existing directory that
+   contains no Python files, yields an empty map without invoking nested pytest.
+   Keep this shortcut conservative: a direct test-file input and any directory
+   containing a Python-file candidate must remain under pytest's discovery
+   authority so project configuration and plugins are honored. Treat every
+   nested `pytest.main` call as an isolated module
    namespace: temporarily remove pre-existing `sys.modules` entries whose module
    leaf collides with a file in the requested tests tree, snapshot the remaining
    module mapping, and in a `finally` block remove modules imported from that tree,

--- a/pdd/prompts/story_regression_python.prompt
+++ b/pdd/prompts/story_regression_python.prompt
@@ -41,12 +41,12 @@ public `story_id` helper so both systems share one identity space.
    e.g. `pytest.main(["--collect-only", "-q", str(tests_dir)], plugins=[collector])`
    with a `pytest_collection_modifyitems` hook that records `item.nodeid` against
    the story ids read from `item.iter_markers(name="story")`. Scope collection to
-   the `tests/` tree. An absent tests path, or an existing directory that
-   contains no Python files, yields an empty map without invoking nested pytest.
-   Keep this shortcut conservative: a direct test-file input and any directory
-   containing a Python-file candidate must remain under pytest's discovery
-   authority so project configuration and plugins are honored. Treat every
-   nested `pytest.main` call as an isolated module
+   the `tests/` tree. An absent tests path, or a literally empty directory,
+   yields an empty map without invoking nested pytest. Keep this shortcut
+   conservative: a direct test-file input and every nonempty entry, including a
+   symlink or plugin candidate, must remain under pytest's discovery authority
+   so project configuration and plugins are honored. Treat every nested
+   `pytest.main` call as an isolated module
    namespace: temporarily remove pre-existing `sys.modules` entries whose module
    leaf collides with a file in the requested tests tree, snapshot the remaining
    module mapping, and in a `finally` block remove modules imported from that tree,

--- a/pdd/story_regression.py
+++ b/pdd/story_regression.py
@@ -291,9 +291,12 @@ def build_story_map(tests_dir: Optional[PathLike] = None) -> StoryTestMap:
     ``--continue-on-collection-errors``) rather than crashing the build.
     """
     resolved_dir = Path(tests_dir) if tests_dir is not None else _default_tests_dir()
-    collector = _StoryCollector(resolved_dir)
     if not resolved_dir.exists():
         return StoryTestMap({}, {})
+    if not any(path.is_file() for path in resolved_dir.rglob("test*.py")):
+        return StoryTestMap({}, {})
+
+    collector = _StoryCollector(resolved_dir)
 
     args = [
         "--collect-only",

--- a/pdd/story_regression.py
+++ b/pdd/story_regression.py
@@ -51,6 +51,7 @@ _STORY_MARKER_HELP = (
 )
 
 PathLike = Union[str, Path]
+_STORY_TEST_GLOBS = ("test*.py", "*_test.py")
 
 
 def _default_tests_dir() -> Path:
@@ -293,7 +294,12 @@ def build_story_map(tests_dir: Optional[PathLike] = None) -> StoryTestMap:
     resolved_dir = Path(tests_dir) if tests_dir is not None else _default_tests_dir()
     if not resolved_dir.exists():
         return StoryTestMap({}, {})
-    if not any(path.is_file() for path in resolved_dir.rglob("test*.py")):
+    has_collection_candidate = any(
+        path.is_file()
+        for pattern in _STORY_TEST_GLOBS
+        for path in resolved_dir.rglob(pattern)
+    )
+    if not has_collection_candidate:
         return StoryTestMap({}, {})
 
     collector = _StoryCollector(resolved_dir)

--- a/pdd/story_regression.py
+++ b/pdd/story_regression.py
@@ -51,7 +51,6 @@ _STORY_MARKER_HELP = (
 )
 
 PathLike = Union[str, Path]
-_STORY_TEST_GLOBS = ("test*.py", "*_test.py")
 
 
 def _default_tests_dir() -> Path:
@@ -294,12 +293,9 @@ def build_story_map(tests_dir: Optional[PathLike] = None) -> StoryTestMap:
     resolved_dir = Path(tests_dir) if tests_dir is not None else _default_tests_dir()
     if not resolved_dir.exists():
         return StoryTestMap({}, {})
-    has_collection_candidate = any(
-        path.is_file()
-        for pattern in _STORY_TEST_GLOBS
-        for path in resolved_dir.rglob(pattern)
-    )
-    if not has_collection_candidate:
+    if resolved_dir.is_dir() and not any(
+        path.is_file() for path in resolved_dir.rglob("*.py")
+    ):
         return StoryTestMap({}, {})
 
     collector = _StoryCollector(resolved_dir)

--- a/pdd/story_regression.py
+++ b/pdd/story_regression.py
@@ -293,9 +293,13 @@ def build_story_map(tests_dir: Optional[PathLike] = None) -> StoryTestMap:
     resolved_dir = Path(tests_dir) if tests_dir is not None else _default_tests_dir()
     if not resolved_dir.exists():
         return StoryTestMap({}, {})
-    if resolved_dir.is_dir() and not any(
-        path.is_file() for path in resolved_dir.rglob("*.py")
-    ):
+    try:
+        is_empty_directory = resolved_dir.is_dir() and next(
+            resolved_dir.iterdir(), None
+        ) is None
+    except OSError:
+        is_empty_directory = False
+    if is_empty_directory:
         return StoryTestMap({}, {})
 
     collector = _StoryCollector(resolved_dir)

--- a/tests/test_cross_unit_story_coverage.py
+++ b/tests/test_cross_unit_story_coverage.py
@@ -110,6 +110,19 @@ def _make_prompt(directory: Path, content: str, name: str = "test_python.prompt"
     return p
 
 
+def _parse_cli_json(result, args: list[str]) -> dict:
+    """Parse CLI JSON after preserving actionable Click failure diagnostics."""
+    assert result.output.strip(), (
+        "coverage CLI emitted no JSON\n"
+        f"args={args!r}\n"
+        f"exit_code={result.exit_code}\n"
+        f"exception={result.exception!r}\n"
+        f"stdout={result.stdout!r}\n"
+        f"stderr={result.stderr!r}"
+    )
+    return json.loads(result.output)
+
+
 # ===========================================================================
 # Scenario 1: Cross-Dev-Unit Story Parsing (8 cases)
 # Tests _parse_story_prompt_metadata() from pdd/user_story_tests.py
@@ -642,17 +655,15 @@ class TestCLICrossUnitOutput:
         _make_story(stories_dir, _CROSS_UNIT_2_STORY, name="story__cross.md")
 
         runner = CliRunner()
-        result = runner.invoke(
-            coverage_cmd,
-            [
-                "--json",
-                "--stories-dir", str(stories_dir),
-                "--tests-dir", str(tests_dir),
-                str(prompts_dir),
-            ],
-        )
+        args = [
+            "--json",
+            "--stories-dir", str(stories_dir),
+            "--tests-dir", str(tests_dir),
+            str(prompts_dir),
+        ]
+        result = runner.invoke(coverage_cmd, args)
         assert result.exit_code in (0, 1, 2)
-        data = json.loads(result.output)
+        data = _parse_cli_json(result, args)
         # 2 prompt files → total_prompts must be 2
         assert data["total_prompts"] == 2, (
             f"total_prompts should be 2 (one per prompt file), got {data['total_prompts']}. "
@@ -691,17 +702,15 @@ class TestCLICrossUnitOutput:
         """Each result item in --json must include 'cross_unit_stories' (issue #1769)."""
         prompt_alpha, stories_dir, tests_dir = self._setup_cli(tmp_path)
         runner = CliRunner()
-        result = runner.invoke(
-            coverage_cmd,
-            [
-                "--json",
-                "--stories-dir", str(stories_dir),
-                "--tests-dir", str(tests_dir),
-                str(prompt_alpha),
-            ],
-        )
+        args = [
+            "--json",
+            "--stories-dir", str(stories_dir),
+            "--tests-dir", str(tests_dir),
+            str(prompt_alpha),
+        ]
+        result = runner.invoke(coverage_cmd, args)
         assert result.exit_code in (0, 1)
-        data = json.loads(result.output)
+        data = _parse_cli_json(result, args)
         items = data["results"]
         for item in items:
             assert "cross_unit_stories" in item, (

--- a/tests/test_cross_unit_story_coverage.py
+++ b/tests/test_cross_unit_story_coverage.py
@@ -113,15 +113,20 @@ def _make_prompt(directory: Path, content: str, name: str = "test_python.prompt"
 
 def _parse_cli_json(result, args: list[str]) -> dict:
     """Parse CLI JSON after preserving actionable Click failure diagnostics."""
-    assert result.output.strip(), (
-        "coverage CLI emitted no JSON\n"
+    context = (
         f"args={args!r}\n"
         f"exit_code={result.exit_code}\n"
         f"exception={result.exception!r}\n"
         f"stdout={result.stdout!r}\n"
         f"stderr={result.stderr!r}"
     )
-    return json.loads(result.output)
+    assert result.output.strip(), "coverage CLI emitted no JSON\n" + context
+    try:
+        return json.loads(result.output)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"coverage CLI emitted malformed JSON: {exc}\n{context}"
+        ) from exc
 
 
 def test_parse_cli_json_preserves_context_for_malformed_output() -> None:

--- a/tests/test_cross_unit_story_coverage.py
+++ b/tests/test_cross_unit_story_coverage.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from click.testing import CliRunner
@@ -121,6 +122,28 @@ def _parse_cli_json(result, args: list[str]) -> dict:
         f"stderr={result.stderr!r}"
     )
     return json.loads(result.output)
+
+
+def test_parse_cli_json_preserves_context_for_malformed_output() -> None:
+    """Malformed non-empty JSON must retain the same Click diagnostics."""
+    result = SimpleNamespace(
+        output="{not-json",
+        exit_code=1,
+        exception=RuntimeError("coverage failed"),
+        stdout="{not-json",
+        stderr="diagnostic stderr",
+    )
+    args = ["--json", "prompts"]
+
+    with pytest.raises(AssertionError) as raised:
+        _parse_cli_json(result, args)
+
+    message = str(raised.value)
+    assert "args=['--json', 'prompts']" in message
+    assert "exit_code=1" in message
+    assert "coverage failed" in message
+    assert "{not-json" in message
+    assert "diagnostic stderr" in message
 
 
 # ===========================================================================

--- a/tests/test_story_regression.py
+++ b/tests/test_story_regression.py
@@ -412,6 +412,28 @@ class TestGracefulDegradation:
             "tests directory without test*.py files invoked pytest.main"
         )
 
+    def test_pytest_suffix_named_candidate_still_starts_collection(
+        self, tmp_path: Path, monkeypatch
+    ):
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "example_test.py").write_text(
+            "def test_example():\n    assert True\n", encoding="utf-8"
+        )
+        nested_pytest_calls = []
+
+        def _record_pytest_main(*args, **kwargs):
+            nested_pytest_calls.append((args, kwargs))
+            return 0
+
+        monkeypatch.setattr(story_regression.pytest, "main", _record_pytest_main)
+
+        build_story_map(tests_dir)
+
+        assert len(nested_pytest_calls) == 1, (
+            "pytest's default *_test.py discovery pattern must remain supported"
+        )
+
     def test_unparseable_module_is_skipped(self, tmp_path: Path):
         d = tmp_path / "tests"
         d.mkdir()

--- a/tests/test_story_regression.py
+++ b/tests/test_story_regression.py
@@ -386,6 +386,26 @@ class TestGracefulDegradation:
         assert smap.story_to_tests == {}
         assert smap.test_to_stories == {}
 
+    def test_empty_existing_tests_dir_does_not_start_nested_pytest(
+        self, tmp_path: Path, monkeypatch
+    ):
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+
+        nested_pytest_calls = []
+
+        def _record_pytest_main(*args, **kwargs):
+            nested_pytest_calls.append((args, kwargs))
+            return 5
+
+        monkeypatch.setattr(story_regression.pytest, "main", _record_pytest_main)
+
+        smap = build_story_map(tests_dir)
+
+        assert smap.story_to_tests == {}
+        assert smap.test_to_stories == {}
+        assert nested_pytest_calls == [], "empty tests directory invoked pytest.main"
+
     def test_unparseable_module_is_skipped(self, tmp_path: Path):
         d = tmp_path / "tests"
         d.mkdir()

--- a/tests/test_story_regression.py
+++ b/tests/test_story_regression.py
@@ -434,6 +434,42 @@ class TestGracefulDegradation:
             "pytest's default *_test.py discovery pattern must remain supported"
         )
 
+    def test_direct_test_file_input_preserves_story_marker(self, tmp_path: Path):
+        test_file = tmp_path / "test_direct.py"
+        test_file.write_text(
+            "import pytest\n"
+            "@pytest.mark.story('direct_flow')\n"
+            "def test_direct():\n"
+            "    assert True\n",
+            encoding="utf-8",
+        )
+
+        smap = build_story_map(test_file)
+
+        assert smap.has_regression_test("direct_flow") is True
+
+    def test_custom_named_python_candidate_still_starts_collection(
+        self, tmp_path: Path, monkeypatch
+    ):
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "custom_spec.py").write_text(
+            "def custom_case():\n    assert True\n", encoding="utf-8"
+        )
+        nested_pytest_calls = []
+
+        def _record_pytest_main(*args, **kwargs):
+            nested_pytest_calls.append((args, kwargs))
+            return 0
+
+        monkeypatch.setattr(story_regression.pytest, "main", _record_pytest_main)
+
+        build_story_map(tests_dir)
+
+        assert len(nested_pytest_calls) == 1, (
+            "custom pytest python_files candidates must not be pre-skipped"
+        )
+
     def test_unparseable_module_is_skipped(self, tmp_path: Path):
         d = tmp_path / "tests"
         d.mkdir()

--- a/tests/test_story_regression.py
+++ b/tests/test_story_regression.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import tomllib
 import sys
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -386,11 +387,14 @@ class TestGracefulDegradation:
         assert smap.story_to_tests == {}
         assert smap.test_to_stories == {}
 
-    def test_empty_existing_tests_dir_does_not_start_nested_pytest(
-        self, tmp_path: Path, monkeypatch
+    @pytest.mark.parametrize("non_test_file", [None, "helper.py"])
+    def test_existing_tests_dir_without_discoverable_tests_skips_nested_pytest(
+        self, tmp_path: Path, monkeypatch, non_test_file: Optional[str]
     ):
         tests_dir = tmp_path / "tests"
         tests_dir.mkdir()
+        if non_test_file:
+            (tests_dir / non_test_file).write_text("VALUE = 1\n", encoding="utf-8")
 
         nested_pytest_calls = []
 
@@ -404,7 +408,9 @@ class TestGracefulDegradation:
 
         assert smap.story_to_tests == {}
         assert smap.test_to_stories == {}
-        assert nested_pytest_calls == [], "empty tests directory invoked pytest.main"
+        assert nested_pytest_calls == [], (
+            "tests directory without test*.py files invoked pytest.main"
+        )
 
     def test_unparseable_module_is_skipped(self, tmp_path: Path):
         d = tmp_path / "tests"

--- a/tests/test_story_regression.py
+++ b/tests/test_story_regression.py
@@ -382,6 +382,16 @@ class TestStaticFallback:
 # --- R9: graceful degradation --------------------------------------------------
 
 class TestGracefulDegradation:
+    def test_prompt_requires_conservative_empty_directory_fast_path(self):
+        template = Path("pdd/prompts/story_regression_python.prompt").read_text(
+            encoding="utf-8"
+        )
+
+        assert "contains no Python files" in template
+        assert "without invoking nested pytest" in template
+        assert "direct test-file input" in template
+        assert "Python-file candidate" in template
+
     def test_absent_tests_dir_yields_empty_map(self, tmp_path: Path):
         smap = build_story_map(tmp_path / "no_such_tests")
         assert smap.story_to_tests == {}

--- a/tests/test_story_regression.py
+++ b/tests/test_story_regression.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import tomllib
 import sys
 from pathlib import Path
-from typing import Optional
 
 import pytest
 
@@ -387,24 +386,21 @@ class TestGracefulDegradation:
             encoding="utf-8"
         )
 
-        assert "contains no Python files" in template
+        assert "literally empty directory" in template
         assert "without invoking nested pytest" in template
         assert "direct test-file input" in template
-        assert "Python-file candidate" in template
+        assert "symlink or plugin candidate" in template
 
     def test_absent_tests_dir_yields_empty_map(self, tmp_path: Path):
         smap = build_story_map(tmp_path / "no_such_tests")
         assert smap.story_to_tests == {}
         assert smap.test_to_stories == {}
 
-    @pytest.mark.parametrize("non_python_file", [None, "README.md"])
-    def test_existing_tests_dir_without_python_files_skips_nested_pytest(
-        self, tmp_path: Path, monkeypatch, non_python_file: Optional[str]
+    def test_existing_empty_tests_dir_skips_nested_pytest(
+        self, tmp_path: Path, monkeypatch
     ):
         tests_dir = tmp_path / "tests"
         tests_dir.mkdir()
-        if non_python_file:
-            (tests_dir / non_python_file).write_text("No tests.\n", encoding="utf-8")
 
         nested_pytest_calls = []
 
@@ -418,9 +414,49 @@ class TestGracefulDegradation:
 
         assert smap.story_to_tests == {}
         assert smap.test_to_stories == {}
-        assert nested_pytest_calls == [], (
-            "tests directory without Python files invoked pytest.main"
+        assert nested_pytest_calls == [], "empty tests directory invoked pytest.main"
+
+    @pytest.mark.parametrize("candidate", ["README.md", "story.case"])
+    def test_nonempty_plugin_candidate_starts_collection(
+        self, tmp_path: Path, monkeypatch, candidate: str
+    ):
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        (tests_dir / candidate).write_text("plugin candidate\n", encoding="utf-8")
+        nested_pytest_calls = []
+
+        def _record_pytest_main(*args, **kwargs):
+            nested_pytest_calls.append((args, kwargs))
+            return 0
+
+        monkeypatch.setattr(story_regression.pytest, "main", _record_pytest_main)
+
+        build_story_map(tests_dir)
+
+        assert len(nested_pytest_calls) == 1
+
+    def test_symlinked_test_directory_starts_collection(
+        self, tmp_path: Path, monkeypatch
+    ):
+        linked_tests = tmp_path / "linked-tests"
+        linked_tests.mkdir()
+        (linked_tests / "test_linked.py").write_text(
+            "def test_linked():\n    assert True\n", encoding="utf-8"
         )
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "linked").symlink_to(linked_tests, target_is_directory=True)
+        nested_pytest_calls = []
+
+        def _record_pytest_main(*args, **kwargs):
+            nested_pytest_calls.append((args, kwargs))
+            return 0
+
+        monkeypatch.setattr(story_regression.pytest, "main", _record_pytest_main)
+
+        build_story_map(tests_dir)
+
+        assert len(nested_pytest_calls) == 1
 
     def test_pytest_suffix_named_candidate_still_starts_collection(
         self, tmp_path: Path, monkeypatch
@@ -444,7 +480,9 @@ class TestGracefulDegradation:
             "pytest's default *_test.py discovery pattern must remain supported"
         )
 
-    def test_direct_test_file_input_preserves_story_marker(self, tmp_path: Path):
+    def test_direct_test_file_input_starts_collection(
+        self, tmp_path: Path, monkeypatch
+    ):
         test_file = tmp_path / "test_direct.py"
         test_file.write_text(
             "import pytest\n"
@@ -453,10 +491,17 @@ class TestGracefulDegradation:
             "    assert True\n",
             encoding="utf-8",
         )
+        nested_pytest_calls = []
 
-        smap = build_story_map(test_file)
+        def _record_pytest_main(*args, **kwargs):
+            nested_pytest_calls.append((args, kwargs))
+            return 0
 
-        assert smap.has_regression_test("direct_flow") is True
+        monkeypatch.setattr(story_regression.pytest, "main", _record_pytest_main)
+
+        build_story_map(test_file)
+
+        assert len(nested_pytest_calls) == 1
 
     def test_custom_named_python_candidate_still_starts_collection(
         self, tmp_path: Path, monkeypatch

--- a/tests/test_story_regression.py
+++ b/tests/test_story_regression.py
@@ -387,14 +387,14 @@ class TestGracefulDegradation:
         assert smap.story_to_tests == {}
         assert smap.test_to_stories == {}
 
-    @pytest.mark.parametrize("non_test_file", [None, "helper.py"])
-    def test_existing_tests_dir_without_discoverable_tests_skips_nested_pytest(
-        self, tmp_path: Path, monkeypatch, non_test_file: Optional[str]
+    @pytest.mark.parametrize("non_python_file", [None, "README.md"])
+    def test_existing_tests_dir_without_python_files_skips_nested_pytest(
+        self, tmp_path: Path, monkeypatch, non_python_file: Optional[str]
     ):
         tests_dir = tmp_path / "tests"
         tests_dir.mkdir()
-        if non_test_file:
-            (tests_dir / non_test_file).write_text("VALUE = 1\n", encoding="utf-8")
+        if non_python_file:
+            (tests_dir / non_python_file).write_text("No tests.\n", encoding="utf-8")
 
         nested_pytest_calls = []
 
@@ -409,7 +409,7 @@ class TestGracefulDegradation:
         assert smap.story_to_tests == {}
         assert smap.test_to_stories == {}
         assert nested_pytest_calls == [], (
-            "tests directory without test*.py files invoked pytest.main"
+            "tests directory without Python files invoked pytest.main"
         )
 
     def test_pytest_suffix_named_candidate_still_starts_collection(

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -325,8 +325,8 @@ def test_detector_contract_rotation_is_exact_and_consumed() -> None:
     assert profiles.coverage == 1.0
 
 
-def test_story_regression_transition_is_exact_and_dormant() -> None:
-    """Preauthorize #2200 bytes without changing the protected prompt/profile."""
+def test_story_regression_transition_is_exact_and_consumed() -> None:
+    """Consume only the exact #2204-protected prompt/profile transition."""
     policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
     rows = [
         row
@@ -338,10 +338,10 @@ def test_story_regression_transition_is_exact_and_dormant() -> None:
     prompt = ROOT / STORY_REGRESSION_DORMANT_ROTATION["prompt_path"]
     prompt_digest = hashlib.sha256(prompt.read_bytes()).hexdigest()
     profile_digest = hashlib.sha256(PROFILE_FILE.read_bytes()).hexdigest()
-    assert prompt_digest == STORY_REGRESSION_DORMANT_ROTATION["base_prompt_sha256"]
-    assert prompt_digest != STORY_REGRESSION_DORMANT_ROTATION["head_prompt_sha256"]
-    assert profile_digest == STORY_REGRESSION_DORMANT_ROTATION["base_policy_sha256"]
-    assert profile_digest != STORY_REGRESSION_DORMANT_ROTATION["head_policy_sha256"]
+    assert prompt_digest != STORY_REGRESSION_DORMANT_ROTATION["base_prompt_sha256"]
+    assert prompt_digest == STORY_REGRESSION_DORMANT_ROTATION["head_prompt_sha256"]
+    assert profile_digest != STORY_REGRESSION_DORMANT_ROTATION["base_policy_sha256"]
+    assert profile_digest == STORY_REGRESSION_DORMANT_ROTATION["head_policy_sha256"]
 
 
 def _requirement_authorization_row(authorization) -> dict[str, str]:
@@ -360,7 +360,7 @@ def _requirement_authorization_row(authorization) -> dict[str, str]:
 
 
 def test_committed_rotations_equal_exact_protected_authority() -> None:
-    """Only exact consumed bootstrap or dormant #2200 bindings reach policy."""
+    """Only exact consumed bootstrap or protected #2204 bindings reach policy."""
     policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
     rows = policy["requirement_rotations"]
     bootstrap_rows = {
@@ -378,11 +378,12 @@ def test_committed_rotations_equal_exact_protected_authority() -> None:
     assert policy_rows == bootstrap_rows
 
     profile_digest = hashlib.sha256(PROFILE_FILE.read_bytes()).hexdigest()
-    assert profile_digest == "71b12a08e5be55b958a737decde889c189f7ca00ceaddccd7b587f9c8b2a4b64"
+    assert profile_digest == STORY_REGRESSION_DORMANT_ROTATION["head_policy_sha256"]
     pdd1989_rows = [
         row
         for row in rows
-        if row["head_policy_sha256"] == profile_digest
+        if row["head_policy_sha256"]
+        == STORY_REGRESSION_DORMANT_ROTATION["base_policy_sha256"]
     ]
     assert len(pdd1989_rows) == 7
     assert {


### PR DESCRIPTION
Fixes #2191.

## Root cause

The hosted-flaky `pdd checkup coverage --json` tests create an existing empty `tests/` directory. `pdd.story_regression.build_story_map()` returned early only for a missing path, so that empty directory started `pytest.main()` inside an already-running hosted pytest/xdist worker even though there was nothing to collect. Nested pytest mutates process/plugin/capture state; Click occasionally returned with empty captured output. The downstream `JSONDecodeError` was the symptom.

Prior commits `1a67d5bee`, `494fdb484`, and `6c3f31a47` established nested collection and the affected fixtures but covered missing paths, cleanup, fallback, and JSON shape—not an existing empty directory.

## Changes

- return an empty `StoryTestMap` before nested pytest only for a literally empty directory;
- preserve pytest authority for direct files and every nonempty directory, including custom names, plugin candidates, unreadable entries, and symlinked trees;
- retain actionable Click args/exit/exception/stdout/stderr before parsing JSON;
- align the canonical source-of-truth prompt with the same conservative contract;
- consume the exact prompt/profile transition preauthorized by merged Phase A PR #2204 without modifying its rotation row.

The broader nonempty nested-pytest redesign remains #2202. The analogous `story_coverage` empty-tree path remains #2201.

## TDD and governance

The PR retains separate RED/GREEN commits for the empty directory, discovery boundaries, diagnostics, prompt alignment, and final empty-only correction. Phase A #2204 merged dormant authority before this Phase B consumption; this PR now produces exactly:

- prompt SHA-256 `fbd4c2c6592bcb6950868a6b57691a66c2c3cd16d0ffd4a39abf3081ba613931`
- profile SHA-256 `56ea5d189034c9d85e91c86348689eb18c4c34fa67406258f78f0ae3330eaeb6`

## Exact-head validation

At `73bdd909f4c237905c8e4f8ca89e06bfe1b8ae9b`:

- full rollout-policy + verification-profile suites: **137 passed**;
- root-cause/discovery/prompt/JSON/affected CLI focus: **17 passed serial**, **17 passed under `-n 2`**;
- `make SKIP_MAKEFILE_REGEN=1 regression-stories`: **15 passed**, 15350 deselected;
- `py_compile`, JSON parse, and `git diff --check`: passed;
- targeted pylint correctness check: **10.00/10**.

The `ci_drift_heal --dry-run` classifier returns the documented `CONFLICT` for `story_regression` because both reviewed code and prompt changed; this safely prevents automation from overwriting either side. The hosted exact-head Unit/auto-heal checks and independent critical review remain merge gates.

## Follow-up automation finding

Plain local `make regression-stories` may try to regenerate the tracked Makefile before testing when its prompt is newer. The general read-only Make target safety fix is tracked in #2206; this PR does not patch around it.

## Risk

Nested pytest remains process-global for nonempty trees; this PR removes only the provably unnecessary empty-tree boundary. Final merged-main Unit and a fresh full 77-task Cloud Batch run remain mandatory before release.
