### PR TITLE
feat(sync): build standalone checker wheel boundary

### DIFF
--- a/.pdd/global-sync/standalone-checker-modules.json
+++ b/.pdd/global-sync/standalone-checker-modules.json
@@ -2,6 +2,7 @@
   "dependencies": [
     "cryptography >=46,<50",
     "filelock >=3.12",
+    "packaging >=24,<26",
     "pytest ==9.0.3",
     "PyYAML ==6.0.3"
   ],

--- a/.pdd/global-sync/standalone-checker-modules.json
+++ b/.pdd/global-sync/standalone-checker-modules.json
@@ -1,0 +1,51 @@
+{
+  "dependencies": [
+    "cryptography >=46,<50",
+    "filelock >=3.12",
+    "pytest ==9.0.3",
+    "PyYAML ==6.0.3"
+  ],
+  "data": [
+    "pytest_probe.py"
+  ],
+  "distribution": "pdd-sync-checker",
+  "entry_point": "pdd_sync_checker.checker_cli:main",
+  "modules": [
+    "alias_policy.py",
+    "artifact_provenance.py",
+    "certificate.py",
+    "checker_cli.py",
+    "classifier.py",
+    "decommission.py",
+    "descriptor_store.py",
+    "durability.py",
+    "evidence_store.py",
+    "fingerprint_store.py",
+    "git_io.py",
+    "global_sync_ledger.py",
+    "identity.py",
+    "includes.py",
+    "isolation.py",
+    "language.py",
+    "manifest.py",
+    "path_policy.py",
+    "released_checker.py",
+    "reporting.py",
+    "runner.py",
+    "signer_process.py",
+    "snapshot.py",
+    "standalone_package.py",
+    "supervisor.py",
+    "transaction.py",
+    "trust.py",
+    "types.py",
+    "verification.py",
+    "waivers.py"
+  ],
+  "package": "pdd_sync_checker",
+  "schema_version": 1,
+  "target": {
+    "glibc": "2.36",
+    "platform": "linux_x86_64_cp312"
+  }
+}

--- a/.pdd/global-sync/standalone-checker-modules.json
+++ b/.pdd/global-sync/standalone-checker-modules.json
@@ -7,7 +7,14 @@
     "PyYAML ==6.0.3"
   ],
   "data": [
-    "pytest_probe.py"
+    {
+      "source": "pdd/data/language_format.csv",
+      "destination": "data/language_format.csv"
+    },
+    {
+      "source": "pdd/sync_core/pytest_probe.py",
+      "destination": "pytest_probe.py"
+    }
   ],
   "distribution": "pdd-sync-checker",
   "entry_point": "pdd_sync_checker.checker_cli:main",

--- a/pdd/sync_core/checker_cli.py
+++ b/pdd/sync_core/checker_cli.py
@@ -1,0 +1,72 @@
+"""Small direct CLI for standalone checker certification and release evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from .released_checker import (
+    ReleasedCheckerError,
+    _evidence_main,
+    _validated_runtime_identity,
+)
+from .reporting import CanonicalReportOptions, build_canonical_report
+
+
+class CheckerCliError(ValueError):
+    """Raised when standalone checker command inputs are malformed."""
+
+
+def _certify(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(prog="pdd-sync-checker certify")
+    parser.add_argument("--base-ref", default="HEAD")
+    parser.add_argument("--head-ref", default="HEAD")
+    parser.add_argument("--module", dest="modules", action="append", default=[])
+    parser.add_argument("--replay-ledger", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(arguments)
+    try:
+        report = build_canonical_report(
+            Path.cwd(),
+            CanonicalReportOptions(
+                base_ref=args.base_ref,
+                head_ref=args.head_ref,
+                modules=tuple(args.modules),
+                replay_ledger_path=(
+                    args.replay_ledger
+                    or Path(os.environ.get(
+                        "PDD_SYNC_TRUST_ROOT", Path.home() / ".pdd/trust/global-sync"
+                    )) / "single.json"
+                ),
+            ),
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        report = {"schema_version": 1, "ok": False, "errors": [str(exc)]}
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0 if report.get("ok") is True else 1
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    """Run only standalone checker commands after installed-wheel provenance passes."""
+    values = tuple(sys.argv[1:] if arguments is None else arguments)
+    if values in (("--help",), ("-h",)):
+        print("usage: pdd-sync-checker {certify,release-pin-evidence} ...")
+        return 0
+    try:
+        _validated_runtime_identity()
+        if not values or values[0] == "certify":
+            return _certify(values[1:] if values else ())
+        if values[0] == "release-pin-evidence":
+            _evidence_main(values[1:])
+            return 0
+    except ReleasedCheckerError as exc:
+        raise CheckerCliError(str(exc)) from exc
+    raise CheckerCliError("command must be certify or release-pin-evidence")

--- a/pdd/sync_core/checker_cli.py
+++ b/pdd/sync_core/checker_cli.py
@@ -57,11 +57,11 @@ def _certify(arguments: Sequence[str]) -> int:
 def main(arguments: Sequence[str] | None = None) -> int:
     """Run only standalone checker commands after installed-wheel provenance passes."""
     values = tuple(sys.argv[1:] if arguments is None else arguments)
-    if values in (("--help",), ("-h",)):
-        print("usage: pdd-sync-checker {certify,release-pin-evidence} ...")
-        return 0
     try:
         _validated_runtime_identity()
+        if values in (("--help",), ("-h",)):
+            print("usage: pdd-sync-checker {certify,release-pin-evidence} ...")
+            return 0
         if not values or values[0] == "certify":
             return _certify(values[1:] if values else ())
         if values[0] == "release-pin-evidence":

--- a/pdd/sync_core/language.py
+++ b/pdd/sync_core/language.py
@@ -132,7 +132,13 @@ class LanguageRegistry:
     @classmethod
     def bundled(cls) -> "LanguageRegistry":
         """Load the package-bundled registry in source and wheel installations."""
-        return cls.from_csv(Path(__file__).parents[1] / "data" / "language_format.csv")
+        module = Path(__file__)
+        data = (
+            module.parent / "data"
+            if __package__ == "pdd_sync_checker"
+            else module.parents[1] / "data"
+        )
+        return cls.from_csv(data / "language_format.csv")
 
     def resolve_alias(self, alias: str) -> LanguageSpec:
         """Resolve one explicit language alias to its stable identity."""

--- a/pdd/sync_core/released_checker.py
+++ b/pdd/sync_core/released_checker.py
@@ -1,10 +1,11 @@
 """Entrypoint and releaseable evidence wrapper for released checker wheels."""
+# pylint: disable=cyclic-import
 
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
-import importlib
 import json
 import os
 import re
@@ -612,30 +613,92 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _verify_installed_package(wheel: Path, installed_package: Path) -> None:
-    """Compare every installed PDD member byte-for-byte with the pinned wheel."""
+def _verify_standalone_wheel_record(archive: zipfile.ZipFile) -> None:
+    """Reject a standalone archive whose RECORD does not bind every regular member."""
+    members = [item for item in archive.infolist() if not item.is_dir()]
+    names = [item.filename for item in members]
+    if len(names) != len(set(names)) or any(
+        "\\" in name or name.startswith("/") or ".." in PurePosixPath(name).parts
+        for name in names
+    ):
+        raise ReleasedCheckerError("released checker wheel has unsafe members")
+    record_names = [name for name in names if name.endswith(".dist-info/RECORD")]
+    if len(record_names) != 1:
+        raise ReleasedCheckerError("released checker wheel RECORD is invalid")
+    try:
+        parsed_rows = [
+            line.split(",")
+            for line in archive.read(record_names[0]).decode("ascii").splitlines()
+        ]
+    except (KeyError, UnicodeDecodeError):
+        raise ReleasedCheckerError("released checker wheel RECORD is invalid") from None
+    if any(len(parts) != 3 for parts in parsed_rows):
+        raise ReleasedCheckerError("released checker wheel RECORD is invalid")
+    rows = {parts[0]: (parts[1], parts[2]) for parts in parsed_rows}
+    if (
+        set(rows) != set(names)
+        or len(rows) != len(names)
+        or len(rows) != len(parsed_rows)
+    ):
+        raise ReleasedCheckerError("released checker wheel RECORD is not closed")
+    for name in names:
+        encoded, size = rows[name]
+        if name == record_names[0]:
+            if encoded or size:
+                raise ReleasedCheckerError("released checker wheel RECORD is invalid")
+            continue
+        content = archive.read(name)
+        hash_value = base64.urlsafe_b64encode(
+            hashlib.sha256(content).digest()
+        ).rstrip(b"=").decode("ascii")
+        if encoded != f"sha256={hash_value}" or size != str(len(content)):
+            raise ReleasedCheckerError("released checker wheel RECORD does not match bytes")
+
+
+def _verify_installed_package(  # pylint: disable=too-many-locals
+    wheel: Path, installed_package: Path
+) -> None:
+    """Compare every installed checker member byte-for-byte with the pinned wheel."""
     package_parts = installed_package.parts
-    package_index = max(
-        index for index, part in enumerate(package_parts) if part == "pdd"
-    )
+    package_name = "pdd_sync_checker" if "pdd_sync_checker" in package_parts else "pdd"
+    package_index = max(index for index, part in enumerate(package_parts) if part == package_name)
     site_packages = Path(*package_parts[:package_index])
     try:
         with zipfile.ZipFile(wheel) as archive:
+            if package_name == "pdd_sync_checker":
+                _verify_standalone_wheel_record(archive)
+                if any(name.startswith("pdd/") for name in archive.namelist()):
+                    raise ReleasedCheckerError("released checker wheel contains the pdd package")
             wheel_members = {
                 name: archive.read(name)
                 for name in archive.namelist()
-                if name.startswith("pdd/") and not name.endswith("/")
+                if name.startswith(f"{package_name}/") and not name.endswith("/")
             }
     except (OSError, zipfile.BadZipFile, KeyError) as exc:
         raise ReleasedCheckerError("released checker wheel cannot be inspected") from exc
     if not wheel_members:
-        raise ReleasedCheckerError("released checker wheel contains no PDD package")
+        raise ReleasedCheckerError("released checker wheel contains no checker package")
     for member, expected in wheel_members.items():
         installed = site_packages / PurePosixPath(member)
         if installed.is_symlink() or not installed.is_file():
             raise ReleasedCheckerError(f"installed checker member is unsafe: {member}")
         if installed.read_bytes() != expected:
             raise ReleasedCheckerError(f"installed checker member differs from wheel: {member}")
+    if package_name == "pdd_sync_checker":
+        package_root = site_packages / package_name
+        expected_paths = {
+            PurePosixPath(member).relative_to(package_name).as_posix()
+            for member in wheel_members
+        }
+        for path in package_root.rglob("*"):
+            relative = path.relative_to(package_root)
+            if "__pycache__" in relative.parts:
+                continue
+            if path.is_symlink() or (path.is_file() and relative.as_posix() not in expected_paths):
+                raise ReleasedCheckerError("installed checker closure differs from wheel")
+        from .standalone_package import installed_checker_runtime_lock  # pylint: disable=import-outside-toplevel
+
+        installed_checker_runtime_lock(wheel, installed_package)
 
 
 def validate_released_checker_runtime(
@@ -716,14 +779,10 @@ def _evidence_main(arguments: Sequence[str]) -> None:
 
 
 def main() -> None:
-    """Verify released provenance before running either checker entrypoint."""
-    if len(sys.argv) > 1 and sys.argv[1] == "release-pin-evidence":
-        _evidence_main(sys.argv[2:])
-        return
-    _validated_runtime_identity()
-    os.environ["PDD_RELEASED_CHECKER_EXECUTION"] = "1"
-    cli = importlib.import_module("pdd.cli").cli
-    cli.main(args=["certify", *sys.argv[1:]], prog_name="pdd-sync-checker", standalone_mode=True)
+    """Run the direct checker CLI without importing the PDD command graph."""
+    from .checker_cli import main as checker_main  # pylint: disable=import-outside-toplevel
+
+    raise SystemExit(checker_main(sys.argv[1:]))
 
 
 if __name__ == "__main__":

--- a/pdd/sync_core/released_checker.py
+++ b/pdd/sync_core/released_checker.py
@@ -685,17 +685,6 @@ def _verify_installed_package(  # pylint: disable=too-many-locals
         if installed.read_bytes() != expected:
             raise ReleasedCheckerError(f"installed checker member differs from wheel: {member}")
     if package_name == "pdd_sync_checker":
-        package_root = site_packages / package_name
-        expected_paths = {
-            PurePosixPath(member).relative_to(package_name).as_posix()
-            for member in wheel_members
-        }
-        for path in package_root.rglob("*"):
-            relative = path.relative_to(package_root)
-            if "__pycache__" in relative.parts:
-                continue
-            if path.is_symlink() or (path.is_file() and relative.as_posix() not in expected_paths):
-                raise ReleasedCheckerError("installed checker closure differs from wheel")
         from .standalone_package import installed_checker_runtime_lock  # pylint: disable=import-outside-toplevel
 
         installed_checker_runtime_lock(wheel, installed_package)

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -3267,7 +3267,7 @@ def _checker_artifact_digest(include_vitest: bool = True) -> str:
     return digest.hexdigest()
 
 
-_VITEST_RUNTIME_SOURCE = "checker/pdd/sync_core/native/vitest_fd_cloexec.c"
+_NATIVE_VITEST_RUNTIME_SOURCE = "checker/pdd/sync_core/native/vitest_fd_cloexec.c"
 
 
 def _released_runtime_closure_paths() -> tuple[tuple[str, Path], ...]:
@@ -3277,7 +3277,7 @@ def _released_runtime_closure_paths() -> tuple[tuple[str, Path], ...]:
         ("checker/pdd/sync_core/runner.py", Path(__file__)),
         ("checker/pdd/sync_core/pytest_probe.py", _CHECKER_PYTEST_PROBE),
         (
-            _VITEST_RUNTIME_SOURCE,
+            _NATIVE_VITEST_RUNTIME_SOURCE,
             Path(__file__).resolve().parent
             / "native"
             / COORDINATOR_ADDON_SOURCE_NAME,
@@ -3296,7 +3296,9 @@ def _profiled_runtime_closure_paths(
     entries = _released_runtime_closure_paths()
     if include_vitest:
         return entries
-    return tuple(entry for entry in entries if entry[0] != _VITEST_RUNTIME_SOURCE)
+    return tuple(
+        entry for entry in entries if entry[0] != _NATIVE_VITEST_RUNTIME_SOURCE
+    )
 
 
 def _runtime_manifest(

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -66,7 +66,7 @@ PYTEST_PROTECTED_FLAGS = (
 )
 _CHECKER_PYTEST_PROBE = Path(__file__).with_name("pytest_probe.py").resolve()
 _runtime_digest_cache: dict[
-    str,
+    bool,
     tuple[
         tuple[tuple[str, Path], ...],
         tuple[tuple[str, str, int, int, int], ...],
@@ -1678,11 +1678,14 @@ def runner_identity_digest(
     config: RunnerConfig = RunnerConfig(),
 ) -> str:
     """Bind evidence to protected adapters, configs, and exact artifact scopes."""
+    includes_vitest = any(
+        obligation.validator_id == "vitest" for obligation in profile.obligations
+    )
     payload = {
         "tool_version": TRUSTED_RUNNER_VERSION,
         "python_runtime": _measured_python_runtime(),
-        "released_runtime_digest": _released_runtime_closure_digest(),
-        "checker_artifact_digest": _checker_artifact_digest(),
+        "released_runtime_digest": _released_runtime_closure_digest(includes_vitest),
+        "checker_artifact_digest": _checker_artifact_digest(includes_vitest),
         "pytest_command": [
             "<measured-python-runtime>",
             "-P",
@@ -3235,21 +3238,22 @@ def _measured_python_runtime() -> dict[str, str]:
     }
 
 
-def _checker_artifact_digest() -> str:
-    """Hash checker modules and locked runtime dependency bytes by logical name."""
+def _checker_artifact_digest(include_vitest: bool = True) -> str:
+    """Hash checker modules and only the native source required by active adapters."""
     digest = hashlib.sha256()
     from . import isolation, supervisor  # pylint: disable=import-outside-toplevel
 
     modules = {
         "pdd/sync_core/runner.py": Path(__file__),
-        "pdd/sync_core/native/vitest_fd_cloexec.c": (
-            Path(__file__).resolve().parent / "native" / COORDINATOR_ADDON_SOURCE_NAME
-        ),
         "pdd/sync_core/pytest_probe.py": _CHECKER_PYTEST_PROBE,
         "pdd/sync_core/supervisor.py": Path(supervisor.__file__),
         "pdd/sync_core/isolation.py": Path(isolation.__file__),
         "pytest/__init__.py": Path(pytest.__file__),
     }
+    if include_vitest:
+        modules["pdd/sync_core/native/vitest_fd_cloexec.c"] = (
+            Path(__file__).resolve().parent / "native" / COORDINATOR_ADDON_SOURCE_NAME
+        )
     for name, path in sorted(modules.items()):
         digest.update(name.encode() + b"\0" + path.read_bytes() + b"\0")
     for distribution_name in ("pytest", "pluggy", "iniconfig", "packaging"):
@@ -3263,19 +3267,22 @@ def _checker_artifact_digest() -> str:
     return digest.hexdigest()
 
 
-def _released_runtime_closure_paths() -> tuple[tuple[str, Path], ...]:
-    """Return the complete, logically named runtime exposed to protected pytest."""
+def _released_runtime_closure_paths(
+    include_vitest: bool = True,
+) -> tuple[tuple[str, Path], ...]:
+    """Return the runtime exposed to the profile's active protected adapters."""
     paths = list(released_runtime_closure_paths())
     paths.extend((
         ("checker/pdd/sync_core/runner.py", Path(__file__)),
-        (
+        ("checker/pdd/sync_core/pytest_probe.py", _CHECKER_PYTEST_PROBE),
+    ))
+    if include_vitest:
+        paths.append((
             "checker/pdd/sync_core/native/vitest_fd_cloexec.c",
             Path(__file__).resolve().parent
             / "native"
             / COORDINATOR_ADDON_SOURCE_NAME,
-        ),
-        ("checker/pdd/sync_core/pytest_probe.py", _CHECKER_PYTEST_PROBE),
-    ))
+        ))
     return tuple(sorted(paths, key=lambda item: item[0]))
 
 
@@ -3320,15 +3327,15 @@ def _hash_runtime_entry(entry: tuple[str, Path]) -> tuple[str, bytes] | None:
     return name, file_digest.digest()
 
 
-def _released_runtime_closure_digest() -> str:
+def _released_runtime_closure_digest(include_vitest: bool = True) -> str:
     """Hash the released runtime by logical name, never installation prefix."""
     default_paths = _released_runtime_closure_paths is _default_runtime_closure_paths
-    cached = _runtime_digest_cache.get("default")
+    cached = _runtime_digest_cache.get(include_vitest)
     if default_paths and cached is not None:
         entries, cached_manifest, cached_digest = cached
         if _runtime_manifest(entries) == cached_manifest:
             return cached_digest
-    entries = _released_runtime_closure_paths()
+    entries = _released_runtime_closure_paths(include_vitest)
     manifest = _runtime_manifest(entries)
     worker_count = min(32, (os.cpu_count() or 1) + 4)
     with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as executor:
@@ -3340,7 +3347,7 @@ def _released_runtime_closure_digest() -> str:
             digest.update(name.encode("utf-8") + b"\0" + content_digest + b"\0")
     result = digest.hexdigest()
     if default_paths:
-        _runtime_digest_cache["default"] = entries, manifest, result
+        _runtime_digest_cache[include_vitest] = entries, manifest, result
     return result
 
 

--- a/pdd/sync_core/runner.py
+++ b/pdd/sync_core/runner.py
@@ -3267,26 +3267,36 @@ def _checker_artifact_digest(include_vitest: bool = True) -> str:
     return digest.hexdigest()
 
 
-def _released_runtime_closure_paths(
-    include_vitest: bool = True,
-) -> tuple[tuple[str, Path], ...]:
-    """Return the runtime exposed to the profile's active protected adapters."""
+_VITEST_RUNTIME_SOURCE = "checker/pdd/sync_core/native/vitest_fd_cloexec.c"
+
+
+def _released_runtime_closure_paths() -> tuple[tuple[str, Path], ...]:
+    """Return the complete runtime exposed to protected adapters."""
     paths = list(released_runtime_closure_paths())
     paths.extend((
         ("checker/pdd/sync_core/runner.py", Path(__file__)),
         ("checker/pdd/sync_core/pytest_probe.py", _CHECKER_PYTEST_PROBE),
-    ))
-    if include_vitest:
-        paths.append((
-            "checker/pdd/sync_core/native/vitest_fd_cloexec.c",
+        (
+            _VITEST_RUNTIME_SOURCE,
             Path(__file__).resolve().parent
             / "native"
             / COORDINATOR_ADDON_SOURCE_NAME,
-        ))
+        ),
+    ))
     return tuple(sorted(paths, key=lambda item: item[0]))
 
 
 _default_runtime_closure_paths = _released_runtime_closure_paths
+
+
+def _profiled_runtime_closure_paths(
+    include_vitest: bool,
+) -> tuple[tuple[str, Path], ...]:
+    """Project the complete installed runtime onto the active adapters."""
+    entries = _released_runtime_closure_paths()
+    if include_vitest:
+        return entries
+    return tuple(entry for entry in entries if entry[0] != _VITEST_RUNTIME_SOURCE)
 
 
 def _runtime_manifest(
@@ -3335,7 +3345,7 @@ def _released_runtime_closure_digest(include_vitest: bool = True) -> str:
         entries, cached_manifest, cached_digest = cached
         if _runtime_manifest(entries) == cached_manifest:
             return cached_digest
-    entries = _released_runtime_closure_paths(include_vitest)
+    entries = _profiled_runtime_closure_paths(include_vitest)
     manifest = _runtime_manifest(entries)
     worker_count = min(32, (os.cpu_count() or 1) + 4)
     with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as executor:

--- a/pdd/sync_core/standalone_package.py
+++ b/pdd/sync_core/standalone_package.py
@@ -46,6 +46,16 @@ def _regular(path: Path, label: str) -> Path:
     return path
 
 
+def _repository_root(root: Path) -> Path:
+    """Return a lexical repository root only when no supplied path component is linked."""
+    repository = Path(root).expanduser().absolute()
+    if not repository.is_dir() or any(
+        component.is_symlink() for component in (repository, *repository.parents)
+    ):
+        raise _error("repository root is unsafe")
+    return repository
+
+
 def _parse_manifest(source: Path | bytes) -> dict[str, Any]:
     if isinstance(source, bytes):
         try:
@@ -98,10 +108,7 @@ def _parse_manifest(source: Path | bytes) -> dict[str, Any]:
 
 def load_standalone_manifest(root: Path) -> dict[str, Any]:
     """Load the one protected module/dependency authority from a safe checkout."""
-    repository = Path(root).resolve()
-    for component in (repository, *repository.parents):
-        if component.is_symlink():
-            raise _error("repository root is unsafe")
+    repository = _repository_root(root)
     return _parse_manifest(repository.joinpath(*_MANIFEST_PATH.parts))
 
 
@@ -215,7 +222,7 @@ def _zip_info(name: str) -> zipfile.ZipInfo:
 
 def build_standalone_wheel(root: Path, output: Path, *, version: str) -> Path:
     """Build one byte-reproducible standalone wheel from manifest-authorized bytes."""
-    repository = Path(root).resolve()
+    repository = _repository_root(root)
     manifest = load_standalone_manifest(repository)
     members = _wheel_members(repository, manifest, version)
     destination = Path(output)

--- a/pdd/sync_core/standalone_package.py
+++ b/pdd/sync_core/standalone_package.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 
 import ast
 import base64
+import contextlib
+from email import policy
+from email.parser import BytesParser
 import hashlib
+import io
 import json
+import os
 import re
 import stat
 from pathlib import Path, PurePosixPath
@@ -30,43 +35,366 @@ _PACKAGE = "pdd_sync_checker"
 _DISTRIBUTION = "pdd-sync-checker"
 _ENTRY_POINT = "pdd_sync_checker.checker_cli:main"
 _EMBEDDED_MANIFEST = f"{_PACKAGE}/standalone-checker-modules.json"
+_INIT_BYTES = b'"""Standalone global-sync checker namespace."""\n'
+_WHEEL_BYTES = (
+    b"Wheel-Version: 1.0\nGenerator: pdd-standalone-checker\n"
+    b"Root-Is-Purelib: true\nTag: py3-none-any\n"
+)
+_DATA_MAPPINGS = (
+    {
+        "source": "pdd/data/language_format.csv",
+        "destination": "data/language_format.csv",
+    },
+    {
+        "source": "pdd/sync_core/pytest_probe.py",
+        "destination": "pytest_probe.py",
+    },
+)
+_DATA_KEYS = frozenset({"source", "destination"})
 _MODULE_NAME = re.compile(r"[a-z][a-z0-9_]*\.py")
+_DATA_PATH = re.compile(r"[a-zA-Z0-9_.-]+(?:/[a-zA-Z0-9_.-]+)*")
 _DEPENDENCY = re.compile(r"[A-Za-z][A-Za-z0-9-]* (?:==|>=)[^ ]+(?:,<[0-9]+)?")
 _SHA256 = re.compile(r"[0-9a-f]{64}")
 _ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+_DIRECTORY_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+_FILE_FLAGS = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+_BOOTSTRAP_PYTHON = r"""import base64
+import hashlib
+import importlib
+import importlib.util
+import io
+import os
+import re
+import stat
+import sys
+import zipfile
+from pathlib import Path, PurePosixPath
+
+def fail(message):
+    raise RuntimeError("standalone checker bootstrap: " + message)
+
+def record_hash(content):
+    return base64.urlsafe_b64encode(
+        hashlib.sha256(content).digest()
+    ).rstrip(b"=").decode("ascii")
+
+def read_regular(path, label, directory=None):
+    try:
+        descriptor = os.open(
+            path,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=directory,
+        )
+    except OSError as exc:
+        fail(label + " is unsafe: " + str(exc))
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            fail(label + " is not regular")
+        chunks = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                return b"".join(chunks)
+            chunks.append(chunk)
+    finally:
+        os.close(descriptor)
+
+def open_directory(parent, name):
+    try:
+        descriptor = os.open(
+            name,
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent,
+        )
+    except OSError as exc:
+        fail("installed package directory is unsafe: " + str(exc))
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        fail("installed package directory is not a directory")
+    return descriptor
+
+launcher = Path(sys.argv[1])
+if not launcher.is_absolute():
+    fail("entrypoint path must be absolute")
+arguments = [str(launcher), *sys.argv[2:]]
+candidate_cwd = os.getcwd()
+venv = launcher.parent.parent
+os.chdir(venv)
+sys.dont_write_bytecode = True
+os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
+sys.prefix = str(venv)
+sys.exec_prefix = str(venv)
+purelib = (
+    venv / "lib" / ("python%d.%d" % sys.version_info[:2]) / "site-packages"
+)
+package_root = purelib / "pdd_sync_checker"
+wheel_value = os.environ.get("PDD_RELEASED_CHECKER_WHEEL_PATH")
+expected_digest = os.environ.get("PDD_RELEASED_CHECKER_WHEEL_SHA256", "")
+if not wheel_value or re.fullmatch("[0-9a-f]{64}", expected_digest) is None:
+    fail("released wheel provenance is required")
+wheel_path = Path(wheel_value)
+if not wheel_path.is_absolute():
+    fail("released wheel path must be absolute")
+wheel_bytes = read_regular(wheel_path, "released wheel")
+if hashlib.sha256(wheel_bytes).hexdigest() != expected_digest:
+    fail("released wheel digest does not match")
+
+try:
+    with zipfile.ZipFile(io.BytesIO(wheel_bytes)) as archive:
+        infos = archive.infolist()
+        names = [item.filename for item in infos]
+        if len(names) != len(set(names)):
+            fail("released wheel contains duplicate members")
+        for item in infos:
+            path = PurePosixPath(item.filename)
+            mode = item.external_attr >> 16
+            if (
+                item.is_dir()
+                or not item.filename
+                or "\\" in item.filename
+                or path.is_absolute()
+                or ".." in path.parts
+                or not stat.S_ISREG(mode)
+            ):
+                fail("released wheel contains an unsafe member")
+        record_names = [
+            name for name in names if name.endswith(".dist-info/RECORD")
+        ]
+        if len(record_names) != 1:
+            fail("released wheel RECORD is invalid")
+        record_name = record_names[0]
+        rows = {}
+        for line in archive.read(record_name).decode("ascii").splitlines():
+            columns = line.split(",")
+            if len(columns) != 3 or not columns[0] or columns[0] in rows:
+                fail("released wheel RECORD is malformed")
+            rows[columns[0]] = (columns[1], columns[2])
+        if set(rows) != set(names):
+            fail("released wheel RECORD is not closed")
+        for name in names:
+            encoded, size = rows[name]
+            if name == record_name:
+                if encoded or size:
+                    fail("released wheel RECORD self-entry is invalid")
+            else:
+                content = archive.read(name)
+                if (
+                    encoded != "sha256=" + record_hash(content)
+                    or size != str(len(content))
+                ):
+                    fail("released wheel RECORD does not match bytes")
+        expected = {
+            PurePosixPath(name).relative_to("pdd_sync_checker").as_posix():
+            archive.read(name)
+            for name in names
+            if name.startswith("pdd_sync_checker/")
+        }
+        bootstrap_names = [
+            name
+            for name in names
+            if name.endswith(".data/scripts/pdd-sync-checker")
+        ]
+        if (
+            len(bootstrap_names) != 1
+            or read_regular(launcher, "installed bootstrap")
+            != archive.read(bootstrap_names[0])
+        ):
+            fail("installed bootstrap differs from released wheel")
+except (OSError, UnicodeDecodeError, zipfile.BadZipFile, KeyError) as exc:
+    fail("released wheel cannot be inspected: " + str(exc))
+if not expected:
+    fail("released wheel contains no checker package")
+
+root_fd = os.open(
+    venv,
+    os.O_RDONLY
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0),
+)
+opened = [root_fd]
+try:
+    for component in (
+        "lib",
+        "python%d.%d" % sys.version_info[:2],
+        "site-packages",
+        "pdd_sync_checker",
+    ):
+        opened.append(open_directory(opened[-1], component))
+    package_fd = opened[-1]
+    expected_directories = {
+        PurePosixPath(*PurePosixPath(name).parts[:index]).as_posix()
+        for name in expected
+        for index in range(1, len(PurePosixPath(name).parts))
+    }
+    actual = set()
+
+    def walk(descriptor, prefix=""):
+        with os.scandir(descriptor) as entries:
+            for entry in entries:
+                relative = prefix + entry.name
+                mode = entry.stat(follow_symlinks=False).st_mode
+                if stat.S_ISDIR(mode):
+                    if relative not in expected_directories:
+                        fail("installed checker has an unlisted directory: " + relative)
+                    child = open_directory(descriptor, entry.name)
+                    try:
+                        walk(child, relative + "/")
+                    finally:
+                        os.close(child)
+                elif stat.S_ISREG(mode):
+                    actual.add(relative)
+                    content = read_regular(
+                        entry.name,
+                        "installed checker member " + relative,
+                        descriptor,
+                    )
+                    if relative not in expected or content != expected[relative]:
+                        fail("installed checker closure differs from wheel")
+                else:
+                    fail("installed checker has a nonregular entry: " + relative)
+
+    walk(package_fd)
+    if actual != set(expected):
+        fail("installed checker closure differs from wheel")
+finally:
+    for descriptor in reversed(opened):
+        os.close(descriptor)
+
+stdlib_paths = [
+    value
+    for value in sys.path
+    if value and Path(value).resolve() not in {Path(candidate_cwd), launcher.parent}
+]
+sys.path[:] = [str(purelib), *stdlib_paths]
+init_path = package_root / "__init__.py"
+spec = importlib.util.spec_from_file_location(
+    "pdd_sync_checker",
+    init_path,
+    submodule_search_locations=[str(package_root)],
+)
+if spec is None or spec.loader is None:
+    fail("installed checker package cannot be loaded")
+package = importlib.util.module_from_spec(spec)
+sys.modules["pdd_sync_checker"] = package
+spec.loader.exec_module(package)
+checker = importlib.import_module("pdd_sync_checker.checker_cli")
+os.chdir(candidate_cwd)
+sys.argv = arguments
+raise SystemExit(checker.main(sys.argv[1:]))
+"""
+_BOOTSTRAP_SCRIPT = (
+    "#!/bin/sh\n"
+    "case \"$0\" in\n"
+    "  /*) ;;\n"
+    "  *) echo 'pdd-sync-checker requires an absolute executable path' >&2; exit 126 ;;\n"
+    "esac\n"
+    "exec \"${0%/*}/python\" -I -B -S - \"$0\" \"$@\" <<'PDD_SYNC_BOOTSTRAP'\n"
+    f"{_BOOTSTRAP_PYTHON}"
+    "PDD_SYNC_BOOTSTRAP\n"
+).encode("ascii")
 
 
 def _error(message: str) -> StandalonePackageError:
     return StandalonePackageError(f"standalone checker package: {message}")
 
 
-def _regular(path: Path, label: str) -> Path:
-    if path.is_symlink() or not path.is_file():
-        raise _error(f"{label} must be a regular file")
-    return path
+@contextlib.contextmanager
+def _open_directory_path(path: Path, label: str):
+    """Open every absolute directory component without following links."""
+    absolute = Path(path).expanduser().absolute()
+    descriptors: list[int] = []
+    try:
+        descriptor = os.open("/", _DIRECTORY_FLAGS)
+        descriptors.append(descriptor)
+        for component in absolute.parts[1:]:
+            descriptor = os.open(
+                component, _DIRECTORY_FLAGS, dir_fd=descriptor
+            )
+            descriptors.append(descriptor)
+        if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            raise _error(f"{label} is not a directory")
+        yield descriptor
+    except OSError as exc:
+        raise _error(f"{label} contains an unsafe path component") from exc
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+
+def _read_relative_regular(root: Path, relative: PurePosixPath, label: str) -> bytes:
+    """Read one regular descendant through stable no-follow descriptors."""
+    if relative.is_absolute() or not relative.parts or ".." in relative.parts:
+        raise _error(f"{label} path is unsafe")
+    descriptors: list[int] = []
+    file_descriptor: int | None = None
+    try:
+        with _open_directory_path(root, "repository root") as root_descriptor:
+            descriptor = os.dup(root_descriptor)
+            descriptors.append(descriptor)
+            for component in relative.parts[:-1]:
+                descriptor = os.open(
+                    component, _DIRECTORY_FLAGS, dir_fd=descriptor
+                )
+                descriptors.append(descriptor)
+            file_descriptor = os.open(
+                relative.parts[-1],
+                _FILE_FLAGS,
+                dir_fd=descriptor,
+            )
+            if not stat.S_ISREG(os.fstat(file_descriptor).st_mode):
+                raise _error(f"{label} must be a regular file")
+            with os.fdopen(file_descriptor, "rb") as handle:
+                file_descriptor = None
+                return handle.read()
+    except OSError as exc:
+        raise _error(f"{label} must be a regular file") from exc
+    finally:
+        if file_descriptor is not None:
+            os.close(file_descriptor)
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+
+def _read_regular_path(path: Path, label: str) -> bytes:
+    absolute = Path(path).expanduser().absolute()
+    return _read_relative_regular(
+        absolute.parent, PurePosixPath(absolute.name), label
+    )
 
 
 def _repository_root(root: Path) -> Path:
-    """Return a lexical repository root only when no supplied path component is linked."""
+    """Return a lexical repository root only when every component is a directory."""
     repository = Path(root).expanduser().absolute()
-    if not repository.is_dir() or any(
-        component.is_symlink() for component in (repository, *repository.parents)
-    ):
-        raise _error("repository root is unsafe")
+    with _open_directory_path(repository, "repository root"):
+        pass
     return repository
+
+
+def _manifest_bytes(manifest: Mapping[str, Any]) -> bytes:
+    return (
+        json.dumps(manifest, indent=2, ensure_ascii=True).encode("utf-8")
+        + b"\n"
+    )
 
 
 def _parse_manifest(source: Path | bytes) -> dict[str, Any]:
     if isinstance(source, bytes):
+        encoded = source
         try:
             payload = json.loads(source.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise _error("module manifest is malformed") from exc
     else:
-        _regular(source, "module manifest")
+        encoded = _read_regular_path(source, "module manifest")
         try:
-            payload = json.loads(source.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            payload = json.loads(encoded.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise _error("module manifest is malformed") from exc
     if not isinstance(payload, dict) or set(payload) != _MANIFEST_KEYS:
         raise _error("module manifest schema is closed and malformed")
@@ -90,7 +418,18 @@ def _parse_manifest(source: Path | bytes) -> dict[str, Any]:
         )
         or modules != sorted(modules)
         or len(modules) != len(set(modules))
-        or data != ["pytest_probe.py"]
+        or not isinstance(data, list)
+        or data != list(_DATA_MAPPINGS)
+        or any(
+            not isinstance(item, dict)
+            or set(item) != _DATA_KEYS
+            or any(
+                not isinstance(value, str)
+                or _DATA_PATH.fullmatch(value) is None
+                for value in item.values()
+            )
+            for item in data
+        )
         or not isinstance(dependencies, list)
         or any(
             not isinstance(item, str) or _DEPENDENCY.fullmatch(item) is None
@@ -103,19 +442,27 @@ def _parse_manifest(source: Path | bytes) -> dict[str, Any]:
         or target != {"platform": "linux_x86_64_cp312", "glibc": "2.36"}
     ):
         raise _error("module manifest closure is malformed")
+    if encoded != _manifest_bytes(payload):
+        raise _error("module manifest is not canonical")
     return payload
 
 
 def load_standalone_manifest(root: Path) -> dict[str, Any]:
     """Load the one protected module/dependency authority from a safe checkout."""
     repository = _repository_root(root)
-    return _parse_manifest(repository.joinpath(*_MANIFEST_PATH.parts))
+    return _parse_manifest(
+        _read_relative_regular(
+            repository, _MANIFEST_PATH, "module manifest"
+        )
+    )
 
 
-def _source_path(root: Path, module: str) -> Path:
-    path = root / "pdd" / "sync_core" / module
-    _regular(path, f"module {module}")
-    return path
+def _source_bytes(root: Path, module: str) -> bytes:
+    return _read_relative_regular(
+        root,
+        PurePosixPath("pdd", "sync_core", module),
+        f"module {module}",
+    )
 
 
 def _relative_imports(module: str, source: bytes) -> set[str]:
@@ -148,7 +495,7 @@ def _checked_module_bytes(root: Path, manifest: Mapping[str, Any]) -> dict[str, 
     required = {"checker_cli.py", "released_checker.py", "standalone_package.py"}
     if not required <= modules:
         raise _error("module manifest omits a required entrypoint module")
-    source = {module: _source_path(root, module).read_bytes() for module in modules}
+    source = {module: _source_bytes(root, module) for module in modules}
     closure = set(required)
     pending = list(required)
     while pending:
@@ -175,12 +522,8 @@ def _dist_info(version: str) -> str:
     return f"pdd_sync_checker-{version}.dist-info"
 
 
-def _wheel_members(root: Path, manifest: Mapping[str, Any], version: str) -> dict[str, bytes]:
-    modules = _checked_module_bytes(root, manifest)
-    data = {item: _source_path(root, item).read_bytes() for item in manifest["data"]}
-    manifest_bytes = (root / _MANIFEST_PATH).read_bytes()
-    dist_info = _dist_info(version)
-    metadata = "\n".join(
+def _metadata_bytes(manifest: Mapping[str, Any], version: str) -> bytes:
+    return "\n".join(
         (
             "Metadata-Version: 2.1",
             f"Name: {manifest['distribution']}",
@@ -190,19 +533,34 @@ def _wheel_members(root: Path, manifest: Mapping[str, Any], version: str) -> dic
             "",
         )
     ).encode("utf-8")
+
+
+def _bootstrap_member(version: str) -> str:
+    return f"pdd_sync_checker-{version}.data/scripts/pdd-sync-checker"
+
+
+def _wheel_members(root: Path, manifest: Mapping[str, Any], version: str) -> dict[str, bytes]:
+    modules = _checked_module_bytes(root, manifest)
+    data = {
+        item["destination"]: _read_relative_regular(
+            root,
+            PurePosixPath(item["source"]),
+            f"data source {item['source']}",
+        )
+        for item in manifest["data"]
+    }
+    manifest_bytes = _read_relative_regular(
+        root, _MANIFEST_PATH, "module manifest"
+    )
+    dist_info = _dist_info(version)
     members = {
-        f"{_PACKAGE}/__init__.py": b'"""Standalone global-sync checker namespace."""\n',
+        f"{_PACKAGE}/__init__.py": _INIT_BYTES,
         **{f"{_PACKAGE}/{module}": content for module, content in modules.items()},
         **{f"{_PACKAGE}/{item}": content for item, content in data.items()},
         _EMBEDDED_MANIFEST: manifest_bytes,
-        f"{dist_info}/METADATA": metadata,
-        f"{dist_info}/WHEEL": (
-            b"Wheel-Version: 1.0\nGenerator: pdd-standalone-checker\n"
-            b"Root-Is-Purelib: true\nTag: py3-none-any\n"
-        ),
-        f"{dist_info}/entry_points.txt": (
-            b"[console_scripts]\npdd-sync-checker = pdd_sync_checker.checker_cli:main\n"
-        ),
+        _bootstrap_member(version): _BOOTSTRAP_SCRIPT,
+        f"{dist_info}/METADATA": _metadata_bytes(manifest, version),
+        f"{dist_info}/WHEEL": _WHEEL_BYTES,
     }
     record = "".join(
         f"{name},sha256={_record_hash(content)},{len(content)}\n"
@@ -212,12 +570,42 @@ def _wheel_members(root: Path, manifest: Mapping[str, Any], version: str) -> dic
     return members
 
 
-def _zip_info(name: str) -> zipfile.ZipInfo:
+def _zip_info(name: str, *, executable: bool = False) -> zipfile.ZipInfo:
     info = zipfile.ZipInfo(name, date_time=_ZIP_TIMESTAMP)
     info.compress_type = zipfile.ZIP_STORED
-    info.external_attr = (stat.S_IFREG | 0o644) << 16
+    info.external_attr = (
+        stat.S_IFREG | (0o755 if executable else 0o644)
+    ) << 16
     info.create_system = 3
     return info
+
+
+@contextlib.contextmanager
+def _open_output_directory(path: Path):
+    """Create and open an output directory without following any component."""
+    destination = Path(path).expanduser().absolute()
+    descriptors: list[int] = []
+    try:
+        descriptor = os.open("/", _DIRECTORY_FLAGS)
+        descriptors.append(descriptor)
+        for component in destination.parts[1:]:
+            try:
+                next_descriptor = os.open(
+                    component, _DIRECTORY_FLAGS, dir_fd=descriptor
+                )
+            except FileNotFoundError:
+                os.mkdir(component, mode=0o755, dir_fd=descriptor)
+                next_descriptor = os.open(
+                    component, _DIRECTORY_FLAGS, dir_fd=descriptor
+                )
+            descriptor = next_descriptor
+            descriptors.append(descriptor)
+        yield destination, descriptor
+    except OSError as exc:
+        raise _error("wheel output directory is unsafe") from exc
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
 
 
 def build_standalone_wheel(root: Path, output: Path, *, version: str) -> Path:
@@ -225,18 +613,36 @@ def build_standalone_wheel(root: Path, output: Path, *, version: str) -> Path:
     repository = _repository_root(root)
     manifest = load_standalone_manifest(repository)
     members = _wheel_members(repository, manifest, version)
-    destination = Path(output)
-    if destination.exists() and (destination.is_symlink() or not destination.is_dir()):
-        raise _error("wheel output directory is unsafe")
-    destination.mkdir(parents=True, exist_ok=True)
-    wheel = destination / f"pdd_sync_checker-{version}-py3-none-any.whl"
-    if wheel.exists() or wheel.is_symlink():
-        raise _error("wheel output already exists")
-    with zipfile.ZipFile(
-        wheel, "w", compression=zipfile.ZIP_STORED, strict_timestamps=True
-    ) as archive:
-        for name, content in sorted(members.items()):
-            archive.writestr(_zip_info(name), content)
+    wheel_name = f"pdd_sync_checker-{version}-py3-none-any.whl"
+    with _open_output_directory(Path(output)) as (destination, directory):
+        wheel = destination / wheel_name
+        try:
+            descriptor = os.open(
+                wheel_name,
+                os.O_RDWR
+                | os.O_CREAT
+                | os.O_EXCL
+                | getattr(os, "O_NOFOLLOW", 0),
+                0o644,
+                dir_fd=directory,
+            )
+        except OSError as exc:
+            raise _error("wheel output already exists or is unsafe") from exc
+        with os.fdopen(descriptor, "w+b") as handle:
+            with zipfile.ZipFile(
+                handle,
+                "w",
+                compression=zipfile.ZIP_STORED,
+                strict_timestamps=True,
+            ) as archive:
+                bootstrap = _bootstrap_member(version)
+                for name, content in sorted(members.items()):
+                    archive.writestr(
+                        _zip_info(name, executable=name == bootstrap),
+                        content,
+                    )
+            handle.flush()
+            os.fsync(handle.fileno())
     validate_standalone_wheel(wheel, manifest)
     return wheel
 
@@ -262,44 +668,108 @@ def _read_record(record: bytes) -> dict[str, tuple[str, str]]:
     return entries
 
 
-def validate_standalone_wheel(wheel_path: Path, manifest: Mapping[str, Any]) -> None:
-    """Fail closed unless the archive has exactly the manifest-authorized RECORD closure."""
-    wheel = _regular(Path(wheel_path), "wheel")
+def _canonical_wheel_files(
+    wheel_bytes: bytes, bootstrap: str
+) -> dict[str, bytes]:
+    """Return archive bytes only when every member has canonical attributes."""
     try:
-        _name, _version, _build, tags = parse_wheel_filename(wheel.name)
-    except InvalidWheelFilename as exc:
-        raise _error("wheel filename is malformed") from exc
-    if {str(tag) for tag in tags} != {"py3-none-any"}:
-        raise _error("wheel tags are not standalone checker tags")
-    expected_prefix = f"{manifest['package']}/"
-    try:
-        with zipfile.ZipFile(wheel) as archive:
+        with zipfile.ZipFile(io.BytesIO(wheel_bytes)) as archive:
             files: dict[str, bytes] = {}
             for member in archive.infolist():
                 path = _safe_member(member.filename)
                 mode = member.external_attr >> 16
-                if member.is_dir() or stat.S_ISLNK(mode) or path.as_posix() in files:
+                expected_mode = stat.S_IFREG | (
+                    0o755 if path.as_posix() == bootstrap else 0o644
+                )
+                if (
+                    member.is_dir()
+                    or mode != expected_mode
+                    or member.create_system != 3
+                    or member.compress_type != zipfile.ZIP_STORED
+                    or member.date_time != _ZIP_TIMESTAMP
+                    or path.as_posix() in files
+                ):
                     raise _error("wheel contains an unsafe member")
                 files[path.as_posix()] = archive.read(member)
     except (OSError, zipfile.BadZipFile) as exc:
         raise _error("wheel cannot be inspected") from exc
+    return files
+
+
+def _validate_metadata_authority(
+    metadata: bytes, manifest: Mapping[str, Any], version: str
+) -> None:
+    """Require parsed and byte-exact core metadata from protected authority."""
+    try:
+        parsed = BytesParser(policy=policy.default).parsebytes(metadata)
+    except (TypeError, ValueError) as exc:
+        raise _error("wheel METADATA is malformed") from exc
+    if (
+        parsed.defects
+        or parsed.get("Metadata-Version") != "2.1"
+        or parsed.get("Name") != manifest["distribution"]
+        or parsed.get("Version") != version
+        or parsed.get_all("Requires-Dist", []) != manifest["dependencies"]
+        or metadata != _metadata_bytes(manifest, version)
+    ):
+        raise _error("wheel METADATA differs from protected authority")
+
+
+def validate_standalone_wheel(wheel_path: Path, manifest: Mapping[str, Any]) -> None:
+    """Fail closed unless the archive has exactly the manifest-authorized RECORD closure."""
+    wheel = Path(wheel_path).expanduser().absolute()
+    wheel_bytes = _read_regular_path(wheel, "wheel")
+    try:
+        name, version_value, build, tags = parse_wheel_filename(wheel.name)
+    except InvalidWheelFilename as exc:
+        raise _error("wheel filename is malformed") from exc
+    version = str(version_value)
+    if (
+        name != manifest["distribution"]
+        or build
+        or wheel.name
+        != f"pdd_sync_checker-{version}-py3-none-any.whl"
+        or {str(tag) for tag in tags} != {"py3-none-any"}
+    ):
+        raise _error("wheel tags are not standalone checker tags")
+    expected_prefix = f"{manifest['package']}/"
+    bootstrap = _bootstrap_member(version)
+    files = _canonical_wheel_files(wheel_bytes, bootstrap)
     if any(name.startswith("pdd/") for name in files):
         raise _error("wheel contains the pdd package")
     expected_modules = {f"{expected_prefix}__init__.py", _EMBEDDED_MANIFEST} | {
         f"{expected_prefix}{module}" for module in manifest["modules"]
-    } | {f"{expected_prefix}{item}" for item in manifest["data"]}
-    dist_infos = {PurePosixPath(name).parts[0] for name in files if ".dist-info/" in name}
-    if len(dist_infos) != 1:
+    } | {
+        f"{expected_prefix}{item['destination']}"
+        for item in manifest["data"]
+    }
+    dist_info = _dist_info(version)
+    dist_infos = {
+        PurePosixPath(member_name).parts[0]
+        for member_name in files
+        if ".dist-info/" in member_name
+    }
+    if dist_infos != {dist_info}:
         raise _error("wheel dist-info closure is invalid")
-    dist_info = next(iter(dist_infos))
     expected = expected_modules | {
+        bootstrap,
         f"{dist_info}/METADATA",
         f"{dist_info}/WHEEL",
-        f"{dist_info}/entry_points.txt",
         f"{dist_info}/RECORD",
     }
     if set(files) != expected:
         raise _error("wheel member closure is invalid")
+    if files[f"{expected_prefix}__init__.py"] != _INIT_BYTES:
+        raise _error("wheel package initializer is invalid")
+    if files[_EMBEDDED_MANIFEST] != _manifest_bytes(manifest):
+        raise _error("wheel embedded module manifest differs from authority")
+    if files[f"{dist_info}/WHEEL"] != _WHEEL_BYTES:
+        raise _error("wheel metadata identity is invalid")
+    if files[bootstrap] != _BOOTSTRAP_SCRIPT:
+        raise _error("wheel bootstrap entrypoint is invalid")
+    _validate_metadata_authority(
+        files[f"{dist_info}/METADATA"], manifest, version
+    )
     record_name = f"{dist_info}/RECORD"
     records = _read_record(files[record_name])
     if set(records) != set(files):
@@ -316,14 +786,18 @@ def validate_standalone_wheel(wheel_path: Path, manifest: Mapping[str, Any]) -> 
 
 def _verified_archive_files(wheel_path: Path) -> dict[str, bytes]:
     """Read one standalone archive only after closing every member through RECORD."""
-    wheel = _regular(Path(wheel_path), "wheel")
+    wheel_bytes = _read_regular_path(Path(wheel_path), "wheel")
     try:
-        with zipfile.ZipFile(wheel) as archive:
+        with zipfile.ZipFile(io.BytesIO(wheel_bytes)) as archive:
             files: dict[str, bytes] = {}
             for member in archive.infolist():
                 path = _safe_member(member.filename)
                 mode = member.external_attr >> 16
-                if member.is_dir() or stat.S_ISLNK(mode) or path.as_posix() in files:
+                if (
+                    member.is_dir()
+                    or not stat.S_ISREG(mode)
+                    or path.as_posix() in files
+                ):
                     raise _error("wheel contains an unsafe member")
                 files[path.as_posix()] = archive.read(member)
     except (OSError, zipfile.BadZipFile) as exc:
@@ -344,6 +818,84 @@ def _verified_archive_files(wheel_path: Path) -> dict[str, bytes]:
     return files
 
 
+def _read_descriptor_regular(
+    directory: int, name: str, label: str
+) -> bytes:
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(name, _FILE_FLAGS, dir_fd=directory)
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise _error(f"{label} is not a regular file")
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = None
+            return handle.read()
+    except OSError as exc:
+        raise _error(f"{label} is unsafe") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _closed_installed_package(
+    package_root: Path, expected: Mapping[str, bytes]
+) -> None:
+    """Compare a no-follow installed tree to the exact wheel package closure."""
+    expected_directories = {
+        PurePosixPath(*PurePosixPath(name).parts[:index]).as_posix()
+        for name in expected
+        for index in range(1, len(PurePosixPath(name).parts))
+    }
+    actual: dict[str, bytes] = {}
+
+    def walk(directory: int, prefix: str = "") -> None:
+        try:
+            with os.scandir(directory) as iterator:
+                entries = sorted(iterator, key=lambda entry: entry.name)
+        except OSError as exc:
+            raise _error("installed checker closure cannot be inspected") from exc
+        for entry in entries:
+            relative = f"{prefix}{entry.name}"
+            try:
+                mode = entry.stat(follow_symlinks=False).st_mode
+            except OSError as exc:
+                raise _error("installed checker closure cannot be inspected") from exc
+            if stat.S_ISDIR(mode):
+                if relative not in expected_directories:
+                    raise _error(
+                        f"installed checker contains unlisted directory {relative}"
+                    )
+                try:
+                    child = os.open(
+                        entry.name, _DIRECTORY_FLAGS, dir_fd=directory
+                    )
+                except OSError as exc:
+                    raise _error(
+                        f"installed checker directory is unsafe: {relative}"
+                    ) from exc
+                try:
+                    walk(child, f"{relative}/")
+                finally:
+                    os.close(child)
+            elif stat.S_ISREG(mode):
+                actual[relative] = _read_descriptor_regular(
+                    directory,
+                    entry.name,
+                    f"installed checker member {relative}",
+                )
+            else:
+                raise _error(
+                    f"installed checker contains nonregular entry {relative}"
+                )
+
+    with _open_directory_path(package_root, "installed checker package") as descriptor:
+        walk(descriptor)
+    if set(actual) != set(expected):
+        raise _error("installed checker closure differs from the wheel")
+    for relative, expected_bytes in expected.items():
+        if actual[relative] != expected_bytes:
+            raise _error("installed checker bytes differ from the wheel")
+
+
 def _installed_package_files(wheel: Path, installed_package: Path) -> dict[str, bytes]:
     """Return the closed checker module set only when installed bytes equal the wheel."""
     files = _verified_archive_files(wheel)
@@ -361,7 +913,7 @@ def _installed_package_files(wheel: Path, installed_package: Path) -> dict[str, 
     }
     if not expected:
         raise _error("wheel contains no standalone checker package")
-    path = _regular(Path(installed_package), "installed checker module")
+    path = Path(installed_package).expanduser().absolute()
     try:
         package_index = max(
             index for index, part in enumerate(path.parts) if part == _PACKAGE
@@ -369,22 +921,10 @@ def _installed_package_files(wheel: Path, installed_package: Path) -> dict[str, 
     except ValueError as exc:
         raise _error("installed checker module is outside its package") from exc
     package_root = Path(*path.parts[: package_index + 1])
-    for relative, expected_bytes in expected.items():
-        candidate = package_root / relative
-        if (
-            candidate.is_symlink()
-            or not candidate.is_file()
-            or candidate.read_bytes() != expected_bytes
-        ):
-            raise _error("installed checker bytes differ from the wheel")
-    for candidate in package_root.rglob("*"):
-        relative = candidate.relative_to(package_root)
-        if "__pycache__" in relative.parts:
-            continue
-        if candidate.is_symlink() or (
-            candidate.is_file() and relative.as_posix() not in expected
-        ):
-            raise _error("installed checker closure differs from the wheel")
+    installed_relative = path.relative_to(package_root).as_posix()
+    if installed_relative not in expected:
+        raise _error("installed checker module is outside the wheel closure")
+    _closed_installed_package(package_root, expected)
     return expected
 
 
@@ -411,7 +951,9 @@ def installed_checker_runtime_lock(wheel: Path, installed_package: Path) -> byte
         ],
         "package": _PACKAGE,
         "schema_version": 1,
-        "wheel_sha256": hashlib.sha256(_regular(wheel, "wheel").read_bytes()).hexdigest(),
+        "wheel_sha256": hashlib.sha256(
+            _read_regular_path(wheel, "wheel")
+        ).hexdigest(),
     }
     return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8") + b"\n"
 

--- a/pdd/sync_core/standalone_package.py
+++ b/pdd/sync_core/standalone_package.py
@@ -1,0 +1,450 @@
+"""Deterministically stage the closed standalone global-sync checker wheel."""
+# pylint: disable=too-many-branches,too-many-locals,too-many-boolean-expressions
+
+from __future__ import annotations
+
+import ast
+import base64
+import hashlib
+import json
+import re
+import stat
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping
+import zipfile
+
+from packaging.utils import InvalidWheelFilename, parse_wheel_filename
+
+
+class StandalonePackageError(ValueError):
+    """Raised when the protected standalone checker boundary is invalid."""
+
+
+_MANIFEST_PATH = PurePosixPath(".pdd/global-sync/standalone-checker-modules.json")
+_MANIFEST_KEYS = frozenset({
+    "schema_version", "package", "distribution", "entry_point", "modules",
+    "data", "dependencies", "target",
+})
+_TARGET_KEYS = frozenset({"platform", "glibc"})
+_PACKAGE = "pdd_sync_checker"
+_DISTRIBUTION = "pdd-sync-checker"
+_ENTRY_POINT = "pdd_sync_checker.checker_cli:main"
+_EMBEDDED_MANIFEST = f"{_PACKAGE}/standalone-checker-modules.json"
+_MODULE_NAME = re.compile(r"[a-z][a-z0-9_]*\.py")
+_DEPENDENCY = re.compile(r"[A-Za-z][A-Za-z0-9-]* (?:==|>=)[^ ]+(?:,<[0-9]+)?")
+_SHA256 = re.compile(r"[0-9a-f]{64}")
+_ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+
+
+def _error(message: str) -> StandalonePackageError:
+    return StandalonePackageError(f"standalone checker package: {message}")
+
+
+def _regular(path: Path, label: str) -> Path:
+    if path.is_symlink() or not path.is_file():
+        raise _error(f"{label} must be a regular file")
+    return path
+
+
+def _parse_manifest(source: Path | bytes) -> dict[str, Any]:
+    if isinstance(source, bytes):
+        try:
+            payload = json.loads(source.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise _error("module manifest is malformed") from exc
+    else:
+        _regular(source, "module manifest")
+        try:
+            payload = json.loads(source.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise _error("module manifest is malformed") from exc
+    if not isinstance(payload, dict) or set(payload) != _MANIFEST_KEYS:
+        raise _error("module manifest schema is closed and malformed")
+    if (
+        payload["schema_version"] != 1
+        or payload["package"] != _PACKAGE
+        or payload["distribution"] != _DISTRIBUTION
+        or payload["entry_point"] != _ENTRY_POINT
+    ):
+        raise _error("module manifest identity is invalid")
+    modules = payload["modules"]
+    data = payload["data"]
+    dependencies = payload["dependencies"]
+    target = payload["target"]
+    if (
+        not isinstance(modules, list)
+        or not modules
+        or any(
+            not isinstance(item, str) or _MODULE_NAME.fullmatch(item) is None
+            for item in modules
+        )
+        or modules != sorted(modules)
+        or len(modules) != len(set(modules))
+        or data != ["pytest_probe.py"]
+        or not isinstance(dependencies, list)
+        or any(
+            not isinstance(item, str) or _DEPENDENCY.fullmatch(item) is None
+            for item in dependencies
+        )
+        or dependencies != sorted(dependencies, key=str.lower)
+        or len(dependencies) != len(set(dependencies))
+        or not isinstance(target, dict)
+        or set(target) != _TARGET_KEYS
+        or target != {"platform": "linux_x86_64_cp312", "glibc": "2.36"}
+    ):
+        raise _error("module manifest closure is malformed")
+    return payload
+
+
+def load_standalone_manifest(root: Path) -> dict[str, Any]:
+    """Load the one protected module/dependency authority from a safe checkout."""
+    repository = Path(root).resolve()
+    for component in (repository, *repository.parents):
+        if component.is_symlink():
+            raise _error("repository root is unsafe")
+    return _parse_manifest(repository.joinpath(*_MANIFEST_PATH.parts))
+
+
+def _source_path(root: Path, module: str) -> Path:
+    path = root / "pdd" / "sync_core" / module
+    _regular(path, f"module {module}")
+    return path
+
+
+def _relative_imports(module: str, source: bytes) -> set[str]:
+    try:
+        tree = ast.parse(source, filename=module)
+    except SyntaxError as exc:
+        raise _error(f"module {module} is malformed") from exc
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name == "pdd" or alias.name.startswith("pdd.") for alias in node.names):
+                raise _error(f"module {module} imports pdd")
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module and (
+                node.module == "pdd" or node.module.startswith("pdd.")
+            ):
+                raise _error(f"module {module} imports pdd")
+            if node.level > 1:
+                raise _error(f"module {module} escapes the standalone namespace")
+            if node.level == 1:
+                if node.module:
+                    imports.add(f"{node.module.split('.', 1)[0]}.py")
+                else:
+                    imports.update(f"{alias.name}.py" for alias in node.names)
+    return imports
+
+
+def _checked_module_bytes(root: Path, manifest: Mapping[str, Any]) -> dict[str, bytes]:
+    modules = set(manifest["modules"])
+    required = {"checker_cli.py", "released_checker.py", "standalone_package.py"}
+    if not required <= modules:
+        raise _error("module manifest omits a required entrypoint module")
+    source = {module: _source_path(root, module).read_bytes() for module in modules}
+    closure = set(required)
+    pending = list(required)
+    while pending:
+        module = pending.pop()
+        for imported in _relative_imports(module, source[module]):
+            if imported not in modules:
+                raise _error(f"module {module} imports unmanifested {imported}")
+            if imported not in closure:
+                closure.add(imported)
+                pending.append(imported)
+    if closure != modules:
+        extra = sorted(modules - closure)
+        raise _error(f"module manifest contains extra module {extra[0]}")
+    return source
+
+
+def _record_hash(content: bytes) -> str:
+    return base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode("ascii")
+
+
+def _dist_info(version: str) -> str:
+    if not re.fullmatch(r"[0-9]+(?:\.[0-9]+){2}", version):
+        raise _error("wheel version must be a canonical X.Y.Z value")
+    return f"pdd_sync_checker-{version}.dist-info"
+
+
+def _wheel_members(root: Path, manifest: Mapping[str, Any], version: str) -> dict[str, bytes]:
+    modules = _checked_module_bytes(root, manifest)
+    data = {item: _source_path(root, item).read_bytes() for item in manifest["data"]}
+    manifest_bytes = (root / _MANIFEST_PATH).read_bytes()
+    dist_info = _dist_info(version)
+    metadata = "\n".join(
+        (
+            "Metadata-Version: 2.1",
+            f"Name: {manifest['distribution']}",
+            f"Version: {version}",
+            "Summary: Standalone PDD global-sync checker",
+            *(f"Requires-Dist: {dependency}" for dependency in manifest["dependencies"]),
+            "",
+        )
+    ).encode("utf-8")
+    members = {
+        f"{_PACKAGE}/__init__.py": b'"""Standalone global-sync checker namespace."""\n',
+        **{f"{_PACKAGE}/{module}": content for module, content in modules.items()},
+        **{f"{_PACKAGE}/{item}": content for item, content in data.items()},
+        _EMBEDDED_MANIFEST: manifest_bytes,
+        f"{dist_info}/METADATA": metadata,
+        f"{dist_info}/WHEEL": (
+            b"Wheel-Version: 1.0\nGenerator: pdd-standalone-checker\n"
+            b"Root-Is-Purelib: true\nTag: py3-none-any\n"
+        ),
+        f"{dist_info}/entry_points.txt": (
+            b"[console_scripts]\npdd-sync-checker = pdd_sync_checker.checker_cli:main\n"
+        ),
+    }
+    record = "".join(
+        f"{name},sha256={_record_hash(content)},{len(content)}\n"
+        for name, content in sorted(members.items())
+    ) + f"{dist_info}/RECORD,,\n"
+    members[f"{dist_info}/RECORD"] = record.encode("ascii")
+    return members
+
+
+def _zip_info(name: str) -> zipfile.ZipInfo:
+    info = zipfile.ZipInfo(name, date_time=_ZIP_TIMESTAMP)
+    info.compress_type = zipfile.ZIP_STORED
+    info.external_attr = (stat.S_IFREG | 0o644) << 16
+    info.create_system = 3
+    return info
+
+
+def build_standalone_wheel(root: Path, output: Path, *, version: str) -> Path:
+    """Build one byte-reproducible standalone wheel from manifest-authorized bytes."""
+    repository = Path(root).resolve()
+    manifest = load_standalone_manifest(repository)
+    members = _wheel_members(repository, manifest, version)
+    destination = Path(output)
+    if destination.exists() and (destination.is_symlink() or not destination.is_dir()):
+        raise _error("wheel output directory is unsafe")
+    destination.mkdir(parents=True, exist_ok=True)
+    wheel = destination / f"pdd_sync_checker-{version}-py3-none-any.whl"
+    if wheel.exists() or wheel.is_symlink():
+        raise _error("wheel output already exists")
+    with zipfile.ZipFile(
+        wheel, "w", compression=zipfile.ZIP_STORED, strict_timestamps=True
+    ) as archive:
+        for name, content in sorted(members.items()):
+            archive.writestr(_zip_info(name), content)
+    validate_standalone_wheel(wheel, manifest)
+    return wheel
+
+
+def _safe_member(name: str) -> PurePosixPath:
+    path = PurePosixPath(name)
+    if not name or "\\" in name or path.is_absolute() or ".." in path.parts:
+        raise _error("wheel contains an unsafe member")
+    return path
+
+
+def _read_record(record: bytes) -> dict[str, tuple[str, str]]:
+    try:
+        lines = record.decode("ascii").splitlines()
+    except UnicodeDecodeError as exc:
+        raise _error("wheel RECORD is not ASCII") from exc
+    entries: dict[str, tuple[str, str]] = {}
+    for line in lines:
+        columns = line.split(",")
+        if len(columns) != 3 or not columns[0] or columns[0] in entries:
+            raise _error("wheel RECORD is malformed")
+        entries[columns[0]] = (columns[1], columns[2])
+    return entries
+
+
+def validate_standalone_wheel(wheel_path: Path, manifest: Mapping[str, Any]) -> None:
+    """Fail closed unless the archive has exactly the manifest-authorized RECORD closure."""
+    wheel = _regular(Path(wheel_path), "wheel")
+    try:
+        _name, _version, _build, tags = parse_wheel_filename(wheel.name)
+    except InvalidWheelFilename as exc:
+        raise _error("wheel filename is malformed") from exc
+    if {str(tag) for tag in tags} != {"py3-none-any"}:
+        raise _error("wheel tags are not standalone checker tags")
+    expected_prefix = f"{manifest['package']}/"
+    try:
+        with zipfile.ZipFile(wheel) as archive:
+            files: dict[str, bytes] = {}
+            for member in archive.infolist():
+                path = _safe_member(member.filename)
+                mode = member.external_attr >> 16
+                if member.is_dir() or stat.S_ISLNK(mode) or path.as_posix() in files:
+                    raise _error("wheel contains an unsafe member")
+                files[path.as_posix()] = archive.read(member)
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise _error("wheel cannot be inspected") from exc
+    if any(name.startswith("pdd/") for name in files):
+        raise _error("wheel contains the pdd package")
+    expected_modules = {f"{expected_prefix}__init__.py", _EMBEDDED_MANIFEST} | {
+        f"{expected_prefix}{module}" for module in manifest["modules"]
+    } | {f"{expected_prefix}{item}" for item in manifest["data"]}
+    dist_infos = {PurePosixPath(name).parts[0] for name in files if ".dist-info/" in name}
+    if len(dist_infos) != 1:
+        raise _error("wheel dist-info closure is invalid")
+    dist_info = next(iter(dist_infos))
+    expected = expected_modules | {
+        f"{dist_info}/METADATA",
+        f"{dist_info}/WHEEL",
+        f"{dist_info}/entry_points.txt",
+        f"{dist_info}/RECORD",
+    }
+    if set(files) != expected:
+        raise _error("wheel member closure is invalid")
+    record_name = f"{dist_info}/RECORD"
+    records = _read_record(files[record_name])
+    if set(records) != set(files):
+        raise _error("wheel RECORD does not close over members")
+    for name, content in files.items():
+        encoded, size = records[name]
+        if name == record_name:
+            if encoded or size:
+                raise _error("wheel RECORD self-entry is invalid")
+            continue
+        if encoded != f"sha256={_record_hash(content)}" or size != str(len(content)):
+            raise _error("wheel RECORD does not match member bytes")
+
+
+def _verified_archive_files(wheel_path: Path) -> dict[str, bytes]:
+    """Read one standalone archive only after closing every member through RECORD."""
+    wheel = _regular(Path(wheel_path), "wheel")
+    try:
+        with zipfile.ZipFile(wheel) as archive:
+            files: dict[str, bytes] = {}
+            for member in archive.infolist():
+                path = _safe_member(member.filename)
+                mode = member.external_attr >> 16
+                if member.is_dir() or stat.S_ISLNK(mode) or path.as_posix() in files:
+                    raise _error("wheel contains an unsafe member")
+                files[path.as_posix()] = archive.read(member)
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise _error("wheel cannot be inspected") from exc
+    record_names = [name for name in files if name.endswith(".dist-info/RECORD")]
+    if len(record_names) != 1:
+        raise _error("wheel RECORD is malformed")
+    records = _read_record(files[record_names[0]])
+    if set(records) != set(files):
+        raise _error("wheel RECORD does not close over members")
+    for name, content in files.items():
+        encoded, size = records[name]
+        if name == record_names[0]:
+            if encoded or size:
+                raise _error("wheel RECORD self-entry is invalid")
+        elif encoded != f"sha256={_record_hash(content)}" or size != str(len(content)):
+            raise _error("wheel RECORD does not match member bytes")
+    return files
+
+
+def _installed_package_files(wheel: Path, installed_package: Path) -> dict[str, bytes]:
+    """Return the closed checker module set only when installed bytes equal the wheel."""
+    files = _verified_archive_files(wheel)
+    try:
+        manifest = _parse_manifest(files[_EMBEDDED_MANIFEST])
+    except KeyError as exc:
+        raise _error("wheel embedded module manifest is missing") from exc
+    validate_standalone_wheel(wheel, manifest)
+    if any(name.startswith("pdd/") for name in files):
+        raise _error("wheel contains the pdd package")
+    expected = {
+        PurePosixPath(name).relative_to(_PACKAGE).as_posix(): content
+        for name, content in files.items()
+        if name.startswith(f"{_PACKAGE}/")
+    }
+    if not expected:
+        raise _error("wheel contains no standalone checker package")
+    path = _regular(Path(installed_package), "installed checker module")
+    try:
+        package_index = max(
+            index for index, part in enumerate(path.parts) if part == _PACKAGE
+        )
+    except ValueError as exc:
+        raise _error("installed checker module is outside its package") from exc
+    package_root = Path(*path.parts[: package_index + 1])
+    for relative, expected_bytes in expected.items():
+        candidate = package_root / relative
+        if (
+            candidate.is_symlink()
+            or not candidate.is_file()
+            or candidate.read_bytes() != expected_bytes
+        ):
+            raise _error("installed checker bytes differ from the wheel")
+    for candidate in package_root.rglob("*"):
+        relative = candidate.relative_to(package_root)
+        if "__pycache__" in relative.parts:
+            continue
+        if candidate.is_symlink() or (
+            candidate.is_file() and relative.as_posix() not in expected
+        ):
+            raise _error("installed checker closure differs from the wheel")
+    return expected
+
+
+def installed_checker_runtime_lock(wheel: Path, installed_package: Path) -> bytes:
+    """Generate a canonical lock solely from validated installed checker bytes."""
+    files = _installed_package_files(wheel, installed_package)
+    archive = _verified_archive_files(wheel)
+    metadata = next(
+        content for name, content in archive.items() if name.endswith(".dist-info/METADATA")
+    )
+    try:
+        dependencies = sorted(
+            line.removeprefix("Requires-Dist: ")
+            for line in metadata.decode("utf-8").splitlines()
+            if line.startswith("Requires-Dist: ")
+        )
+    except UnicodeDecodeError as exc:
+        raise _error("wheel metadata is not UTF-8") from exc
+    payload = {
+        "dependencies": dependencies,
+        "files": [
+            {"path": path, "sha256": hashlib.sha256(content).hexdigest()}
+            for path, content in sorted(files.items())
+        ],
+        "package": _PACKAGE,
+        "schema_version": 1,
+        "wheel_sha256": hashlib.sha256(_regular(wheel, "wheel").read_bytes()).hexdigest(),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8") + b"\n"
+
+
+def validate_installed_checker_runtime_lock(
+    lock: bytes, wheel: Path, installed_package: Path
+) -> None:
+    """Reject lock drift, including source-checkout substitution and installed tampering."""
+    if not isinstance(lock, bytes) or not lock.endswith(b"\n"):
+        raise _error("installed checker runtime lock is malformed")
+    try:
+        payload = json.loads(lock)
+    except json.JSONDecodeError as exc:
+        raise _error("installed checker runtime lock is malformed") from exc
+    expected = installed_checker_runtime_lock(wheel, installed_package)
+    if lock != expected or not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        raise _error("installed checker runtime lock differs from installed bytes")
+
+
+def wheel_is_compatible_with_target(filename: str) -> bool:
+    """Apply the fixed CPython 3.12/Linux glibc compatibility policy to one wheel."""
+    try:
+        _name, _version, _build, tags = parse_wheel_filename(filename)
+    except InvalidWheelFilename:
+        return False
+    for tag in tags:
+        if (
+            tag.interpreter in {"py3", "py312", "py2.py3"}
+            and tag.abi == "none"
+            and tag.platform == "any"
+        ):
+            return True
+        match = re.fullmatch(r"manylinux_(2)_(\d+)_x86_64", tag.platform)
+        if match is None or int(match.group(2)) > 36:
+            continue
+        if tag.interpreter == "cp312" and tag.abi in {"cp312", "abi3", "none"}:
+            return True
+        if tag.interpreter in {"py3", "py312", "py2.py3"} and tag.abi == "none":
+            return True
+        abi3 = re.fullmatch(r"cp(3[0-9]{1,2})", tag.interpreter)
+        if abi3 and tag.abi == "abi3" and 32 <= int(abi3.group(1)) <= 312:
+            return True
+    return False

--- a/tests/test_sync_core_checker_cli.py
+++ b/tests/test_sync_core_checker_cli.py
@@ -1,0 +1,67 @@
+"""Direct CLI tests for the standalone global-sync checker."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+import sys
+import venv
+
+import pytest
+
+from pdd.sync_core.standalone_package import build_standalone_wheel
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_clean_installed_console_uses_standalone_module_not_checkout(tmp_path) -> None:
+    wheel = build_standalone_wheel(ROOT, tmp_path / "wheel", version="1.0.0")
+    environment = tmp_path / "venv"
+    venv.EnvBuilder(with_pip=True, system_site_packages=True).create(environment)
+    python = environment / "bin/python"
+    console = environment / "bin/pdd-sync-checker"
+    subprocess.run(
+        [str(python), "-m", "pip", "install", "--no-deps", str(wheel)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    shadow = tmp_path / "shadow"
+    (shadow / "pdd").mkdir(parents=True)
+    (shadow / "pdd/__init__.py").write_text("raise RuntimeError('checkout imported')\n")
+    environment_values = os.environ | {
+        "PDD_RELEASED_CHECKER_WHEEL_PATH": str(wheel),
+        "PDD_RELEASED_CHECKER_WHEEL_SHA256": hashlib.sha256(wheel.read_bytes()).hexdigest(),
+        "PDD_RELEASED_CHECKER_REF": "refs/tags/v1.0.0",
+        "PDD_RELEASED_CHECKER_WORKFLOW_IDENTITY": (
+            "promptdriven/pdd/.github/workflows/release.yml@refs/tags/v1.0.0"
+        ),
+        "PYTHONPATH": str(shadow),
+    }
+
+    result = subprocess.run(
+        [str(console), "--help"],
+        cwd=shadow,
+        env=environment_values,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "certify" in result.stdout
+    assert "pdd" not in result.stderr.lower()
+
+
+def test_direct_cli_rejects_candidate_arguments_before_loading_them(monkeypatch, tmp_path) -> None:
+    from pdd.sync_core import checker_cli
+
+    monkeypatch.setattr(checker_cli, "validate_released_checker_runtime", lambda *_args: None)
+    monkeypatch.setattr(checker_cli, "checker_identity_from_environment", lambda **_kwargs: object())
+    monkeypatch.setenv("PDD_RELEASED_CHECKER_WHEEL_PATH", str(tmp_path / "missing.whl"))
+
+    with pytest.raises(checker_cli.CheckerCliError, match="regular JSON"):
+        checker_cli.main(("release-pin-evidence", "--ledger-source", str(tmp_path / "missing")))

--- a/tests/test_sync_core_checker_cli.py
+++ b/tests/test_sync_core_checker_cli.py
@@ -10,6 +10,7 @@ import sys
 import venv
 
 import pytest
+import cryptography
 
 from pdd.sync_core.standalone_package import build_standalone_wheel
 
@@ -39,7 +40,7 @@ def test_clean_installed_console_uses_standalone_module_not_checkout(tmp_path) -
         "PDD_RELEASED_CHECKER_WORKFLOW_IDENTITY": (
             "promptdriven/pdd/.github/workflows/release.yml@refs/tags/v1.0.0"
         ),
-        "PYTHONPATH": str(shadow),
+        "PYTHONPATH": str(shadow) + os.pathsep + str(Path(cryptography.__file__).parents[1]),
     }
 
     result = subprocess.run(
@@ -59,9 +60,14 @@ def test_clean_installed_console_uses_standalone_module_not_checkout(tmp_path) -
 def test_direct_cli_rejects_candidate_arguments_before_loading_them(monkeypatch, tmp_path) -> None:
     from pdd.sync_core import checker_cli
 
-    monkeypatch.setattr(checker_cli, "validate_released_checker_runtime", lambda *_args: None)
-    monkeypatch.setattr(checker_cli, "checker_identity_from_environment", lambda **_kwargs: object())
-    monkeypatch.setenv("PDD_RELEASED_CHECKER_WHEEL_PATH", str(tmp_path / "missing.whl"))
+    monkeypatch.setattr(checker_cli, "_validated_runtime_identity", lambda: object())
+    monkeypatch.setattr(
+        checker_cli,
+        "_evidence_main",
+        lambda _arguments: (_ for _ in ()).throw(
+            checker_cli.CheckerCliError("regular JSON input is required")
+        ),
+    )
 
     with pytest.raises(checker_cli.CheckerCliError, match="regular JSON"):
         checker_cli.main(("release-pin-evidence", "--ledger-source", str(tmp_path / "missing")))

--- a/tests/test_sync_core_checker_cli.py
+++ b/tests/test_sync_core_checker_cli.py
@@ -84,11 +84,11 @@ def test_clean_installed_console_uses_standalone_module_not_checkout(tmp_path) -
     assert "counts" in report and "units" in report
     assert "cannot read language registry" not in result.stdout
     assert not marker.exists()
-    assert not list((environment / "lib").rglob("__pycache__"))
 
     package_root = next(
         (environment / "lib").glob("python*/site-packages/pdd_sync_checker")
     )
+    assert not list(package_root.rglob("__pycache__"))
     malicious_pyc = package_root / "__pycache__/checker_cli.cpython-312.pyc"
     malicious_pyc.parent.mkdir()
     malicious_pyc.write_bytes(b"malicious bytecode")

--- a/tests/test_sync_core_checker_cli.py
+++ b/tests/test_sync_core_checker_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 from pathlib import Path
 import subprocess
@@ -10,9 +11,10 @@ import sys
 import venv
 
 import pytest
-import cryptography
 
-from pdd.sync_core.standalone_package import build_standalone_wheel
+from pdd.sync_core.standalone_package import (
+    build_standalone_wheel,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -21,18 +23,32 @@ ROOT = Path(__file__).resolve().parents[1]
 def test_clean_installed_console_uses_standalone_module_not_checkout(tmp_path) -> None:
     wheel = build_standalone_wheel(ROOT, tmp_path / "wheel", version="1.0.0")
     environment = tmp_path / "venv"
-    venv.EnvBuilder(with_pip=True, system_site_packages=True).create(environment)
+    venv.EnvBuilder(with_pip=True).create(environment)
     python = environment / "bin/python"
     console = environment / "bin/pdd-sync-checker"
     subprocess.run(
-        [str(python), "-m", "pip", "install", "--no-deps", str(wheel)],
+        [str(python), "-m", "pip", "install", "--no-compile", str(wheel)],
         check=True,
         capture_output=True,
         text=True,
     )
-    shadow = tmp_path / "shadow"
-    (shadow / "pdd").mkdir(parents=True)
-    (shadow / "pdd/__init__.py").write_text("raise RuntimeError('checkout imported')\n")
+    shadow = tmp_path / "candidate"
+    subprocess.run(
+        ["git", "clone", "-q", "--no-hardlinks", str(ROOT), str(shadow)],
+        check=True,
+        capture_output=True,
+    )
+    marker = tmp_path / "shadow-imported"
+    shadow_code = (
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('shadow imported', encoding='utf-8')\n"
+        "raise RuntimeError('candidate shadow imported')\n"
+    )
+    (shadow / "pdd/__init__.py").write_text(shadow_code, encoding="utf-8")
+    (shadow / "pdd_sync_checker").mkdir()
+    (shadow / "pdd_sync_checker/__init__.py").write_text(
+        shadow_code, encoding="utf-8"
+    )
     environment_values = os.environ | {
         "PDD_RELEASED_CHECKER_WHEEL_PATH": str(wheel),
         "PDD_RELEASED_CHECKER_WHEEL_SHA256": hashlib.sha256(wheel.read_bytes()).hexdigest(),
@@ -40,10 +56,10 @@ def test_clean_installed_console_uses_standalone_module_not_checkout(tmp_path) -
         "PDD_RELEASED_CHECKER_WORKFLOW_IDENTITY": (
             "promptdriven/pdd/.github/workflows/release.yml@refs/tags/v1.0.0"
         ),
-        "PYTHONPATH": str(shadow) + os.pathsep + str(Path(cryptography.__file__).parents[1]),
+        "PYTHONPATH": str(shadow),
     }
 
-    result = subprocess.run(
+    help_result = subprocess.run(
         [str(console), "--help"],
         cwd=shadow,
         env=environment_values,
@@ -51,10 +67,54 @@ def test_clean_installed_console_uses_standalone_module_not_checkout(tmp_path) -
         text=True,
         check=False,
     )
+    result = subprocess.run(
+        [str(console), "certify", "--base-ref", "HEAD", "--head-ref", "HEAD"],
+        cwd=shadow,
+        env=environment_values,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
-    assert result.returncode == 0, result.stderr
-    assert "certify" in result.stdout
-    assert "pdd" not in result.stderr.lower()
+    assert help_result.returncode == 0, help_result.stderr
+    assert "certify" in help_result.stdout
+    report = json.loads(result.stdout)
+    assert result.returncode in {0, 1}, result.stderr
+    assert report["schema_version"] == 1
+    assert "counts" in report and "units" in report
+    assert "cannot read language registry" not in result.stdout
+    assert not marker.exists()
+    assert not list((environment / "lib").rglob("__pycache__"))
+
+    package_root = next(
+        (environment / "lib").glob("python*/site-packages/pdd_sync_checker")
+    )
+    malicious_pyc = package_root / "__pycache__/checker_cli.cpython-312.pyc"
+    malicious_pyc.parent.mkdir()
+    malicious_pyc.write_bytes(b"malicious bytecode")
+    pyc_result = subprocess.run(
+        [str(console), "--help"],
+        cwd=shadow,
+        env=environment_values,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert pyc_result.returncode != 0
+    malicious_pyc.unlink()
+    malicious_pyc.parent.rmdir()
+
+    malicious_fifo = package_root / "malicious"
+    os.mkfifo(malicious_fifo)
+    fifo_result = subprocess.run(
+        [str(console), "--help"],
+        cwd=shadow,
+        env=environment_values,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert fifo_result.returncode != 0
 
 
 def test_direct_cli_rejects_candidate_arguments_before_loading_them(monkeypatch, tmp_path) -> None:
@@ -71,3 +131,18 @@ def test_direct_cli_rejects_candidate_arguments_before_loading_them(monkeypatch,
 
     with pytest.raises(checker_cli.CheckerCliError, match="regular JSON"):
         checker_cli.main(("release-pin-evidence", "--ledger-source", str(tmp_path / "missing")))
+
+
+def test_direct_cli_help_requires_runtime_provenance(monkeypatch) -> None:
+    from pdd.sync_core import checker_cli
+
+    monkeypatch.setattr(
+        checker_cli,
+        "_validated_runtime_identity",
+        lambda: (_ for _ in ()).throw(
+            checker_cli.ReleasedCheckerError("provenance failed")
+        ),
+    )
+
+    with pytest.raises(checker_cli.CheckerCliError, match="provenance failed"):
+        checker_cli.main(("--help",))

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -1818,7 +1818,10 @@ def test_standalone_checker_package_boundary_is_exactly_preauthorized() -> None:
         not path.endswith("/") and not any(token in path for token in ("*", "?", "["))
         for path in STANDALONE_CHECKER_PREAUTHORIZED_PATHS
     )
-    assert all(not (ROOT / path).exists() for path in STANDALONE_CHECKER_PREAUTHORIZED_PATHS)
+    assert all(
+        (ROOT / path).is_file() and not (ROOT / path).is_symlink()
+        for path in sorted(STANDALONE_CHECKER_PREAUTHORIZED_PATHS)
+    )
 
 
 def test_standalone_checker_package_boundary_composes_offline_and_fails_closed(

--- a/tests/test_sync_core_runner.py
+++ b/tests/test_sync_core_runner.py
@@ -1260,6 +1260,32 @@ def test_released_runtime_digest_binds_installed_native_dependency(
     assert runner_module._released_runtime_closure_digest() != first
 
 
+def test_pytest_runtime_digest_projects_vitest_from_zero_argument_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = tmp_path / "runtime.py"
+    vitest_source = tmp_path / "vitest_fd_cloexec.c"
+    runtime.write_bytes(b"runtime")
+    vitest_source.write_bytes(b"vitest-v1")
+    monkeypatch.setattr(
+        runner_module,
+        "_released_runtime_closure_paths",
+        lambda: (
+            ("checker/pdd/sync_core/runner.py", runtime),
+            (
+                "checker/pdd/sync_core/native/vitest_fd_cloexec.c",
+                vitest_source,
+            ),
+        ),
+    )
+
+    pytest_digest = runner_module._released_runtime_closure_digest(False)
+    vitest_source.write_bytes(b"vitest-v2")
+
+    assert runner_module._released_runtime_closure_digest(False) == pytest_digest
+    assert runner_module._released_runtime_closure_digest(True) != pytest_digest
+
+
 def test_default_runtime_digest_cache_invalidates_changed_native_bytes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_sync_core_runner.py
+++ b/tests/test_sync_core_runner.py
@@ -1197,7 +1197,9 @@ def test_runner_identity_binds_measured_runtime_and_checker(
     monkeypatch.setattr("pdd.sync_core.runner.platform.python_version", lambda: "99.1")
     assert runner_identity_digest(profile, root=root, ref=commit) != first
     monkeypatch.undo()
-    monkeypatch.setattr("pdd.sync_core.runner._checker_artifact_digest", lambda: "0" * 64)
+    monkeypatch.setattr(
+        "pdd.sync_core.runner._checker_artifact_digest", lambda _vitest: "0" * 64
+    )
     assert runner_identity_digest(profile, root=root, ref=commit) != first
 
 

--- a/tests/test_sync_core_standalone_package.py
+++ b/tests/test_sync_core_standalone_package.py
@@ -42,6 +42,7 @@ def test_builder_is_reproducible_and_copies_only_closed_checker_modules(tmp_path
         )
         metadata = next(name for name in names if name.endswith(".dist-info/METADATA"))
         assert "Requires-Dist: z3-solver" not in wheel.read(metadata).decode("utf-8")
+        assert "Requires-Dist: packaging >=24,<26" in wheel.read(metadata).decode("utf-8")
         assert "Requires-Dist: pytest ==9.0.3" in wheel.read(metadata).decode("utf-8")
     validate_standalone_wheel(first, manifest)
 

--- a/tests/test_sync_core_standalone_package.py
+++ b/tests/test_sync_core_standalone_package.py
@@ -1,0 +1,106 @@
+"""Contract tests for the standalone global-sync checker wheel."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import zipfile
+
+import pytest
+
+from pdd.sync_core.standalone_package import (
+    StandalonePackageError,
+    build_standalone_wheel,
+    load_standalone_manifest,
+    validate_standalone_wheel,
+    wheel_is_compatible_with_target,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_builder_is_reproducible_and_copies_only_closed_checker_modules(tmp_path) -> None:
+    manifest = load_standalone_manifest(ROOT)
+    first = build_standalone_wheel(ROOT, tmp_path / "first", version="1.0.0")
+    second = build_standalone_wheel(ROOT, tmp_path / "second", version="1.0.0")
+
+    assert first.read_bytes() == second.read_bytes()
+    with zipfile.ZipFile(first) as wheel:
+        names = set(wheel.namelist())
+        assert not any(name.startswith("pdd/") for name in names)
+        assert "pdd_sync_checker/checker_cli.py" in names
+        assert "pdd_sync_checker/released_checker.py" in names
+        assert all(
+            wheel.read(f"pdd_sync_checker/{module}")
+            == (ROOT / "pdd" / "sync_core" / module).read_bytes()
+            for module in manifest["modules"]
+        )
+        metadata = next(name for name in names if name.endswith(".dist-info/METADATA"))
+        assert "Requires-Dist: z3-solver" not in wheel.read(metadata).decode("utf-8")
+        assert "Requires-Dist: pytest ==9.0.3" in wheel.read(metadata).decode("utf-8")
+    validate_standalone_wheel(first, manifest)
+
+
+@pytest.mark.parametrize("mutation", ["absolute-import", "missing", "extra", "symlink"])
+def test_builder_rejects_unclosed_or_unsafe_manifest_inputs(tmp_path, mutation: str) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    manifest = json.loads(
+        (ROOT / ".pdd/global-sync/standalone-checker-modules.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    (source / "pdd/sync_core").mkdir(parents=True)
+    for module in manifest["modules"]:
+        target = source / "pdd/sync_core" / module
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes((ROOT / "pdd/sync_core" / module).read_bytes())
+    (source / ".pdd/global-sync").mkdir(parents=True)
+    manifest_path = source / ".pdd/global-sync/standalone-checker-modules.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    if mutation == "absolute-import":
+        (source / "pdd/sync_core/checker_cli.py").write_text("import pdd.cli\n")
+    elif mutation == "missing":
+        (source / "pdd/sync_core" / manifest["modules"][0]).unlink()
+    elif mutation == "extra":
+        (source / "pdd/sync_core/unlisted.py").write_text("VALUE = 1\n")
+        manifest["modules"].append("unlisted.py")
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    else:
+        target = source / "pdd/sync_core" / manifest["modules"][0]
+        copied = source / "copied.py"
+        copied.write_bytes(target.read_bytes())
+        target.unlink()
+        target.symlink_to(copied)
+
+    with pytest.raises(StandalonePackageError):
+        build_standalone_wheel(source, tmp_path / "wheel", version="1.0.0")
+
+
+def test_wheel_validation_rejects_record_and_member_tampering(tmp_path) -> None:
+    wheel = build_standalone_wheel(ROOT, tmp_path / "wheel", version="1.0.0")
+    manifest = load_standalone_manifest(ROOT)
+    tampered = tmp_path / "tampered.whl"
+    with zipfile.ZipFile(wheel) as source, zipfile.ZipFile(tampered, "w") as target:
+        for entry in source.infolist():
+            content = source.read(entry.filename)
+            if entry.filename.endswith("pdd_sync_checker/checker_cli.py"):
+                content += b"# modified\n"
+            target.writestr(entry, content)
+
+    with pytest.raises(StandalonePackageError, match="RECORD"):
+        validate_standalone_wheel(tampered, manifest)
+
+
+def test_z3_manylinux_227_is_accepted_only_for_the_supported_glibc_target() -> None:
+    manifest = load_standalone_manifest(ROOT)
+
+    assert manifest["target"]["glibc"] == "2.36"
+    assert wheel_is_compatible_with_target(
+        "z3_solver-4.16.0.0-py3-none-manylinux_2_27_x86_64.whl"
+    )
+    assert not wheel_is_compatible_with_target(
+        "z3_solver-4.16.0.0-py3-none-manylinux_2_37_x86_64.whl"
+    )

--- a/tests/test_sync_core_standalone_package.py
+++ b/tests/test_sync_core_standalone_package.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
+import os
 from pathlib import Path
+import stat
 import subprocess
 import sys
 import zipfile
@@ -24,6 +28,84 @@ from pdd.sync_core.standalone_package import (
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _record_hash(content: bytes) -> str:
+    return base64.urlsafe_b64encode(
+        hashlib.sha256(content).digest()
+    ).rstrip(b"=").decode("ascii")
+
+
+def _rerecorded_mutation(
+    source_path: Path, target_path: Path, mutation: str
+) -> Path:
+    target_path.parent.mkdir(parents=True)
+    with zipfile.ZipFile(source_path) as source:
+        contents = {
+            entry.filename: source.read(entry.filename)
+            for entry in source.infolist()
+        }
+        infos = {entry.filename: entry for entry in source.infolist()}
+    record_name = next(
+        name for name in contents if name.endswith(".dist-info/RECORD")
+    )
+    if mutation == "dependency":
+        metadata = next(name for name in contents if name.endswith(".dist-info/METADATA"))
+        contents[metadata] += b"Requires-Dist: attacker >=1\n"
+    elif mutation == "bootstrap":
+        bootstrap = next(
+            name for name in contents if name.endswith(".data/scripts/pdd-sync-checker")
+        )
+        contents[bootstrap] += b"\n# attacker entrypoint\n"
+    elif mutation == "wheel":
+        wheel = next(name for name in contents if name.endswith(".dist-info/WHEEL"))
+        contents[wheel] += b"Generator: attacker\n"
+    elif mutation == "manifest":
+        manifest = next(
+            name for name in contents if name.endswith("standalone-checker-modules.json")
+        )
+        contents[manifest] += b" "
+    elif mutation == "dist-info":
+        original = record_name.split("/", 1)[0]
+        replacement = "attacker-1.0.0.dist-info"
+        contents = {
+            name.replace(f"{original}/", f"{replacement}/", 1): content
+            if name.startswith(f"{original}/")
+            else content
+            for name, content in contents.items()
+        }
+        infos = {
+            name.replace(f"{original}/", f"{replacement}/", 1): info
+            if name.startswith(f"{original}/")
+            else info
+            for name, info in infos.items()
+        }
+        record_name = f"{replacement}/RECORD"
+    elif mutation == "nonregular-mode":
+        member = "pdd_sync_checker/checker_cli.py"
+        infos[member].external_attr = (stat.S_IFIFO | 0o644) << 16
+    else:
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+    contents[record_name] = (
+        "".join(
+            f"{name},sha256={_record_hash(content)},{len(content)}\n"
+            for name, content in sorted(contents.items())
+            if name != record_name
+        )
+        + f"{record_name},,\n"
+    ).encode("ascii")
+    with zipfile.ZipFile(target_path, "w") as target:
+        for name, content in sorted(contents.items()):
+            info = infos[name]
+            if info.filename != name:
+                renamed = zipfile.ZipInfo(name, date_time=info.date_time)
+                renamed.compress_type = info.compress_type
+                renamed.create_system = info.create_system
+                renamed.external_attr = info.external_attr
+                info = renamed
+            target.writestr(info, content)
+    return target_path
+
+
 def test_builder_is_reproducible_and_copies_only_closed_checker_modules(tmp_path) -> None:
     manifest = load_standalone_manifest(ROOT)
     first = build_standalone_wheel(ROOT, tmp_path / "first", version="1.0.0")
@@ -35,6 +117,8 @@ def test_builder_is_reproducible_and_copies_only_closed_checker_modules(tmp_path
         assert not any(name.startswith("pdd/") for name in names)
         assert "pdd_sync_checker/checker_cli.py" in names
         assert "pdd_sync_checker/released_checker.py" in names
+        assert "pdd_sync_checker/data/language_format.csv" in names
+        assert any(name.endswith(".data/scripts/pdd-sync-checker") for name in names)
         assert all(
             wheel.read(f"pdd_sync_checker/{module}")
             == (ROOT / "pdd" / "sync_core" / module).read_bytes()
@@ -48,7 +132,15 @@ def test_builder_is_reproducible_and_copies_only_closed_checker_modules(tmp_path
 
 
 @pytest.mark.parametrize(
-    "mutation", ["absolute-import", "missing", "extra", "symlink", "root-symlink"]
+    "mutation",
+    [
+        "absolute-import",
+        "missing",
+        "extra",
+        "symlink",
+        "root-symlink",
+        "sync-core-symlink",
+    ],
 )
 def test_builder_rejects_unclosed_or_unsafe_manifest_inputs(tmp_path, mutation: str) -> None:
     source = tmp_path / "source"
@@ -64,8 +156,14 @@ def test_builder_rejects_unclosed_or_unsafe_manifest_inputs(tmp_path, mutation: 
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes((ROOT / "pdd/sync_core" / module).read_bytes())
     for data in manifest["data"]:
-        target = source / "pdd/sync_core" / data
-        target.write_bytes((ROOT / "pdd/sync_core" / data).read_bytes())
+        data_source = (
+            Path(data["source"])
+            if isinstance(data, dict)
+            else Path("pdd/sync_core") / data
+        )
+        target = source / data_source
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes((ROOT / data_source).read_bytes())
     (source / ".pdd/global-sync").mkdir(parents=True)
     manifest_path = source / ".pdd/global-sync/standalone-checker-modules.json"
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
@@ -84,13 +182,28 @@ def test_builder_rejects_unclosed_or_unsafe_manifest_inputs(tmp_path, mutation: 
         copied.write_bytes(target.read_bytes())
         target.unlink()
         target.symlink_to(copied)
-    else:
+    elif mutation == "root-symlink":
         linked_source = tmp_path / "linked-source"
         linked_source.symlink_to(source, target_is_directory=True)
         source = linked_source
+    else:
+        sync_core = source / "pdd/sync_core"
+        copied = source / "copied-sync-core"
+        sync_core.rename(copied)
+        sync_core.symlink_to(copied, target_is_directory=True)
 
     with pytest.raises(StandalonePackageError):
         build_standalone_wheel(source, tmp_path / "wheel", version="1.0.0")
+
+
+def test_builder_rejects_symlinked_output_parent(tmp_path) -> None:
+    real_output = tmp_path / "real-output"
+    real_output.mkdir()
+    linked_output = tmp_path / "linked-output"
+    linked_output.symlink_to(real_output, target_is_directory=True)
+
+    with pytest.raises(StandalonePackageError, match="output"):
+        build_standalone_wheel(ROOT, linked_output / "wheel", version="1.0.0")
 
 
 def test_wheel_validation_rejects_record_and_member_tampering(tmp_path) -> None:
@@ -109,11 +222,45 @@ def test_wheel_validation_rejects_record_and_member_tampering(tmp_path) -> None:
         validate_standalone_wheel(tampered, manifest)
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "dependency",
+        "bootstrap",
+        "wheel",
+        "manifest",
+        "dist-info",
+        "nonregular-mode",
+    ],
+)
+def test_wheel_validation_rejects_rerecorded_authority_mutations(
+    tmp_path, mutation: str
+) -> None:
+    wheel = build_standalone_wheel(ROOT, tmp_path / "wheel", version="1.0.0")
+    manifest = load_standalone_manifest(ROOT)
+    tampered = _rerecorded_mutation(
+        wheel, tmp_path / "tampered" / mutation / wheel.name, mutation
+    )
+
+    with pytest.raises(StandalonePackageError):
+        validate_standalone_wheel(tampered, manifest)
+
+
 def test_runtime_lock_is_generated_and_validated_from_installed_checker_bytes(tmp_path) -> None:
     wheel = build_standalone_wheel(ROOT, tmp_path / "wheel", version="1.0.0")
     installed = tmp_path / "installed"
     subprocess.run(
-        [sys.executable, "-m", "pip", "install", "--no-deps", "--target", str(installed), str(wheel)],
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-compile",
+            "--no-deps",
+            "--target",
+            str(installed),
+            str(wheel),
+        ],
         check=True,
         capture_output=True,
         text=True,
@@ -126,6 +273,42 @@ def test_runtime_lock_is_generated_and_validated_from_installed_checker_bytes(tm
 
     with pytest.raises(StandalonePackageError, match="installed"):
         validate_installed_checker_runtime_lock(lock, wheel, package)
+
+
+@pytest.mark.parametrize("mutation", ["pyc", "nonregular"])
+def test_runtime_lock_rejects_unlisted_installed_entry(
+    tmp_path, mutation: str
+) -> None:
+    wheel = build_standalone_wheel(ROOT, tmp_path / "wheel", version="1.0.0")
+    installed = tmp_path / "installed"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-compile",
+            "--no-deps",
+            "--target",
+            str(installed),
+            str(wheel),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    package_root = installed / "pdd_sync_checker"
+    if mutation == "pyc":
+        malicious = package_root / "__pycache__/checker_cli.cpython-312.pyc"
+        malicious.parent.mkdir()
+        malicious.write_bytes(b"malicious bytecode")
+    else:
+        os.mkfifo(package_root / "malicious")
+
+    with pytest.raises(StandalonePackageError, match="installed"):
+        installed_checker_runtime_lock(
+            wheel, package_root / "released_checker.py"
+        )
 
 
 def test_z3_manylinux_227_is_accepted_only_for_the_supported_glibc_target() -> None:

--- a/tests/test_sync_core_standalone_package.py
+++ b/tests/test_sync_core_standalone_package.py
@@ -62,7 +62,11 @@ def _rerecorded_mutation(
         manifest = next(
             name for name in contents if name.endswith("standalone-checker-modules.json")
         )
-        contents[manifest] += b" "
+        payload = json.loads(contents[manifest])
+        payload["entry_point"] = "attacker.checker:main"
+        contents[manifest] = (
+            json.dumps(payload, indent=2).encode("utf-8") + b"\n"
+        )
     elif mutation == "dist-info":
         original = record_name.split("/", 1)[0]
         replacement = "attacker-1.0.0.dist-info"
@@ -166,7 +170,9 @@ def test_builder_rejects_unclosed_or_unsafe_manifest_inputs(tmp_path, mutation: 
         target.write_bytes((ROOT / data_source).read_bytes())
     (source / ".pdd/global-sync").mkdir(parents=True)
     manifest_path = source / ".pdd/global-sync/standalone-checker-modules.json"
-    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
 
     if mutation == "absolute-import":
         (source / "pdd/sync_core/checker_cli.py").write_text("import pdd.cli\n")
@@ -175,7 +181,9 @@ def test_builder_rejects_unclosed_or_unsafe_manifest_inputs(tmp_path, mutation: 
     elif mutation == "extra":
         (source / "pdd/sync_core/unlisted.py").write_text("VALUE = 1\n")
         manifest["modules"].append("unlisted.py")
-        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
     elif mutation == "symlink":
         target = source / "pdd/sync_core" / manifest["modules"][0]
         copied = source / "copied.py"
@@ -275,7 +283,9 @@ def test_runtime_lock_is_generated_and_validated_from_installed_checker_bytes(tm
         validate_installed_checker_runtime_lock(lock, wheel, package)
 
 
-@pytest.mark.parametrize("mutation", ["pyc", "nonregular"])
+@pytest.mark.parametrize(
+    "mutation", ["pyc", "unlisted", "symlink", "nonregular"]
+)
 def test_runtime_lock_rejects_unlisted_installed_entry(
     tmp_path, mutation: str
 ) -> None:
@@ -302,6 +312,14 @@ def test_runtime_lock_rejects_unlisted_installed_entry(
         malicious = package_root / "__pycache__/checker_cli.cpython-312.pyc"
         malicious.parent.mkdir()
         malicious.write_bytes(b"malicious bytecode")
+    elif mutation == "unlisted":
+        (package_root / "malicious.txt").write_text(
+            "unlisted", encoding="utf-8"
+        )
+    elif mutation == "symlink":
+        (package_root / "malicious").symlink_to(
+            package_root / "checker_cli.py"
+        )
     else:
         os.mkfifo(package_root / "malicious")
 

--- a/tests/test_sync_core_standalone_package.py
+++ b/tests/test_sync_core_standalone_package.py
@@ -46,7 +46,9 @@ def test_builder_is_reproducible_and_copies_only_closed_checker_modules(tmp_path
     validate_standalone_wheel(first, manifest)
 
 
-@pytest.mark.parametrize("mutation", ["absolute-import", "missing", "extra", "symlink"])
+@pytest.mark.parametrize(
+    "mutation", ["absolute-import", "missing", "extra", "symlink", "root-symlink"]
+)
 def test_builder_rejects_unclosed_or_unsafe_manifest_inputs(tmp_path, mutation: str) -> None:
     source = tmp_path / "source"
     source.mkdir()
@@ -60,6 +62,9 @@ def test_builder_rejects_unclosed_or_unsafe_manifest_inputs(tmp_path, mutation: 
         target = source / "pdd/sync_core" / module
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes((ROOT / "pdd/sync_core" / module).read_bytes())
+    for data in manifest["data"]:
+        target = source / "pdd/sync_core" / data
+        target.write_bytes((ROOT / "pdd/sync_core" / data).read_bytes())
     (source / ".pdd/global-sync").mkdir(parents=True)
     manifest_path = source / ".pdd/global-sync/standalone-checker-modules.json"
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
@@ -72,12 +77,16 @@ def test_builder_rejects_unclosed_or_unsafe_manifest_inputs(tmp_path, mutation: 
         (source / "pdd/sync_core/unlisted.py").write_text("VALUE = 1\n")
         manifest["modules"].append("unlisted.py")
         manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
-    else:
+    elif mutation == "symlink":
         target = source / "pdd/sync_core" / manifest["modules"][0]
         copied = source / "copied.py"
         copied.write_bytes(target.read_bytes())
         target.unlink()
         target.symlink_to(copied)
+    else:
+        linked_source = tmp_path / "linked-source"
+        linked_source.symlink_to(source, target_is_directory=True)
+        source = linked_source
 
     with pytest.raises(StandalonePackageError):
         build_standalone_wheel(source, tmp_path / "wheel", version="1.0.0")

--- a/tests/test_sync_core_standalone_package.py
+++ b/tests/test_sync_core_standalone_package.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import subprocess
+import sys
 import zipfile
 
 import pytest
@@ -11,7 +13,9 @@ import pytest
 from pdd.sync_core.standalone_package import (
     StandalonePackageError,
     build_standalone_wheel,
+    installed_checker_runtime_lock,
     load_standalone_manifest,
+    validate_installed_checker_runtime_lock,
     validate_standalone_wheel,
     wheel_is_compatible_with_target,
 )
@@ -82,7 +86,8 @@ def test_builder_rejects_unclosed_or_unsafe_manifest_inputs(tmp_path, mutation: 
 def test_wheel_validation_rejects_record_and_member_tampering(tmp_path) -> None:
     wheel = build_standalone_wheel(ROOT, tmp_path / "wheel", version="1.0.0")
     manifest = load_standalone_manifest(ROOT)
-    tampered = tmp_path / "tampered.whl"
+    tampered = tmp_path / "tampered" / wheel.name
+    tampered.parent.mkdir()
     with zipfile.ZipFile(wheel) as source, zipfile.ZipFile(tampered, "w") as target:
         for entry in source.infolist():
             content = source.read(entry.filename)
@@ -92,6 +97,25 @@ def test_wheel_validation_rejects_record_and_member_tampering(tmp_path) -> None:
 
     with pytest.raises(StandalonePackageError, match="RECORD"):
         validate_standalone_wheel(tampered, manifest)
+
+
+def test_runtime_lock_is_generated_and_validated_from_installed_checker_bytes(tmp_path) -> None:
+    wheel = build_standalone_wheel(ROOT, tmp_path / "wheel", version="1.0.0")
+    installed = tmp_path / "installed"
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--no-deps", "--target", str(installed), str(wheel)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    package = installed / "pdd_sync_checker" / "released_checker.py"
+
+    lock = installed_checker_runtime_lock(wheel, package)
+    validate_installed_checker_runtime_lock(lock, wheel, package)
+    package.write_bytes(package.read_bytes() + b"# tampered\n")
+
+    with pytest.raises(StandalonePackageError, match="installed"):
+        validate_installed_checker_runtime_lock(lock, wheel, package)
 
 
 def test_z3_manylinux_227_is_accepted_only_for_the_supported_glibc_target() -> None:


### PR DESCRIPTION
## Scope
Implements the first Gate 2 layer as a deterministic standalone `pdd-sync-checker` wheel:

- packages the exact manifest-authorized `pdd/sync_core` closure under `pdd_sync_checker` without shipping or importing `pdd`;
- installs a wheel-bound isolated bootstrap that validates the pinned wheel, bootstrap, and installed package closure before checker imports;
- provides direct local `certify` and release-evidence CLI paths without `pdd.cli`;
- embeds the package-relative language registry and checker-only dependency metadata;
- generates and validates an installed-checker byte lock;
- excludes the frozen Vitest native diagnostic source from pytest-only runtime identity while retaining it for Vitest profiles;
- validates exact wheel identity, metadata, bootstrap, modes, timestamps, members, and RECORD;
- retains the fixed Linux/glibc compatible-wheel policy including the real z3 manylinux 2.27 regression.

This PR does not release the wheel, build the Git-capable OCI, add protected release/pin wiring, promote a gate, or claim Certificate A/B evidence.

## Local validation
- `pytest -q tests/test_sync_core_standalone_package.py tests/test_sync_core_checker_cli.py tests/test_sync_core_runner.py tests/test_sync_core_released_checker.py tests/test_sync_core_pdd_rollout_policy.py` -> 162 passed, 46 skipped
- `pylint pdd/sync_core/standalone_package.py pdd/sync_core/checker_cli.py pdd/sync_core/language.py pdd/sync_core/released_checker.py pdd/sync_core/runner.py` -> 10.00/10
- deterministic independent builds -> identical SHA-256 `2f6bb048ef6eb3c8486f2e2df5c62066b9907b89dcc55a76bab0993556424438`
- wheel scan -> 38 closed members, no `pdd/` members, one isolated bootstrap, bundled language registry
- clean-venv real `certify`, candidate `pdd`/`pdd_sync_checker` shadows, malicious pyc/FIFO, linked source/output, and consistently re-RECORDed wheel mutations covered
- `git diff --check origin/main...HEAD` -> pass

## Adversarial review
Sol HIGH reviewed full head `d9d95155b11531d07c4df0715754c7416c244387` and found five blocking issues: missing registry data, pre-provenance shadow imports, unbound bytecode/nonregular entries, linked/raceable path traversal, and incomplete semantic/mode wheel validation. Terra HIGH corrected all five in one bounded cycle. The same Sol reviewer verified only those findings and approved exact head `be90cbdc7e5280eae19db02d041fd05467315b11`.