### PR TITLE
fix(sync): reject invalid verification profiles

### DIFF
--- a/pdd/sync_core/finalize.py
+++ b/pdd/sync_core/finalize.py
@@ -333,6 +333,10 @@ def finalize_unit(
     if len(matches) != 1:
         raise ValueError(f"finalization requires exactly one managed unit: {module}")
     profiles = load_verification_profiles(repository_root, manifest)
+    if profiles.invalid_reasons:
+        raise ValueError(
+            "canonical finalization requires valid protected verification profiles"
+        )
     profile = profiles.for_unit(matches[0].unit_id)
     if profile is None or not profile.complete:
         raise ValueError("finalization requires a complete protected profile")

--- a/pdd/sync_core/reporting.py
+++ b/pdd/sync_core/reporting.py
@@ -127,6 +127,17 @@ def _error_verdict(unit: ManifestUnit, baseline: BaselineStatus, reason: str) ->
     )
 
 
+def _invalid_profile_verdict(unit: ManifestUnit) -> SyncVerdict:
+    """Return a non-current unknown verdict without consulting stale evidence."""
+    return SyncVerdict(
+        unit.unit_id,
+        InventoryStatus.MANAGED,
+        BaselineStatus.CORRUPT,
+        SemanticStatus.UNKNOWN,
+        VerdictDetails((), "verification profile reconciliation is invalid"),
+    )
+
+
 def _evidence(
     context: ReportContext,
     expectation: EvidenceExpectation,
@@ -187,6 +198,8 @@ def _evidence(
 def _unit_verdict(context: ReportContext, unit: ManifestUnit) -> SyncVerdict:
     if context.manifest.invalid_reasons:
         return _error_verdict(unit, BaselineStatus.CORRUPT, "manifest is invalid")
+    if context.profiles.invalid_reasons:
+        return _invalid_profile_verdict(unit)
     profile = context.profiles.for_unit(unit.unit_id)
     if profile is None:
         return _error_verdict(unit, BaselineStatus.CORRUPT, "profile is missing")

--- a/tests/test_sync_core_reporting.py
+++ b/tests/test_sync_core_reporting.py
@@ -230,6 +230,43 @@ def _options(tmp_path: Path, commit: str) -> CanonicalReportOptions:
     )
 
 
+def _durable_state(root: Path) -> dict[PurePosixPath, bytes]:
+    """Capture checker-owned evidence and fingerprints for no-write assertions."""
+    return {
+        PurePosixPath(path.relative_to(root).as_posix()): path.read_bytes()
+        for directory in (root / ".pdd/evidence/v2", root / ".pdd/meta/v2")
+        if directory.exists()
+        for path in directory.rglob("*")
+        if path.is_file()
+    }
+
+
+def _invalid_candidate_profile(root: Path, mutation: str) -> None:
+    """Commit one invalid protected-profile transition over the trusted base."""
+    profile_path = root / ".pdd/verification-profiles.json"
+    payload = json.loads(profile_path.read_text(encoding="utf-8"))
+    profile = payload["profiles"][0]
+    if mutation == "removed-protected-obligation":
+        profile["obligations"] = []
+    elif mutation == "changed-requirement":
+        profile["required_requirement_ids"] = ["REQ-2"]
+        profile["obligations"][0]["requirement_ids"] = ["REQ-2"]
+        with (root / "prompts/widget_python.prompt").open("a", encoding="utf-8") as prompt:
+            prompt.write("REQ-2: Reject invalid widgets\n")
+    else:
+        raise ValueError(f"unknown invalid profile mutation: {mutation}")
+    profile_path.write_text(json.dumps(payload), encoding="utf-8")
+    _git(
+        root,
+        "add",
+        "-u",
+        "--",
+        ".pdd/verification-profiles.json",
+        "prompts/widget_python.prompt",
+    )
+    _git(root, "commit", "-q", "-m", f"invalid candidate profile: {mutation}")
+
+
 def test_trusted_transactional_baseline_passes_canonical_predicate(tmp_path) -> None:
     root, commit = _repository(tmp_path)
     _finalize_trusted_baseline(root, commit)
@@ -239,6 +276,40 @@ def test_trusted_transactional_baseline_passes_canonical_predicate(tmp_path) -> 
     assert report["counts"]["trusted_in_sync"] == 1
     assert report["counts"]["unaccounted_tracked_paths"] == 0
     assert report["units"][0]["in_sync"] is True
+
+
+def test_invalid_profile_reconciliation_cannot_reuse_verified_evidence(
+    tmp_path: Path,
+) -> None:
+    """Invalid protected profiles cannot certify with stale attestations."""
+    root, base = _repository(tmp_path)
+    _finalize_trusted_baseline(root, base)
+    _invalid_candidate_profile(root, "removed-protected-obligation")
+    head = _git(root, "rev-parse", "HEAD")
+
+    with patch(
+        "pdd.sync_core.reporting._evidence",
+        side_effect=AssertionError("invalid profile attempted evidence verification"),
+    ):
+        report = build_canonical_report(
+            root,
+            CanonicalReportOptions(
+                base_ref=base,
+                head_ref=head,
+                replay_ledger_path=tmp_path / "external-trust/invalid-profile.json",
+                now=NOW,
+            ),
+        )
+
+    assert report["ok"] is False
+    assert report["counts"]["invalid"] == 1
+    assert report["counts"]["unknown"] == 1
+    assert report["counts"]["trusted_current_evidence"] == 0
+    assert report["counts"]["trusted_in_sync"] == 0
+    assert report["units"][0]["baseline"] == "CORRUPT"
+    assert report["units"][0]["semantic"] == "UNKNOWN"
+    assert report["units"][0]["evidence_complete"] is False
+    assert report["units"][0]["in_sync"] is False
 
 
 def test_managed_waiver_is_counted_and_blocks_certificate_predicate(tmp_path) -> None:
@@ -951,6 +1022,48 @@ def test_trusted_finalizer_rejects_invalid_next_protected_base(tmp_path) -> None
             signer=SIGNER,
             replay_ledger_path=tmp_path / "external-trust/invalid-base.json",
         )
+
+
+@pytest.mark.parametrize(
+    "mutation", ["removed-protected-obligation", "changed-requirement"]
+)
+def test_trusted_finalizer_rejects_invalid_profile_before_trusted_state(
+    tmp_path: Path, mutation: str
+) -> None:
+    """Invalid profile reconciliation stops before all trust/write boundaries."""
+    root, base = _repository(tmp_path)
+    _finalize_trusted_baseline(root, base)
+    before = _durable_state(root)
+    _invalid_candidate_profile(root, mutation)
+    head = _git(root, "rev-parse", "HEAD")
+
+    with patch(
+        "pdd.sync_core.finalize._reusable_result",
+        side_effect=AssertionError("invalid profile attempted evidence reuse"),
+    ) as reusable, patch(
+        "pdd.sync_core.finalize.run_profile",
+        side_effect=AssertionError("invalid profile invoked runner"),
+    ) as runner, patch(
+        "pdd.sync_core.finalize.TransactionManager",
+        side_effect=AssertionError("invalid profile created transaction manager"),
+    ) as transaction_manager:
+        with pytest.raises(
+            ValueError,
+            match="canonical finalization requires valid protected verification profiles",
+        ):
+            finalize_unit(
+                root,
+                PurePosixPath("prompts/widget_python.prompt"),
+                base_ref=base,
+                head_ref=head,
+                signer=SIGNER,
+                replay_ledger_path=tmp_path / f"external-trust/{mutation}.json",
+            )
+
+    reusable.assert_not_called()
+    runner.assert_not_called()
+    transaction_manager.assert_not_called()
+    assert _durable_state(root) == before
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

- fail closed when protected verification profiles contain invalid reasons
- stop reporting before stale evidence, runner execution, or transaction activity
- preserve durable evidence and metadata bytes on the fail-closed path

## Scope

This is the first bounded Gate 2 pytest-only checker release layer extracted from the frozen PR #1995 evidence. It changes exactly three existing files and excludes Vitest, Jest, Playwright, native-addon, lifecycle, workflow, and diagnostic changes. It does not claim Gate 2, release, deployment, or certificate completion.

## Validation

- focused invalid-profile reporting/finalization tests: 3 passed
- protected-obligation deletion test: passed
- sync-core CLI tests: 6 passed
- source certify/validate fail-closed predicates: 16/16 passed
- production pylint: 10/10
- Sol HIGH approved exact head `b8d3ea7d34d5b0a03df75fc74a0c91295ef633e9`

The four full-file reporting failures reproduced unchanged on protected main under local macOS because pytest collection returns `COLLECTION_ERROR`; hosted Linux Unit and Package lanes are required to resolve that baseline-platform gap.