### PR TITLE
fix(sync): preauthorize global sync ledger paths

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -3045,6 +3045,13 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "docs/global_sync_evidence_ledger_source.yaml",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "docs/global_sync_extraction_manifest.md",
       "preauthorize_absent": true,
       "role": "human-maintained"
@@ -6043,6 +6050,13 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "pdd/sync_core/git_io.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "pdd/sync_core/global_sync_ledger.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
@@ -12532,6 +12546,13 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "tests/test_git_update.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_global_sync_ledger.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -99,6 +99,11 @@ GATE1_EXISTING_HUMAN_PATHS = {
     "docs/global_sync_resolution_plan.md",
 }
 GATE1_CHANGED_PATHS = GATE1_PREAUTHORIZED_PATHS | GATE1_EXISTING_HUMAN_PATHS
+GLOBAL_SYNC_LEDGER_PREAUTHORIZED_PATHS = {
+    "docs/global_sync_evidence_ledger_source.yaml",
+    "pdd/sync_core/global_sync_ledger.py",
+    "tests/test_global_sync_ledger.py",
+}
 PR_2017_ABSENT_METADATA_PATHS = {
     ".pdd/meta/agentic_langtest_python.json",
     ".pdd/meta/agentic_langtest_python_run.json",
@@ -111,6 +116,7 @@ PREAUTHORIZED_CHILD_PATHS = (
     LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS
     | ISSUE_2083_VITEST_COORDINATOR_PREAUTHORIZED_PATHS
     | GATE1_PREAUTHORIZED_PATHS
+    | GLOBAL_SYNC_LEDGER_PREAUTHORIZED_PATHS
     | PR_2017_ABSENT_METADATA_PATHS
     | {
         ".github/toolchains/playwright_manifest.py",
@@ -1614,6 +1620,131 @@ def test_gate1_paths_compose_with_protected_preauthorization(
         if item.candidate_id.artifact_relpath.as_posix() in GATE1_PREAUTHORIZED_PATHS
     }
     assert set(records) == GATE1_PREAUTHORIZED_PATHS
+    assert not manifest.unaccounted_tracked_paths
+    assert not manifest.invalid_reasons
+    assert all(
+        item.inventory.value == "HUMAN_OWNED"
+        and item.candidate_id.role == "human-maintained"
+        and item.ownership_provenance
+        == f"protected-ownership:pdd-maintainers:{path}"
+        for path, item in records.items()
+    )
+    assert len(manifest.expected_managed) == EXPECTED_MANAGED_UNITS
+
+
+def test_global_sync_ledger_paths_are_exactly_preauthorized() -> None:
+    """Only the three reviewed global-sync ledger paths are preauthorized."""
+    ownership = json.loads(OWNERSHIP_PATH.read_text(encoding="utf-8"))
+    rules = {row["pattern"]: row for row in ownership["rules"]}
+    assert {
+        path: rules.get(path) for path in GLOBAL_SYNC_LEDGER_PREAUTHORIZED_PATHS
+    } == {
+        path: {"pattern": path, **PREAUTHORIZED_CHILD_OWNERSHIP}
+        for path in GLOBAL_SYNC_LEDGER_PREAUTHORIZED_PATHS
+    }
+    assert {
+        row["pattern"]
+        for row in ownership["rules"]
+        if row.get("preauthorize_absent", False)
+        and (
+            row["pattern"].startswith("docs/global_sync_evidence_ledger_source")
+            or row["pattern"].startswith("pdd/sync_core/global_sync_ledger")
+            or row["pattern"].startswith("tests/test_global_sync_ledger")
+        )
+    } == GLOBAL_SYNC_LEDGER_PREAUTHORIZED_PATHS
+
+
+def test_global_sync_ledger_paths_compose_with_protected_preauthorization(
+    tmp_path: Path,
+) -> None:
+    """A branch-only checkout composes ledger paths from protected preauth."""
+    protected_source = tmp_path / "protected-preauth-source"
+    root = tmp_path / "global-sync-ledger-preauth-composition"
+    subprocess.run(
+        ["git", "init", "-q", str(protected_source)],
+        check=True,
+        capture_output=True,
+    )
+    _git(
+        protected_source,
+        "fetch",
+        "-q",
+        "--no-tags",
+        str(ROOT),
+        "HEAD:refs/heads/protected-preauth",
+    )
+    assert subprocess.check_output(
+        ["git", "for-each-ref", "--format=%(refname)"],
+        cwd=protected_source,
+        text=True,
+    ).splitlines() == ["refs/heads/protected-preauth"]
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "-q",
+            "--no-hardlinks",
+            "--single-branch",
+            "--branch",
+            "protected-preauth",
+            str(protected_source),
+            str(root),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    protected_base = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+    _git(root, "update-ref", "refs/remotes/origin/main", protected_base)
+    assert not any(
+        "global-sync-ledger" in ref
+        for ref in subprocess.check_output(
+            ["git", "for-each-ref", "--format=%(refname)"], cwd=root, text=True
+        ).splitlines()
+    )
+
+    inert_paths = {
+        "docs/global_sync_evidence_ledger_source.yaml": b"ledger: {}\n",
+        "pdd/sync_core/global_sync_ledger.py": b'"""Synthetic ledger."""\n',
+        "tests/test_global_sync_ledger.py": b'"""Synthetic ledger test."""\n',
+    }
+    for path, content in inert_paths.items():
+        candidate = root / path
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        candidate.write_bytes(content)
+    _commit(root, "compose synthetic global-sync ledger paths")
+
+    changed_paths = set(
+        subprocess.check_output(
+            ["git", "diff", "--name-only", "origin/main...HEAD"],
+            cwd=root,
+            text=True,
+        ).splitlines()
+    )
+    assert changed_paths == GLOBAL_SYNC_LEDGER_PREAUTHORIZED_PATHS
+    for detector in (
+        "scripts/ci_detect_changed_modules.py",
+        "pdd/ci_detect_changed_modules.py",
+    ):
+        result = subprocess.run(
+            [sys.executable, detector, "--diff-base", "origin/main...HEAD"],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert not result.stdout.strip()
+
+    manifest = build_unit_manifest(root, base_ref="origin/main", head_ref="HEAD")
+    records = {
+        item.candidate_id.artifact_relpath.as_posix(): item
+        for item in manifest.candidates
+        if item.candidate_id.artifact_relpath.as_posix()
+        in GLOBAL_SYNC_LEDGER_PREAUTHORIZED_PATHS
+    }
+    assert set(records) == GLOBAL_SYNC_LEDGER_PREAUTHORIZED_PATHS
     assert not manifest.unaccounted_tracked_paths
     assert not manifest.invalid_reasons
     assert all(


### PR DESCRIPTION
## Summary
- preauthorize the three absent global-sync ledger paths as protected `HUMAN_OWNED`
- preserve the protected managed-unit denominator at 468
- prove child-PR composition through both changed-module detectors and manifest provenance

## Dependency
This is the protected-base ownership prerequisite for #2219. Candidate-only ownership is intentionally rejected; #2219 must rebase after this PR merges and remove its invalid `architecture.json` ownership entry.

## Validation
- `/opt/homebrew/Caskroom/miniforge/base/envs/pdd/bin/python -m pytest tests/test_sync_core_pdd_rollout_policy.py -q` -> 71 passed
- JSON duplicate/policy validation -> passed
- source/packaged detector composition -> passed
- expected managed units -> 468
- Sol HIGH review of exact `1c2abbdb495f9364614fe95fb8670b55275d2f70` -> APPROVED, no substantive findings

## Scope
Only `.pdd/sync-ownership.json` and `tests/test_sync_core_pdd_rollout_policy.py` change.