### PR TITLE
fix(sync): preauthorize story regression prompt transition

### DIFF
--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -98,17 +98,6 @@
       "head_prompt_sha256": "fc595464ceb1bac758864cd66a87fd1ba4f72bae79660a1dd334e060cbb861f7"
     },
     {
-      "prompt_path": "pdd/prompts/story_regression_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:e5cc19e846c9fefe9608658c6186b911420c0fe4a769ed28a6be267d070909e4",
-      "to_requirement_id": "CONTRACT-SHA256:88ba7a932f444bb1b91e17429ca8c211742fadc8457b96d71b648b2529785d4f",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "7df63fe892ac14382f226ea97dbd2ac186a8cb48213faec958ad32c51d51aeb5",
-      "head_policy_sha256": "8e3ba247e42d1a4e1df3e1ba968b390595aa1173184f93419eea16af32fa89fc",
-      "base_prompt_sha256": "e5cc19e846c9fefe9608658c6186b911420c0fe4a769ed28a6be267d070909e4",
-      "head_prompt_sha256": "88ba7a932f444bb1b91e17429ca8c211742fadc8457b96d71b648b2529785d4f"
-    },
-    {
       "prompt_path": "pdd/prompts/agentic_common_python.prompt",
       "language_id": "python",
       "from_requirement_id": "CONTRACT-SHA256:86e47992102e2344fe59ee9a3ece4c6cf356025edaadf693c12acac63a5c7490",
@@ -261,6 +250,17 @@
       "head_policy_sha256": "1b4641d57921012a4aa7c507bb38b31c29dcc8ad23b370f0c4b979d8ff0a5d18",
       "base_prompt_sha256": "f1d49d5906b0a00226a0b33cf74be34ca4970efccc9531dbcd1b96c4b57e3724",
       "head_prompt_sha256": "e01fb2968590ca4911044ef59f1091c2ea5de10b6257941078c63282c52e7d37"
+    },
+    {
+      "prompt_path": "pdd/prompts/story_regression_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:88ba7a932f444bb1b91e17429ca8c211742fadc8457b96d71b648b2529785d4f",
+      "to_requirement_id": "CONTRACT-SHA256:fbd4c2c6592bcb6950868a6b57691a66c2c3cd16d0ffd4a39abf3081ba613931",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "71b12a08e5be55b958a737decde889c189f7ca00ceaddccd7b587f9c8b2a4b64",
+      "head_policy_sha256": "56ea5d189034c9d85e91c86348689eb18c4c34fa67406258f78f0ae3330eaeb6",
+      "base_prompt_sha256": "88ba7a932f444bb1b91e17429ca8c211742fadc8457b96d71b648b2529785d4f",
+      "head_prompt_sha256": "fbd4c2c6592bcb6950868a6b57691a66c2c3cd16d0ffd4a39abf3081ba613931"
     }
   ]
 }

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -359,8 +359,8 @@ def _requirement_authorization_row(authorization) -> dict[str, str]:
     }
 
 
-def test_committed_rotations_equal_exact_bootstrap_authority() -> None:
-    """Only exact current-main or #1989 bootstrap bindings reach the policy."""
+def test_committed_rotations_equal_exact_protected_authority() -> None:
+    """Only exact consumed bootstrap or dormant #2200 bindings reach policy."""
     policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
     rows = policy["requirement_rotations"]
     bootstrap_rows = {
@@ -372,6 +372,9 @@ def test_committed_rotations_equal_exact_bootstrap_authority() -> None:
     }
     policy_rows = {(row["prompt_path"], row["language_id"]): row for row in rows}
     assert len(rows) == len(policy_rows) == len(bootstrap_rows) == 23
+    story_identity = (STORY_REGRESSION_DORMANT_ROTATION["prompt_path"], "python")
+    assert bootstrap_rows[story_identity] != STORY_REGRESSION_DORMANT_ROTATION
+    bootstrap_rows[story_identity] = STORY_REGRESSION_DORMANT_ROTATION
     assert policy_rows == bootstrap_rows
 
     profile_digest = hashlib.sha256(PROFILE_FILE.read_bytes()).hexdigest()
@@ -409,7 +412,7 @@ def test_committed_rotations_equal_exact_bootstrap_authority() -> None:
         if row["head_policy_sha256"]
         == "8e3ba247e42d1a4e1df3e1ba968b390595aa1173184f93419eea16af32fa89fc"
     ]
-    assert len(pr1790_rows) == 8
+    assert len(pr1790_rows) == 7
     base_policy_digest = pr1790_rows[0]["base_policy_sha256"]
     head_policy_digest = pr1790_rows[0]["head_policy_sha256"]
     assert base_policy_digest == (

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -142,6 +142,29 @@ CI_DETECT_REQUIREMENT_ROTATION = {
         "f0d873e5505d40035d3c7364fd3961b5602d21519ec9be2049c2f38b16239712"
     ),
 }
+STORY_REGRESSION_DORMANT_ROTATION = {
+    "prompt_path": "pdd/prompts/story_regression_python.prompt",
+    "language_id": "python",
+    "from_requirement_id": (
+        "CONTRACT-SHA256:88ba7a932f444bb1b91e17429ca8c211742fadc8457b96d71b648b2529785d4f"
+    ),
+    "to_requirement_id": (
+        "CONTRACT-SHA256:fbd4c2c6592bcb6950868a6b57691a66c2c3cd16d0ffd4a39abf3081ba613931"
+    ),
+    "policy_path": ".pdd/verification-profiles.json",
+    "base_policy_sha256": (
+        "71b12a08e5be55b958a737decde889c189f7ca00ceaddccd7b587f9c8b2a4b64"
+    ),
+    "head_policy_sha256": (
+        "56ea5d189034c9d85e91c86348689eb18c4c34fa67406258f78f0ae3330eaeb6"
+    ),
+    "base_prompt_sha256": (
+        "88ba7a932f444bb1b91e17429ca8c211742fadc8457b96d71b648b2529785d4f"
+    ),
+    "head_prompt_sha256": (
+        "fbd4c2c6592bcb6950868a6b57691a66c2c3cd16d0ffd4a39abf3081ba613931"
+    ),
+}
 LEGACY_SCHEMA_1_REQUIREMENT_ROTATION = {
     "prompt_path": "pdd/prompts/ci_detect_changed_modules_python.prompt",
     "language_id": "python",
@@ -300,6 +323,25 @@ def test_detector_contract_rotation_is_exact_and_consumed() -> None:
     profiles = load_verification_profiles(ROOT, manifest)
     assert not profiles.invalid_reasons
     assert profiles.coverage == 1.0
+
+
+def test_story_regression_transition_is_exact_and_dormant() -> None:
+    """Preauthorize #2200 bytes without changing the protected prompt/profile."""
+    policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
+    rows = [
+        row
+        for row in policy["requirement_rotations"]
+        if row["prompt_path"] == STORY_REGRESSION_DORMANT_ROTATION["prompt_path"]
+    ]
+    assert rows == [STORY_REGRESSION_DORMANT_ROTATION]
+
+    prompt = ROOT / STORY_REGRESSION_DORMANT_ROTATION["prompt_path"]
+    prompt_digest = hashlib.sha256(prompt.read_bytes()).hexdigest()
+    profile_digest = hashlib.sha256(PROFILE_FILE.read_bytes()).hexdigest()
+    assert prompt_digest == STORY_REGRESSION_DORMANT_ROTATION["base_prompt_sha256"]
+    assert prompt_digest != STORY_REGRESSION_DORMANT_ROTATION["head_prompt_sha256"]
+    assert profile_digest == STORY_REGRESSION_DORMANT_ROTATION["base_policy_sha256"]
+    assert profile_digest != STORY_REGRESSION_DORMANT_ROTATION["head_policy_sha256"]
 
 
 def _requirement_authorization_row(authorization) -> dict[str, str]:


### PR DESCRIPTION
## Summary

Preauthorizes the exact protected `story_regression_python.prompt` transition required by #2200 without changing or consuming the managed prompt/profile bytes.

- replaces the already-consumed story-regression rotation with the next exact dormant binding
- preserves every other authority row and the current prompt/profile
- adds exact tests that distinguish bootstrap history from the protected dormant authority

Fixes #2203.

## Root cause

PR #2200 correctly aligns the source-of-truth prompt with its implementation, but changing a managed prompt and its verification profile in the same PR would self-authorize the transition. The protected rollout contract requires a separate Phase A authority merge before Phase B consumption.

## TDD

RED commit `efc6db11c`: the new exact dormant-transition assertion fails against the previously consumed authority.
GREEN commit `38ddf4938`: installs only the dormant rotation and updates the protected-authority inventory test.

## Validation

- `pytest -q tests/test_sync_core_pdd_rollout_policy.py` — 57 passed
- `pytest -q tests/test_sync_core_verification_profiles.py` — 80 passed
- focused exact authority tests — 2 passed
- Python compile, JSON parse, and `git diff --check` — passed
- prompt/profile bytes versus `origin/main` — unchanged

## Phase boundary

This PR intentionally does not change `pdd/prompts/story_regression_python.prompt` or `.pdd/verification-profiles.json`. PR #2200 must rebase after this merges and consume the exact preauthorized binding.
