### PR TITLE
Authorize PR 2168 requirement transitions

### DIFF
--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -21,17 +21,6 @@
       "head_prompt_sha256": "f0d873e5505d40035d3c7364fd3961b5602d21519ec9be2049c2f38b16239712"
     },
     {
-      "prompt_path": "pdd/prompts/agentic_checkup_orchestrator_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:fc372c0369c895e42b4bb8f9277560facf086d999233d88bef8401766bccdf34",
-      "to_requirement_id": "CONTRACT-SHA256:379831026c7d037c2b7b529d48fcff8f33bfeb909b3608cc56aa35abdffa4134",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "7df63fe892ac14382f226ea97dbd2ac186a8cb48213faec958ad32c51d51aeb5",
-      "head_policy_sha256": "8e3ba247e42d1a4e1df3e1ba968b390595aa1173184f93419eea16af32fa89fc",
-      "base_prompt_sha256": "fc372c0369c895e42b4bb8f9277560facf086d999233d88bef8401766bccdf34",
-      "head_prompt_sha256": "379831026c7d037c2b7b529d48fcff8f33bfeb909b3608cc56aa35abdffa4134"
-    },
-    {
       "prompt_path": "pdd/prompts/agentic_checkup_python.prompt",
       "language_id": "python",
       "from_requirement_id": "CONTRACT-SHA256:fef53dad8950c06cc11e41265956a2ee174a90ff9e4985d7f30610f18c47b08b",
@@ -96,17 +85,6 @@
       "head_policy_sha256": "8e3ba247e42d1a4e1df3e1ba968b390595aa1173184f93419eea16af32fa89fc",
       "base_prompt_sha256": "e12dc6b48f34111182afb4a73b9ba66596617b9a6d8e393766d2cd6b847562ec",
       "head_prompt_sha256": "fc595464ceb1bac758864cd66a87fd1ba4f72bae79660a1dd334e060cbb861f7"
-    },
-    {
-      "prompt_path": "pdd/prompts/agentic_common_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:86e47992102e2344fe59ee9a3ece4c6cf356025edaadf693c12acac63a5c7490",
-      "to_requirement_id": "CONTRACT-SHA256:c00fe698b5d829e1f2801c290f1bf425d2e7b392b733b7916519c6c39528b900",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "f0f1d36e337541ba4425f081e236c42847f8132cb61f9f8fe06334a805fc5c7b",
-      "head_policy_sha256": "71b12a08e5be55b958a737decde889c189f7ca00ceaddccd7b587f9c8b2a4b64",
-      "base_prompt_sha256": "86e47992102e2344fe59ee9a3ece4c6cf356025edaadf693c12acac63a5c7490",
-      "head_prompt_sha256": "c00fe698b5d829e1f2801c290f1bf425d2e7b392b733b7916519c6c39528b900"
     },
     {
       "prompt_path": "pdd/prompts/commands/checkup_python.prompt",
@@ -283,6 +261,28 @@
       "head_policy_sha256": "85fbc4f5957e9872b7d368a1b6f9e8c3bad852142ed4c0ec49589eaf63bd8fb3",
       "base_prompt_sha256": "afffd825b4495819b853fec9a86b0be7644f6fe0468d40548d8b9b2803d183ce",
       "head_prompt_sha256": "8f4ef46cf85f9ed8e4ff28732dba2614005a1d50d6793ceb25e15608d5ffb751"
+    },
+    {
+      "prompt_path": "pdd/prompts/agentic_checkup_orchestrator_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:379831026c7d037c2b7b529d48fcff8f33bfeb909b3608cc56aa35abdffa4134",
+      "to_requirement_id": "CONTRACT-SHA256:1c1d2b6f57e191e486cd33dd5540cc27c25b64c88ec4e9a08edf2151f6468d12",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "56ea5d189034c9d85e91c86348689eb18c4c34fa67406258f78f0ae3330eaeb6",
+      "head_policy_sha256": "b3886522c0056e872c6d336d2b46c4900467f12b5f66d9f4b21aa2251e1180a3",
+      "base_prompt_sha256": "379831026c7d037c2b7b529d48fcff8f33bfeb909b3608cc56aa35abdffa4134",
+      "head_prompt_sha256": "1c1d2b6f57e191e486cd33dd5540cc27c25b64c88ec4e9a08edf2151f6468d12"
+    },
+    {
+      "prompt_path": "pdd/prompts/agentic_common_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:c00fe698b5d829e1f2801c290f1bf425d2e7b392b733b7916519c6c39528b900",
+      "to_requirement_id": "CONTRACT-SHA256:e4b8ea5e9122504817d93e4229ff4328a082cb2fd2ab94ac3b0be2a89096207c",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "56ea5d189034c9d85e91c86348689eb18c4c34fa67406258f78f0ae3330eaeb6",
+      "head_policy_sha256": "b3886522c0056e872c6d336d2b46c4900467f12b5f66d9f4b21aa2251e1180a3",
+      "base_prompt_sha256": "c00fe698b5d829e1f2801c290f1bf425d2e7b392b733b7916519c6c39528b900",
+      "head_prompt_sha256": "e4b8ea5e9122504817d93e4229ff4328a082cb2fd2ab94ac3b0be2a89096207c"
     }
   ]
 }

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -189,6 +189,22 @@ _BOOTSTRAP_REQUIREMENT_TRANSITIONS = (
         "8e3ba247e42d1a4e1df3e1ba968b390595aa1173184f93419eea16af32fa89fc",
     ),
     _exact_bootstrap_requirement_transition(
+        "pdd/prompts/agentic_checkup_orchestrator_python.prompt",
+        "python",
+        "379831026c7d037c2b7b529d48fcff8f33bfeb909b3608cc56aa35abdffa4134",
+        "1c1d2b6f57e191e486cd33dd5540cc27c25b64c88ec4e9a08edf2151f6468d12",
+        "56ea5d189034c9d85e91c86348689eb18c4c34fa67406258f78f0ae3330eaeb6",
+        "b3886522c0056e872c6d336d2b46c4900467f12b5f66d9f4b21aa2251e1180a3",
+    ),
+    _exact_bootstrap_requirement_transition(
+        "pdd/prompts/agentic_common_python.prompt",
+        "python",
+        "c00fe698b5d829e1f2801c290f1bf425d2e7b392b733b7916519c6c39528b900",
+        "e4b8ea5e9122504817d93e4229ff4328a082cb2fd2ab94ac3b0be2a89096207c",
+        "56ea5d189034c9d85e91c86348689eb18c4c34fa67406258f78f0ae3330eaeb6",
+        "b3886522c0056e872c6d336d2b46c4900467f12b5f66d9f4b21aa2251e1180a3",
+    ),
+    _exact_bootstrap_requirement_transition(
         "pdd/prompts/agentic_checkup_python.prompt",
         "python",
         "fef53dad8950c06cc11e41265956a2ee174a90ff9e4985d7f30610f18c47b08b",

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -478,22 +478,60 @@ def _requirement_authorization_row(authorization) -> dict[str, str]:
 
 
 def test_committed_rotations_equal_exact_protected_authority() -> None:
-    """Only exact consumed bootstrap or protected #2204 bindings reach policy."""
+    """Only exact bootstrap bindings reach active protected authority."""
     policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
     rows = policy["requirement_rotations"]
-    bootstrap_rows = {
-        (row["prompt_path"], row["language_id"]): row
-        for row in map(
+    bootstrap_rows = list(
+        map(
             _requirement_authorization_row,
             verification._BOOTSTRAP_REQUIREMENT_TRANSITIONS,  # pylint: disable=protected-access
         )
+    )
+    parsed_rows = verification._parse_requirement_transition_authorizations(  # pylint: disable=protected-access
+        ROTATION_FILE.read_bytes(), "protected"
+    )
+    parsed_retirements = verification._parse_requirement_transition_retirements(  # pylint: disable=protected-access
+        ROTATION_FILE.read_bytes(), "protected"
+    )
+    active_rows = verification._active_requirement_transition_authorizations(  # pylint: disable=protected-access
+        parsed_rows, parsed_retirements, "protected"
+    )
+    policy_rows = {
+        (row["prompt_path"], row["language_id"]): row
+        for row in map(_requirement_authorization_row, active_rows)
     }
-    policy_rows = {(row["prompt_path"], row["language_id"]): row for row in rows}
-    assert len(rows) == len(policy_rows) == len(bootstrap_rows) == 25
+    consumed_rows = {
+        (
+            "pdd/prompts/agentic_checkup_orchestrator_python.prompt",
+            "CONTRACT-SHA256:fc372c0369c895e42b4bb8f9277560facf086d999233d88bef8401766bccdf34",
+        ),
+        (
+            "pdd/prompts/agentic_common_python.prompt",
+            "CONTRACT-SHA256:86e47992102e2344fe59ee9a3ece4c6cf356025edaadf693c12acac63a5c7490",
+        ),
+    }
+    expected_rows = {
+        (row["prompt_path"], row["language_id"]): row
+        for row in bootstrap_rows
+        if (row["prompt_path"], row["from_requirement_id"]) not in consumed_rows
+    }
+    assert policy["schema_version"] == 2
+    assert len(rows) == 25
+    assert len(bootstrap_rows) == 27
+    assert not parsed_retirements
+    assert len(active_rows) == len(policy_rows) == len(expected_rows) == 25
+    assert not any(
+        (row["prompt_path"], row["from_requirement_id"]) in consumed_rows
+        for row in rows
+    )
+    assert all(
+        row in bootstrap_rows or row == STORY_REGRESSION_DORMANT_ROTATION
+        for row in rows
+    )
     story_identity = (STORY_REGRESSION_DORMANT_ROTATION["prompt_path"], "python")
-    assert bootstrap_rows[story_identity] != STORY_REGRESSION_DORMANT_ROTATION
-    bootstrap_rows[story_identity] = STORY_REGRESSION_DORMANT_ROTATION
-    assert policy_rows == bootstrap_rows
+    assert expected_rows[story_identity] != STORY_REGRESSION_DORMANT_ROTATION
+    expected_rows[story_identity] = STORY_REGRESSION_DORMANT_ROTATION
+    assert policy_rows == expected_rows
 
     profile_digest = hashlib.sha256(PROFILE_FILE.read_bytes()).hexdigest()
     assert profile_digest == STORY_REGRESSION_DORMANT_ROTATION["head_policy_sha256"]
@@ -521,9 +559,8 @@ def test_committed_rotations_equal_exact_protected_authority() -> None:
         if row["head_policy_sha256"]
         == STORY_REGRESSION_DORMANT_ROTATION["base_policy_sha256"]
     ]
-    assert len(pdd1989_rows) == 7
+    assert len(pdd1989_rows) == 6
     assert {row["prompt_path"] for row in pdd1989_rows} == {
-        "pdd/prompts/agentic_common_python.prompt",
         "pdd/prompts/commands/checkup_python.prompt",
         "pdd/prompts/generate_model_catalog_python.prompt",
         "pdd/prompts/llm_invoke_python.prompt",
@@ -548,7 +585,7 @@ def test_committed_rotations_equal_exact_protected_authority() -> None:
         if row["head_policy_sha256"]
         == "8e3ba247e42d1a4e1df3e1ba968b390595aa1173184f93419eea16af32fa89fc"
     ]
-    assert len(pr1790_rows) == 7
+    assert len(pr1790_rows) == 6
     base_policy_digest = pr1790_rows[0]["base_policy_sha256"]
     head_policy_digest = pr1790_rows[0]["head_policy_sha256"]
     assert base_policy_digest == (


### PR DESCRIPTION
## Summary

- preauthorize the exact `agentic_checkup_orchestrator` and `agentic_common` requirement transitions needed by #2168
- remove the two already-consumed historical rows while preserving every surviving schema-2 row byte-for-byte and in order
- append the two replacement authorities bound to current `main` profile `56ea5d18…` and projected rebased #2168 profile `b3886522…`
- extend bootstrap authority and governance tests for the exact protected history

## Why

PR #2168 cannot validly install and consume these protected transitions in one candidate under the two-phase governance contract. This authority-only Phase-A change establishes the reviewed transition authority on `main`; #2168 can then update from `main` and consume it without weakening or rewriting protected baselines.

## Impact

This PR changes no managed prompt bytes, verification-profile bytes, runtime verifier behavior, or #2168 implementation. It installs only narrowly scoped authority bound to exact prompt and policy hashes.

## Validation

- exact HEAD-based Phase-A dormancy and rollout selection: 4 passed
- `tests/test_sync_core_verification_profiles.py`: 80 passed
- schema-2 consumed-row and replacement selection: 6 passed
- committed-ledger focused gate: passed
- JSON validation and `git diff --check`: passed

The broader initial local selection encountered host disk exhaustion in clone-heavy tests; required exact-head CI is the authoritative broad gate.

## Follow-up

After this Phase-A PR is reviewed and merged, update existing PR #2168 from `main`, resolve its now-mechanical conflicts, rerun exact-head checks and Sol review, and keep all CLI implementation changes on #2168.

Replaces #2234, which was opened through the wrong connected GitHub identity and was not merged.