### PR TITLE
fix(release-video): classify shell surfaces by context

### DIFF
--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -125,11 +125,15 @@ UNAMBIGUOUS_SHELL_IMPLEMENTATION_RE = re.compile(
 COMMAND_SHELL_NAME_PATTERN = (
     r"(?:bash|zsh|xonsh|korn|ksh|csh|tcsh|bourne(?:[-\s]+again)?|powershell)"
 )
-BASH_NAMED_SURFACE_RE = re.compile(
-    r"\bBash\s+(?:history|scripts?|sessions?|windows?)\b"
+BASH_STRONG_SURFACE_RE = re.compile(
+    r"\bbash\s+(?:history|scripts?|windows?)\b",
+    flags=re.IGNORECASE,
+)
+BASH_SESSION_RE = re.compile(
+    r"\bBash\s+sessions?\b"
 )
 COMMAND_SHELL_PATH_RE = re.compile(
-    rf"(?<!\w)/bin/{COMMAND_SHELL_NAME_PATTERN}\b",
+    rf"(?<!\w)/bin/(?:sh|dash|fish|{COMMAND_SHELL_NAME_PATTERN})\b",
     flags=re.IGNORECASE,
 )
 NAMED_COMMAND_SHELL_RE = re.compile(
@@ -151,7 +155,8 @@ COMMAND_SHELL_EXECUTION_RE = re.compile(
 )
 SHELL_SUBJECT_CONTEXT_PATTERN = (
     r"(?:(?![.!?;]|\b(?:that|who|which)\b|"
-    r"\b(?:beside|near|alongside)\s+(?:a|an|the)\b).){0,100}"
+    r"\b(?:beside|near|alongside)\s+(?:a|an|the)\b|"
+    r",\s*(?:and|but|while|whereas|yet)\s+(?:a|an|the)\b).){0,100}"
 )
 SHELL_OWNED_COMPUTING_RE = re.compile(
     r"\bshell[-\s]+outputs?\s+windows?\b|"
@@ -166,10 +171,11 @@ SHELL_OWNED_COMPUTING_RE = re.compile(
     r"\bshell(?:s|-like)?(?:['’]s)?\b"
     rf"{SHELL_SUBJECT_CONTEXT_PATTERN}\b"
     r"(?:is|has|with|hosts?|contains?|shows?|reads?|invokes?|displays?|"
-    r"displaying|presents?|presenting|renders?|rendering)\b"
+    r"displaying|presents?|presenting|renders?|rendering|prints?|writes?)\b"
     r"(?:(?![.!?;]).){0,60}\b"
     rf"(?:{COMMAND_SHELL_NAME_PATTERN}\s+sessions?|prompts?|"
-    r"(?:blinking\s+)?(?:cursors?|carets?)(?![-\s]+shaped\b)|cli|keystrokes?|"
+    r"(?:blinking\s+)?(?:cursors?|carets?)(?![-\s]+(?:shaped|like)\b)|"
+    r"cli|keystrokes?|"
     r"stdout|stderr|system\s+sessions?|login\s+sessions?|stdin|"
     r"working\s+director(?:y|ies)|"
     r"standard\s+outputs?|current\s+outputs?|command\s+outputs?|outputs?)\b",
@@ -186,11 +192,10 @@ UNAMBIGUOUS_COMPUTING_SURFACE_RE = re.compile(
     r"\b(?:a|an|the|its|shell(?:s|['’]s|-like)?)?\s*"
     r"(?:blinking\s+)?prompts?\s+(?:appears?|blinks?|rests?|waits?|is\b)|"
     r"\b(?:blinking|visible|onscreen|on[-\s]+screen)\s+"
-    r"(?:cursors?|carets?)(?![-\s]+shaped\b)\b|"
+    r"(?:cursors?|carets?)(?![-\s]+(?:shaped|like)\b)\b|"
     r"\b(?:shows?|displays?|presents?|contains?)\s+(?:a\s+|the\s+|its\s+)?"
-    r"(?:cursors?|carets?)\b(?![-\s]+shaped\b)|"
+    r"(?:cursors?|carets?)\b(?![-\s]+(?:shaped|like)\b)|"
     r"\btyped\s+inputs?\b|"
-    r"\b(?:prints?|writes?)\b(?:(?![.!?;]).){0,40}\boutputs?\b|"
     r"\b(?:stdout|stderr|cli|repl|keystrokes?|command\s+outputs?|"
     r"standard\s+outputs?|stdin|environment\s+variables?|"
     r"(?:login|terminal|command|system)\s+sessions?)\b",
@@ -3535,7 +3540,8 @@ def has_risky_shell_visual(cue: str) -> bool:
         pattern.search(cue)
         for pattern in (
             UNAMBIGUOUS_SHELL_IMPLEMENTATION_RE,
-            BASH_NAMED_SURFACE_RE,
+            BASH_STRONG_SURFACE_RE,
+            BASH_SESSION_RE,
             COMMAND_SHELL_PATH_RE,
             NAMED_COMMAND_SHELL_RE,
             COMMAND_SHELL_EXECUTION_RE,

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -122,51 +122,31 @@ SHELL_VISUAL_RE = re.compile(
     r"\b(?:powershell|shell(?:s|['’]s|-like)?)\b",
     flags=re.IGNORECASE,
 )
-SHELL_CLAUSE_SPLIT_RE = re.compile(
-    r"[.;:]\s*|,\s*(?=(?:and|but|or|yet)\b)",
-    flags=re.IGNORECASE,
-)
-SHELL_EXPLICIT_TECHNICAL_RE = re.compile(
-    r"\b(?:bash|posix|unix|zsh|ksh|csh|tcsh|powershell|"
-    r"bourne(?:[-\s]+again)?|cli|commands?|terminals?|consoles?|prompts?|"
-    r"cursors?|carets?|keystrokes?|keyboards?|stdout|stderr|sessions?|screens?|"
-    r"(?:typed|keyboard|command[-\s]+line|user)\s+inputs?)\b",
-    flags=re.IGNORECASE,
-)
-SHELL_RELATION_VERB_PATTERN = (
-    r"(?:has|contains|shows|invokes|displays|presents|renders)"
-)
-SHELL_COMPUTING_HOMONYM_RE = re.compile(
-    r"\b(?:shell(?:s|-like)?|command|terminal|console|cli|application|browser|"
-    r"software|user)(?:['’]s)?[-\s]+(?:outputs?|windows?|interfaces?)\b|"
-    r"\b(?:current|command|terminal|console|cli|readable|text)[-\s]+outputs?\b|"
-    r"\bshell(?:s|-like)?(?:['’]s)?[-\s]+"
-    r"(?:technical|interactive|command[-\s]+line)[-\s]+surfaces?\b|"
-    rf"\b{SHELL_RELATION_VERB_PATTERN}\b"
-    rf"(?:(?![.;:]).){{0,40}}\boutputs?\b"
-    rf"(?!\s+as\s+(?:diffuse|soft)\s+light)",
-    flags=re.IGNORECASE | re.DOTALL,
-)
-TECHNICAL_SHELL_PREFIX_RE = re.compile(
+TECHNICAL_SHELL_VISUAL_RE = re.compile(
+    r"\bpowershell\b|"
     r"\b(?:bash|posix|unix|zsh|fish|ksh|csh|tcsh|dash|"
     r"bourne(?:[-\s]+again)?|root|system|windows?|default|os|terminal|console|"
     r"interactive|login|command(?:[-\s]+line)?)"
     r"(?:[\s,-]+(?:driven|based|style|styled|technical|interactive|login|"
     r"abstract|translucent|protective|geometric|outer|physical|luminous|"
     r"glowing|transparent|frosted|matte|ceramic|delicate|organic|glass)){0,3}"
-    r"[\s,-]+shell(?:s|-like)?\b",
-    flags=re.IGNORECASE,
-)
-SHELL_CLAUSE_REFERENCE_RE = re.compile(
-    r"^\s*(?:(?:and|but|or|yet)\s+)?"
-    r"(?:it\b|its\b|(?:inside|within|on|across)\s+(?:it|the\s+shell)\b)",
-    flags=re.IGNORECASE,
-)
-SHELL_CLAUSE_TECHNICAL_START_RE = re.compile(
-    r"^\s*(?:(?:and|but|or|yet)\s+)?(?:a\s+|an\s+|the\s+)?"
-    r"(?:blinking\s+|visible\s+|current\s+)?"
-    r"(?:prompts?|cursors?|carets?|keystrokes?|keyboards?|stdout|stderr|cli)\b",
-    flags=re.IGNORECASE,
+    r"[\s,-]+shell(?:s|-like)?\b|"
+    r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
+    r"(?:blinking\s+)?(?:prompts?|cli|windows?|screens?|interfaces?|sessions?|"
+    r"current\s+outputs?|technical\s+surfaces?)\b|"
+    r"\bshell(?:s|-like)?(?:['’]s)?\b"
+    r"(?:(?![.!?;]).){0,100}\b"
+    r"(?:has|contains|shows|invokes|displays|presents|renders|accepts|awaits|"
+    r"waits\s+for)\b(?:(?![.!?;]).){0,60}\b"
+    r"(?:bash|prompts?|blinking\s+(?:cursors?|carets?)|cli|keystrokes?|"
+    r"keyboard\s+inputs?|typed\s+inputs?|stdout|stderr|system\s+sessions?|"
+    r"current\s+outputs?|command\s+outputs?)\b|"
+    r"\b(?:a|an|the|its|shell(?:s|['’]s|-like)?)?\s*"
+    r"(?:blinking\s+)?prompts?\s+(?:appears?|blinks?|rests?|is\b)|"
+    r"\b(?:cursors?|carets?)\b|"
+    r"\b(?:typed|keyboard)\s+inputs?\b|"
+    r"\b(?:stdout|stderr|cli|keystrokes?|command\s+outputs?)\b",
+    flags=re.IGNORECASE | re.DOTALL,
 )
 SAFE_SHELL_MODIFIER_RE = re.compile(
     r"\b(?:(?:abstract|translucent|protective|geometric|outer|physical|"
@@ -3514,50 +3494,18 @@ def visual_safety_categories(cue: str) -> list[str]:
 
 
 def has_risky_shell_visual(cue: str) -> bool:
-    """Reject shell visuals unless every use has strong non-computing context."""
-    clauses = shell_visual_clauses(cue)
-    for index, clause in enumerate(clauses):
-        if not SHELL_VISUAL_RE.search(clause):
-            continue
-        context = clause
-        if index + 1 < len(clauses) and shell_clause_refers_back(clauses[index + 1]):
-            context = f"{clause} {clauses[index + 1]}"
-        if shell_clause_has_risky_visual(context):
-            return True
-    return False
-
-
-def shell_visual_clauses(cue: str) -> list[str]:
-    """Split a cue where a new sentence or coordinated subject can begin."""
-    return [part.strip() for part in SHELL_CLAUSE_SPLIT_RE.split(cue) if part.strip()]
-
-
-def shell_clause_refers_back(clause: str) -> bool:
-    """Return whether a following clause explicitly refers to the prior shell."""
-    return bool(
-        SHELL_CLAUSE_REFERENCE_RE.search(clause)
-        or SHELL_CLAUSE_TECHNICAL_START_RE.search(clause)
-    )
-
-
-def shell_clause_has_risky_visual(clause: str) -> bool:
-    """Classify shell occurrences inside one subject-bounded clause."""
-    shell_matches = list(SHELL_VISUAL_RE.finditer(clause))
-    if SHELL_EXPLICIT_TECHNICAL_RE.search(clause):
-        return True
-    if SHELL_COMPUTING_HOMONYM_RE.search(clause):
+    """Reject unknown shell imagery and unambiguous computing surfaces."""
+    if TECHNICAL_SHELL_VISUAL_RE.search(cue):
         return True
 
-    technical_spans = shell_context_spans(clause, TECHNICAL_SHELL_PREFIX_RE)
+    shell_matches = list(SHELL_VISUAL_RE.finditer(cue))
     safe_spans = shell_context_spans(
-        clause,
+        cue,
         SAFE_SHELL_MODIFIER_RE,
         SAFE_SHELL_MATERIAL_RE,
     )
     for shell in shell_matches:
         if shell.group(0).lower() == "powershell":
-            return True
-        if span_contains_offset(technical_spans, shell.start()):
             return True
         if not span_contains_offset(safe_spans, shell.start()):
             return True

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -118,38 +118,59 @@ READABLE_VISUAL_RE = re.compile(
     r"(?:graphical|software|application|app)\s+(?:user\s+)?interfaces?)\b",
     flags=re.IGNORECASE,
 )
-NAMED_COMMAND_SHELL_PATTERN = (
-    r"(?:bash|posix|unix|zsh|fish|ksh|csh|tcsh|dash|"
-    r"bourne(?:[-\s]+again)?|powershell)"
+UNAMBIGUOUS_SHELL_IMPLEMENTATION_RE = re.compile(
+    r"\b(?:powershell|pwsh|xonsh|zsh|ksh|csh|tcsh)\b",
+    flags=re.IGNORECASE,
 )
-TECHNICAL_SHELL_VISUAL_RE = re.compile(
-    rf"\b{NAMED_COMMAND_SHELL_PATTERN}\s+(?:sessions?|prompts?)\b|"
-    rf"\b(?:runs?|executes?|invokes?|launches?)\s+(?:a\s+|the\s+)?"
-    rf"{NAMED_COMMAND_SHELL_PATTERN}\b|"
-    rf"\b(?:{NAMED_COMMAND_SHELL_PATTERN}|root|system|windows?|default|os|"
-    r"terminal|console|interactive|login|command(?:[-\s]+line)?)"
+COMMAND_SHELL_NAME_PATTERN = (
+    r"(?:bash|zsh|xonsh|korn|ksh|csh|tcsh|bourne(?:[-\s]+again)?|powershell)"
+)
+NAMED_COMMAND_SHELL_RE = re.compile(
+    rf"\b(?:{COMMAND_SHELL_NAME_PATTERN}|posix|unix)\s+shell(?:s|-like)?\b|"
+    r"\b(?:root|system|windows?|default|os|terminal|console|interactive|login|"
+    r"command(?:[-\s]+line)?)"
     r"(?:[\s,-]+(?:driven|based|style|styled|technical|interactive|login|"
     r"abstract|translucent|protective|geometric|outer|physical|luminous|"
     r"glowing|transparent|frosted|matte|ceramic|delicate|organic|glass)){0,3}"
-    r"[\s,-]+shell(?:s|-like)?\b|"
+    r"[\s,-]+shell(?:s|-like)?\b",
+    flags=re.IGNORECASE,
+)
+COMMAND_SHELL_EXECUTION_RE = re.compile(
+    rf"\b(?:runs?|executes?|invokes?|launches?|starts?|spawns?)\s+"
+    rf"(?:a\s+|the\s+)?(?:/bin/)?{COMMAND_SHELL_NAME_PATTERN}\b",
+    flags=re.IGNORECASE,
+)
+SHELL_OWNED_COMPUTING_RE = re.compile(
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
-    r"(?:blinking\s+)?(?:prompts?|cli|windows?|screens?|interfaces?|sessions?|"
-    r"current\s+outputs?|outputs?|technical\s+surfaces?)\b|"
+    r"(?:scripts?|history|prompts?|cli|windows?|screens?|interfaces?|sessions?|"
+    r"working\s+director(?:y|ies)|standard\s+outputs?|current\s+outputs?|"
+    r"outputs?|technical\s+surfaces?)\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?\b"
     r"(?:(?![.!?;]).){0,100}\b"
-    r"(?:is|has|hosts?|contains?|shows?|invokes?|displays?|displaying|"
-    r"presents?|presenting|renders?|rendering|accepts?|awaits?|waits\s+for)\b"
+    r"(?:is|has|with|hosts?|contains?|shows?|reads?|invokes?|displays?|"
+    r"displaying|presents?|presenting|renders?|rendering|accepts?|awaits?|"
+    r"waits\s+for)\b"
     r"(?:(?![.!?;]).){0,60}\b"
-    rf"(?:{NAMED_COMMAND_SHELL_PATTERN}\s+sessions?|prompts?|"
-    r"blinking\s+(?:cursors?|carets?)|cli|keystrokes?|"
+    rf"(?:{COMMAND_SHELL_NAME_PATTERN}\s+sessions?|prompts?|"
+    r"(?:blinking\s+)?(?:cursors?|carets?)|cli|keystrokes?|"
     r"keyboard\s+inputs?|typed\s+inputs?|stdout|stderr|system\s+sessions?|"
-    r"login\s+sessions?|current\s+outputs?|command\s+outputs?|outputs?)\b|"
+    r"login\s+sessions?|stdin|user\s+inputs?|working\s+director(?:y|ies)|"
+    r"standard\s+outputs?|current\s+outputs?|command\s+outputs?|outputs?)\b",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+UNAMBIGUOUS_COMPUTING_SURFACE_RE = re.compile(
     r"\b(?:a|an|the|its|shell(?:s|['’]s|-like)?)?\s*"
     r"(?:blinking\s+)?prompts?\s+(?:appears?|blinks?|rests?|waits?|is\b)|"
-    r"\b(?:cursors?|carets?)\b|"
-    r"\b(?:typed|keyboard)\s+inputs?\b|"
+    r"\b(?:blinking|visible|onscreen|on[-\s]+screen)\s+"
+    r"(?:cursors?|carets?)\b|"
+    r"\b(?:shows?|displays?|presents?|contains?)\s+(?:a\s+|the\s+|its\s+)?"
+    r"(?:cursors?|carets?)\b|"
+    r"\btyped\s+inputs?\b|"
+    r"\b(?:accepts?|awaits?|waits\s+for)\s+(?:typed\s+|keyboard\s+|user\s+)"
+    r"inputs?\b|"
     r"\b(?:stdout|stderr|cli|repl|keystrokes?|command\s+outputs?|"
-    r"environment\s+variables?|(?:login|terminal|command)\s+sessions?)\b",
+    r"standard\s+outputs?|stdin|environment\s+variables?|"
+    r"(?:login|terminal|command|system)\s+sessions?)\b",
     flags=re.IGNORECASE | re.DOTALL,
 )
 EXACT_GEOMETRY_VISUAL_RE = re.compile(
@@ -3487,7 +3508,16 @@ def visual_safety_categories(cue: str) -> list[str]:
 
 def has_risky_shell_visual(cue: str) -> bool:
     """Return whether a cue positively identifies a command/readable surface."""
-    return bool(TECHNICAL_SHELL_VISUAL_RE.search(cue))
+    return any(
+        pattern.search(cue)
+        for pattern in (
+            UNAMBIGUOUS_SHELL_IMPLEMENTATION_RE,
+            NAMED_COMMAND_SHELL_RE,
+            COMMAND_SHELL_EXECUTION_RE,
+            SHELL_OWNED_COMPUTING_RE,
+            UNAMBIGUOUS_COMPUTING_SURFACE_RE,
+        )
+    )
 
 
 def has_unsafe_visual_motion(cue: str) -> bool:

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -122,10 +122,30 @@ SHELL_VISUAL_RE = re.compile(
     r"\b(?:powershell|shell(?:s|['’]s|-like)?)\b",
     flags=re.IGNORECASE,
 )
-SHELL_TECHNICAL_SURFACE_PATTERN = (
-    r"(?:cli|prompts?|cursors?|carets?|stdout|stderr|keyboard(?:\s+input)?|"
-    r"typed\s+input|inputs?|outputs?|commands?|terminals?|consoles?|sessions?|"
-    r"screens?|interfaces?|windows?|surfaces?)"
+SHELL_CLAUSE_SPLIT_RE = re.compile(
+    r"[.;:]\s*|,\s*(?=(?:and|but|or|yet)\b)",
+    flags=re.IGNORECASE,
+)
+SHELL_EXPLICIT_TECHNICAL_RE = re.compile(
+    r"\b(?:bash|posix|unix|zsh|ksh|csh|tcsh|powershell|"
+    r"bourne(?:[-\s]+again)?|cli|commands?|terminals?|consoles?|prompts?|"
+    r"cursors?|carets?|keystrokes?|keyboards?|stdout|stderr|sessions?|screens?|"
+    r"(?:typed|keyboard|command[-\s]+line|user)\s+inputs?)\b",
+    flags=re.IGNORECASE,
+)
+SHELL_RELATION_VERB_PATTERN = (
+    r"(?:has|contains|shows|invokes|displays|presents|renders)"
+)
+SHELL_COMPUTING_HOMONYM_RE = re.compile(
+    r"\b(?:shell(?:s|-like)?|command|terminal|console|cli|application|browser|"
+    r"software|user)(?:['’]s)?[-\s]+(?:outputs?|windows?|interfaces?)\b|"
+    r"\b(?:current|command|terminal|console|cli|readable|text)[-\s]+outputs?\b|"
+    r"\bshell(?:s|-like)?(?:['’]s)?[-\s]+"
+    r"(?:technical|interactive|command[-\s]+line)[-\s]+surfaces?\b|"
+    rf"\b{SHELL_RELATION_VERB_PATTERN}\b"
+    rf"(?:(?![.;:]).){{0,40}}\boutputs?\b"
+    rf"(?!\s+as\s+(?:diffuse|soft)\s+light)",
+    flags=re.IGNORECASE | re.DOTALL,
 )
 TECHNICAL_SHELL_PREFIX_RE = re.compile(
     r"\b(?:bash|posix|unix|zsh|fish|ksh|csh|tcsh|dash|"
@@ -137,26 +157,16 @@ TECHNICAL_SHELL_PREFIX_RE = re.compile(
     r"[\s,-]+shell(?:s|-like)?\b",
     flags=re.IGNORECASE,
 )
-TECHNICAL_SHELL_DIRECT_RE = re.compile(
-    rf"\bshell(?:s|-like)?\b(?:['’]s)?\s*(?:[-:—]\s*)?"
-    rf"(?:(?:a|an|the|its|current|blinking|visible|technical|interactive|"
-    rf"command[-\s]+line)\s+){{0,4}}{SHELL_TECHNICAL_SURFACE_PATTERN}\b",
+SHELL_CLAUSE_REFERENCE_RE = re.compile(
+    r"^\s*(?:(?:and|but|or|yet)\s+)?"
+    r"(?:it\b|its\b|(?:inside|within|on|across)\s+(?:it|the\s+shell)\b)",
     flags=re.IGNORECASE,
 )
-TECHNICAL_SHELL_WITH_RE = re.compile(
-    rf"\bshell(?:s|-like)?\b(?:['’]s)?\s+"
-    rf"(?:with|containing|featuring)\s+"
-    rf"(?:(?:a|an|the|its|current|blinking|visible|typed|keyboard)\s+){{0,4}}"
-    rf"{SHELL_TECHNICAL_SURFACE_PATTERN}\b",
+SHELL_CLAUSE_TECHNICAL_START_RE = re.compile(
+    r"^\s*(?:(?:and|but|or|yet)\s+)?(?:a\s+|an\s+|the\s+)?"
+    r"(?:blinking\s+|visible\s+|current\s+)?"
+    r"(?:prompts?|cursors?|carets?|keystrokes?|keyboards?|stdout|stderr|cli)\b",
     flags=re.IGNORECASE,
-)
-TECHNICAL_SHELL_ACTION_RE = re.compile(
-    rf"\bshell(?:s|-like)?\b"
-    rf"(?:(?![.;]|\b(?:while|whereas|which|that)\b).){{0,120}}?"
-    rf"\b(?:accepts?|awaits?|displays?|shows?|presents?|renders?|emits?|"
-    rf"receives?|waits?\s+for)\b"
-    rf"(?:(?![.;]).){{0,60}}?{SHELL_TECHNICAL_SURFACE_PATTERN}\b",
-    flags=re.IGNORECASE | re.DOTALL,
 )
 SAFE_SHELL_MODIFIER_RE = re.compile(
     r"\b(?:(?:abstract|translucent|protective|geometric|outer|physical|"
@@ -3505,19 +3515,42 @@ def visual_safety_categories(cue: str) -> list[str]:
 
 def has_risky_shell_visual(cue: str) -> bool:
     """Reject shell visuals unless every use has strong non-computing context."""
-    shell_matches = list(SHELL_VISUAL_RE.finditer(cue))
-    if not shell_matches:
-        return False
+    clauses = shell_visual_clauses(cue)
+    for index, clause in enumerate(clauses):
+        if not SHELL_VISUAL_RE.search(clause):
+            continue
+        context = clause
+        if index + 1 < len(clauses) and shell_clause_refers_back(clauses[index + 1]):
+            context = f"{clause} {clauses[index + 1]}"
+        if shell_clause_has_risky_visual(context):
+            return True
+    return False
 
-    technical_spans = shell_context_spans(
-        cue,
-        TECHNICAL_SHELL_PREFIX_RE,
-        TECHNICAL_SHELL_DIRECT_RE,
-        TECHNICAL_SHELL_WITH_RE,
-        TECHNICAL_SHELL_ACTION_RE,
+
+def shell_visual_clauses(cue: str) -> list[str]:
+    """Split a cue where a new sentence or coordinated subject can begin."""
+    return [part.strip() for part in SHELL_CLAUSE_SPLIT_RE.split(cue) if part.strip()]
+
+
+def shell_clause_refers_back(clause: str) -> bool:
+    """Return whether a following clause explicitly refers to the prior shell."""
+    return bool(
+        SHELL_CLAUSE_REFERENCE_RE.search(clause)
+        or SHELL_CLAUSE_TECHNICAL_START_RE.search(clause)
     )
+
+
+def shell_clause_has_risky_visual(clause: str) -> bool:
+    """Classify shell occurrences inside one subject-bounded clause."""
+    shell_matches = list(SHELL_VISUAL_RE.finditer(clause))
+    if SHELL_EXPLICIT_TECHNICAL_RE.search(clause):
+        return True
+    if SHELL_COMPUTING_HOMONYM_RE.search(clause):
+        return True
+
+    technical_spans = shell_context_spans(clause, TECHNICAL_SHELL_PREFIX_RE)
     safe_spans = shell_context_spans(
-        cue,
+        clause,
         SAFE_SHELL_MODIFIER_RE,
         SAFE_SHELL_MATERIAL_RE,
     )

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -118,14 +118,24 @@ READABLE_VISUAL_RE = re.compile(
     r"(?:graphical|software|application|app)\s+(?:user\s+)?interfaces?)\b",
     flags=re.IGNORECASE,
 )
-COMMAND_SHELL_VISUAL_RE = re.compile(
-    r"\b(?:(?:bash|posix|unix|zsh|fish|ksh|csh|tcsh|dash|"
-    r"bourne(?:[-\s]+again)?|terminal|interactive|login|"
-    r"command(?:[-\s]+line)?)[-\s]+shell|"
-    r"shell(?:[-\s]+(?:cli|prompt|commands?|output|session|terminal|console|"
-    r"windows?|screens?|interfaces?)|['’]s\s+(?:cli|prompt|commands?|output)|"
-    r"\s+(?:display(?:s|ed|ing)|show(?:s|ed|ing)|render(?:s|ed|ing)|"
-    r"present(?:s|ed|ing))\s+(?:(?:its|the)\s+)?(?:prompt|commands?|output)))\b",
+SHELL_VISUAL_RE = re.compile(
+    r"\b(?:powershell|shell(?:s|['’]s|-like)?)\b",
+    flags=re.IGNORECASE,
+)
+SHELL_TECHNICAL_EVIDENCE_RE = re.compile(
+    r"\b(?:bash|posix|unix|zsh|fish|ksh|csh|tcsh|dash|powershell|"
+    r"bourne(?:[-\s]+again)?|root|system|default|os|technical|"
+    r"terminal|console|interactive|login|command(?:[-\s]+line)?|cli|"
+    r"prompts?|outputs?|sessions?|screens?|interfaces?|windows?)\b",
+    flags=re.IGNORECASE,
+)
+SAFE_SHELL_MODIFIER_RE = re.compile(
+    r"\b(?:abstract|translucent|protective|geometric|outer|physical|luminous|"
+    r"glowing)(?:[\s,;:—-]+\w+){0,3}[\s,;:—-]+shells?\b",
+    flags=re.IGNORECASE,
+)
+SAFE_SHELL_MATERIAL_RE = re.compile(
+    r"\bshells?\b\s*(?:[—,:;-]\s*)?of\s+(?:\w+\s+){0,2}(?:light|glow)\b",
     flags=re.IGNORECASE,
 )
 EXACT_GEOMETRY_VISUAL_RE = re.compile(
@@ -3448,7 +3458,7 @@ def visual_safety_categories(cue: str) -> list[str]:
     """Classify one visual cue using stable, machine-readable categories."""
     categories: list[str] = []
     readable_candidate = SAFE_TEXT_QUALIFIER_RE.sub("", cue)
-    if READABLE_VISUAL_RE.search(readable_candidate) or COMMAND_SHELL_VISUAL_RE.search(
+    if READABLE_VISUAL_RE.search(readable_candidate) or has_risky_shell_visual(
         readable_candidate
     ):
         categories.append("risky_readable_surface")
@@ -3457,6 +3467,28 @@ def visual_safety_categories(cue: str) -> list[str]:
     if has_unsafe_visual_motion(cue):
         categories.append("brittle_mandatory_motion")
     return categories
+
+
+def has_risky_shell_visual(cue: str) -> bool:
+    """Reject shell visuals unless every use has strong non-computing context."""
+    shell_matches = list(SHELL_VISUAL_RE.finditer(cue))
+    if not shell_matches:
+        return False
+
+    # Technical evidence wins over physical/art-direction modifiers. This keeps
+    # mixed cues such as "translucent shell with a prompt" fail-closed.
+    if SHELL_TECHNICAL_EVIDENCE_RE.search(cue):
+        return True
+
+    safe_spans = [
+        match.span()
+        for pattern in (SAFE_SHELL_MODIFIER_RE, SAFE_SHELL_MATERIAL_RE)
+        for match in pattern.finditer(cue)
+    ]
+    return any(
+        not any(start <= shell.start() < end for start, end in safe_spans)
+        for shell in shell_matches
+    )
 
 
 def has_unsafe_visual_motion(cue: str) -> bool:

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -118,49 +118,39 @@ READABLE_VISUAL_RE = re.compile(
     r"(?:graphical|software|application|app)\s+(?:user\s+)?interfaces?)\b",
     flags=re.IGNORECASE,
 )
-SHELL_VISUAL_RE = re.compile(
-    r"\b(?:powershell|shell(?:s|['’]s|-like)?)\b",
-    flags=re.IGNORECASE,
+NAMED_COMMAND_SHELL_PATTERN = (
+    r"(?:bash|posix|unix|zsh|fish|ksh|csh|tcsh|dash|"
+    r"bourne(?:[-\s]+again)?|powershell)"
 )
 TECHNICAL_SHELL_VISUAL_RE = re.compile(
-    r"\bpowershell\b|"
-    r"\b(?:bash|posix|unix|zsh|fish|ksh|csh|tcsh|dash|"
-    r"bourne(?:[-\s]+again)?|root|system|windows?|default|os|terminal|console|"
-    r"interactive|login|command(?:[-\s]+line)?)"
+    rf"\b{NAMED_COMMAND_SHELL_PATTERN}\s+(?:sessions?|prompts?)\b|"
+    rf"\b(?:runs?|executes?|invokes?|launches?)\s+(?:a\s+|the\s+)?"
+    rf"{NAMED_COMMAND_SHELL_PATTERN}\b|"
+    rf"\b(?:{NAMED_COMMAND_SHELL_PATTERN}|root|system|windows?|default|os|"
+    r"terminal|console|interactive|login|command(?:[-\s]+line)?)"
     r"(?:[\s,-]+(?:driven|based|style|styled|technical|interactive|login|"
     r"abstract|translucent|protective|geometric|outer|physical|luminous|"
     r"glowing|transparent|frosted|matte|ceramic|delicate|organic|glass)){0,3}"
     r"[\s,-]+shell(?:s|-like)?\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
     r"(?:blinking\s+)?(?:prompts?|cli|windows?|screens?|interfaces?|sessions?|"
-    r"current\s+outputs?|technical\s+surfaces?)\b|"
+    r"current\s+outputs?|outputs?|technical\s+surfaces?)\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?\b"
     r"(?:(?![.!?;]).){0,100}\b"
-    r"(?:has|contains|shows|invokes|displays|presents|renders|accepts|awaits|"
-    r"waits\s+for)\b(?:(?![.!?;]).){0,60}\b"
-    r"(?:bash|prompts?|blinking\s+(?:cursors?|carets?)|cli|keystrokes?|"
+    r"(?:is|has|hosts?|contains?|shows?|invokes?|displays?|displaying|"
+    r"presents?|presenting|renders?|rendering|accepts?|awaits?|waits\s+for)\b"
+    r"(?:(?![.!?;]).){0,60}\b"
+    rf"(?:{NAMED_COMMAND_SHELL_PATTERN}\s+sessions?|prompts?|"
+    r"blinking\s+(?:cursors?|carets?)|cli|keystrokes?|"
     r"keyboard\s+inputs?|typed\s+inputs?|stdout|stderr|system\s+sessions?|"
-    r"current\s+outputs?|command\s+outputs?)\b|"
+    r"login\s+sessions?|current\s+outputs?|command\s+outputs?|outputs?)\b|"
     r"\b(?:a|an|the|its|shell(?:s|['’]s|-like)?)?\s*"
-    r"(?:blinking\s+)?prompts?\s+(?:appears?|blinks?|rests?|is\b)|"
+    r"(?:blinking\s+)?prompts?\s+(?:appears?|blinks?|rests?|waits?|is\b)|"
     r"\b(?:cursors?|carets?)\b|"
     r"\b(?:typed|keyboard)\s+inputs?\b|"
-    r"\b(?:stdout|stderr|cli|keystrokes?|command\s+outputs?)\b",
+    r"\b(?:stdout|stderr|cli|repl|keystrokes?|command\s+outputs?|"
+    r"environment\s+variables?|(?:login|terminal|command)\s+sessions?)\b",
     flags=re.IGNORECASE | re.DOTALL,
-)
-SAFE_SHELL_MODIFIER_RE = re.compile(
-    r"\b(?:(?:abstract|translucent|protective|geometric|outer|physical|"
-    r"luminous|glowing|transparent|frosted|glass|matte|ceramic|delicate|organic)"
-    r"[\s,;:—-]+){1,4}shells?\b",
-    flags=re.IGNORECASE,
-)
-SAFE_SHELL_MATERIAL_RE = re.compile(
-    r"\bshells?\b\s*(?:[—,:;-]\s*)?"
-    r"(?:of\s+(?:(?:soft|faint|diffuse|radiant|translucent|transparent)\s+){0,2}"
-    r"(?:light|glow)|(?:made|formed|crafted)\s+of\s+"
-    r"(?:(?:transparent|translucent|frosted|matte|delicate)\s+){0,2}"
-    r"(?:glass|ceramic|organic\s+material))\b",
-    flags=re.IGNORECASE,
 )
 EXACT_GEOMETRY_VISUAL_RE = re.compile(
     r"\b(?:exact(?:ly)?|precise(?:ly)?|perfect(?:ly)?|parallel|"
@@ -229,7 +219,9 @@ MOTION_REQUIRED_PREFIX_RE = re.compile(
 )
 SAFE_TEXT_QUALIFIER_RE = re.compile(
     r"\b(?:text[- ]free|non[- ]textual|unlabeled|without\s+(?:readable\s+)?"
-    r"(?:text|words?|labels?|logos?)|no\s+(?:readable\s+)?(?:text|words?|labels?|logos?))\b",
+    r"(?:text|words?|labels?|logos?)|no\s+(?:readable\s+)?"
+    r"(?:text|words?|labels?|logos?)(?:\s*(?:,|and|or)\s*"
+    r"(?:text|words?|labels?|logos?))*)\b",
     flags=re.IGNORECASE,
 )
 RELEASE_VIDEO_AUDIT_FIX_POLICY_ARGS = (
@@ -3494,32 +3486,8 @@ def visual_safety_categories(cue: str) -> list[str]:
 
 
 def has_risky_shell_visual(cue: str) -> bool:
-    """Reject unknown shell imagery and unambiguous computing surfaces."""
-    if TECHNICAL_SHELL_VISUAL_RE.search(cue):
-        return True
-
-    shell_matches = list(SHELL_VISUAL_RE.finditer(cue))
-    safe_spans = shell_context_spans(
-        cue,
-        SAFE_SHELL_MODIFIER_RE,
-        SAFE_SHELL_MATERIAL_RE,
-    )
-    for shell in shell_matches:
-        if shell.group(0).lower() == "powershell":
-            return True
-        if not span_contains_offset(safe_spans, shell.start()):
-            return True
-    return False
-
-
-def shell_context_spans(cue: str, *patterns: re.Pattern[str]) -> list[tuple[int, int]]:
-    """Return phrase spans that grammatically relate context to a shell."""
-    return [match.span() for pattern in patterns for match in pattern.finditer(cue)]
-
-
-def span_contains_offset(spans: list[tuple[int, int]], offset: int) -> bool:
-    """Return whether an offset belongs to one of the supplied phrase spans."""
-    return any(start <= offset < end for start, end in spans)
+    """Return whether a cue positively identifies a command/readable surface."""
+    return bool(TECHNICAL_SHELL_VISUAL_RE.search(cue))
 
 
 def has_unsafe_visual_motion(cue: str) -> bool:

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -149,9 +149,13 @@ SHELL_DIRECT_TARGET_PATTERN = (
     rf"(?:{SHELL_SURFACE_TARGET_PATTERN}|sessions?|"
     r"(?:standard|current|command)\s+outputs?)"
 )
+SHELL_TECHNICAL_ACTION_PREDICATE_PATTERN = (
+    r"(?:hosts?|hosting|contains?|containing|shows?|showing|reads?|reading|"
+    r"lists?|listing|invokes?|invoking|displays?|displaying|presents?|"
+    r"presenting|renders?|rendering|prints?|printing|writes?|writing)"
+)
 SHELL_EVIDENCE_VERB_PATTERN = (
-    r"(?:is|has|hosts?|contains?|shows?|reads?|lists?|invokes?|displays?|"
-    r"displaying|presents?|presenting|renders?|rendering|prints?|writes?)"
+    rf"(?:is|has|{SHELL_TECHNICAL_ACTION_PREDICATE_PATTERN})"
 )
 SHELL_INPUT_VERB_PATTERN = (
     r"(?:accepts?|awaits?|receives?|takes?|waits\s+for)"
@@ -239,8 +243,8 @@ SHELL_WITH_COMPUTING_RE = re.compile(
     flags=re.IGNORECASE | re.DOTALL,
 )
 PANE_COMPUTING_PREDICATE_PATTERN = (
-    r"(?:shows?|showing|displays?|displaying|presents?|presenting|"
-    r"contains?|containing|renders?|rendering)"
+    rf"(?:(?:(?:is|are|was|were)\s+)?"
+    rf"{SHELL_TECHNICAL_ACTION_PREDICATE_PATTERN})"
 )
 PANE_EXPLICIT_REFERENCE_PATTERN = (
     r"(?:,?\s+(?:and|but|while|whereas|yet)\s+(?:it|the\s+pane)\s+)"

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -159,22 +159,27 @@ SHELL_INPUT_VERB_PATTERN = (
 SHELL_SUBJECT_PREDICATE_PATTERN = (
     rf"(?:{SHELL_EVIDENCE_VERB_PATTERN}|{SHELL_INPUT_VERB_PATTERN})"
 )
-SHELL_OTHER_SUBJECT_PATTERN = (
-    r"(?:(?:he|she|they|we|this|that|these|those)\b|"
-    r"(?:(?:a|an|the|another|each|every|either|neither|some|any|many|"
-    r"several|few|one|two|three|four|five|six|seven|eight|nine|ten|\d+)\s+"
-    r"(?:[a-z][\w-]*\s+){0,3}[a-z][\w-]*)\b|"
-    r"(?:[a-z][\w-]*\s+){0,2}[a-z][\w-]*s\b)"
+SHELL_SAME_SUBJECT_MODIFIER_PATTERN = (
+    r"(?:then|eventually|later|softly|prominently|always|sometimes|"
+    r"afterwards|subsequently|immediately|directly|visibly|clearly|quietly|"
+    r"briefly|gently|slowly|rapidly|continuously|still|again|soon|"
+    r"after\s+(?:(?:a|the|one)\s+)?(?:brief\s+)?"
+    r"(?:moment|pause|beat|delay|interval))"
+)
+SHELL_SAME_SUBJECT_CONTINUATION_PATTERN = (
+    rf"(?:(?:(?:it|the\s+shell(?:s|-like)?)\s+)?"
+    rf"(?:{SHELL_SAME_SUBJECT_MODIFIER_PATTERN}\s+){{0,3}}"
+    rf"{SHELL_SUBJECT_PREDICATE_PATTERN}\b|"
+    rf"its\s+(?:[\w-]+\s+){{1,3}}{SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
 )
 SHELL_NEW_SUBJECT_BOUNDARY_PATTERN = (
     r"\b(?:and|but|while|whereas|yet|as)\b\s+"
-    r"(?!(?:(?:it|its)\b|the\s+shell(?:s|-like)?\b))"
-    rf"(?={SHELL_OTHER_SUBJECT_PATTERN}\s+"
-    rf"{SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
+    rf"(?!{SHELL_SAME_SUBJECT_CONTINUATION_PATTERN})"
+    rf"(?=(?:(?![.!?;,]).){{1,50}}\b{SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
 )
 SHELL_WITH_OTHER_SUBJECT_BOUNDARY_PATTERN = (
-    rf"\bwith\s+{SHELL_OTHER_SUBJECT_PATTERN}\s+"
-    rf"(?={SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
+    r"\bwith\b"
+    rf"(?=(?:(?![.!?;,]).){{1,50}}\b{SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
 )
 BASH_STRONG_SURFACE_RE = re.compile(
     r"\bbash\s+(?:history|windows?|"

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -159,27 +159,32 @@ SHELL_INPUT_VERB_PATTERN = (
 SHELL_SUBJECT_PREDICATE_PATTERN = (
     rf"(?:{SHELL_EVIDENCE_VERB_PATTERN}|{SHELL_INPUT_VERB_PATTERN})"
 )
+SHELL_ADVERB_MORPHOLOGY_PATTERN = r"(?-i:[a-z][\w-]*(?:ly|wards|wise))"
+SHELL_CONTINUATION_PARTICLE_PATTERN = (
+    r"(?:now|then|later|still|again|soon|always|sometimes|often|never)"
+)
+SHELL_TEMPORAL_MODIFIER_PATTERN = (
+    r"(?:after|before)\s+(?:[\w-]+\s+)?(?:brief\s+)?"
+    r"(?:moments?|pauses?|beats?|delays?|intervals?|seconds?|minutes?)"
+)
 SHELL_SAME_SUBJECT_MODIFIER_PATTERN = (
-    r"(?:then|eventually|later|softly|prominently|always|sometimes|"
-    r"afterwards|subsequently|immediately|directly|visibly|clearly|quietly|"
-    r"briefly|gently|slowly|rapidly|continuously|still|again|soon|"
-    r"after\s+(?:(?:a|the|one)\s+)?(?:brief\s+)?"
-    r"(?:moment|pause|beat|delay|interval))"
+    rf"(?:{SHELL_ADVERB_MORPHOLOGY_PATTERN}|"
+    rf"{SHELL_CONTINUATION_PARTICLE_PATTERN}|{SHELL_TEMPORAL_MODIFIER_PATTERN})"
 )
 SHELL_SAME_SUBJECT_CONTINUATION_PATTERN = (
     rf"(?:(?:(?:it|the\s+shell(?:s|-like)?)\s+)?"
-    rf"(?:{SHELL_SAME_SUBJECT_MODIFIER_PATTERN}\s+){{0,3}}"
+    rf"(?:{SHELL_SAME_SUBJECT_MODIFIER_PATTERN}(?:\s+|,\s*)){{0,3}}"
     rf"{SHELL_SUBJECT_PREDICATE_PATTERN}\b|"
     rf"its\s+(?:[\w-]+\s+){{1,3}}{SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
 )
 SHELL_NEW_SUBJECT_BOUNDARY_PATTERN = (
     r"\b(?:and|but|while|whereas|yet|as)\b\s+"
     rf"(?!{SHELL_SAME_SUBJECT_CONTINUATION_PATTERN})"
-    rf"(?=(?:(?![.!?;,]).){{1,50}}\b{SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
+    rf"(?=(?:(?![.!?;]).){{1,50}}\b{SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
 )
 SHELL_WITH_OTHER_SUBJECT_BOUNDARY_PATTERN = (
     r"\bwith\b"
-    rf"(?=(?:(?![.!?;,]).){{1,50}}\b{SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
+    rf"(?=(?:(?![.!?;]).){{1,50}}\b{SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
 )
 BASH_STRONG_SURFACE_RE = re.compile(
     r"\bbash\s+(?:history|windows?|"
@@ -226,7 +231,9 @@ SHELL_TARGET_CONTEXT_PATTERN = (
 )
 SHELL_WITH_COMPUTING_RE = re.compile(
     r"\bshell(?:s|-like)?(?:['’]s)?\b\s*,?\s+with\s+"
-    r"(?:a\s+|an\s+|the\s+|its\s+)?(?:blinking\s+)?"
+    r"(?:a\s+|an\s+|the\s+|its\s+)?"
+    rf"(?:{SHELL_ADVERB_MORPHOLOGY_PATTERN}\s+){{0,2}}"
+    rf"(?:(?!{SHELL_SUBJECT_PREDICATE_PATTERN}\b)[\w-]+\s+)?"
     rf"(?:{SHELL_DIRECT_TARGET_PATTERN}|"
     r"(?:keyboard\s+|typed\s+|user\s+)?inputs?)\b",
     flags=re.IGNORECASE | re.DOTALL,

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -105,7 +105,7 @@ VISUAL_SAFETY_CHECKS = {
     "brittle_mandatory_motion": "hasNoMandatoryMotionVisuals",
 }
 READABLE_VISUAL_RE = re.compile(
-    r"\b(?:workstation|laptops?|phones?|monitors?|screens?|terminal|console|shell|"
+    r"\b(?:workstation|laptops?|phones?|monitors?|screens?|terminal|console|"
     r"source\s+code|code(?:\s+snippet)?|commands?|makefile|browsers?|web\s+pages?|"
     r"user\s+interface|ui|dashboard|documents?|docs?|changelog|release\s+notes?|"
     r"github(?:\s+page)?|pull\s+requests?|issues?|json|ya?ml|configuration|config|"
@@ -116,6 +116,12 @@ READABLE_VISUAL_RE = re.compile(
     r"(?:data|rows?|columns?|cells?|values?|text)|column\s+headers?|"
     r"ui\s+controls?|(?:input|web|application)\s+forms?|"
     r"(?:graphical|software|application|app)\s+(?:user\s+)?interfaces?)\b",
+    flags=re.IGNORECASE,
+)
+COMMAND_SHELL_VISUAL_RE = re.compile(
+    r"\b(?:(?:terminal|interactive|login|command(?:[-\s]+line)?)"
+    r"[-\s]+shell|shell[-\s]+(?:prompt|commands?|output|session|terminal|"
+    r"console|windows?|screens?|interfaces?))\b",
     flags=re.IGNORECASE,
 )
 EXACT_GEOMETRY_VISUAL_RE = re.compile(
@@ -3438,7 +3444,9 @@ def visual_safety_categories(cue: str) -> list[str]:
     """Classify one visual cue using stable, machine-readable categories."""
     categories: list[str] = []
     readable_candidate = SAFE_TEXT_QUALIFIER_RE.sub("", cue)
-    if READABLE_VISUAL_RE.search(readable_candidate):
+    if READABLE_VISUAL_RE.search(readable_candidate) or COMMAND_SHELL_VISUAL_RE.search(
+        readable_candidate
+    ):
         categories.append("risky_readable_surface")
     if EXACT_GEOMETRY_VISUAL_RE.search(cue):
         categories.append("brittle_exact_geometry")

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -126,7 +126,7 @@ COMMAND_SHELL_NAME_PATTERN = (
     r"(?:bash|zsh|xonsh|korn|ksh|csh|tcsh|bourne(?:[-\s]+again)?|powershell)"
 )
 BASH_STRONG_SURFACE_RE = re.compile(
-    r"\bbash\s+(?:history|scripts?|windows?)\b",
+    r"\bbash\s+(?:history|scripts?|windows?|panes?)\b",
     flags=re.IGNORECASE,
 )
 BASH_SESSION_RE = re.compile(
@@ -156,12 +156,24 @@ COMMAND_SHELL_EXECUTION_RE = re.compile(
 SHELL_SUBJECT_CONTEXT_PATTERN = (
     r"(?:(?![.!?;]|\b(?:that|who|which)\b|"
     r"\b(?:beside|near|alongside)\s+(?:a|an|the)\b|"
-    r",\s*(?:and|but|while|whereas|yet)\s+(?:a|an|the)\b).){0,100}"
+    r",?\s*(?:and|but|while|whereas|yet|as)\s+"
+    r"(?:a|an|the|another)\b).){0,100}"
+)
+SHELL_DIRECT_RELATIVE_COMPUTING_RE = re.compile(
+    r"\bshell(?:s|-like)?(?:['’]s)?\s+(?:that|which)\s+"
+    r"(?:shows?|displays?|presents?)\s+(?:a\s+|an\s+|the\s+|its\s+)?"
+    r"(?:prompts?|outputs?|directory\s+listings?|file\s+listings?|filenames?)\b|"
+    r"\bshell(?:s|-like)?(?:['’]s)?\s+(?:that|which)\s+"
+    r"(?:accepts?|receives?|takes?)\s+(?:keyboard\s+|typed\s+|user\s+)?inputs?\b|"
+    r"\bshell(?:s|-like)?(?:['’]s)?\s+(?:that|which)\s+"
+    r"(?:prints?|writes?)\s+(?:(?:diagnostic|build|command|standard|current)\s+)?"
+    r"outputs?\b",
+    flags=re.IGNORECASE,
 )
 SHELL_OWNED_COMPUTING_RE = re.compile(
     r"\bshell[-\s]+outputs?\s+windows?\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
-    r"(?:scripts?|prompts?|cli|screens?|sessions?|"
+    r"(?:scripts?|prompts?|cli|screens?|sessions?|panes?|transcripts?|"
     r"working\s+director(?:y|ies)|standard\s+outputs?|current\s+outputs?|"
     r"command\s+outputs?|technical\s+surfaces?)\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
@@ -170,14 +182,15 @@ SHELL_OWNED_COMPUTING_RE = re.compile(
     r"interfaces?\b(?!\s+between\b)|"
     r"\bshell(?:s|-like)?(?:['’]s)?\b"
     rf"{SHELL_SUBJECT_CONTEXT_PATTERN}\b"
-    r"(?:is|has|with|hosts?|contains?|shows?|reads?|invokes?|displays?|"
+    r"(?:is|has|with|hosts?|contains?|shows?|reads?|lists?|invokes?|displays?|"
     r"displaying|presents?|presenting|renders?|rendering|prints?|writes?)\b"
     r"(?:(?![.!?;]).){0,60}\b"
     rf"(?:{COMMAND_SHELL_NAME_PATTERN}\s+sessions?|prompts?|"
     r"(?:blinking\s+)?(?:cursors?|carets?)(?![-\s]+(?:shaped|like)\b)|"
     r"cli|keystrokes?|"
     r"stdout|stderr|system\s+sessions?|login\s+sessions?|stdin|"
-    r"working\s+director(?:y|ies)|"
+    r"working\s+director(?:y|ies)|directory\s+listings?|file\s+listings?|"
+    r"filenames?|files?|"
     r"standard\s+outputs?|current\s+outputs?|command\s+outputs?|outputs?)\b",
     flags=re.IGNORECASE | re.DOTALL,
 )
@@ -3545,6 +3558,7 @@ def has_risky_shell_visual(cue: str) -> bool:
             COMMAND_SHELL_PATH_RE,
             NAMED_COMMAND_SHELL_RE,
             COMMAND_SHELL_EXECUTION_RE,
+            SHELL_DIRECT_RELATIVE_COMPUTING_RE,
             SHELL_OWNED_COMPUTING_RE,
             SHELL_INPUT_INTERACTION_RE,
             UNAMBIGUOUS_COMPUTING_SURFACE_RE,

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -125,6 +125,13 @@ UNAMBIGUOUS_SHELL_IMPLEMENTATION_RE = re.compile(
 COMMAND_SHELL_NAME_PATTERN = (
     r"(?:bash|zsh|xonsh|korn|ksh|csh|tcsh|bourne(?:[-\s]+again)?|powershell)"
 )
+BASH_NAMED_SURFACE_RE = re.compile(
+    r"\bBash\s+(?:history|scripts?|sessions?|windows?)\b"
+)
+COMMAND_SHELL_PATH_RE = re.compile(
+    rf"(?<!\w)/bin/{COMMAND_SHELL_NAME_PATTERN}\b",
+    flags=re.IGNORECASE,
+)
 NAMED_COMMAND_SHELL_RE = re.compile(
     rf"(?<!\w)(?:/bin/)?{COMMAND_SHELL_NAME_PATTERN}\s+"
     r"(?:prompts?|outputs?|standard\s+outputs?)\b|"
@@ -142,22 +149,27 @@ COMMAND_SHELL_EXECUTION_RE = re.compile(
     rf"(?:a\s+|the\s+)?(?:/bin/)?{COMMAND_SHELL_NAME_PATTERN}\b",
     flags=re.IGNORECASE,
 )
+SHELL_SUBJECT_CONTEXT_PATTERN = (
+    r"(?:(?![.!?;]|\b(?:that|who|which)\b|"
+    r"\b(?:beside|near|alongside)\s+(?:a|an|the)\b).){0,100}"
+)
 SHELL_OWNED_COMPUTING_RE = re.compile(
+    r"\bshell[-\s]+outputs?\s+windows?\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
-    r"(?:scripts?|history|prompts?|cli|screens?|sessions?|"
+    r"(?:scripts?|prompts?|cli|screens?|sessions?|"
     r"working\s+director(?:y|ies)|standard\s+outputs?|current\s+outputs?|"
-    r"outputs?|technical\s+surfaces?)\b|"
+    r"command\s+outputs?|technical\s+surfaces?)\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
     r"windows?\b(?!\s+of\s+(?:light|glow))|"
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
     r"interfaces?\b(?!\s+between\b)|"
     r"\bshell(?:s|-like)?(?:['’]s)?\b"
-    r"(?:(?![.!?;]).){0,100}\b"
+    rf"{SHELL_SUBJECT_CONTEXT_PATTERN}\b"
     r"(?:is|has|with|hosts?|contains?|shows?|reads?|invokes?|displays?|"
     r"displaying|presents?|presenting|renders?|rendering)\b"
     r"(?:(?![.!?;]).){0,60}\b"
     rf"(?:{COMMAND_SHELL_NAME_PATTERN}\s+sessions?|prompts?|"
-    r"(?:blinking\s+)?(?:cursors?|carets?)|cli|keystrokes?|"
+    r"(?:blinking\s+)?(?:cursors?|carets?)(?![-\s]+shaped\b)|cli|keystrokes?|"
     r"stdout|stderr|system\s+sessions?|login\s+sessions?|stdin|"
     r"working\s+director(?:y|ies)|"
     r"standard\s+outputs?|current\s+outputs?|command\s+outputs?|outputs?)\b",
@@ -165,8 +177,7 @@ SHELL_OWNED_COMPUTING_RE = re.compile(
 )
 SHELL_INPUT_INTERACTION_RE = re.compile(
     r"\bshell(?:s|-like)?(?:['’]s)?\b"
-    r"(?:(?![.!?;]|\b(?:that|who|which)\b|"
-    r"\b(?:beside|near|alongside)\s+(?:a|an|the)\b).){0,80}"
+    rf"{SHELL_SUBJECT_CONTEXT_PATTERN}"
     r"\b(?:accepts?|awaits?|receives?|takes?|waits\s+for)\b"
     r"(?:(?![.!?;]).){0,20}\b(?:keyboard\s+|typed\s+|user\s+)?inputs?\b",
     flags=re.IGNORECASE | re.DOTALL,
@@ -179,7 +190,7 @@ UNAMBIGUOUS_COMPUTING_SURFACE_RE = re.compile(
     r"\b(?:shows?|displays?|presents?|contains?)\s+(?:a\s+|the\s+|its\s+)?"
     r"(?:cursors?|carets?)\b(?![-\s]+shaped\b)|"
     r"\btyped\s+inputs?\b|"
-    r"\b(?:prints?|writes?)\s+(?:(?:its|the|current)\s+){0,2}outputs?\b|"
+    r"\b(?:prints?|writes?)\b(?:(?![.!?;]).){0,40}\boutputs?\b|"
     r"\b(?:stdout|stderr|cli|repl|keystrokes?|command\s+outputs?|"
     r"standard\s+outputs?|stdin|environment\s+variables?|"
     r"(?:login|terminal|command|system)\s+sessions?)\b",
@@ -3524,6 +3535,8 @@ def has_risky_shell_visual(cue: str) -> bool:
         pattern.search(cue)
         for pattern in (
             UNAMBIGUOUS_SHELL_IMPLEMENTATION_RE,
+            BASH_NAMED_SURFACE_RE,
+            COMMAND_SHELL_PATH_RE,
             NAMED_COMMAND_SHELL_RE,
             COMMAND_SHELL_EXECUTION_RE,
             SHELL_OWNED_COMPUTING_RE,

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -126,7 +126,8 @@ COMMAND_SHELL_NAME_PATTERN = (
     r"(?:bash|zsh|xonsh|korn|ksh|csh|tcsh|bourne(?:[-\s]+again)?|powershell)"
 )
 NAMED_COMMAND_SHELL_RE = re.compile(
-    rf"(?<!\w)(?:/bin/)?{COMMAND_SHELL_NAME_PATTERN}\s+prompts?\b|"
+    rf"(?<!\w)(?:/bin/)?{COMMAND_SHELL_NAME_PATTERN}\s+"
+    r"(?:prompts?|outputs?|standard\s+outputs?)\b|"
     rf"\b(?:{COMMAND_SHELL_NAME_PATTERN}|posix|unix)\s+shell(?:s|-like)?\b|"
     r"\b(?:root|system|windows?|default|os|terminal|console|interactive|login|"
     r"command(?:[-\s]+line)?)"
@@ -153,25 +154,32 @@ SHELL_OWNED_COMPUTING_RE = re.compile(
     r"\bshell(?:s|-like)?(?:['’]s)?\b"
     r"(?:(?![.!?;]).){0,100}\b"
     r"(?:is|has|with|hosts?|contains?|shows?|reads?|invokes?|displays?|"
-    r"displaying|presents?|presenting|renders?|rendering|accepts?|awaits?|"
-    r"receives?|takes?|waits\s+for)\b"
+    r"displaying|presents?|presenting|renders?|rendering)\b"
     r"(?:(?![.!?;]).){0,60}\b"
     rf"(?:{COMMAND_SHELL_NAME_PATTERN}\s+sessions?|prompts?|"
     r"(?:blinking\s+)?(?:cursors?|carets?)|cli|keystrokes?|"
-    r"keyboard\s+inputs?|typed\s+inputs?|stdout|stderr|system\s+sessions?|"
-    r"login\s+sessions?|stdin|(?:keyboard\s+|typed\s+|user\s+)?inputs?|"
+    r"stdout|stderr|system\s+sessions?|login\s+sessions?|stdin|"
     r"working\s+director(?:y|ies)|"
     r"standard\s+outputs?|current\s+outputs?|command\s+outputs?|outputs?)\b",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+SHELL_INPUT_INTERACTION_RE = re.compile(
+    r"\bshell(?:s|-like)?(?:['’]s)?\b"
+    r"(?:(?![.!?;]|\b(?:that|who|which)\b|"
+    r"\b(?:beside|near|alongside)\s+(?:a|an|the)\b).){0,80}"
+    r"\b(?:accepts?|awaits?|receives?|takes?|waits\s+for)\b"
+    r"(?:(?![.!?;]).){0,20}\b(?:keyboard\s+|typed\s+|user\s+)?inputs?\b",
     flags=re.IGNORECASE | re.DOTALL,
 )
 UNAMBIGUOUS_COMPUTING_SURFACE_RE = re.compile(
     r"\b(?:a|an|the|its|shell(?:s|['’]s|-like)?)?\s*"
     r"(?:blinking\s+)?prompts?\s+(?:appears?|blinks?|rests?|waits?|is\b)|"
     r"\b(?:blinking|visible|onscreen|on[-\s]+screen)\s+"
-    r"(?:cursors?|carets?)\b|"
+    r"(?:cursors?|carets?)(?![-\s]+shaped\b)\b|"
     r"\b(?:shows?|displays?|presents?|contains?)\s+(?:a\s+|the\s+|its\s+)?"
     r"(?:cursors?|carets?)\b(?![-\s]+shaped\b)|"
     r"\btyped\s+inputs?\b|"
+    r"\b(?:prints?|writes?)\s+(?:(?:its|the|current)\s+){0,2}outputs?\b|"
     r"\b(?:stdout|stderr|cli|repl|keystrokes?|command\s+outputs?|"
     r"standard\s+outputs?|stdin|environment\s+variables?|"
     r"(?:login|terminal|command|system)\s+sessions?)\b",
@@ -3519,6 +3527,7 @@ def has_risky_shell_visual(cue: str) -> bool:
             NAMED_COMMAND_SHELL_RE,
             COMMAND_SHELL_EXECUTION_RE,
             SHELL_OWNED_COMPUTING_RE,
+            SHELL_INPUT_INTERACTION_RE,
             UNAMBIGUOUS_COMPUTING_SURFACE_RE,
         )
     )

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -126,6 +126,7 @@ COMMAND_SHELL_NAME_PATTERN = (
     r"(?:bash|zsh|xonsh|korn|ksh|csh|tcsh|bourne(?:[-\s]+again)?|powershell)"
 )
 NAMED_COMMAND_SHELL_RE = re.compile(
+    rf"(?<!\w)(?:/bin/)?{COMMAND_SHELL_NAME_PATTERN}\s+prompts?\b|"
     rf"\b(?:{COMMAND_SHELL_NAME_PATTERN}|posix|unix)\s+shell(?:s|-like)?\b|"
     r"\b(?:root|system|windows?|default|os|terminal|console|interactive|login|"
     r"command(?:[-\s]+line)?)"
@@ -142,19 +143,24 @@ COMMAND_SHELL_EXECUTION_RE = re.compile(
 )
 SHELL_OWNED_COMPUTING_RE = re.compile(
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
-    r"(?:scripts?|history|prompts?|cli|windows?|screens?|interfaces?|sessions?|"
+    r"(?:scripts?|history|prompts?|cli|screens?|sessions?|"
     r"working\s+director(?:y|ies)|standard\s+outputs?|current\s+outputs?|"
     r"outputs?|technical\s+surfaces?)\b|"
+    r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
+    r"windows?\b(?!\s+of\s+(?:light|glow))|"
+    r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
+    r"interfaces?\b(?!\s+between\b)|"
     r"\bshell(?:s|-like)?(?:['’]s)?\b"
     r"(?:(?![.!?;]).){0,100}\b"
     r"(?:is|has|with|hosts?|contains?|shows?|reads?|invokes?|displays?|"
     r"displaying|presents?|presenting|renders?|rendering|accepts?|awaits?|"
-    r"waits\s+for)\b"
+    r"receives?|takes?|waits\s+for)\b"
     r"(?:(?![.!?;]).){0,60}\b"
     rf"(?:{COMMAND_SHELL_NAME_PATTERN}\s+sessions?|prompts?|"
     r"(?:blinking\s+)?(?:cursors?|carets?)|cli|keystrokes?|"
     r"keyboard\s+inputs?|typed\s+inputs?|stdout|stderr|system\s+sessions?|"
-    r"login\s+sessions?|stdin|user\s+inputs?|working\s+director(?:y|ies)|"
+    r"login\s+sessions?|stdin|(?:keyboard\s+|typed\s+|user\s+)?inputs?|"
+    r"working\s+director(?:y|ies)|"
     r"standard\s+outputs?|current\s+outputs?|command\s+outputs?|outputs?)\b",
     flags=re.IGNORECASE | re.DOTALL,
 )
@@ -164,10 +170,8 @@ UNAMBIGUOUS_COMPUTING_SURFACE_RE = re.compile(
     r"\b(?:blinking|visible|onscreen|on[-\s]+screen)\s+"
     r"(?:cursors?|carets?)\b|"
     r"\b(?:shows?|displays?|presents?|contains?)\s+(?:a\s+|the\s+|its\s+)?"
-    r"(?:cursors?|carets?)\b|"
+    r"(?:cursors?|carets?)\b(?![-\s]+shaped\b)|"
     r"\btyped\s+inputs?\b|"
-    r"\b(?:accepts?|awaits?|waits\s+for)\s+(?:typed\s+|keyboard\s+|user\s+)"
-    r"inputs?\b|"
     r"\b(?:stdout|stderr|cli|repl|keystrokes?|command\s+outputs?|"
     r"standard\s+outputs?|stdin|environment\s+variables?|"
     r"(?:login|terminal|command|system)\s+sessions?)\b",

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -126,7 +126,10 @@ COMMAND_SHELL_NAME_PATTERN = (
     r"(?:bash|zsh|xonsh|korn|ksh|csh|tcsh|bourne(?:[-\s]+again)?|powershell)"
 )
 BASH_STRONG_SURFACE_RE = re.compile(
-    r"\bbash\s+(?:history|scripts?|windows?|panes?)\b",
+    r"\bbash\s+(?:history|scripts?|windows?|panes?|transcripts?|"
+    r"directory\s+listings?)\b|"
+    r"\bbash\s+(?:prompts?|cursors?|carets?)\b"
+    r"(?![-\s]+(?:shaped|like)\b)",
     flags=re.IGNORECASE,
 )
 BASH_SESSION_RE = re.compile(
@@ -156,15 +159,31 @@ COMMAND_SHELL_EXECUTION_RE = re.compile(
 SHELL_SUBJECT_CONTEXT_PATTERN = (
     r"(?:(?![.!?;]|\b(?:that|who|which)\b|"
     r"\b(?:beside|near|alongside)\s+(?:a|an|the)\b|"
+    r"(?:,|:)\s*(?:a|an|the|another)\b|"
     r",?\s*(?:and|but|while|whereas|yet|as)\s+"
     r"(?:a|an|the|another)\b).){0,100}"
 )
+SHELL_TARGET_CONTEXT_PATTERN = (
+    r"(?:(?![.!?;]|\b(?:that|who|which)\b|"
+    r"\b(?:beside|near|alongside)\s+(?:a|an|the)\b|"
+    r"(?:,|:)\s*(?:a|an|the|another)\b|"
+    r",?\s*(?:and|but|while|whereas|yet|as)\s+"
+    r"(?:a|an|the|another)\b).){0,60}"
+)
 SHELL_DIRECT_RELATIVE_COMPUTING_RE = re.compile(
     r"\bshell(?:s|-like)?(?:['’]s)?\s+(?:that|which)\s+"
-    r"(?:shows?|displays?|presents?)\s+(?:a\s+|an\s+|the\s+|its\s+)?"
-    r"(?:prompts?|outputs?|directory\s+listings?|file\s+listings?|filenames?)\b|"
+    r"(?:shows?|displays?|presents?|renders?)\s+"
+    r"(?:a\s+|an\s+|the\s+|its\s+)?"
+    r"(?:prompts?\b(?![-\s]+(?:shaped|like)\b)|"
+    r"(?:(?:diagnostic|build|command|standard|current)\s+)?outputs?|"
+    r"directory\s+listings?|file\s+listings?|file\s+names?|files?)\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?\s+(?:that|which)\s+"
-    r"(?:accepts?|receives?|takes?)\s+(?:keyboard\s+|typed\s+|user\s+)?inputs?\b|"
+    r"lists?\s+(?:a\s+|an\s+|the\s+|its\s+)?"
+    r"(?:directory|directory\s+listings?|file\s+listings?|"
+    r"file\s+names?|files?)\b|"
+    r"\bshell(?:s|-like)?(?:['’]s)?\s+(?:that|which)\s+"
+    r"(?:accepts?|awaits?|receives?|takes?|waits\s+for)\s+"
+    r"(?:keyboard\s+|typed\s+|user\s+)?inputs?\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?\s+(?:that|which)\s+"
     r"(?:prints?|writes?)\s+(?:(?:diagnostic|build|command|standard|current)\s+)?"
     r"outputs?\b",
@@ -173,7 +192,8 @@ SHELL_DIRECT_RELATIVE_COMPUTING_RE = re.compile(
 SHELL_OWNED_COMPUTING_RE = re.compile(
     r"\bshell[-\s]+outputs?\s+windows?\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
-    r"(?:scripts?|prompts?|cli|screens?|sessions?|panes?|transcripts?|"
+    r"(?:scripts?|prompts?\b(?![-\s]+(?:shaped|like)\b)|cli|"
+    r"screens?|sessions?|panes?|transcripts?|"
     r"working\s+director(?:y|ies)|standard\s+outputs?|current\s+outputs?|"
     r"command\s+outputs?|technical\s+surfaces?)\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
@@ -184,8 +204,9 @@ SHELL_OWNED_COMPUTING_RE = re.compile(
     rf"{SHELL_SUBJECT_CONTEXT_PATTERN}\b"
     r"(?:is|has|with|hosts?|contains?|shows?|reads?|lists?|invokes?|displays?|"
     r"displaying|presents?|presenting|renders?|rendering|prints?|writes?)\b"
-    r"(?:(?![.!?;]).){0,60}\b"
-    rf"(?:{COMMAND_SHELL_NAME_PATTERN}\s+sessions?|prompts?|"
+    rf"{SHELL_TARGET_CONTEXT_PATTERN}\b"
+    rf"(?:{COMMAND_SHELL_NAME_PATTERN}\s+sessions?|"
+    r"prompts?\b(?![-\s]+(?:shaped|like)\b)|"
     r"(?:blinking\s+)?(?:cursors?|carets?)(?![-\s]+(?:shaped|like)\b)|"
     r"cli|keystrokes?|"
     r"stdout|stderr|system\s+sessions?|login\s+sessions?|stdin|"

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -150,7 +150,7 @@ SHELL_DIRECT_TARGET_PATTERN = (
     r"(?:standard|current|command)\s+outputs?)"
 )
 SHELL_EVIDENCE_VERB_PATTERN = (
-    r"(?:is|has|with|hosts?|contains?|shows?|reads?|lists?|invokes?|displays?|"
+    r"(?:is|has|hosts?|contains?|shows?|reads?|lists?|invokes?|displays?|"
     r"displaying|presents?|presenting|renders?|rendering|prints?|writes?)"
 )
 SHELL_INPUT_VERB_PATTERN = (
@@ -159,11 +159,22 @@ SHELL_INPUT_VERB_PATTERN = (
 SHELL_SUBJECT_PREDICATE_PATTERN = (
     rf"(?:{SHELL_EVIDENCE_VERB_PATTERN}|{SHELL_INPUT_VERB_PATTERN})"
 )
+SHELL_OTHER_SUBJECT_PATTERN = (
+    r"(?:(?:he|she|they|we|this|that|these|those)\b|"
+    r"(?:(?:a|an|the|another|each|every|either|neither|some|any|many|"
+    r"several|few|one|two|three|four|five|six|seven|eight|nine|ten|\d+)\s+"
+    r"(?:[a-z][\w-]*\s+){0,3}[a-z][\w-]*)\b|"
+    r"(?:[a-z][\w-]*\s+){0,2}[a-z][\w-]*s\b)"
+)
 SHELL_NEW_SUBJECT_BOUNDARY_PATTERN = (
     r"\b(?:and|but|while|whereas|yet|as)\b\s+"
-    rf"(?!(?:(?:it|its)\b|the\s+shell(?:s|-like)?\b|"
-    rf"{SHELL_SUBJECT_PREDICATE_PATTERN}\b))"
-    rf"(?=(?:(?![.!?;,]).){{0,50}}\b{SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
+    r"(?!(?:(?:it|its)\b|the\s+shell(?:s|-like)?\b))"
+    rf"(?={SHELL_OTHER_SUBJECT_PATTERN}\s+"
+    rf"{SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
+)
+SHELL_WITH_OTHER_SUBJECT_BOUNDARY_PATTERN = (
+    rf"\bwith\s+{SHELL_OTHER_SUBJECT_PATTERN}\s+"
+    rf"(?={SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
 )
 BASH_STRONG_SURFACE_RE = re.compile(
     r"\bbash\s+(?:history|windows?|"
@@ -198,13 +209,22 @@ SHELL_SUBJECT_CONTEXT_PATTERN = (
     r"(?:(?![.!?;]|\b(?:that|who|which)\b|"
     r"\b(?:beside|near|alongside)\s+(?:a|an|the)\b|"
     r"(?:,|:)\s*(?:a|an|the|another)\b|"
+    rf"{SHELL_WITH_OTHER_SUBJECT_BOUNDARY_PATTERN}|"
     rf"{SHELL_NEW_SUBJECT_BOUNDARY_PATTERN}).){{0,100}}"
 )
 SHELL_TARGET_CONTEXT_PATTERN = (
     r"(?:(?![.!?;]|\b(?:that|who|which)\b|"
     r"\b(?:beside|near|alongside)\s+(?:a|an|the)\b|"
     r"(?:,|:)\s*(?:a|an|the|another)\b|"
+    rf"{SHELL_WITH_OTHER_SUBJECT_BOUNDARY_PATTERN}|"
     rf"{SHELL_NEW_SUBJECT_BOUNDARY_PATTERN}).){{0,60}}"
+)
+SHELL_WITH_COMPUTING_RE = re.compile(
+    r"\bshell(?:s|-like)?(?:['’]s)?\b\s*,?\s+with\s+"
+    r"(?:a\s+|an\s+|the\s+|its\s+)?(?:blinking\s+)?"
+    rf"(?:{SHELL_DIRECT_TARGET_PATTERN}|"
+    r"(?:keyboard\s+|typed\s+|user\s+)?inputs?)\b",
+    flags=re.IGNORECASE | re.DOTALL,
 )
 SHELL_DIRECT_RELATIVE_COMPUTING_RE = re.compile(
     r"\bshell(?:s|-like)?(?:['’]s)?\s+(?:that|which)\s+"
@@ -3596,6 +3616,7 @@ def has_risky_shell_visual(cue: str) -> bool:
             COMMAND_SHELL_PATH_RE,
             NAMED_COMMAND_SHELL_RE,
             COMMAND_SHELL_EXECUTION_RE,
+            SHELL_WITH_COMPUTING_RE,
             SHELL_DIRECT_RELATIVE_COMPUTING_RE,
             SHELL_OWNED_COMPUTING_RE,
             SHELL_INPUT_INTERACTION_RE,

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -234,8 +234,19 @@ SHELL_WITH_COMPUTING_RE = re.compile(
     r"(?:a\s+|an\s+|the\s+|its\s+)?"
     rf"(?:{SHELL_ADVERB_MORPHOLOGY_PATTERN}\s+){{0,2}}"
     rf"(?:(?!{SHELL_SUBJECT_PREDICATE_PATTERN}\b)[\w-]+\s+)?"
-    rf"(?:{SHELL_DIRECT_TARGET_PATTERN}|"
+    rf"(?!(?:panes?)\b)(?:{SHELL_DIRECT_TARGET_PATTERN}|"
     r"(?:keyboard\s+|typed\s+|user\s+)?inputs?)\b",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+SHELL_WITH_PANE_COMPUTING_RE = re.compile(
+    r"\bshell(?:s|-like)?(?:['’]s)?\b\s*,?\s+with\s+"
+    r"(?:(?![.!?;,]).){0,60}\bpanes?\b"
+    r"(?![-\s]+(?:shaped|like)\b)"
+    r"(?:(?![.!?;,]).){0,30}\b"
+    r"(?:shows?|showing|displays?|displaying|presents?|presenting|"
+    r"contains?|containing|renders?|rendering)\b"
+    r"(?:(?![.!?;,]).){0,30}\b"
+    rf"{SHELL_READABLE_TARGET_PATTERN}\b",
     flags=re.IGNORECASE | re.DOTALL,
 )
 SHELL_DIRECT_RELATIVE_COMPUTING_RE = re.compile(
@@ -3629,6 +3640,7 @@ def has_risky_shell_visual(cue: str) -> bool:
             NAMED_COMMAND_SHELL_RE,
             COMMAND_SHELL_EXECUTION_RE,
             SHELL_WITH_COMPUTING_RE,
+            SHELL_WITH_PANE_COMPUTING_RE,
             SHELL_DIRECT_RELATIVE_COMPUTING_RE,
             SHELL_OWNED_COMPUTING_RE,
             SHELL_INPUT_INTERACTION_RE,

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -158,8 +158,10 @@ SHELL_EVIDENCE_VERB_PATTERN = (
     rf"(?:is|has|{SHELL_TECHNICAL_ACTION_PREDICATE_PATTERN})"
 )
 SHELL_INPUT_VERB_PATTERN = (
-    r"(?:accepts?|awaits?|receives?|takes?|waits\s+for)"
+    r"(?:accepts?|accepting|awaits?|awaiting|receives?|receiving|takes?|"
+    r"taking|waits?\s+for|waiting\s+for)"
 )
+SHELL_INPUT_TARGET_PATTERN = r"(?:keyboard\s+|typed\s+|user\s+)?inputs?"
 SHELL_SUBJECT_PREDICATE_PATTERN = (
     rf"(?:{SHELL_EVIDENCE_VERB_PATTERN}|{SHELL_INPUT_VERB_PATTERN})"
 )
@@ -249,15 +251,23 @@ PANE_COMPUTING_PREDICATE_PATTERN = (
 PANE_EXPLICIT_REFERENCE_PATTERN = (
     r"(?:,?\s+(?:and|but|while|whereas|yet)\s+(?:it|the\s+pane)\s+)"
 )
+PANE_OWNED_PREDICATE_PREFIX_PATTERN = (
+    rf"(?:\s+(?:(?:that|which)\s+)?|{PANE_EXPLICIT_REFERENCE_PATTERN})"
+)
+PANE_READABLE_OBJECT_PATTERN = (
+    r"(?:a\s+|an\s+|the\s+|its\s+)?"
+    rf"(?:(?!{SHELL_SUBJECT_PREDICATE_PATTERN}\b)[\w-]+\s+){{0,2}}"
+    rf"{SHELL_READABLE_TARGET_PATTERN}\b"
+)
 SHELL_WITH_PANE_COMPUTING_RE = re.compile(
     r"\bshell(?:s|-like)?(?:['’]s)?\b\s*,?\s+with\s+"
     r"(?:(?![.!?;,]).){0,60}\bpanes?\b"
     r"(?![-\s]+(?:shaped|like)\b)"
-    rf"(?:\s+(?:(?:that|which)\s+)?|{PANE_EXPLICIT_REFERENCE_PATTERN})"
-    rf"{PANE_COMPUTING_PREDICATE_PATTERN}\b\s+"
-    r"(?:a\s+|an\s+|the\s+|its\s+)?"
-    rf"(?:(?!{SHELL_SUBJECT_PREDICATE_PATTERN}\b)[\w-]+\s+){{0,2}}"
-    rf"{SHELL_READABLE_TARGET_PATTERN}\b",
+    rf"{PANE_OWNED_PREDICATE_PREFIX_PATTERN}"
+    rf"(?:{PANE_COMPUTING_PREDICATE_PATTERN}\b\s+"
+    rf"{PANE_READABLE_OBJECT_PATTERN}|"
+    rf"{SHELL_INPUT_VERB_PATTERN}\b\s+{SHELL_INPUT_TARGET_PATTERN}\b|"
+    rf"has\b\s+{PANE_READABLE_OBJECT_PATTERN})",
     flags=re.IGNORECASE | re.DOTALL,
 )
 SHELL_DIRECT_RELATIVE_COMPUTING_RE = re.compile(

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -125,11 +125,49 @@ UNAMBIGUOUS_SHELL_IMPLEMENTATION_RE = re.compile(
 COMMAND_SHELL_NAME_PATTERN = (
     r"(?:bash|zsh|xonsh|korn|ksh|csh|tcsh|bourne(?:[-\s]+again)?|powershell)"
 )
+SHELL_PROMPT_TARGET_PATTERN = r"prompts?\b(?![-\s]+(?:shaped|like)\b)"
+SHELL_FILE_TARGET_PATTERN = (
+    r"(?:working\s+director(?:y|ies)|directory|directory\s+listings?|"
+    r"file\s+listings?|file\s+names?|filenames?|files?)"
+)
+SHELL_OUTPUT_TARGET_PATTERN = (
+    r"(?:(?:diagnostic|build|command|standard|current)\s+)?outputs?"
+)
+SHELL_SURFACE_TARGET_PATTERN = (
+    rf"(?:{SHELL_PROMPT_TARGET_PATTERN}|"
+    r"(?:blinking\s+)?(?:cursors?|carets?)(?![-\s]+(?:shaped|like)\b)|"
+    r"cli|scripts?|screens?|panes?|transcripts?|"
+    rf"{SHELL_FILE_TARGET_PATTERN}|"
+    r"keystrokes?|stdout|stderr|stdin|"
+    r"technical\s+surfaces?)"
+)
+SHELL_READABLE_TARGET_PATTERN = (
+    rf"(?:{SHELL_SURFACE_TARGET_PATTERN}|{SHELL_OUTPUT_TARGET_PATTERN}|"
+    r"system\s+sessions?|login\s+sessions?)"
+)
+SHELL_DIRECT_TARGET_PATTERN = (
+    rf"(?:{SHELL_SURFACE_TARGET_PATTERN}|sessions?|"
+    r"(?:standard|current|command)\s+outputs?)"
+)
+SHELL_EVIDENCE_VERB_PATTERN = (
+    r"(?:is|has|with|hosts?|contains?|shows?|reads?|lists?|invokes?|displays?|"
+    r"displaying|presents?|presenting|renders?|rendering|prints?|writes?)"
+)
+SHELL_INPUT_VERB_PATTERN = (
+    r"(?:accepts?|awaits?|receives?|takes?|waits\s+for)"
+)
+SHELL_SUBJECT_PREDICATE_PATTERN = (
+    rf"(?:{SHELL_EVIDENCE_VERB_PATTERN}|{SHELL_INPUT_VERB_PATTERN})"
+)
+SHELL_NEW_SUBJECT_BOUNDARY_PATTERN = (
+    r"\b(?:and|but|while|whereas|yet|as)\b\s+"
+    rf"(?!(?:(?:it|its)\b|the\s+shell(?:s|-like)?\b|"
+    rf"{SHELL_SUBJECT_PREDICATE_PATTERN}\b))"
+    rf"(?=(?:(?![.!?;,]).){{0,50}}\b{SHELL_SUBJECT_PREDICATE_PATTERN}\b)"
+)
 BASH_STRONG_SURFACE_RE = re.compile(
-    r"\bbash\s+(?:history|scripts?|windows?|panes?|transcripts?|"
-    r"directory\s+listings?)\b|"
-    r"\bbash\s+(?:prompts?|cursors?|carets?)\b"
-    r"(?![-\s]+(?:shaped|like)\b)",
+    r"\bbash\s+(?:history|windows?|"
+    rf"{SHELL_READABLE_TARGET_PATTERN})\b",
     flags=re.IGNORECASE,
 )
 BASH_SESSION_RE = re.compile(
@@ -141,7 +179,7 @@ COMMAND_SHELL_PATH_RE = re.compile(
 )
 NAMED_COMMAND_SHELL_RE = re.compile(
     rf"(?<!\w)(?:/bin/)?{COMMAND_SHELL_NAME_PATTERN}\s+"
-    r"(?:prompts?|outputs?|standard\s+outputs?)\b|"
+    rf"(?:{SHELL_PROMPT_TARGET_PATTERN}|{SHELL_OUTPUT_TARGET_PATTERN})\b|"
     rf"\b(?:{COMMAND_SHELL_NAME_PATTERN}|posix|unix)\s+shell(?:s|-like)?\b|"
     r"\b(?:root|system|windows?|default|os|terminal|console|interactive|login|"
     r"command(?:[-\s]+line)?)"
@@ -160,65 +198,44 @@ SHELL_SUBJECT_CONTEXT_PATTERN = (
     r"(?:(?![.!?;]|\b(?:that|who|which)\b|"
     r"\b(?:beside|near|alongside)\s+(?:a|an|the)\b|"
     r"(?:,|:)\s*(?:a|an|the|another)\b|"
-    r",?\s*(?:and|but|while|whereas|yet|as)\s+"
-    r"(?:a|an|the|another)\b).){0,100}"
+    rf"{SHELL_NEW_SUBJECT_BOUNDARY_PATTERN}).){{0,100}}"
 )
 SHELL_TARGET_CONTEXT_PATTERN = (
     r"(?:(?![.!?;]|\b(?:that|who|which)\b|"
     r"\b(?:beside|near|alongside)\s+(?:a|an|the)\b|"
     r"(?:,|:)\s*(?:a|an|the|another)\b|"
-    r",?\s*(?:and|but|while|whereas|yet|as)\s+"
-    r"(?:a|an|the|another)\b).){0,60}"
+    rf"{SHELL_NEW_SUBJECT_BOUNDARY_PATTERN}).){{0,60}}"
 )
 SHELL_DIRECT_RELATIVE_COMPUTING_RE = re.compile(
     r"\bshell(?:s|-like)?(?:['’]s)?\s+(?:that|which)\s+"
-    r"(?:shows?|displays?|presents?|renders?)\s+"
+    rf"{SHELL_EVIDENCE_VERB_PATTERN}\s+"
     r"(?:a\s+|an\s+|the\s+|its\s+)?"
-    r"(?:prompts?\b(?![-\s]+(?:shaped|like)\b)|"
-    r"(?:(?:diagnostic|build|command|standard|current)\s+)?outputs?|"
-    r"directory\s+listings?|file\s+listings?|file\s+names?|files?)\b|"
+    rf"{SHELL_READABLE_TARGET_PATTERN}\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?\s+(?:that|which)\s+"
-    r"lists?\s+(?:a\s+|an\s+|the\s+|its\s+)?"
-    r"(?:directory|directory\s+listings?|file\s+listings?|"
-    r"file\s+names?|files?)\b|"
-    r"\bshell(?:s|-like)?(?:['’]s)?\s+(?:that|which)\s+"
-    r"(?:accepts?|awaits?|receives?|takes?|waits\s+for)\s+"
-    r"(?:keyboard\s+|typed\s+|user\s+)?inputs?\b|"
-    r"\bshell(?:s|-like)?(?:['’]s)?\s+(?:that|which)\s+"
-    r"(?:prints?|writes?)\s+(?:(?:diagnostic|build|command|standard|current)\s+)?"
-    r"outputs?\b",
+    rf"{SHELL_INPUT_VERB_PATTERN}\s+"
+    r"(?:keyboard\s+|typed\s+|user\s+)?inputs?\b",
     flags=re.IGNORECASE,
 )
 SHELL_OWNED_COMPUTING_RE = re.compile(
     r"\bshell[-\s]+outputs?\s+windows?\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
-    r"(?:scripts?|prompts?\b(?![-\s]+(?:shaped|like)\b)|cli|"
-    r"screens?|sessions?|panes?|transcripts?|"
-    r"working\s+director(?:y|ies)|standard\s+outputs?|current\s+outputs?|"
-    r"command\s+outputs?|technical\s+surfaces?)\b|"
+    rf"{SHELL_DIRECT_TARGET_PATTERN}\b|"
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
     r"windows?\b(?!\s+of\s+(?:light|glow))|"
     r"\bshell(?:s|-like)?(?:['’]s)?(?:\s*[-:—]\s*|\s+)"
     r"interfaces?\b(?!\s+between\b)|"
     r"\bshell(?:s|-like)?(?:['’]s)?\b"
     rf"{SHELL_SUBJECT_CONTEXT_PATTERN}\b"
-    r"(?:is|has|with|hosts?|contains?|shows?|reads?|lists?|invokes?|displays?|"
-    r"displaying|presents?|presenting|renders?|rendering|prints?|writes?)\b"
+    rf"{SHELL_EVIDENCE_VERB_PATTERN}\b"
     rf"{SHELL_TARGET_CONTEXT_PATTERN}\b"
     rf"(?:{COMMAND_SHELL_NAME_PATTERN}\s+sessions?|"
-    r"prompts?\b(?![-\s]+(?:shaped|like)\b)|"
-    r"(?:blinking\s+)?(?:cursors?|carets?)(?![-\s]+(?:shaped|like)\b)|"
-    r"cli|keystrokes?|"
-    r"stdout|stderr|system\s+sessions?|login\s+sessions?|stdin|"
-    r"working\s+director(?:y|ies)|directory\s+listings?|file\s+listings?|"
-    r"filenames?|files?|"
-    r"standard\s+outputs?|current\s+outputs?|command\s+outputs?|outputs?)\b",
+    rf"{SHELL_READABLE_TARGET_PATTERN})\b",
     flags=re.IGNORECASE | re.DOTALL,
 )
 SHELL_INPUT_INTERACTION_RE = re.compile(
     r"\bshell(?:s|-like)?(?:['’]s)?\b"
     rf"{SHELL_SUBJECT_CONTEXT_PATTERN}"
-    r"\b(?:accepts?|awaits?|receives?|takes?|waits\s+for)\b"
+    rf"\b{SHELL_INPUT_VERB_PATTERN}\b"
     r"(?:(?![.!?;]).){0,20}\b(?:keyboard\s+|typed\s+|user\s+)?inputs?\b",
     flags=re.IGNORECASE | re.DOTALL,
 )

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -119,9 +119,13 @@ READABLE_VISUAL_RE = re.compile(
     flags=re.IGNORECASE,
 )
 COMMAND_SHELL_VISUAL_RE = re.compile(
-    r"\b(?:(?:terminal|interactive|login|command(?:[-\s]+line)?)"
-    r"[-\s]+shell|shell[-\s]+(?:prompt|commands?|output|session|terminal|"
-    r"console|windows?|screens?|interfaces?))\b",
+    r"\b(?:(?:bash|posix|unix|zsh|fish|ksh|csh|tcsh|dash|"
+    r"bourne(?:[-\s]+again)?|terminal|interactive|login|"
+    r"command(?:[-\s]+line)?)[-\s]+shell|"
+    r"shell(?:[-\s]+(?:cli|prompt|commands?|output|session|terminal|console|"
+    r"windows?|screens?|interfaces?)|['’]s\s+(?:cli|prompt|commands?|output)|"
+    r"\s+(?:display(?:s|ed|ing)|show(?:s|ed|ing)|render(?:s|ed|ing)|"
+    r"present(?:s|ed|ing))\s+(?:(?:its|the)\s+)?(?:prompt|commands?|output)))\b",
     flags=re.IGNORECASE,
 )
 EXACT_GEOMETRY_VISUAL_RE = re.compile(

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -238,14 +238,21 @@ SHELL_WITH_COMPUTING_RE = re.compile(
     r"(?:keyboard\s+|typed\s+|user\s+)?inputs?)\b",
     flags=re.IGNORECASE | re.DOTALL,
 )
+PANE_COMPUTING_PREDICATE_PATTERN = (
+    r"(?:shows?|showing|displays?|displaying|presents?|presenting|"
+    r"contains?|containing|renders?|rendering)"
+)
+PANE_EXPLICIT_REFERENCE_PATTERN = (
+    r"(?:,?\s+(?:and|but|while|whereas|yet)\s+(?:it|the\s+pane)\s+)"
+)
 SHELL_WITH_PANE_COMPUTING_RE = re.compile(
     r"\bshell(?:s|-like)?(?:['’]s)?\b\s*,?\s+with\s+"
     r"(?:(?![.!?;,]).){0,60}\bpanes?\b"
     r"(?![-\s]+(?:shaped|like)\b)"
-    r"(?:(?![.!?;,]).){0,30}\b"
-    r"(?:shows?|showing|displays?|displaying|presents?|presenting|"
-    r"contains?|containing|renders?|rendering)\b"
-    r"(?:(?![.!?;,]).){0,30}\b"
+    rf"(?:\s+(?:(?:that|which)\s+)?|{PANE_EXPLICIT_REFERENCE_PATTERN})"
+    rf"{PANE_COMPUTING_PREDICATE_PATTERN}\b\s+"
+    r"(?:a\s+|an\s+|the\s+|its\s+)?"
+    rf"(?:(?!{SHELL_SUBJECT_PREDICATE_PATTERN}\b)[\w-]+\s+){{0,2}}"
     rf"{SHELL_READABLE_TARGET_PATTERN}\b",
     flags=re.IGNORECASE | re.DOTALL,
 )

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -122,20 +122,54 @@ SHELL_VISUAL_RE = re.compile(
     r"\b(?:powershell|shell(?:s|['’]s|-like)?)\b",
     flags=re.IGNORECASE,
 )
-SHELL_TECHNICAL_EVIDENCE_RE = re.compile(
-    r"\b(?:bash|posix|unix|zsh|fish|ksh|csh|tcsh|dash|powershell|"
-    r"bourne(?:[-\s]+again)?|root|system|default|os|technical|"
-    r"terminal|console|interactive|login|command(?:[-\s]+line)?|cli|"
-    r"prompts?|outputs?|sessions?|screens?|interfaces?|windows?)\b",
+SHELL_TECHNICAL_SURFACE_PATTERN = (
+    r"(?:cli|prompts?|cursors?|carets?|stdout|stderr|keyboard(?:\s+input)?|"
+    r"typed\s+input|inputs?|outputs?|commands?|terminals?|consoles?|sessions?|"
+    r"screens?|interfaces?|windows?|surfaces?)"
+)
+TECHNICAL_SHELL_PREFIX_RE = re.compile(
+    r"\b(?:bash|posix|unix|zsh|fish|ksh|csh|tcsh|dash|"
+    r"bourne(?:[-\s]+again)?|root|system|windows?|default|os|terminal|console|"
+    r"interactive|login|command(?:[-\s]+line)?)"
+    r"(?:[\s,-]+(?:driven|based|style|styled|technical|interactive|login|"
+    r"abstract|translucent|protective|geometric|outer|physical|luminous|"
+    r"glowing|transparent|frosted|matte|ceramic|delicate|organic|glass)){0,3}"
+    r"[\s,-]+shell(?:s|-like)?\b",
     flags=re.IGNORECASE,
 )
+TECHNICAL_SHELL_DIRECT_RE = re.compile(
+    rf"\bshell(?:s|-like)?\b(?:['’]s)?\s*(?:[-:—]\s*)?"
+    rf"(?:(?:a|an|the|its|current|blinking|visible|technical|interactive|"
+    rf"command[-\s]+line)\s+){{0,4}}{SHELL_TECHNICAL_SURFACE_PATTERN}\b",
+    flags=re.IGNORECASE,
+)
+TECHNICAL_SHELL_WITH_RE = re.compile(
+    rf"\bshell(?:s|-like)?\b(?:['’]s)?\s+"
+    rf"(?:with|containing|featuring)\s+"
+    rf"(?:(?:a|an|the|its|current|blinking|visible|typed|keyboard)\s+){{0,4}}"
+    rf"{SHELL_TECHNICAL_SURFACE_PATTERN}\b",
+    flags=re.IGNORECASE,
+)
+TECHNICAL_SHELL_ACTION_RE = re.compile(
+    rf"\bshell(?:s|-like)?\b"
+    rf"(?:(?![.;]|\b(?:while|whereas|which|that)\b).){{0,120}}?"
+    rf"\b(?:accepts?|awaits?|displays?|shows?|presents?|renders?|emits?|"
+    rf"receives?|waits?\s+for)\b"
+    rf"(?:(?![.;]).){{0,60}}?{SHELL_TECHNICAL_SURFACE_PATTERN}\b",
+    flags=re.IGNORECASE | re.DOTALL,
+)
 SAFE_SHELL_MODIFIER_RE = re.compile(
-    r"\b(?:abstract|translucent|protective|geometric|outer|physical|luminous|"
-    r"glowing)(?:[\s,;:—-]+\w+){0,3}[\s,;:—-]+shells?\b",
+    r"\b(?:(?:abstract|translucent|protective|geometric|outer|physical|"
+    r"luminous|glowing|transparent|frosted|glass|matte|ceramic|delicate|organic)"
+    r"[\s,;:—-]+){1,4}shells?\b",
     flags=re.IGNORECASE,
 )
 SAFE_SHELL_MATERIAL_RE = re.compile(
-    r"\bshells?\b\s*(?:[—,:;-]\s*)?of\s+(?:\w+\s+){0,2}(?:light|glow)\b",
+    r"\bshells?\b\s*(?:[—,:;-]\s*)?"
+    r"(?:of\s+(?:(?:soft|faint|diffuse|radiant|translucent|transparent)\s+){0,2}"
+    r"(?:light|glow)|(?:made|formed|crafted)\s+of\s+"
+    r"(?:(?:transparent|translucent|frosted|matte|delicate)\s+){0,2}"
+    r"(?:glass|ceramic|organic\s+material))\b",
     flags=re.IGNORECASE,
 )
 EXACT_GEOMETRY_VISUAL_RE = re.compile(
@@ -3475,20 +3509,36 @@ def has_risky_shell_visual(cue: str) -> bool:
     if not shell_matches:
         return False
 
-    # Technical evidence wins over physical/art-direction modifiers. This keeps
-    # mixed cues such as "translucent shell with a prompt" fail-closed.
-    if SHELL_TECHNICAL_EVIDENCE_RE.search(cue):
-        return True
-
-    safe_spans = [
-        match.span()
-        for pattern in (SAFE_SHELL_MODIFIER_RE, SAFE_SHELL_MATERIAL_RE)
-        for match in pattern.finditer(cue)
-    ]
-    return any(
-        not any(start <= shell.start() < end for start, end in safe_spans)
-        for shell in shell_matches
+    technical_spans = shell_context_spans(
+        cue,
+        TECHNICAL_SHELL_PREFIX_RE,
+        TECHNICAL_SHELL_DIRECT_RE,
+        TECHNICAL_SHELL_WITH_RE,
+        TECHNICAL_SHELL_ACTION_RE,
     )
+    safe_spans = shell_context_spans(
+        cue,
+        SAFE_SHELL_MODIFIER_RE,
+        SAFE_SHELL_MATERIAL_RE,
+    )
+    for shell in shell_matches:
+        if shell.group(0).lower() == "powershell":
+            return True
+        if span_contains_offset(technical_spans, shell.start()):
+            return True
+        if not span_contains_offset(safe_spans, shell.start()):
+            return True
+    return False
+
+
+def shell_context_spans(cue: str, *patterns: re.Pattern[str]) -> list[tuple[int, int]]:
+    """Return phrase spans that grammatically relate context to a shell."""
+    return [match.span() for pattern in patterns for match in pattern.finditer(cue)]
+
+
+def span_contains_offset(spans: list[tuple[int, int]], offset: int) -> bool:
+    """Return whether an offset belongs to one of the supplied phrase spans."""
+    return any(start <= offset < end for start, end in spans)
 
 
 def has_unsafe_visual_motion(cue: str) -> bool:

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -509,6 +509,11 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "A visible cursor-shaped ornament rests beside a physical shell.",
         "A blinking caret-shaped seashell rests in diffuse light.",
         "A physical shell rests beside a synthesizer that accepts keyboard input.",
+        "A physical shell rests beside a sculpture that presents its output as diffuse light.",
+        "A shell of light rests beside a lantern which displays its output as a diffuse glow.",
+        "A physical shell rests beside an ornament that shows a blinking caret-shaped accent.",
+        "A protective shell's output is diffuse blue light.",
+        "A physical shell's history is represented by concentric rings.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
@@ -555,6 +560,12 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "/bin/bash output appears.",
         "A shell prints output.",
         "A shell writes its current output.",
+        "The Bash history appears in the foreground.",
+        "A Bash script appears in the foreground.",
+        "A Bash session appears in the foreground.",
+        "/bin/bash appears in the foreground.",
+        "A shell prints diagnostic output in the foreground.",
+        "A shell writes the build output in the foreground.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -641,6 +641,15 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "A shell rests and always displays output.",
         "A shell pauses but sometimes shows files.",
         "A shell rests and afterwards presents a directory listing.",
+        "A shell rests and gradually displays output.",
+        "A shell pauses but finally shows files.",
+        "A shell glows while subtly displaying output.",
+        "A shell rests and now presents a directory listing.",
+        "A shell rests and it gradually displays output.",
+        "A shell rests and after two moments displays a file listing.",
+        "A shell with a softly blinking prompt glows.",
+        "A shell with a bright pane displaying output glows.",
+        "A shell with its bright current output visible glows.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -538,6 +538,9 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "A physical shell is translucent as each nearby lantern displays output as blue light.",
         "A Bash prompt-shaped ornament rests beside the orb.",
         "A Bash prompt-like glow surrounds a matte cube.",
+        "A physical shell with nearby lamps displaying output as colored light.",
+        "A physical shell with two lanterns presenting output as a diffuse glow.",
+        "A physical shell, with nearby lamps displaying output as colored light, surrounds an orb.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
@@ -624,6 +627,13 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "A shell that displays its working directory appears.",
         "A shell which has a transcript appears.",
         "A shell that reads files appears.",
+        "A shell rests and then displays output.",
+        "A shell pauses but eventually displays output.",
+        "A shell sits still, yet later shows files.",
+        "A shell glows while softly displaying output.",
+        "A shell is translucent and prominently displays its working directory.",
+        "A shell rests and after a moment displays a file listing.",
+        "A shell with a blinking prompt appears.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -548,6 +548,10 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "A physical shell with a glass pane surrounds a matte orb.",
         "A physical shell with a window pane of diffuse light surrounds a matte orb.",
         "A physical shell with a ceramic pane-like opening surrounds a matte orb.",
+        "A physical shell with a glass pane beside a lamp displaying output as diffuse light.",
+        "A physical shell with a window pane and a nearby lamp showing files as colored patterns.",
+        "A physical shell with a ceramic pane near machinery presenting output as a soft glow.",
+        "A physical shell with a glass pane alongside Maya displaying output as bands of light.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -541,6 +541,10 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "A physical shell with nearby lamps displaying output as colored light.",
         "A physical shell with two lanterns presenting output as a diffuse glow.",
         "A physical shell, with nearby lamps displaying output as colored light, surrounds an orb.",
+        "A physical shell is matte while Maya displays output as colored light.",
+        "A physical shell is translucent as machinery presents output as diffuse light.",
+        "A physical shell is matte, with machinery displaying output as colored light.",
+        "A physical shell has concentric rings and Alice presents her output as a soft glow.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
@@ -634,6 +638,9 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "A shell is translucent and prominently displays its working directory.",
         "A shell rests and after a moment displays a file listing.",
         "A shell with a blinking prompt appears.",
+        "A shell rests and always displays output.",
+        "A shell pauses but sometimes shows files.",
+        "A shell rests and afterwards presents a directory listing.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -316,8 +316,17 @@ def test_release_video_visual_safety_allows_abstract_shell_cues(cue: str):
     [
         "A terminal shell appears in the foreground.",
         "A command shell appears in the foreground.",
+        "A Bash shell appears in the foreground.",
+        "A POSIX shell appears in the foreground.",
+        "A Unix shell appears in the foreground.",
+        "A Zsh shell appears in the foreground.",
         "A SHELL PROMPT appears in the foreground.",
+        "A shell's prompt appears in the foreground.",
+        "A shell’s prompt appears in the foreground.",
         "A shell-output window appears in the foreground.",
+        "A shell displaying output appears in the foreground.",
+        "A shell showing its prompt appears in the foreground.",
+        "A shell CLI appears in the foreground.",
     ],
 )
 def test_release_video_visual_safety_rejects_command_shell_surfaces(cue: str):

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -484,6 +484,62 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
 @pytest.mark.parametrize(
     "cue",
     [
+        "A shell of light with a blinking cursor appears.",
+        "A shell made of frosted glass with a blinking caret appears.",
+        "A translucent shell has a prompt.",
+        "A protective shell contains a blinking cursor.",
+        "A luminous shell shows keystrokes.",
+        "A physical shell invokes Bash.",
+        "A translucent shell surrounds one orb, and it shows a cursor.",
+        "A protective shell rests by a lamp, but its prompt blinks.",
+        "A glowing shell rests; inside the shell, a blinking caret appears.",
+        "A physical shell rests: within the shell, typed input appears.",
+        "A geometric shell rests,\nand it displays stdout.",
+        "A shell of light rests, and across the shell a CLI prompt appears.",
+        "A protective shell rests; on the shell, keystrokes appear.",
+    ],
+)
+def test_release_video_visual_safety_rejects_shell_clause_technical_references(
+    cue: str,
+):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "risky_readable_surface" in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
+        "A translucent shell surrounds one orb, and a separate membrane "
+        "presents an interface between blue and violet layers.",
+        "A protective shell rests by a lamp, but the lamp emits its output as "
+        "diffuse light.",
+        "A glowing shell rests beside a sculpture, and the sculpture shows a "
+        "window-shaped opening filled with light.",
+        "A physical shell rests; a separate lamp emits output as diffuse light.",
+        "A geometric shell rests: a sculpture presents an interface between "
+        "two ceramic layers.",
+        "A translucent shell rests.\nA separate sculpture shows a window of light.",
+        "A protective shell emits its output as diffuse light.",
+        "A translucent shell has a window of light.",
+        "A physical shell presents an interface between ceramic layers.",
+    ],
+)
+def test_release_video_visual_safety_ignores_other_subject_or_physical_homonyms(
+    cue: str,
+):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "risky_readable_surface" not in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
         "Optional particles may appear; the camera must push in toward the orb.",
         "The orb can be blue while the camera pushes in toward it.",
         "An optional camera drift may be used; the camera must tilt down afterward.",

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -525,6 +525,14 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "A physical shell rests under a lantern, while another lamp presents its output as diffuse light.",
         "A physical shell rests under a lantern as a nearby lamp presents its output as diffuse light.",
         "A physical shell surrounds an orb and a nearby lantern displays its output as blue light.",
+        "A physical shell is matte, while a nearby lamp presents its output as blue light.",
+        "A physical shell has concentric rings, and another lamp displays output as diffuse light.",
+        "A physical shell is translucent and a nearby lantern displays its output as blue light.",
+        "A physical shell is beside a sculpture that displays its output as diffuse light.",
+        "A physical shell with concentric rings rests beside a lamp that displays output as diffuse light.",
+        "A physical shell is matte: a lamp displays output as diffuse light.",
+        "A shell that shows a prompt-shaped ornament surrounds an orb.",
+        "A physical shell shows a prompt-like glow around the package cube.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
@@ -592,6 +600,16 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "A shell lists files.",
         "A shell shows filenames.",
         "A shell transcript appears.",
+        "A shell that lists files appears.",
+        "A shell which waits for user input appears.",
+        "A shell that awaits keyboard input appears.",
+        "A shell that shows file names appears.",
+        "A shell that displays files appears.",
+        "A shell which lists a directory appears.",
+        "A shell which renders build output appears.",
+        "A Bash transcript appears in the foreground.",
+        "A Bash directory listing appears in the foreground.",
+        "A Bash cursor appears in the foreground.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -664,6 +664,12 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "A shell with a pane listing files glows.",
         "A shell with a pane that lists files glows.",
         "A shell with a pane, and it is displaying output.",
+        "A shell with a pane that accepts keyboard input glows.",
+        "A shell with a pane which waits for user input glows.",
+        "A shell with a pane receiving input glows.",
+        "A shell with a pane, and it takes input.",
+        "A shell with a pane that has a prompt glows.",
+        "A shell with a pane which has current output glows.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -314,6 +314,31 @@ def test_release_video_visual_safety_allows_abstract_shell_cues(cue: str):
 @pytest.mark.parametrize(
     "cue",
     [
+        "A translucent shell surrounds a matte cube in diffuse blue light.",
+        "A protective shell surrounds a rounded package cube.",
+        "An abstract geometric shell rests in a violet field.",
+        "A hard outer shell physically encloses a simple matte orb.",
+        "A physical enclosure forms an outer shell around the package cube.",
+        "A shell of light surrounds the matte cubes.",
+        "A SHELL OF GLOW surrounds a simple orb.",
+        "A luminous shell—of soft light—surrounds the package cube.",
+        "An abstract, geometric shell; translucent and unlabeled, surrounds an orb.",
+        "A seashell, eggshell texture, and shellfish silhouette rest in soft light.",
+    ],
+)
+def test_release_video_visual_safety_allows_strong_physical_shell_contexts(
+    cue: str,
+):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "risky_readable_surface" not in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
         "A terminal shell appears in the foreground.",
         "A command shell appears in the foreground.",
         "A Bash shell appears in the foreground.",
@@ -327,9 +352,51 @@ def test_release_video_visual_safety_allows_abstract_shell_cues(cue: str):
         "A shell displaying output appears in the foreground.",
         "A shell showing its prompt appears in the foreground.",
         "A shell CLI appears in the foreground.",
+        "A shell with a blinking prompt appears.",
+        "A shell's blinking prompt appears.",
+        "A shell’s blinking prompt appears.",
+        "A shell: prompt appears.",
+        "A shell:\nprompt appears.",
+        "A root shell appears.",
+        "A system shell appears.",
+        "A Windows shell appears.",
+        "A default shell appears.",
+        "A shell presenting its current output appears.",
+        "A shell presents the current output.",
+        "A shell window appears.",
+        "A shell screen appears.",
+        "A shell interface appears.",
+        "A shell session appears.",
+        "An OS shell appears.",
+        "A PowerShell prompt appears.",
+        "A shell-like technical surface presents command output.",
+        "A bare shell appears in the foreground.",
+        "A shell appears in the foreground.",
     ],
 )
 def test_release_video_visual_safety_rejects_command_shell_surfaces(cue: str):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "risky_readable_surface" in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
+        "A translucent shell with a blinking prompt appears.",
+        "A protective shell's current output appears.",
+        "An abstract geometric shell: CLI prompt appears.",
+        "A shell of light surrounds a terminal window.",
+        "A physical outer shell presents a system session.",
+        "A translucent Windows shell displays output.",
+        "A protective Bash shell appears.",
+    ],
+)
+def test_release_video_visual_safety_technical_shell_evidence_overrides_safe_context(
+    cue: str,
+):
     release_video = load_release_video_module()
 
     categories = release_video.visual_safety_categories(cue)

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -370,8 +370,6 @@ def test_release_video_visual_safety_allows_strong_physical_shell_contexts(
         "An OS shell appears.",
         "A PowerShell prompt appears.",
         "A shell-like technical surface presents command output.",
-        "A bare shell appears in the foreground.",
-        "A shell appears in the foreground.",
     ],
 )
 def test_release_video_visual_safety_rejects_command_shell_surfaces(cue: str):
@@ -492,6 +490,13 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "A protective shell sits beside an unlabeled musical keyboard.",
         "A glowing shell appears at a celebratory bash.",
         "A physical shell rests near a caretaker who shows an unlabeled keyboard instrument.",
+        "A bare shell appears in the foreground.",
+        "A shell appears in the foreground.",
+        "A smooth shell surrounds a matte orb.",
+        "A thin shell encloses the package cube.",
+        "An iridescent shell floats in diffuse blue light.",
+        "A hollow shell cradles a simple sphere.",
+        "A metal shell surrounds the mechanism, with no text or labels.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
@@ -511,6 +516,13 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "A shell of light rests; there, its prompt blinks.",
         "A shell made of glass. In the foreground, it displays stdout.",
         "A protective shell rests. It glows. Its prompt blinks.",
+        "A translucent shell runs zsh.",
+        "A translucent shell executes Bash.",
+        "A physical shell is a Bash session.",
+        "A translucent shell hosts a login session.",
+        "A glowing shell opens into a REPL.",
+        "A translucent shell with a prompt waits in the foreground.",
+        "A matte shell shows environment variables.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -521,6 +521,10 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "A shell-shaped sculpture rests near a plotter which writes a patterned output on paper.",
         "A visible cursor-like ornament rests beside the orb.",
         "A blinking caret-like accent rests on the sculpture.",
+        "A physical shell rests under a lantern, and another lamp presents its output as diffuse light.",
+        "A physical shell rests under a lantern, while another lamp presents its output as diffuse light.",
+        "A physical shell rests under a lantern as a nearby lamp presents its output as diffuse light.",
+        "A physical shell surrounds an orb and a nearby lantern displays its output as blue light.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
@@ -579,6 +583,15 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "/bin/sh appears in the foreground.",
         "/bin/dash appears in the foreground.",
         "/bin/fish appears in the foreground.",
+        "A shell that shows a prompt.",
+        "A shell which accepts user input.",
+        "A shell that prints diagnostic output.",
+        "A shell which writes build output.",
+        "A Bash pane appears.",
+        "A shell displays a directory listing.",
+        "A shell lists files.",
+        "A shell shows filenames.",
+        "A shell transcript appears.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -292,6 +292,45 @@ def test_release_video_visual_safety_allows_safe_abstract_cues():
 @pytest.mark.parametrize(
     "cue",
     [
+        "A rounded package cube rests inside a faint translucent shell in diffuse blue light.",
+        "A matte orb rests inside a protective shell, lit by a soft violet glow.",
+        "Three abstract geometric shells (translucent and unlabeled) rest in blue light.",
+        "A rounded cube sits within a TRANSLUCENT SHELL; soft light fills the scene.",
+    ],
+)
+def test_release_video_visual_safety_allows_abstract_shell_cues(cue: str):
+    release_video = load_release_video_module()
+
+    artifacts = release_video.prepare_release_video_script(
+        visual_safety_script(cue),
+        source="script-path",
+    )
+
+    assert artifacts["validation"]["checks"]["hasNoReadableSurfaceVisuals"] is True
+    assert artifacts["validation"]["visualSafetyFindings"] == []
+    assert artifacts["validation"]["errors"] == []
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
+        "A terminal shell appears in the foreground.",
+        "A command shell appears in the foreground.",
+        "A SHELL PROMPT appears in the foreground.",
+        "A shell-output window appears in the foreground.",
+    ],
+)
+def test_release_video_visual_safety_rejects_command_shell_surfaces(cue: str):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "risky_readable_surface" in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
         "Optional particles may appear; the camera must push in toward the orb.",
         "The orb can be blue while the camera pushes in toward it.",
         "An optional camera drift may be used; the camera must tilt down afterward.",

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -484,6 +484,48 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
 @pytest.mark.parametrize(
     "cue",
     [
+        "A shell: of soft light surrounds a matte orb.",
+        "A shell:\nof diffuse glow surrounds a matte orb.",
+        "A shell: made of frosted glass surrounds a rounded cube.",
+        "A shell; made of matte ceramic encloses an orb.",
+        "A translucent shell rests during an unlabeled portrait session.",
+        "A protective shell sits beside an unlabeled musical keyboard.",
+        "A glowing shell appears at a celebratory bash.",
+        "A physical shell rests near a caretaker who shows an unlabeled keyboard instrument.",
+    ],
+)
+def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
+    cue: str,
+):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "risky_readable_surface" not in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
+        "A translucent shell rests: with a blinking cursor inside.",
+        "A shell of light rests; there, its prompt blinks.",
+        "A shell made of glass. In the foreground, it displays stdout.",
+        "A protective shell rests. It glows. Its prompt blinks.",
+    ],
+)
+def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(
+    cue: str,
+):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "risky_readable_surface" in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
         "A shell of light with a blinking cursor appears.",
         "A shell made of frosted glass with a blinking caret appears.",
         "A translucent shell has a prompt.",

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -497,6 +497,11 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "An iridescent shell floats in diffuse blue light.",
         "A hollow shell cradles a simple sphere.",
         "A metal shell surrounds the mechanism, with no text or labels.",
+        "A fish-shell sculpture rests in diffuse light.",
+        "A dash shell of blue paint rims the sculpture.",
+        "A musical keyboard input jack rests beside a physical shell.",
+        "A birthday bash session unfolds beside a physical shell.",
+        "A cursor-shaped seashell rests in diffuse light.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
@@ -523,6 +528,17 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "A glowing shell opens into a REPL.",
         "A translucent shell with a prompt waits in the foreground.",
         "A matte shell shows environment variables.",
+        "PowerShell appears in the foreground.",
+        "A pwsh window appears.",
+        "An xonsh shell appears.",
+        "A Korn shell appears.",
+        "A shell script appears.",
+        "A shell's standard output appears.",
+        "A shell reads stdin.",
+        "A shell awaits user input.",
+        "A shell starts Bash.",
+        "A shell spawns zsh.",
+        "A shell launches /bin/zsh.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -659,6 +659,11 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "A shell with its bright current output visible glows.",
         "A shell with a bright rectangular pane displaying output glows.",
         "A shell with a large bright pane showing files glows.",
+        "A shell with a pane that is displaying output glows.",
+        "A shell with a pane which is showing files glows.",
+        "A shell with a pane listing files glows.",
+        "A shell with a pane that lists files glows.",
+        "A shell with a pane, and it is displaying output.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -545,6 +545,9 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "A physical shell is translucent as machinery presents output as diffuse light.",
         "A physical shell is matte, with machinery displaying output as colored light.",
         "A physical shell has concentric rings and Alice presents her output as a soft glow.",
+        "A physical shell with a glass pane surrounds a matte orb.",
+        "A physical shell with a window pane of diffuse light surrounds a matte orb.",
+        "A physical shell with a ceramic pane-like opening surrounds a matte orb.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
@@ -650,6 +653,8 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "A shell with a softly blinking prompt glows.",
         "A shell with a bright pane displaying output glows.",
         "A shell with its bright current output visible glows.",
+        "A shell with a bright rectangular pane displaying output glows.",
+        "A shell with a large bright pane showing files glows.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -514,6 +514,13 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "A physical shell rests beside an ornament that shows a blinking caret-shaped accent.",
         "A protective shell's output is diffuse blue light.",
         "A physical shell's history is represented by concentric rings.",
+        "A physical shell rests under a lantern, and the lantern presents its output as diffuse light.",
+        "A translucent shell rests beneath a sculpture, but the sculpture displays its output as bands of color.",
+        "A ceramic shell surrounds an orb, while a nearby lamp presents its output as a soft glow.",
+        "A physical shell rests near a printer that prints artistic output onto paper.",
+        "A shell-shaped sculpture rests near a plotter which writes a patterned output on paper.",
+        "A visible cursor-like ornament rests beside the orb.",
+        "A blinking caret-like accent rests on the sculpture.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
@@ -566,6 +573,12 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "/bin/bash appears in the foreground.",
         "A shell prints diagnostic output in the foreground.",
         "A shell writes the build output in the foreground.",
+        "A bash script appears in the foreground.",
+        "The bash history appears in the foreground.",
+        "A BASH window appears in the foreground.",
+        "/bin/sh appears in the foreground.",
+        "/bin/dash appears in the foreground.",
+        "/bin/fish appears in the foreground.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -407,6 +407,83 @@ def test_release_video_visual_safety_technical_shell_evidence_overrides_safe_con
 @pytest.mark.parametrize(
     "cue",
     [
+        "A translucent shell with a blinking cursor appears.",
+        "A protective shell accepts keyboard input.",
+        "A glowing shell waits for typed input.",
+        "A luminous shell displays stdout and stderr.",
+        "A physical shell shows a blinking caret.",
+        "A translucent shell: blinking cursor appears.",
+        "A protective shell—after a brief pause—accepts typed input.",
+        "A geometric shell\ndisplays its current stdout.",
+        "A ceramic shell's blinking caret awaits keyboard input.",
+        "A command-driven translucent shell appears.",
+        "A protective fish shell presents a prompt.",
+        "A translucent shell in the foreground, softly lit and centered, "
+        "presents its current command output.",
+        "A translucent shell surrounds an orb; a command shell shows a prompt.",
+    ],
+)
+def test_release_video_visual_safety_rejects_local_shell_interaction_evidence(
+    cue: str,
+):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "risky_readable_surface" in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
+        "A translucent shell rests beside a fish silhouette.",
+        "A protective shell surrounds an abstract root system.",
+        "A glowing shell carries a dash of blue.",
+        "A luminous shell frames a window of soft light.",
+        "A physical shell forms the interface between two ceramic layers.",
+        "A root system grows near a protective shell in diffuse light.",
+        "A fish silhouette rests near a translucent shell; both remain unlabeled.",
+        "A translucent shell rests in the foreground. Far behind it, a window "
+        "of light frames a ceramic sculpture.",
+        "A geometric shell—frosted and text-free—rests beside a dash of blue.",
+    ],
+)
+def test_release_video_visual_safety_ignores_unrelated_technical_homonyms(
+    cue: str,
+):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "risky_readable_surface" not in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
+        "A transparent glass shell surrounds a matte cube.",
+        "A matte ceramic shell rests in diffuse violet light.",
+        "A shell made of frosted glass surrounds a simple orb.",
+        "A shell formed of transparent glass encloses a package cube.",
+        "A delicate organic shell rests on a matte surface.",
+        "A protective, geometric shell surrounds an unlabeled orb.",
+        "A TRANSLUCENT GLASS SHELL; softly lit, surrounds a ceramic shape.",
+        "A shell\nmade of matte ceramic encloses a rounded cube.",
+    ],
+)
+def test_release_video_visual_safety_allows_local_physical_shell_materials(
+    cue: str,
+):
+    release_video = load_release_video_module()
+
+    categories = release_video.visual_safety_categories(cue)
+
+    assert "risky_readable_surface" not in categories
+
+
+@pytest.mark.parametrize(
+    "cue",
+    [
         "Optional particles may appear; the camera must push in toward the orb.",
         "The orb can be blue while the camera pushes in toward it.",
         "An optional camera drift may be used; the camera must tilt down afterward.",

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -502,6 +502,10 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "A musical keyboard input jack rests beside a physical shell.",
         "A birthday bash session unfolds beside a physical shell.",
         "A cursor-shaped seashell rests in diffuse light.",
+        "A physical shell's window of light frames the sculpture.",
+        "A shell's interface between ceramic layers remains unlabeled.",
+        "A sculpture displays a cursor-shaped seashell.",
+        "A synthesizer accepts keyboard input beside a physical shell.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
@@ -539,6 +543,11 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "A shell starts Bash.",
         "A shell spawns zsh.",
         "A shell launches /bin/zsh.",
+        "The Bash prompt glows.",
+        "/bin/bash prompt appears.",
+        "A shell accepts input.",
+        "A shell receives user input.",
+        "A shell takes keyboard input.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -506,6 +506,9 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "A shell's interface between ceramic layers remains unlabeled.",
         "A sculpture displays a cursor-shaped seashell.",
         "A synthesizer accepts keyboard input beside a physical shell.",
+        "A visible cursor-shaped ornament rests beside a physical shell.",
+        "A blinking caret-shaped seashell rests in diffuse light.",
+        "A physical shell rests beside a synthesizer that accepts keyboard input.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
@@ -548,6 +551,10 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "A shell accepts input.",
         "A shell receives user input.",
         "A shell takes keyboard input.",
+        "The Bash output appears.",
+        "/bin/bash output appears.",
+        "A shell prints output.",
+        "A shell writes its current output.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -533,6 +533,11 @@ def test_release_video_visual_safety_allows_local_physical_shell_materials(
         "A physical shell is matte: a lamp displays output as diffuse light.",
         "A shell that shows a prompt-shaped ornament surrounds an orb.",
         "A physical shell shows a prompt-like glow around the package cube.",
+        "A physical shell is matte while nearby lamps present output as blue light.",
+        "A physical shell has concentric rings and two lamps display output as diffuse light.",
+        "A physical shell is translucent as each nearby lantern displays output as blue light.",
+        "A Bash prompt-shaped ornament rests beside the orb.",
+        "A Bash prompt-like glow surrounds a matte cube.",
     ],
 )
 def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_homonyms(
@@ -610,6 +615,15 @@ def test_release_video_visual_safety_preserves_physical_shell_punctuation_and_ho
         "A Bash transcript appears in the foreground.",
         "A Bash directory listing appears in the foreground.",
         "A Bash cursor appears in the foreground.",
+        "A shell has a matte surface, and it accepts keyboard input.",
+        "A shell has the outer form of an orb, but it waits for user input.",
+        "A shell rests, and it accepts keyboard input.",
+        "A physical shell is translucent, and it displays output.",
+        "A Bash file listing appears in the foreground.",
+        "A Bash file names appear in the foreground.",
+        "A shell that displays its working directory appears.",
+        "A shell which has a transcript appears.",
+        "A shell that reads files appears.",
     ],
 )
 def test_release_video_visual_safety_rejects_technical_surface_after_punctuation(


### PR DESCRIPTION
## Summary

- remove the ambiguous bare `shell` token from the generic readable-surface classifier
- classify command-shell visuals only when surrounding context identifies a terminal, command-line, prompt, output, session, window, screen, or interface surface
- preserve terminal/command-shell rejection while allowing abstract translucent, protective, and geometric shells

## Root cause

`READABLE_VISUAL_RE` treated every singular `shell` as a readable computer surface. In release-video art direction, `shell` also commonly describes a non-textual enclosure, so safe abstract cues failed before PDS invocation.

## TDD and validation

- RED commit `c044bdea1`: `3 failed, 5 passed` for the new abstract-shell and command-shell controls
- Review-correction RED commit `540edf5c3`: `9 failed, 8 passed` for named, possessive, display, and CLI shell grammar
- GREEN: `pytest -q tests/test_release_video.py -k visual_safety` — `49 passed`
- Full affected suite: `pytest -q tests/test_release_video.py` — `248 passed`
- Pylint fatal/error checks: `10.00/10`
- Black checks on changed regions: unchanged
- `py_compile` and `git diff --check`: passed
- Exact saved v0.0.305 workflow and corrected recovery scripts passed `prepare_release_video_script(..., source="script-path")` with all checks true, zero errors, and zero findings

No release, PDS, deploy, or production mutation was performed.

Closes #2209
