### PR TITLE
feat(sync): add target runtime lock contract

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -586,13 +586,13 @@ jobs:
           set -euo pipefail
           image='python:3.12.13-slim-bookworm@sha256:72d3d75f2639ab82b34b29390ad3d6e0827c775befee94edda8e9976818f488d'
           runtime="$RUNNER_TEMP/pdd-target-runtime"
-          mkdir -p "$runtime/project" "$runtime/wheelhouse" "$runtime/tooling" "$runtime/generator" "$runtime/candidate"
+          mkdir -p "$runtime/source" "$runtime/project" "$runtime/wheelhouse" "$runtime/tooling" "$runtime/generator" "$runtime/candidate"
+          tar --exclude=.git -C "$GITHUB_WORKSPACE" -cf - . | tar -C "$runtime/source" -xf -
           docker pull "$image"
           test "$(docker image inspect --format '{{.Architecture}}' "$image")" = amd64
           docker run --rm --network bridge \
-            -v "$GITHUB_WORKSPACE:/workspace:ro" \
             -v "$runtime:/runtime" \
-            -w /workspace "$image" bash -ceu '
+            -w /runtime/source "$image" bash -ceu '
               python -m pip install --disable-pip-version-check --upgrade pip==25.1.1 build==1.2.2.post1
               python -m pip download --disable-pip-version-check --only-binary=:all: --dest /runtime/tooling pip==25.1.1
               SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PDD_CLI=0.0.0 python -m build --wheel --outdir /runtime/project

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -576,7 +576,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -600,18 +600,25 @@ jobs:
               test -n "$project_wheel"
               python -m pip download --disable-pip-version-check --only-binary=:all: --dest /runtime/wheelhouse "$project_wheel"
               find /runtime/wheelhouse -maxdepth 1 -type f -name "pdd_cli-*.whl" -delete
-              PYTHONPATH=/runtime/generator python -m pip install --disable-pip-version-check --no-index --only-binary=:all: --find-links /runtime/wheelhouse --target /runtime/generator "$project_wheel"
+              python -m pip install --disable-pip-version-check --no-index --only-binary=:all: --find-links /runtime/wheelhouse --target /runtime/generator "$project_wheel"
               cd /tmp
-              PYTHONPATH=/runtime/generator python -m pdd.sync_core.artifact_provenance generate --wheelhouse /runtime/wheelhouse --output /runtime/candidate/runtime-linux-x86_64-cp312.lock --inventory /runtime/candidate/wheel-inventory.json
-              PYTHONPATH=/runtime/generator python - <<"PY"
-              from pathlib import Path
-              from pdd.sync_core.artifact_provenance import _inspect_wheel
+              python -I -S -c "import sys; exec(sys.stdin.read())" generate --wheelhouse /runtime/wheelhouse --output /runtime/candidate/runtime-linux-x86_64-cp312.lock --inventory /runtime/candidate/wheel-inventory.json <<PY
+          import runpy
+          import sys
+          sys.path.insert(0, "/runtime/generator")
+          runpy.run_module("pdd.sync_core.artifact_provenance", run_name="__main__")
+          PY
+              python -I -S -c "import sys; exec(sys.stdin.read())" <<PY
+          from pathlib import Path
+          import sys
+          sys.path.insert(0, "/runtime/generator")
+          from pdd.sync_core.artifact_provenance import _inspect_wheel
 
-              project = _inspect_wheel(next(Path("/runtime/project").glob("pdd_cli-*.whl")))
-              lock = Path("/runtime/candidate/runtime-linux-x86_64-cp312.lock").read_text(encoding="ascii")
-              requirement = f"pdd-cli=={project.version} --hash=sha256:{project.digest}\n"
-              Path("/runtime/requirements.lock").write_text(lock + requirement, encoding="ascii")
-              PY
+          project = _inspect_wheel(next(Path("/runtime/project").glob("pdd_cli-*.whl")))
+          lock = Path("/runtime/candidate/runtime-linux-x86_64-cp312.lock").read_text(encoding="ascii")
+          requirement = f"pdd-cli=={project.version} --hash=sha256:{project.digest}\n"
+          Path("/runtime/requirements.lock").write_text(lock + requirement, encoding="ascii")
+          PY
             '
 
       - name: Validate candidate in fresh network-none container
@@ -628,8 +635,13 @@ jobs:
             -w /tmp "$image" bash -ceu '
               python -m venv /tmp/target-runtime
               /tmp/target-runtime/bin/python -m pip install --disable-pip-version-check --no-index --find-links /runtime/tooling --upgrade pip==25.1.1
-              /tmp/target-runtime/bin/python -m pip install --disable-pip-version-check --no-index --only-binary=:all: --require-hashes --find-links /runtime/wheelhouse --target /installed -r /runtime/requirements.lock
-              PYTHONPATH=/installed /tmp/target-runtime/bin/python -m pdd.sync_core.artifact_provenance validate-installed --lock /runtime/candidate/runtime-linux-x86_64-cp312.lock --wheelhouse /runtime/wheelhouse --site-packages /installed --project-wheel /runtime/project/$(basename /runtime/project/pdd_cli-*.whl)
+              /tmp/target-runtime/bin/python -m pip install --disable-pip-version-check --no-index --only-binary=:all: --no-compile --require-hashes --find-links /runtime/wheelhouse --find-links /runtime/project --target /installed -r /runtime/requirements.lock
+              /tmp/target-runtime/bin/python -I -S -c "import sys; exec(sys.stdin.read())" validate-installed --lock /runtime/candidate/runtime-linux-x86_64-cp312.lock --wheelhouse /runtime/wheelhouse --site-packages /installed --project-wheel /runtime/project/$(basename /runtime/project/pdd_cli-*.whl) --script-python /tmp/target-runtime/bin/python <<PY
+          import runpy
+          import sys
+          sys.path.insert(0, "/installed")
+          runpy.run_module("pdd.sync_core.artifact_provenance", run_name="__main__")
+          PY
             '
 
       - name: Compare committed target lock when present

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -595,7 +595,7 @@ jobs:
             -w /workspace "$image" bash -ceu '
               python -m pip install --disable-pip-version-check --upgrade pip==25.1.1 build==1.2.2.post1
               python -m pip download --disable-pip-version-check --only-binary=:all: --dest /runtime/tooling pip==25.1.1
-              python -m build --wheel --outdir /runtime/project
+              SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PDD_CLI=0.0.0 python -m build --wheel --outdir /runtime/project
               project_wheel=$(find /runtime/project -maxdepth 1 -type f -name "pdd_cli-*.whl" -print -quit)
               test -n "$project_wheel"
               python -m pip download --disable-pip-version-check --only-binary=:all: --dest /runtime/wheelhouse "$project_wheel"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -567,3 +567,86 @@ jobs:
       - name: Stop hard-tier containers
         if: always()
         run: docker compose down -v
+
+  target-runtime-lock:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
+    name: Target Runtime Lock Candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate Linux CPython 3.12 candidate lock online
+        shell: bash
+        run: |
+          set -euo pipefail
+          image='python:3.12.13-slim-bookworm@sha256:72d3d75f2639ab82b34b29390ad3d6e0827c775befee94edda8e9976818f488d'
+          runtime="$RUNNER_TEMP/pdd-target-runtime"
+          mkdir -p "$runtime/project" "$runtime/wheelhouse" "$runtime/tooling" "$runtime/generator" "$runtime/candidate"
+          docker pull "$image"
+          test "$(docker image inspect --format '{{.Architecture}}' "$image")" = amd64
+          docker run --rm --network bridge \
+            -v "$GITHUB_WORKSPACE:/workspace:ro" \
+            -v "$runtime:/runtime" \
+            -w /workspace "$image" bash -ceu '
+              python -m pip install --disable-pip-version-check --upgrade pip==25.1.1 build==1.2.2.post1
+              python -m pip download --disable-pip-version-check --only-binary=:all: --dest /runtime/tooling pip==25.1.1
+              python -m build --wheel --outdir /runtime/project
+              project_wheel=$(find /runtime/project -maxdepth 1 -type f -name "pdd_cli-*.whl" -print -quit)
+              test -n "$project_wheel"
+              python -m pip download --disable-pip-version-check --only-binary=:all: --dest /runtime/wheelhouse "$project_wheel"
+              find /runtime/wheelhouse -maxdepth 1 -type f -name "pdd_cli-*.whl" -delete
+              PYTHONPATH=/runtime/generator python -m pip install --disable-pip-version-check --no-index --only-binary=:all: --find-links /runtime/wheelhouse --target /runtime/generator "$project_wheel"
+              cd /tmp
+              PYTHONPATH=/runtime/generator python -m pdd.sync_core.artifact_provenance generate --wheelhouse /runtime/wheelhouse --output /runtime/candidate/runtime-linux-x86_64-cp312.lock --inventory /runtime/candidate/wheel-inventory.json
+              PYTHONPATH=/runtime/generator python - <<"PY"
+              from pathlib import Path
+              from pdd.sync_core.artifact_provenance import _inspect_wheel
+
+              project = _inspect_wheel(next(Path("/runtime/project").glob("pdd_cli-*.whl")))
+              lock = Path("/runtime/candidate/runtime-linux-x86_64-cp312.lock").read_text(encoding="ascii")
+              requirement = f"pdd-cli=={project.version} --hash=sha256:{project.digest}\n"
+              Path("/runtime/requirements.lock").write_text(lock + requirement, encoding="ascii")
+              PY
+            '
+
+      - name: Validate candidate in fresh network-none container
+        shell: bash
+        run: |
+          set -euo pipefail
+          image='python:3.12.13-slim-bookworm@sha256:72d3d75f2639ab82b34b29390ad3d6e0827c775befee94edda8e9976818f488d'
+          runtime="$RUNNER_TEMP/pdd-target-runtime"
+          installed="$RUNNER_TEMP/pdd-target-runtime-installed"
+          mkdir -p "$installed"
+          docker run --rm --network none \
+            -v "$runtime:/runtime:ro" \
+            -v "$installed:/installed" \
+            -w /tmp "$image" bash -ceu '
+              python -m venv /tmp/target-runtime
+              /tmp/target-runtime/bin/python -m pip install --disable-pip-version-check --no-index --find-links /runtime/tooling --upgrade pip==25.1.1
+              /tmp/target-runtime/bin/python -m pip install --disable-pip-version-check --no-index --only-binary=:all: --require-hashes --find-links /runtime/wheelhouse --target /installed -r /runtime/requirements.lock
+              PYTHONPATH=/installed /tmp/target-runtime/bin/python -m pdd.sync_core.artifact_provenance validate-installed --lock /runtime/candidate/runtime-linux-x86_64-cp312.lock --wheelhouse /runtime/wheelhouse --site-packages /installed --project-wheel /runtime/project/$(basename /runtime/project/pdd_cli-*.whl)
+            '
+
+      - name: Compare committed target lock when present
+        shell: bash
+        run: |
+          set -euo pipefail
+          protected='.pdd/global-sync/runtime-linux-x86_64-cp312.lock'
+          candidate="$RUNNER_TEMP/pdd-target-runtime/candidate/runtime-linux-x86_64-cp312.lock"
+          if test -e "$protected"; then
+            cmp -- "$protected" "$candidate"
+          fi
+
+      - name: Upload target runtime lock candidate
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: target-runtime-lock-linux-x86_64-cp312
+          if-no-files-found: error
+          path: |
+            ${{ runner.temp }}/pdd-target-runtime/candidate/runtime-linux-x86_64-cp312.lock
+            ${{ runner.temp }}/pdd-target-runtime/candidate/wheel-inventory.json

--- a/pdd/sync_core/artifact_provenance.py
+++ b/pdd/sync_core/artifact_provenance.py
@@ -1,25 +1,517 @@
 """Verification of protected build attestations for candidate wheels."""
 # pylint: disable=duplicate-code,too-many-instance-attributes,too-many-boolean-expressions
+# pylint: disable=too-many-locals,too-many-branches,too-many-statements
 
 from __future__ import annotations
 
 import base64
+import argparse
+import csv
 import hashlib
+import io
 import json
 import os
+import re
+import stat
+import sys
 import tempfile
+import zipfile
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from pathlib import PurePosixPath
+from typing import Any, Iterable
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel_filename
+from packaging.version import InvalidVersion, Version
 from .descriptor_store import DescriptorStoreError, update_json
 
 
 class CandidateArtifactProvenanceError(ValueError):
     """Raised when a candidate wheel lacks protected build provenance."""
+
+
+class TargetRuntimeLockError(ValueError):
+    """Raised when an untrusted target runtime lock or wheel closure is invalid."""
+
+
+TARGET_RUNTIME = "linux_x86_64-cp312"
+TARGET_BASE_IMAGE = (
+    "python:3.12.13-slim-bookworm@"
+    "sha256:72d3d75f2639ab82b34b29390ad3d6e0827c775befee94edda8e9976818f488d"
+)
+TARGET_RESOLVER = "pip==25.1.1"
+_LOCK_HEADER = (
+    "# pdd-runtime-lock-format: 1",
+    f"# target: {TARGET_RUNTIME}",
+    f"# resolver: {TARGET_RESOLVER}",
+    f"# base-image: {TARGET_BASE_IMAGE}",
+)
+_LOCK_ROW = re.compile(
+    r"(?P<name>[a-z0-9]+(?:-[a-z0-9]+)*)==(?P<version>[^ ]+)"
+    r"(?P<hashes>(?: --hash=sha256:[0-9a-f]{64})+)"
+)
+_SHA256_HASH = re.compile(r"[0-9a-f]{64}")
+_MANYLINUX_PLATFORM = re.compile(r"manylinux(?:_[0-9]+|[0-9]+)_[0-9]+_x86_64")
+
+
+@dataclass(frozen=True)
+class TargetRuntimeLockEntry:
+    """One exact, hash-bound dependency in the target runtime closure."""
+
+    name: str
+    version: str
+    hashes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TargetRuntimeLock:
+    """Canonical Linux CPython 3.12 dependency lock."""
+
+    entries: tuple[TargetRuntimeLockEntry, ...]
+
+    def bytes(self) -> bytes:
+        """Serialize the lock in its sole accepted canonical representation."""
+        rows = list(_LOCK_HEADER)
+        for entry in self.entries:
+            hashes = "".join(f" --hash=sha256:{value}" for value in entry.hashes)
+            rows.append(f"{entry.name}=={entry.version}{hashes}")
+        return ("\n".join(rows) + "\n").encode("ascii")
+
+
+@dataclass(frozen=True)
+class _WheelInfo:
+    """Verified wheel identity and archive bytes used by closure validators."""
+
+    path: Path
+    name: str
+    version: str
+    digest: str
+    files: dict[PurePosixPath, bytes]
+
+
+def _runtime_error(message: str) -> TargetRuntimeLockError:
+    return TargetRuntimeLockError(f"target runtime lock: {message}")
+
+
+def _canonical_version(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise _runtime_error("version is invalid")
+    try:
+        parsed = Version(value)
+    except InvalidVersion as exc:
+        raise _runtime_error("version is not PEP 440") from exc
+    if str(parsed) != value:
+        raise _runtime_error("version is not canonical PEP 440")
+    return value
+
+
+def _canonical_name(value: object) -> str:
+    if not isinstance(value, str) or not re.fullmatch(
+        r"[a-z0-9]+(?:-[a-z0-9]+)*", value
+    ):
+        raise _runtime_error("distribution name is not normalized")
+    if canonicalize_name(value) != value:
+        raise _runtime_error("distribution name is not normalized")
+    return value
+
+
+def parse_target_runtime_lock(payload: bytes) -> TargetRuntimeLock:
+    """Strictly parse canonical bytes for the one supported target runtime."""
+    if not isinstance(payload, bytes) or not payload or b"\r" in payload:
+        raise _runtime_error("lock bytes are malformed")
+    try:
+        text = payload.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise _runtime_error("lock must be ASCII") from exc
+    if not text.endswith("\n") or "\n\n" in text:
+        raise _runtime_error("lock formatting is malformed")
+    lines = text[:-1].split("\n")
+    if tuple(lines[: len(_LOCK_HEADER)]) != _LOCK_HEADER:
+        raise _runtime_error("header is malformed or does not bind the target")
+    entries: list[TargetRuntimeLockEntry] = []
+    previous = ""
+    seen: set[str] = set()
+    for line in lines[len(_LOCK_HEADER) :]:
+        matched = _LOCK_ROW.fullmatch(line)
+        if matched is None:
+            raise _runtime_error("contains an unrecognized requirement line")
+        name = _canonical_name(matched.group("name"))
+        version = _canonical_version(matched.group("version"))
+        if name == "pdd-cli":
+            raise _runtime_error("must not include pdd-cli")
+        hashes = tuple(
+            item.removeprefix(" --hash=sha256:")
+            for item in re.findall(r" --hash=sha256:[0-9a-f]{64}", matched.group("hashes"))
+        )
+        if (
+            not hashes
+            or len(hashes) != len(set(hashes))
+            or tuple(sorted(hashes)) != hashes
+            or any(_SHA256_HASH.fullmatch(item) is None for item in hashes)
+        ):
+            raise _runtime_error("hash list is malformed")
+        if name in seen or name <= previous:
+            raise _runtime_error("distribution rows are duplicate or unsorted")
+        seen.add(name)
+        previous = name
+        entries.append(TargetRuntimeLockEntry(name, version, hashes))
+    lock = TargetRuntimeLock(tuple(entries))
+    if lock.bytes() != payload:
+        raise _runtime_error("lock is not canonical")
+    return lock
+
+
+def _safe_directory(path: Path, label: str) -> Path:
+    candidate = Path(path)
+    if candidate.is_symlink() or not candidate.is_dir():
+        raise _runtime_error(f"{label} is unsafe")
+    return candidate
+
+
+def _wheel_tags_are_compatible(filename: str) -> bool:
+    """Accept only pure or manylinux x86_64 wheels usable by CPython 3.12."""
+    try:
+        _name, _version, _build, tags = parse_wheel_filename(filename)
+    except InvalidWheelFilename:
+        return False
+    for tag in tags:
+        if tag.platform == "any" and tag.abi == "none" and tag.interpreter in {
+            "py3", "py312", "py2.py3"
+        }:
+            return True
+        if _MANYLINUX_PLATFORM.fullmatch(tag.platform) is None:
+            continue
+        if tag.interpreter == "cp312" and tag.abi in {"cp312", "abi3", "none"}:
+            return True
+        match = re.fullmatch(r"cp(3[0-9]{1,2})", tag.interpreter)
+        if match and tag.abi == "abi3" and 32 <= int(match.group(1)) <= 312:
+            return True
+    return False
+
+
+def _safe_zip_path(value: str) -> PurePosixPath:
+    if not value or "\\" in value:
+        raise _runtime_error("wheel archive contains an unsafe member")
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or path == PurePosixPath("."):
+        raise _runtime_error("wheel archive contains an unsafe member")
+    return path
+
+
+def _metadata_identity(metadata: bytes) -> tuple[str, str]:
+    """Read the two required core metadata fields without coercion."""
+    try:
+        text = metadata.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise _runtime_error("wheel METADATA is not UTF-8") from exc
+    fields: dict[str, list[str]] = {}
+    for line in text.splitlines():
+        if not line:
+            break
+        if line[0] in " \t" or ":" not in line:
+            raise _runtime_error("wheel METADATA headers are malformed")
+        name, value = line.split(":", 1)
+        if not name or not value.startswith(" "):
+            raise _runtime_error("wheel METADATA headers are malformed")
+        fields.setdefault(name.lower(), []).append(value.strip())
+    names = fields.get("name", [])
+    versions = fields.get("version", [])
+    if len(names) != 1 or len(versions) != 1:
+        raise _runtime_error("wheel METADATA identity is malformed")
+    raw_name = names[0]
+    normalized = canonicalize_name(raw_name)
+    if not raw_name or normalized == "" or "\n" in raw_name:
+        raise _runtime_error("wheel METADATA name is malformed")
+    return normalized, _canonical_version(versions[0])
+
+
+def _inspect_wheel(path: Path) -> _WheelInfo:
+    """Return one safe wheel only after filename, tags, metadata, and bytes agree."""
+    wheel = Path(path)
+    if wheel.is_symlink() or not wheel.is_file() or wheel.suffix != ".whl":
+        raise _runtime_error("wheel path is unsafe")
+    if not _wheel_tags_are_compatible(wheel.name):
+        raise _runtime_error("wheel tags are incompatible with linux_x86_64-cp312")
+    try:
+        filename_name, filename_version, _build, _tags = parse_wheel_filename(wheel.name)
+    except InvalidWheelFilename as exc:
+        raise _runtime_error("wheel filename is malformed") from exc
+    name = canonicalize_name(str(filename_name))
+    version = _canonical_version(str(filename_version))
+    files: dict[PurePosixPath, bytes] = {}
+    members: set[PurePosixPath] = set()
+    metadata_members: list[PurePosixPath] = []
+    record_members: list[PurePosixPath] = []
+    try:
+        with zipfile.ZipFile(wheel) as archive:
+            for member in archive.infolist():
+                member_path = _safe_zip_path(member.filename.rstrip("/"))
+                mode = member.external_attr >> 16
+                if stat.S_ISLNK(mode) or member_path in members:
+                    raise _runtime_error("wheel archive contains unsafe duplicate or link")
+                members.add(member_path)
+                if member.is_dir():
+                    continue
+                files[member_path] = archive.read(member)
+                if member_path.name == "METADATA" and member_path.parent.name.endswith(
+                    ".dist-info"
+                ):
+                    metadata_members.append(member_path)
+                if member_path.name == "RECORD" and member_path.parent.name.endswith(
+                    ".dist-info"
+                ):
+                    record_members.append(member_path)
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise _runtime_error("wheel archive cannot be read") from exc
+    if len(metadata_members) != 1 or len(record_members) != 1:
+        raise _runtime_error("wheel archive lacks an unambiguous dist-info record")
+    metadata_name, metadata_version = _metadata_identity(files[metadata_members[0]])
+    if metadata_name != name or metadata_version != version:
+        raise _runtime_error("wheel filename and METADATA identity disagree")
+    return _WheelInfo(wheel, name, version, _sha256(wheel), files)
+
+
+def _wheelhouse_wheels(wheelhouse: Path) -> tuple[Path, ...]:
+    root = _safe_directory(wheelhouse, "wheelhouse")
+    wheels: list[Path] = []
+    for child in sorted(root.iterdir(), key=lambda item: item.name):
+        if child.is_symlink() or not child.is_file() or child.suffix != ".whl":
+            raise _runtime_error("wheelhouse contains a non-wheel or unsafe member")
+        wheels.append(child)
+    return tuple(wheels)
+
+
+def validate_target_wheelhouse(
+    lock: TargetRuntimeLock, wheelhouse: Path
+) -> dict[str, _WheelInfo]:
+    """Require an exact lock-to-wheel bijection for the fixed target runtime."""
+    lock = parse_target_runtime_lock(lock.bytes())
+    expected = {entry.name: entry for entry in lock.entries}
+    found: dict[str, _WheelInfo] = {}
+    for wheel in _wheelhouse_wheels(wheelhouse):
+        info = _inspect_wheel(wheel)
+        if info.name in found:
+            raise _runtime_error("wheelhouse has duplicate distributions")
+        entry = expected.get(info.name)
+        if entry is None:
+            raise _runtime_error("wheelhouse has an extra distribution")
+        if info.version != entry.version or info.digest not in entry.hashes:
+            raise _runtime_error("wheelhouse wheel does not match lock identity or hash")
+        found[info.name] = info
+    if set(found) != set(expected):
+        raise _runtime_error("wheelhouse is missing a locked distribution")
+    return found
+
+
+def generate_target_runtime_lock(wheelhouse: Path) -> TargetRuntimeLock:
+    """Generate canonical bytes only from a complete, target-compatible wheelhouse."""
+    entries: list[TargetRuntimeLockEntry] = []
+    seen: set[str] = set()
+    for wheel in _wheelhouse_wheels(wheelhouse):
+        info = _inspect_wheel(wheel)
+        if info.name == "pdd-cli":
+            raise _runtime_error("wheelhouse generator input must exclude pdd-cli")
+        if info.name in seen:
+            raise _runtime_error("wheelhouse has duplicate distributions")
+        seen.add(info.name)
+        entries.append(TargetRuntimeLockEntry(info.name, info.version, (info.digest,)))
+    lock = TargetRuntimeLock(tuple(sorted(entries, key=lambda entry: entry.name)))
+    # Validate the generated contract against the same wheelhouse before emission.
+    validate_target_wheelhouse(lock, wheelhouse)
+    return parse_target_runtime_lock(lock.bytes())
+
+
+def _record_rows(record: Path) -> Iterable[tuple[str, str, str]]:
+    try:
+        with record.open("r", encoding="utf-8", newline="") as handle:
+            text = handle.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise _runtime_error("installed RECORD cannot be read") from exc
+    try:
+        rows = tuple(csv.reader(io.StringIO(text)))
+    except csv.Error as exc:
+        raise _runtime_error("installed RECORD is malformed") from exc
+    if not rows or any(len(row) != 3 for row in rows):
+        raise _runtime_error("installed RECORD is malformed")
+    return tuple((row[0], row[1], row[2]) for row in rows)
+
+
+def _installed_path(root: Path, relative: str) -> tuple[Path, PurePosixPath]:
+    try:
+        path = _safe_zip_path(relative)
+    except TargetRuntimeLockError as exc:
+        raise _runtime_error("installed RECORD has an unsafe path") from exc
+    target = root.joinpath(*path.parts)
+    if target.is_symlink() or not target.is_file():
+        raise _runtime_error("installed RECORD references an unsafe or missing file")
+    return target, path
+
+
+def _record_hash(value: bytes) -> str:
+    encoded = base64.urlsafe_b64encode(hashlib.sha256(value).digest())
+    return encoded.rstrip(b"=").decode("ascii")
+
+
+def _wheel_install_path(path: PurePosixPath) -> PurePosixPath | None:
+    """Map only the wheel layouts allowed in the isolated --target installation."""
+    if path.name == "RECORD" and path.parent.name.endswith(".dist-info"):
+        return None
+    for index, part in enumerate(path.parts):
+        if not part.endswith(".data"):
+            continue
+        if (
+            index + 2 < len(path.parts)
+            and path.parts[index + 1] in {"purelib", "platlib"}
+        ):
+            return PurePosixPath(*path.parts[index + 2 :])
+        return None
+    return path
+
+
+def _expected_installed_files(info: _WheelInfo) -> dict[PurePosixPath, bytes]:
+    expected: dict[PurePosixPath, bytes] = {}
+    for archive_path, content in info.files.items():
+        installed_path = _wheel_install_path(archive_path)
+        if installed_path is None:
+            continue
+        if installed_path in expected:
+            raise _runtime_error("wheel has ambiguous installed paths")
+        expected[installed_path] = content
+    return expected
+
+
+def validate_installed_target_runtime(
+    lock: TargetRuntimeLock,
+    wheelhouse: Path,
+    site_packages: Path,
+    project_wheel: Path,
+) -> None:
+    """Verify an isolated install against locked wheels plus one exact pdd-cli wheel."""
+    lock = parse_target_runtime_lock(lock.bytes())
+    wheels = validate_target_wheelhouse(lock, wheelhouse)
+    project = _inspect_wheel(project_wheel)
+    if project.name != "pdd-cli":
+        raise _runtime_error("separate project wheel is not pdd-cli")
+    expected_wheels = {**wheels, project.name: project}
+    root = _safe_directory(site_packages, "installed site-packages")
+    dist_infos = sorted(root.glob("*.dist-info"), key=lambda item: item.name)
+    if any(item.is_symlink() or not item.is_dir() for item in dist_infos):
+        raise _runtime_error("installed distribution metadata is unsafe")
+    installed: dict[str, tuple[Path, _WheelInfo]] = {}
+    seen_files: dict[PurePosixPath, str] = {}
+    for dist_info in dist_infos:
+        metadata = dist_info / "METADATA"
+        record = dist_info / "RECORD"
+        if (
+            metadata.is_symlink()
+            or record.is_symlink()
+            or not metadata.is_file()
+            or not record.is_file()
+        ):
+            raise _runtime_error("installed distribution lacks regular METADATA or RECORD")
+        name, version = _metadata_identity(metadata.read_bytes())
+        expected = expected_wheels.get(name)
+        if expected is None or expected.version != version or name in installed:
+            raise _runtime_error("installed distribution set does not match target runtime")
+        installed[name] = (dist_info, expected)
+        record_relative = PurePosixPath(dist_info.name, "RECORD")
+        expected_files = _expected_installed_files(expected)
+        recorded_expected: set[PurePosixPath] = set()
+        for relative, declared_hash, declared_size in _record_rows(record):
+            target, relative_path = _installed_path(root, relative)
+            if relative_path in seen_files:
+                raise _runtime_error("installed RECORD closure overlaps")
+            seen_files[relative_path] = name
+            if relative_path == record_relative:
+                if declared_hash or declared_size:
+                    raise _runtime_error("installed RECORD self row must omit hash and size")
+                continue
+            content = target.read_bytes()
+            if (
+                not re.fullmatch(r"sha256=[A-Za-z0-9_-]+", declared_hash)
+                or declared_hash.removeprefix("sha256=") != _record_hash(content)
+                or declared_size != str(len(content))
+            ):
+                raise _runtime_error("installed RECORD hash or size does not match")
+            allowed_generated = (
+                relative_path.parent == PurePosixPath(dist_info.name)
+                and relative_path.name in {"INSTALLER", "REQUESTED"}
+            )
+            expected_content = expected_files.get(relative_path)
+            if not allowed_generated and expected_content != content:
+                raise _runtime_error("installed files do not match their exact wheel")
+            if not allowed_generated:
+                recorded_expected.add(relative_path)
+        if recorded_expected != set(expected_files):
+            raise _runtime_error("installed RECORD does not close over its exact wheel")
+    if set(installed) != set(expected_wheels):
+        raise _runtime_error("installed distribution set is incomplete or has extras")
+    actual_files: set[PurePosixPath] = set()
+    expected_directories = {PurePosixPath(".")}
+    for relative in seen_files:
+        expected_directories.update(relative.parents)
+    for current, directories, filenames in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        relative_directory = PurePosixPath(current_path.relative_to(root).as_posix())
+        if relative_directory not in expected_directories:
+            raise _runtime_error("installed tree contains an extra directory")
+        for directory in directories:
+            path = current_path / directory
+            if path.is_symlink() or not path.is_dir():
+                raise _runtime_error("installed tree contains an unsafe directory")
+        for filename in filenames:
+            path = current_path / filename
+            relative = PurePosixPath(path.relative_to(root).as_posix())
+            if path.is_symlink() or not path.is_file():
+                raise _runtime_error("installed tree contains a non-regular file")
+            actual_files.add(relative)
+    if actual_files != set(seen_files):
+        raise _runtime_error("installed RECORD closure has missing or extra files")
+
+
+def target_wheel_inventory(wheelhouse: Path) -> bytes:
+    """Produce a compact deterministic inventory for the candidate artifact."""
+    inventory = [
+        {"filename": wheel.name, "sha256": _inspect_wheel(wheel).digest}
+        for wheel in _wheelhouse_wheels(wheelhouse)
+    ]
+    return (json.dumps(inventory, sort_keys=True, separators=(",", ":")) + "\n").encode("ascii")
+
+
+def _runtime_lock_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="pdd-target-runtime-lock")
+    commands = parser.add_subparsers(dest="command", required=True)
+    generate = commands.add_parser("generate")
+    generate.add_argument("--wheelhouse", type=Path, required=True)
+    generate.add_argument("--output", type=Path, required=True)
+    generate.add_argument("--inventory", type=Path, required=True)
+    validate_wheelhouse = commands.add_parser("validate-wheelhouse")
+    validate_wheelhouse.add_argument("--lock", type=Path, required=True)
+    validate_wheelhouse.add_argument("--wheelhouse", type=Path, required=True)
+    validate_installed = commands.add_parser("validate-installed")
+    validate_installed.add_argument("--lock", type=Path, required=True)
+    validate_installed.add_argument("--wheelhouse", type=Path, required=True)
+    validate_installed.add_argument("--site-packages", type=Path, required=True)
+    validate_installed.add_argument("--project-wheel", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "generate":
+            args.output.write_bytes(generate_target_runtime_lock(args.wheelhouse).bytes())
+            args.inventory.write_bytes(target_wheel_inventory(args.wheelhouse))
+        else:
+            lock = parse_target_runtime_lock(args.lock.read_bytes())
+            if args.command == "validate-wheelhouse":
+                validate_target_wheelhouse(lock, args.wheelhouse)
+            else:
+                validate_installed_target_runtime(
+                    lock, args.wheelhouse, args.site_packages, args.project_wheel
+                )
+    except (OSError, TargetRuntimeLockError) as exc:
+        parser.error(str(exc))
+    return 0
 
 
 _MAXIMUM_ATTESTATION_LIFETIME = timedelta(minutes=15)
@@ -386,3 +878,7 @@ def candidate_artifact_policy_from_environment() -> CandidateArtifactPolicy:
             "candidate artifact public key is malformed"
         ) from exc
     return CandidateArtifactPolicy(**values)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(_runtime_lock_main())

--- a/pdd/sync_core/artifact_provenance.py
+++ b/pdd/sync_core/artifact_provenance.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import base64
 import argparse
+import configparser
 import csv
 import hashlib
 import io
@@ -54,7 +55,17 @@ _LOCK_ROW = re.compile(
     r"(?P<hashes>(?: --hash=sha256:[0-9a-f]{64})+)"
 )
 _SHA256_HASH = re.compile(r"[0-9a-f]{64}")
-_MANYLINUX_PLATFORM = re.compile(r"manylinux(?:_[0-9]+|[0-9]+)_[0-9]+_x86_64")
+_MANYLINUX_GLIBC_CEILING = (2, 36)
+_MANYLINUX_LEGACY_FLOORS = {
+    "manylinux1_x86_64": (2, 5),
+    "manylinux2010_x86_64": (2, 12),
+    "manylinux2014_x86_64": (2, 17),
+}
+_SCRIPT_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*")
+_ENTRY_POINT = re.compile(
+    r"(?P<module>[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)"
+    r":(?P<callable>[A-Za-z_][A-Za-z0-9_]*)"
+)
 
 
 @dataclass(frozen=True)
@@ -182,7 +193,7 @@ def _wheel_tags_are_compatible(filename: str) -> bool:
             "py3", "py312", "py2.py3"
         }:
             return True
-        if _MANYLINUX_PLATFORM.fullmatch(tag.platform) is None:
+        if not _manylinux_tag_is_compatible(tag.platform):
             continue
         if tag.interpreter == "cp312" and tag.abi in {"cp312", "abi3", "none"}:
             return True
@@ -190,6 +201,18 @@ def _wheel_tags_are_compatible(filename: str) -> bool:
         if match and tag.abi == "abi3" and 32 <= int(match.group(1)) <= 312:
             return True
     return False
+
+
+def _manylinux_tag_is_compatible(platform: str) -> bool:
+    """Accept x86_64 manylinux floors that bookworm's glibc can satisfy."""
+    legacy_floor = _MANYLINUX_LEGACY_FLOORS.get(platform)
+    if legacy_floor is not None:
+        return legacy_floor <= _MANYLINUX_GLIBC_CEILING
+    matched = re.fullmatch(r"manylinux_(\d+)_(\d+)_x86_64", platform)
+    if matched is None:
+        return False
+    minor = int(matched.group(2))
+    return matched.group(1) == "2" and minor <= _MANYLINUX_GLIBC_CEILING[1]
 
 
 def _safe_zip_path(value: str) -> PurePosixPath:
@@ -340,14 +363,26 @@ def _record_rows(record: Path) -> Iterable[tuple[str, str, str]]:
 
 
 def _installed_path(root: Path, relative: str) -> tuple[Path, PurePosixPath]:
-    try:
-        path = _safe_zip_path(relative)
-    except TargetRuntimeLockError as exc:
-        raise _runtime_error("installed RECORD has an unsafe path") from exc
-    target = root.joinpath(*path.parts)
-    if target.is_symlink() or not target.is_file():
+    """Resolve regular package files and pip's fixed --target script record form."""
+    if "\\" in relative:
+        raise _runtime_error("installed RECORD has an unsafe path")
+    record_path = PurePosixPath(relative)
+    if (
+        len(record_path.parts) == 4
+        and record_path.parts[:3] == ("..", "..", "bin")
+        and _SCRIPT_NAME.fullmatch(record_path.name)
+    ):
+        path = root / "bin" / record_path.name
+        relative_path = PurePosixPath("bin", record_path.name)
+    else:
+        try:
+            relative_path = _safe_zip_path(relative)
+        except TargetRuntimeLockError as exc:
+            raise _runtime_error("installed RECORD has an unsafe path") from exc
+        path = root.joinpath(*relative_path.parts)
+    if path.is_symlink() or not path.is_file():
         raise _runtime_error("installed RECORD references an unsafe or missing file")
-    return target, path
+    return path, relative_path
 
 
 def _record_hash(value: bytes) -> str:
@@ -383,11 +418,69 @@ def _expected_installed_files(info: _WheelInfo) -> dict[PurePosixPath, bytes]:
     return expected
 
 
+def _expected_console_scripts(info: _WheelInfo) -> dict[PurePosixPath, tuple[str, str]]:
+    """Read only simple Linux console entry points from the reviewed wheel bytes."""
+    entry_points = [
+        content
+        for path, content in info.files.items()
+        if path.name == "entry_points.txt" and path.parent.name.endswith(".dist-info")
+    ]
+    if not entry_points:
+        return {}
+    if len(entry_points) != 1:
+        raise _runtime_error("wheel has ambiguous entry point metadata")
+    parser = configparser.ConfigParser(interpolation=None)
+    try:
+        parser.read_string(entry_points[0].decode("utf-8"))
+    except (UnicodeDecodeError, configparser.Error) as exc:
+        raise _runtime_error("wheel entry point metadata is malformed") from exc
+    scripts: dict[PurePosixPath, tuple[str, str]] = {}
+    for group in ("console_scripts", "gui_scripts"):
+        if not parser.has_section(group):
+            continue
+        for name, specification in parser.items(group):
+            matched = _ENTRY_POINT.fullmatch(specification.strip())
+            if _SCRIPT_NAME.fullmatch(name) is None or matched is None:
+                raise _runtime_error("wheel entry point metadata is unsupported")
+            path = PurePosixPath("bin", name)
+            if path in scripts:
+                raise _runtime_error("wheel entry point metadata is ambiguous")
+            scripts[path] = (matched.group("module"), matched.group("callable"))
+    return scripts
+
+
+def _matches_pip_script(
+    content: bytes, script_python: Path, entry_point: tuple[str, str]
+) -> bool:
+    """Accept only known pip 25.1 Linux script forms for a declared entry point."""
+    module, callable_name = entry_point
+    current = (
+        f"#!{script_python}\n"
+        "import sys\n"
+        f"from {module} import {callable_name}\n"
+        "if __name__ == '__main__':\n"
+        "    sys.argv[0] = sys.argv[0].removesuffix('.exe')\n"
+        f"    sys.exit({callable_name}())\n"
+    ).encode("utf-8")
+    legacy = (
+        f"#!{script_python}\n"
+        "# -*- coding: utf-8 -*-\n"
+        "import re\n"
+        "import sys\n"
+        f"from {module} import {callable_name}\n"
+        "if __name__ == '__main__':\n"
+        "    sys.argv[0] = re.sub(r'(-script\\.pyw|\\.exe)?$', '', sys.argv[0])\n"
+        f"    sys.exit({callable_name}())\n"
+    ).encode("utf-8")
+    return content in {current, legacy}
+
+
 def validate_installed_target_runtime(
     lock: TargetRuntimeLock,
     wheelhouse: Path,
     site_packages: Path,
     project_wheel: Path,
+    script_python: Path | None = None,
 ) -> None:
     """Verify an isolated install against locked wheels plus one exact pdd-cli wheel."""
     lock = parse_target_runtime_lock(lock.bytes())
@@ -396,6 +489,12 @@ def validate_installed_target_runtime(
     if project.name != "pdd-cli":
         raise _runtime_error("separate project wheel is not pdd-cli")
     expected_wheels = {**wheels, project.name: project}
+    expected_scripts: dict[PurePosixPath, tuple[str, str]] = {}
+    for wheel in expected_wheels.values():
+        for script_path, entry_point in _expected_console_scripts(wheel).items():
+            if script_path in expected_scripts:
+                raise _runtime_error("installed wheel set has duplicate console scripts")
+            expected_scripts[script_path] = entry_point
     root = _safe_directory(site_packages, "installed site-packages")
     dist_infos = sorted(root.glob("*.dist-info"), key=lambda item: item.name)
     if any(item.is_symlink() or not item.is_dir() for item in dist_infos):
@@ -436,14 +535,20 @@ def validate_installed_target_runtime(
                 or declared_size != str(len(content))
             ):
                 raise _runtime_error("installed RECORD hash or size does not match")
-            allowed_generated = (
+            allowed_metadata = (
                 relative_path.parent == PurePosixPath(dist_info.name)
                 and relative_path.name in {"INSTALLER", "REQUESTED"}
             )
+            entry_point = expected_scripts.get(relative_path)
+            allowed_script = (
+                entry_point is not None
+                and script_python is not None
+                and _matches_pip_script(content, script_python, entry_point)
+            )
             expected_content = expected_files.get(relative_path)
-            if not allowed_generated and expected_content != content:
+            if not allowed_metadata and not allowed_script and expected_content != content:
                 raise _runtime_error("installed files do not match their exact wheel")
-            if not allowed_generated:
+            if not allowed_metadata and not allowed_script:
                 recorded_expected.add(relative_path)
         if recorded_expected != set(expected_files):
             raise _runtime_error("installed RECORD does not close over its exact wheel")
@@ -496,6 +601,7 @@ def _runtime_lock_main(argv: list[str] | None = None) -> int:
     validate_installed.add_argument("--wheelhouse", type=Path, required=True)
     validate_installed.add_argument("--site-packages", type=Path, required=True)
     validate_installed.add_argument("--project-wheel", type=Path, required=True)
+    validate_installed.add_argument("--script-python", type=Path, required=True)
     args = parser.parse_args(argv)
     try:
         if args.command == "generate":
@@ -507,7 +613,11 @@ def _runtime_lock_main(argv: list[str] | None = None) -> int:
                 validate_target_wheelhouse(lock, args.wheelhouse)
             else:
                 validate_installed_target_runtime(
-                    lock, args.wheelhouse, args.site_packages, args.project_wheel
+                    lock,
+                    args.wheelhouse,
+                    args.site_packages,
+                    args.project_wheel,
+                    args.script_python,
                 )
     except (OSError, TargetRuntimeLockError) as exc:
         parser.error(str(exc))

--- a/tests/test_sync_core_candidate_artifact_provenance.py
+++ b/tests/test_sync_core_candidate_artifact_provenance.py
@@ -657,6 +657,11 @@ def test_target_runtime_workflow_is_offline_validated_before_artifact_upload() -
     assert target_job.count("SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PDD_CLI") == 1
     assert synthetic_build in build_step
     assert "export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PDD_CLI" not in build_step
+    assert 'mkdir -p "$runtime/source"' in build_step
+    assert 'tar --exclude=.git -C "$GITHUB_WORKSPACE" -cf - .' in build_step
+    assert 'tar -C "$runtime/source" -xf -' in build_step
+    assert '-w /runtime/source "$image"' in build_step
+    assert "$GITHUB_WORKSPACE:/workspace" not in build_step
     assert not any(
         line.strip().startswith(("git ", "apt-get ", "sudo apt-get "))
         for line in target_job.splitlines()

--- a/tests/test_sync_core_candidate_artifact_provenance.py
+++ b/tests/test_sync_core_candidate_artifact_provenance.py
@@ -1,24 +1,39 @@
 """Strict tests for protected candidate-wheel build provenance."""
-# pylint: disable=missing-function-docstring,line-too-long
+# pylint: disable=missing-function-docstring,line-too-long,too-many-arguments
 
+import base64
 import hashlib
 import json
+import subprocess
+import sys
 import threading
+import zipfile
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
+import yaml
 
 from pdd.sync_core import AttestationSigner
 from pdd.sync_core.artifact_provenance import (
     CandidateArtifactPolicy,
     CandidateArtifactProvenanceError,
+    TARGET_BASE_IMAGE,
+    TARGET_RESOLVER,
+    TARGET_RUNTIME,
+    TargetRuntimeLockError,
+    generate_target_runtime_lock,
     load_candidate_artifact_provenance,
+    parse_target_runtime_lock,
+    validate_installed_target_runtime,
+    validate_target_wheelhouse,
 )
 
 
 SOURCE_SHA = "a" * 40
 LOCK_SHA256 = "b" * 64
 WORKFLOW = "promptdriven/pdd/.github/workflows/candidate-wheel.yml@refs/heads/main"
+ROOT = Path(__file__).resolve().parents[1]
 TARGET = {
     "implementation": "CPython",
     "version": "3.12.3",
@@ -281,3 +296,272 @@ def test_durable_replay_ledger_rejects_symlink_lock(tmp_path) -> None:
             _policy_with_replay_ledger(authority, replay_ledger),
             expected_source_sha=SOURCE_SHA,
         )
+
+
+def _record_hash(content: bytes) -> str:
+    return base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode()
+
+
+def _wheel(
+    root,
+    name: str,
+    version: str = "1.0",
+    *,
+    tags: str = "py3-none-any",
+    metadata_name: str | None = None,
+    extra: dict[str, bytes] | None = None,
+) -> Path:
+    """Make a minimal regular wheel with a valid, deterministic RECORD."""
+    filename = f"{name.replace('-', '_')}-{version}-{tags}.whl"
+    path = root / filename
+    distribution = f"{name.replace('-', '_')}-{version}.dist-info"
+    files = {
+        f"{name.replace('-', '_')}/__init__.py": b"VALUE = 1\n",
+        f"{distribution}/METADATA": (
+            f"Metadata-Version: 2.1\nName: {metadata_name or name}\nVersion: {version}\n"
+        ).encode(),
+        f"{distribution}/WHEEL": b"Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: true\n",
+    }
+    files.update(extra or {})
+    record = "".join(
+        f"{entry},sha256={_record_hash(content)},{len(content)}\n"
+        for entry, content in sorted(files.items())
+    ) + f"{distribution}/RECORD,,\n"
+    with zipfile.ZipFile(path, "w") as archive:
+        for entry, content in files.items():
+            archive.writestr(entry, content)
+        archive.writestr(f"{distribution}/RECORD", record)
+    return path
+
+
+def _install_wheel(wheel, target) -> None:
+    """Materialize the exact --target-style contents expected by the validator."""
+    with zipfile.ZipFile(wheel) as archive:
+        files = {
+            name: archive.read(name)
+            for name in archive.namelist()
+            if not name.endswith("/") and not name.endswith(".dist-info/RECORD")
+        }
+    dist_info_name = next(
+        Path(name).parent.name for name in files if name.endswith(".dist-info/METADATA")
+    )
+    for relative, content in files.items():
+        destination = target / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(content)
+    rows = []
+    for relative, content in sorted(files.items()):
+        rows.append(f"{relative},sha256={_record_hash(content)},{len(content)}\n")
+    (target / dist_info_name / "RECORD").write_text(
+        "".join(rows) + f"{dist_info_name}/RECORD,,\n", encoding="utf-8"
+    )
+
+
+def _runtime_fixture(tmp_path):
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    dependency = _wheel(wheelhouse, "demo-dependency")
+    project = _wheel(tmp_path, "pdd-cli", "2.0")
+    lock = generate_target_runtime_lock(wheelhouse)
+    installed = tmp_path / "installed"
+    installed.mkdir()
+    _install_wheel(dependency, installed)
+    _install_wheel(project, installed)
+    return lock, wheelhouse, installed, project
+
+
+def test_target_lock_round_trip_has_fixed_target_bindings(tmp_path) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _wheel(wheelhouse, "zeta")
+    _wheel(wheelhouse, "alpha", "2.0")
+
+    lock = generate_target_runtime_lock(wheelhouse)
+
+    assert parse_target_runtime_lock(lock.bytes()) == lock
+    assert lock.bytes().decode().splitlines()[:4] == [
+        "# pdd-runtime-lock-format: 1",
+        f"# target: {TARGET_RUNTIME}",
+        f"# resolver: {TARGET_RESOLVER}",
+        f"# base-image: {TARGET_BASE_IMAGE}",
+    ]
+    assert [entry.name for entry in lock.entries] == ["alpha", "zeta"]
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        b"# pdd-runtime-lock-format: 1\n# target: linux_x86_64-cp312\n# resolver: pip==25.1.1\n# base-image: fake\n",
+        b"# pdd-runtime-lock-format: 1\n# target: linux_x86_64-cp312\n# resolver: pip==25.1.1\n# base-image: python:3.12.13-slim-bookworm@sha256:72d3d75f2639ab82b34b29390ad3d6e0827c775befee94edda8e9976818f488d\n# comment\n",
+        b"# pdd-runtime-lock-format: 1\n# target: linux_x86_64-cp312\n# resolver: pip==25.1.1\n# base-image: python:3.12.13-slim-bookworm@sha256:72d3d75f2639ab82b34b29390ad3d6e0827c775befee94edda8e9976818f488d\ndemo_dependency==1.0 --hash=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+        b"# pdd-runtime-lock-format: 1\n# target: linux_x86_64-cp312\n# resolver: pip==25.1.1\n# base-image: python:3.12.13-slim-bookworm@sha256:72d3d75f2639ab82b34b29390ad3d6e0827c775befee94edda8e9976818f488d\npdd-cli==1.0 --hash=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+        b"# pdd-runtime-lock-format: 1\n# target: linux_x86_64-cp312\n# resolver: pip==25.1.1\n# base-image: python:3.12.13-slim-bookworm@sha256:72d3d75f2639ab82b34b29390ad3d6e0827c775befee94edda8e9976818f488d\ndemo==1.0; python_version > '3' --hash=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+    ],
+)
+def test_target_lock_rejects_noncanonical_or_unsafe_rows(mutation) -> None:
+    with pytest.raises(TargetRuntimeLockError):
+        parse_target_runtime_lock(mutation)
+
+
+@pytest.mark.parametrize(
+    ("tags", "metadata_name"),
+    [
+        ("cp312-cp312-macosx_11_0_x86_64", None),
+        ("cp312-cp312-win_amd64", None),
+        ("cp312-cp312-manylinux_2_17_aarch64", None),
+        ("py3-none-any", "different"),
+    ],
+)
+def test_target_wheelhouse_rejects_incompatible_or_misidentified_wheel(
+    tmp_path, tags, metadata_name
+) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _wheel(wheelhouse, "demo", tags=tags, metadata_name=metadata_name)
+
+    with pytest.raises(TargetRuntimeLockError):
+        generate_target_runtime_lock(wheelhouse)
+
+
+def test_target_wheelhouse_requires_exact_bijection_and_regular_members(tmp_path) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _wheel(wheelhouse, "demo")
+    lock = generate_target_runtime_lock(wheelhouse)
+    _wheel(wheelhouse, "extra")
+    with pytest.raises(TargetRuntimeLockError, match="extra"):
+        validate_target_wheelhouse(lock, wheelhouse)
+
+    (wheelhouse / "README.txt").write_text("not a wheel", encoding="utf-8")
+    with pytest.raises(TargetRuntimeLockError, match="non-wheel"):
+        validate_target_wheelhouse(lock, wheelhouse)
+
+
+def test_target_wheelhouse_rejects_archive_escape_links_and_ambiguous_names(tmp_path) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    malicious = _wheel(wheelhouse, "demo")
+    with zipfile.ZipFile(malicious, "a") as archive:
+        link = zipfile.ZipInfo("demo/link")
+        link.external_attr = 0o120777 << 16
+        archive.writestr(link, b"outside")
+    with pytest.raises(TargetRuntimeLockError, match="unsafe"):
+        generate_target_runtime_lock(wheelhouse)
+
+    malicious.unlink()
+    _wheel(wheelhouse, "demo", tags="py3-none-any")
+    _wheel(wheelhouse, "demo", tags="cp312-cp312-manylinux_2_17_x86_64")
+    with pytest.raises(TargetRuntimeLockError, match="duplicate"):
+        generate_target_runtime_lock(wheelhouse)
+
+
+@pytest.mark.parametrize("tamper", ["hash", "nohash", "extra", "overlap", "project", "base"])
+def test_installed_target_runtime_fails_closed_on_tampering(tmp_path, tamper) -> None:
+    lock, wheelhouse, installed, project = _runtime_fixture(tmp_path)
+    demo_record = next(installed.glob("demo_dependency-*.dist-info/RECORD"))
+    if tamper == "hash":
+        demo_record.write_text(
+            demo_record.read_text(encoding="utf-8").replace("sha256=", "sha256=x", 1),
+            encoding="utf-8",
+        )
+    elif tamper == "nohash":
+        demo_record.write_text(
+            demo_record.read_text(encoding="utf-8").replace("sha256=", "", 1),
+            encoding="utf-8",
+        )
+    elif tamper == "extra":
+        (installed / "unexpected.py").write_text("x = 1\n", encoding="utf-8")
+    elif tamper == "overlap":
+        project_record = next(installed.glob("pdd_cli-*.dist-info/RECORD"))
+        project_record.write_text(
+            project_record.read_text(encoding="utf-8")
+            + demo_record.read_text(encoding="utf-8").splitlines()[0]
+            + "\n",
+            encoding="utf-8",
+        )
+    elif tamper == "base":
+        base = installed / "base-1.0.dist-info"
+        base.mkdir()
+        (base / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: base\nVersion: 1.0\n", encoding="utf-8"
+        )
+        (base / "RECORD").write_text("base-1.0.dist-info/RECORD,,\n", encoding="utf-8")
+    else:
+        (installed / "pdd_cli/__init__.py").write_text("VALUE = 2\n", encoding="utf-8")
+    with pytest.raises(TargetRuntimeLockError):
+        validate_installed_target_runtime(lock, wheelhouse, installed, project)
+
+
+def test_installed_target_runtime_accepts_exact_wheel_closure(tmp_path) -> None:
+    lock, wheelhouse, installed, project = _runtime_fixture(tmp_path)
+
+    validate_installed_target_runtime(lock, wheelhouse, installed, project)
+
+
+def test_target_runtime_lock_cli_generates_and_validates(tmp_path) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _wheel(wheelhouse, "demo")
+    lock_path = tmp_path / "runtime.lock"
+    inventory = tmp_path / "inventory.json"
+    command = [sys.executable, "-m", "pdd.sync_core.artifact_provenance"]
+
+    subprocess.run(
+        command
+        + [
+            "generate",
+            "--wheelhouse",
+            str(wheelhouse),
+            "--output",
+            str(lock_path),
+            "--inventory",
+            str(inventory),
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+    subprocess.run(
+        command + ["validate-wheelhouse", "--lock", str(lock_path), "--wheelhouse", str(wheelhouse)],
+        cwd=ROOT,
+        check=True,
+    )
+    assert parse_target_runtime_lock(lock_path.read_bytes()).entries[0].name == "demo"
+    assert json.loads(inventory.read_text(encoding="ascii"))[0]["filename"].endswith(".whl")
+
+
+def test_target_runtime_workflow_is_offline_validated_before_artifact_upload() -> None:
+    workflow_path = ROOT / ".github/workflows/unit-tests.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    payload = yaml.safe_load(workflow)
+    job = payload["jobs"]["target-runtime-lock"]
+    steps = job["steps"]
+    names = [step["name"] for step in steps]
+    generation = workflow.index("Generate Linux CPython 3.12 candidate lock online")
+    validation = workflow.index("Validate candidate in fresh network-none container")
+    upload = workflow.index("Upload target runtime lock candidate")
+
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["timeout-minutes"] == 30
+    assert generation < validation < upload
+    assert "python:3.12.13-slim-bookworm@sha256:72d3d75f2639ab82b34b29390ad3d6e0827c775befee94edda8e9976818f488d" in workflow
+    assert "docker run --rm --network bridge" in workflow
+    assert "docker run --rm --network none" in workflow
+    assert "--only-binary=:all:" in workflow
+    assert "--require-hashes" in workflow
+    assert "pip==25.1.1 build==1.2.2.post1" in workflow
+    assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in workflow
+    assert "release.yml" not in workflow[workflow.index("  target-runtime-lock:") :]
+    assert "Gate 2" not in workflow
+    assert "Certificate" not in workflow
+    assert names[-1] == "Upload target runtime lock candidate"
+    for step in steps:
+        if "run" in step:
+            checked = subprocess.run(
+                ["bash", "-n"], input=step["run"], text=True, capture_output=True, check=False
+            )
+            assert checked.returncode == 0, checked.stderr
+    assert subprocess.run(
+        ["git", "diff", "--quiet", "HEAD", "--", ".github/workflows/release.yml"],
+        cwd=ROOT,
+        check=False,
+    ).returncode == 0

--- a/tests/test_sync_core_candidate_artifact_provenance.py
+++ b/tests/test_sync_core_candidate_artifact_provenance.py
@@ -645,14 +645,32 @@ def test_target_runtime_workflow_is_offline_validated_before_artifact_upload() -
     assert "Certificate" not in workflow
     assert names[-1] == "Upload target runtime lock candidate"
     target_job = workflow[workflow.index("  target-runtime-lock:") :]
+    build_step = next(
+        step["run"]
+        for step in steps
+        if step["name"] == "Generate Linux CPython 3.12 candidate lock online"
+    )
+    synthetic_build = (
+        "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PDD_CLI=0.0.0 "
+        "python -m build --wheel --outdir /runtime/project"
+    )
+    assert target_job.count("SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PDD_CLI") == 1
+    assert synthetic_build in build_step
+    assert "export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PDD_CLI" not in build_step
+    assert not any(
+        line.strip().startswith(("git ", "apt-get ", "sudo apt-get "))
+        for line in target_job.splitlines()
+    )
     assert "PYTHONPATH" not in target_job
     assert target_job.count("-I -S -c") == 3
     removed_project_wheel = (
         'find /runtime/wheelhouse -maxdepth 1 -type f -name "pdd_cli-*.whl" -delete'
     )
     assert removed_project_wheel in target_job
-    assert target_job.index(removed_project_wheel) < target_job.index(
-        "generate --wheelhouse /runtime/wheelhouse"
+    assert (
+        target_job.index(synthetic_build)
+        < target_job.index(removed_project_wheel)
+        < target_job.index("generate --wheelhouse /runtime/wheelhouse")
     )
     assert "--find-links /runtime/wheelhouse --find-links /runtime/project" in target_job
     for step in steps:

--- a/tests/test_sync_core_candidate_artifact_provenance.py
+++ b/tests/test_sync_core_candidate_artifact_provenance.py
@@ -409,6 +409,7 @@ def test_target_lock_rejects_noncanonical_or_unsafe_rows(mutation) -> None:
         ("cp312-cp312-macosx_11_0_x86_64", None),
         ("cp312-cp312-win_amd64", None),
         ("cp312-cp312-manylinux_2_17_aarch64", None),
+        ("cp312-cp312-manylinux_2_99_x86_64", None),
         ("py3-none-any", "different"),
     ],
 )
@@ -421,6 +422,14 @@ def test_target_wheelhouse_rejects_incompatible_or_misidentified_wheel(
 
     with pytest.raises(TargetRuntimeLockError):
         generate_target_runtime_lock(wheelhouse)
+
+
+def test_target_wheelhouse_accepts_bookworm_compatible_legacy_manylinux_tag(tmp_path) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _wheel(wheelhouse, "demo", tags="cp312-cp312-manylinux2014_x86_64")
+
+    assert generate_target_runtime_lock(wheelhouse).entries[0].name == "demo"
 
 
 def test_target_wheelhouse_requires_exact_bijection_and_regular_members(tmp_path) -> None:
@@ -498,6 +507,84 @@ def test_installed_target_runtime_accepts_exact_wheel_closure(tmp_path) -> None:
     validate_installed_target_runtime(lock, wheelhouse, installed, project)
 
 
+def test_real_pip_target_install_closes_console_scripts_under_target_root(tmp_path) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    project_directory = tmp_path / "project"
+    wheelhouse.mkdir()
+    project_directory.mkdir()
+    _wheel(wheelhouse, "demo-dependency")
+    project = _wheel(
+        project_directory,
+        "pdd-cli",
+        "2.0",
+        extra={
+            "pdd_cli-2.0.dist-info/entry_points.txt": b"[console_scripts]\npdd = pdd_cli:main\n"
+        },
+    )
+    lock = generate_target_runtime_lock(wheelhouse)
+    requirements = tmp_path / "requirements.lock"
+    requirements.write_bytes(
+        lock.bytes()
+        + f"pdd-cli==2.0 --hash=sha256:{hashlib.sha256(project.read_bytes()).hexdigest()}\n".encode()
+    )
+    installed = tmp_path / "installed"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-index",
+            "--no-compile",
+            "--only-binary=:all:",
+            "--require-hashes",
+            "--find-links",
+            str(wheelhouse),
+            "--find-links",
+            str(project_directory),
+            "--target",
+            str(installed),
+            "-r",
+            str(requirements),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    validate_installed_target_runtime(
+        lock, wheelhouse, installed, project, Path(sys.executable)
+    )
+    record = next(installed.glob("pdd_cli-*.dist-info/RECORD")).read_text(encoding="utf-8")
+    assert "../../bin/pdd," in record
+    assert (installed / "bin/pdd").is_file()
+
+
+def test_isolated_runtime_bootstrap_does_not_execute_candidate_sitecustomize(tmp_path) -> None:
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    marker = tmp_path / "sitecustomize-ran"
+    (candidate / "sitecustomize.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n", encoding="utf-8"
+    )
+    bootstrap = "import sys; sys.path.insert(0, sys.argv[1])"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            bootstrap,
+            str(candidate),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert not marker.exists()
+
+
 def test_target_runtime_lock_cli_generates_and_validates(tmp_path) -> None:
     wheelhouse = tmp_path / "wheelhouse"
     wheelhouse.mkdir()
@@ -547,13 +634,27 @@ def test_target_runtime_workflow_is_offline_validated_before_artifact_upload() -
     assert "docker run --rm --network bridge" in workflow
     assert "docker run --rm --network none" in workflow
     assert "--only-binary=:all:" in workflow
+    assert "--no-compile" in workflow
     assert "--require-hashes" in workflow
+    assert "--find-links /runtime/project" in workflow
     assert "pip==25.1.1 build==1.2.2.post1" in workflow
+    assert "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" in workflow
     assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in workflow
     assert "release.yml" not in workflow[workflow.index("  target-runtime-lock:") :]
     assert "Gate 2" not in workflow
     assert "Certificate" not in workflow
     assert names[-1] == "Upload target runtime lock candidate"
+    target_job = workflow[workflow.index("  target-runtime-lock:") :]
+    assert "PYTHONPATH" not in target_job
+    assert target_job.count("-I -S -c") == 3
+    removed_project_wheel = (
+        'find /runtime/wheelhouse -maxdepth 1 -type f -name "pdd_cli-*.whl" -delete'
+    )
+    assert removed_project_wheel in target_job
+    assert target_job.index(removed_project_wheel) < target_job.index(
+        "generate --wheelhouse /runtime/wheelhouse"
+    )
+    assert "--find-links /runtime/wheelhouse --find-links /runtime/project" in target_job
     for step in steps:
         if "run" in step:
             checked = subprocess.run(


### PR DESCRIPTION
## Archived diagnostic evidence

This PR is closed without merge. Do not revive or use this branch as a release vehicle.

The target-lock components remain useful extraction input, but the hosted bootstrap established that this architecture cannot satisfy Gate 2:

- Run 29699017734 / job 88224752678 built `pdd-cli==0.0.0` and installed the full Linux CPython 3.12 wheel closure, then failed when candidate-owned `pdd.sync_core.artifact_provenance` executed the monolithic `pdd/__init__.py` import boundary and GitPython required a missing Git executable.
- The actual checker requires Git for clean clones, ancestry, tree inventory, and exact-SHA validation, while this lock covers Python wheels only.
- Candidate code generated and validated its own lock, so even a green lane would be bootstrap evidence rather than independent released-checker evidence.
- The resolved closure also exposed a pending compatible `py3-none-manylinux` tag case for the z3 wheel.

Sol HIGH disposition: preserve this branch and its hosted runs as diagnostic evidence; extract the strict lock/RECORD logic into a fresh standalone checker distribution, then build a digest-bound OCI runtime with an attested Git/system closure, then add protected release and pin wiring.

## Legitimate evidence only

This PR proves the pinned base can build the candidate and resolve/install its Python wheel closure. It does **not** provide a committed target lock, hosted-green validator, released checker wheel digest, OCI digest/attestation, Gate 2 progress, or either certificate.

## Preserved scope

- strict canonical Linux x86_64 CPython 3.12 dependency-lock parser/generator
- exact lock-to-wheelhouse and lock-to-installed-RECORD closure validation
- target wheel-tag, metadata, hash, path, script, and manylinux/glibc checks
- pinned Linux/amd64 Python 3.12.13 bootstrap base
- hosted runs 29698754085, 29698879393, and 29699017734 as bounded failure evidence
