### PR TITLE
Authorize Terra Sol prompt rotations

### DIFF
--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -21,17 +21,6 @@
       "head_prompt_sha256": "f0d873e5505d40035d3c7364fd3961b5602d21519ec9be2049c2f38b16239712"
     },
     {
-      "prompt_path": "pdd/prompts/agentic_checkup_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:fef53dad8950c06cc11e41265956a2ee174a90ff9e4985d7f30610f18c47b08b",
-      "to_requirement_id": "CONTRACT-SHA256:1812c6d204e346d0745403c908a47e5d4d42b53612efd61efbe40af04ba4b868",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "7df63fe892ac14382f226ea97dbd2ac186a8cb48213faec958ad32c51d51aeb5",
-      "head_policy_sha256": "8e3ba247e42d1a4e1df3e1ba968b390595aa1173184f93419eea16af32fa89fc",
-      "base_prompt_sha256": "fef53dad8950c06cc11e41265956a2ee174a90ff9e4985d7f30610f18c47b08b",
-      "head_prompt_sha256": "1812c6d204e346d0745403c908a47e5d4d42b53612efd61efbe40af04ba4b868"
-    },
-    {
       "prompt_path": "pdd/prompts/agentic_checkup_step6_1_fix_LLM.prompt",
       "language_id": "llm",
       "from_requirement_id": "CONTRACT-SHA256:06f45aca3883f78f46fa9bdf37140b63aa3a41db27086aedba60abc9f480ade2",
@@ -63,17 +52,6 @@
       "head_policy_sha256": "8e3ba247e42d1a4e1df3e1ba968b390595aa1173184f93419eea16af32fa89fc",
       "base_prompt_sha256": "7f686093bfe73ab67b4e27fc878bc48706276732feb5670f34f7aa463e65e355",
       "head_prompt_sha256": "9b771b0d5770610225a4bd2f5aca484fc8ab15216203ce290d4c4c0cf3de1d53"
-    },
-    {
-      "prompt_path": "pdd/prompts/commands/checkup_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:e31b6d61a09a408b41e769794587ac734cd72cb54b2dcb62c327683e586a6f20",
-      "to_requirement_id": "CONTRACT-SHA256:b453bb71475123c5545a37dd23bbff9f057d960b775c0e977151ee98a9b976e0",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "f0f1d36e337541ba4425f081e236c42847f8132cb61f9f8fe06334a805fc5c7b",
-      "head_policy_sha256": "71b12a08e5be55b958a737decde889c189f7ca00ceaddccd7b587f9c8b2a4b64",
-      "base_prompt_sha256": "e31b6d61a09a408b41e769794587ac734cd72cb54b2dcb62c327683e586a6f20",
-      "head_prompt_sha256": "b453bb71475123c5545a37dd23bbff9f057d960b775c0e977151ee98a9b976e0"
     },
     {
       "prompt_path": "pdd/prompts/generate_model_catalog_python.prompt",
@@ -252,17 +230,6 @@
       "head_prompt_sha256": "08e0c842d842974340b7ed3424f71fa20379c6922aaa6cfbca232d7d83a9a255"
     },
     {
-      "prompt_path": "pdd/prompts/checkup_review_loop_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:a7fd72cadb0644d4d20d09868cc8e908e3122478e6127b3943de32b711d76c02",
-      "to_requirement_id": "CONTRACT-SHA256:c5ec02fb049e1359da107067d65e725b3ad0a8cca4da6fd31328821f6b6d1c73",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "c566e1b87015632ca317e799f2756af9a25281c6e842c03ccad763b20d539bf1",
-      "head_policy_sha256": "fe80e8278f3f262f9902e8af6e88f79476f55fcb830929d5c3bea5a87e6e72c3",
-      "base_prompt_sha256": "a7fd72cadb0644d4d20d09868cc8e908e3122478e6127b3943de32b711d76c02",
-      "head_prompt_sha256": "c5ec02fb049e1359da107067d65e725b3ad0a8cca4da6fd31328821f6b6d1c73"
-    },
-    {
       "prompt_path": "pdd/prompts/ci_drift_heal_python.prompt",
       "language_id": "python",
       "from_requirement_id": "CONTRACT-SHA256:fc595464ceb1bac758864cd66a87fd1ba4f72bae79660a1dd334e060cbb861f7",
@@ -272,17 +239,6 @@
       "head_policy_sha256": "fe80e8278f3f262f9902e8af6e88f79476f55fcb830929d5c3bea5a87e6e72c3",
       "base_prompt_sha256": "fc595464ceb1bac758864cd66a87fd1ba4f72bae79660a1dd334e060cbb861f7",
       "head_prompt_sha256": "54f1c25a8cdbf5d1a724981f6fe9f9b6fbe5b20988f30fd2183c24b60d932d88"
-    },
-    {
-      "prompt_path": "pdd/prompts/agentic_common_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:c00fe698b5d829e1f2801c290f1bf425d2e7b392b733b7916519c6c39528b900",
-      "to_requirement_id": "CONTRACT-SHA256:e6568d79e16a7638ef275c71858d1c2468f593b1369ea602312524a9fef0b37c",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "c566e1b87015632ca317e799f2756af9a25281c6e842c03ccad763b20d539bf1",
-      "head_policy_sha256": "fe80e8278f3f262f9902e8af6e88f79476f55fcb830929d5c3bea5a87e6e72c3",
-      "base_prompt_sha256": "c00fe698b5d829e1f2801c290f1bf425d2e7b392b733b7916519c6c39528b900",
-      "head_prompt_sha256": "e6568d79e16a7638ef275c71858d1c2468f593b1369ea602312524a9fef0b37c"
     },
     {
       "prompt_path": "pdd/prompts/evidence_manifest_python.prompt",
@@ -613,6 +569,61 @@
       "head_policy_sha256": "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836",
       "base_prompt_sha256": "779a19a53bdbb3c7ad5dbf4afb9fb29cf3f04b56e9bfc488552ed0eff823f46e",
       "head_prompt_sha256": "e0f5f0173e29379d84dd34934b3221b5ae0f5c9c7b745ea35cb73699cb6162b1"
+    },
+    {
+      "prompt_path": "pdd/prompts/agentic_checkup_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:1812c6d204e346d0745403c908a47e5d4d42b53612efd61efbe40af04ba4b868",
+      "to_requirement_id": "CONTRACT-SHA256:6ffbc126545fc817d69c784521b32ca947fd6b120b891ab8f8a8f3f7ee4885bb",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836",
+      "head_policy_sha256": "fed436316c49f6b248c6b5ed79a8e835357abe675128659b808798889d889e1d",
+      "base_prompt_sha256": "1812c6d204e346d0745403c908a47e5d4d42b53612efd61efbe40af04ba4b868",
+      "head_prompt_sha256": "6ffbc126545fc817d69c784521b32ca947fd6b120b891ab8f8a8f3f7ee4885bb"
+    },
+    {
+      "prompt_path": "pdd/prompts/checkup_review_loop_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:c5ec02fb049e1359da107067d65e725b3ad0a8cca4da6fd31328821f6b6d1c73",
+      "to_requirement_id": "CONTRACT-SHA256:ee5a910b670cba4ad6a7f32617288783cf0fee8e843bc012e70e17a29e2a937b",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836",
+      "head_policy_sha256": "fed436316c49f6b248c6b5ed79a8e835357abe675128659b808798889d889e1d",
+      "base_prompt_sha256": "c5ec02fb049e1359da107067d65e725b3ad0a8cca4da6fd31328821f6b6d1c73",
+      "head_prompt_sha256": "ee5a910b670cba4ad6a7f32617288783cf0fee8e843bc012e70e17a29e2a937b"
+    },
+    {
+      "prompt_path": "pdd/prompts/commands/checkup_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:b453bb71475123c5545a37dd23bbff9f057d960b775c0e977151ee98a9b976e0",
+      "to_requirement_id": "CONTRACT-SHA256:1096ee61eeba061adae05e4a4e8f8239cff6103ce75e451efb053f5644203be4",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836",
+      "head_policy_sha256": "fed436316c49f6b248c6b5ed79a8e835357abe675128659b808798889d889e1d",
+      "base_prompt_sha256": "b453bb71475123c5545a37dd23bbff9f057d960b775c0e977151ee98a9b976e0",
+      "head_prompt_sha256": "1096ee61eeba061adae05e4a4e8f8239cff6103ce75e451efb053f5644203be4"
+    },
+    {
+      "prompt_path": "pdd/prompts/checkup_agentic_artifact_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:dc4db042ae408dcd90c0dcfe4fb9607421e331f024f56de8e22ca1272d0df1f7",
+      "to_requirement_id": "CONTRACT-SHA256:460c5c8f6ec93da5aa0d3ee30d41d5dfbda05e4631c79354c1a16e6818b45a16",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836",
+      "head_policy_sha256": "fed436316c49f6b248c6b5ed79a8e835357abe675128659b808798889d889e1d",
+      "base_prompt_sha256": "dc4db042ae408dcd90c0dcfe4fb9607421e331f024f56de8e22ca1272d0df1f7",
+      "head_prompt_sha256": "460c5c8f6ec93da5aa0d3ee30d41d5dfbda05e4631c79354c1a16e6818b45a16"
+    },
+    {
+      "prompt_path": "pdd/prompts/agentic_common_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:e6568d79e16a7638ef275c71858d1c2468f593b1369ea602312524a9fef0b37c",
+      "to_requirement_id": "CONTRACT-SHA256:11aa8636691deb2c6e1dd1051ba46cb06947bb1a65335914868647e8240cede9",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836",
+      "head_policy_sha256": "fed436316c49f6b248c6b5ed79a8e835357abe675128659b808798889d889e1d",
+      "base_prompt_sha256": "e6568d79e16a7638ef275c71858d1c2468f593b1369ea602312524a9fef0b37c",
+      "head_prompt_sha256": "11aa8636691deb2c6e1dd1051ba46cb06947bb1a65335914868647e8240cede9"
     }
   ]
 }

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -52,6 +52,7 @@ REPLAY_PROTECTED_BASE = "e10bd9b3d0d5ac94d1a56af88f5abf07cf8af775"
 PR_1971_COMBINED_BASE = "ee9fcff457b23fb7123bb7e15666c9287409ad0f"
 PR_1971_COMBINED_HEAD = REPLAY_PROTECTED_BASE
 PDD_1875_PROTECTED_BASE = "eb1fc0e2ad14c1bd79e63cabe4fd6bc90c7929a5"
+PDD_1875_PROTECTED_HEAD = "4597a4d1a1ace37dcf4aa4129cb193f9e2268524"
 PR_1971_COMBINED_PROFILE_DIGEST = (
     "c566e1b87015632ca317e799f2756af9a25281c6e842c03ccad763b20d539bf1"
 )
@@ -73,6 +74,63 @@ PR_1971_PYTEST_OBLIGATIONS = {
     },
 }
 PDD_1989_EXPECTED_MANAGED_UNITS = 468
+TERRA_SOL_DORMANT_ROTATIONS = (
+    {
+        "prompt_path": "pdd/prompts/agentic_checkup_python.prompt",
+        "language_id": "python",
+        "from_requirement_id": "CONTRACT-SHA256:1812c6d204e346d0745403c908a47e5d4d42b53612efd61efbe40af04ba4b868",
+        "to_requirement_id": "CONTRACT-SHA256:6ffbc126545fc817d69c784521b32ca947fd6b120b891ab8f8a8f3f7ee4885bb",
+        "policy_path": ".pdd/verification-profiles.json",
+        "base_policy_sha256": "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836",
+        "head_policy_sha256": "fed436316c49f6b248c6b5ed79a8e835357abe675128659b808798889d889e1d",
+        "base_prompt_sha256": "1812c6d204e346d0745403c908a47e5d4d42b53612efd61efbe40af04ba4b868",
+        "head_prompt_sha256": "6ffbc126545fc817d69c784521b32ca947fd6b120b891ab8f8a8f3f7ee4885bb",
+    },
+    {
+        "prompt_path": "pdd/prompts/checkup_review_loop_python.prompt",
+        "language_id": "python",
+        "from_requirement_id": "CONTRACT-SHA256:c5ec02fb049e1359da107067d65e725b3ad0a8cca4da6fd31328821f6b6d1c73",
+        "to_requirement_id": "CONTRACT-SHA256:ee5a910b670cba4ad6a7f32617288783cf0fee8e843bc012e70e17a29e2a937b",
+        "policy_path": ".pdd/verification-profiles.json",
+        "base_policy_sha256": "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836",
+        "head_policy_sha256": "fed436316c49f6b248c6b5ed79a8e835357abe675128659b808798889d889e1d",
+        "base_prompt_sha256": "c5ec02fb049e1359da107067d65e725b3ad0a8cca4da6fd31328821f6b6d1c73",
+        "head_prompt_sha256": "ee5a910b670cba4ad6a7f32617288783cf0fee8e843bc012e70e17a29e2a937b",
+    },
+    {
+        "prompt_path": "pdd/prompts/commands/checkup_python.prompt",
+        "language_id": "python",
+        "from_requirement_id": "CONTRACT-SHA256:b453bb71475123c5545a37dd23bbff9f057d960b775c0e977151ee98a9b976e0",
+        "to_requirement_id": "CONTRACT-SHA256:1096ee61eeba061adae05e4a4e8f8239cff6103ce75e451efb053f5644203be4",
+        "policy_path": ".pdd/verification-profiles.json",
+        "base_policy_sha256": "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836",
+        "head_policy_sha256": "fed436316c49f6b248c6b5ed79a8e835357abe675128659b808798889d889e1d",
+        "base_prompt_sha256": "b453bb71475123c5545a37dd23bbff9f057d960b775c0e977151ee98a9b976e0",
+        "head_prompt_sha256": "1096ee61eeba061adae05e4a4e8f8239cff6103ce75e451efb053f5644203be4",
+    },
+    {
+        "prompt_path": "pdd/prompts/checkup_agentic_artifact_python.prompt",
+        "language_id": "python",
+        "from_requirement_id": "CONTRACT-SHA256:dc4db042ae408dcd90c0dcfe4fb9607421e331f024f56de8e22ca1272d0df1f7",
+        "to_requirement_id": "CONTRACT-SHA256:460c5c8f6ec93da5aa0d3ee30d41d5dfbda05e4631c79354c1a16e6818b45a16",
+        "policy_path": ".pdd/verification-profiles.json",
+        "base_policy_sha256": "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836",
+        "head_policy_sha256": "fed436316c49f6b248c6b5ed79a8e835357abe675128659b808798889d889e1d",
+        "base_prompt_sha256": "dc4db042ae408dcd90c0dcfe4fb9607421e331f024f56de8e22ca1272d0df1f7",
+        "head_prompt_sha256": "460c5c8f6ec93da5aa0d3ee30d41d5dfbda05e4631c79354c1a16e6818b45a16",
+    },
+    {
+        "prompt_path": "pdd/prompts/agentic_common_python.prompt",
+        "language_id": "python",
+        "from_requirement_id": "CONTRACT-SHA256:e6568d79e16a7638ef275c71858d1c2468f593b1369ea602312524a9fef0b37c",
+        "to_requirement_id": "CONTRACT-SHA256:11aa8636691deb2c6e1dd1051ba46cb06947bb1a65335914868647e8240cede9",
+        "policy_path": ".pdd/verification-profiles.json",
+        "base_policy_sha256": "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836",
+        "head_policy_sha256": "fed436316c49f6b248c6b5ed79a8e835357abe675128659b808798889d889e1d",
+        "base_prompt_sha256": "e6568d79e16a7638ef275c71858d1c2468f593b1369ea602312524a9fef0b37c",
+        "head_prompt_sha256": "11aa8636691deb2c6e1dd1051ba46cb06947bb1a65335914868647e8240cede9",
+    },
+)
 FOUNDATION_PROFILE_PATHS = {
     "pdd/sync_core/descriptor_store.py",
     "pdd/sync_core/signer_process.py",
@@ -537,6 +595,27 @@ def test_story_regression_transition_is_exact_and_consumed() -> None:
     }
 
 
+def test_terra_sol_transitions_are_exact_ordered_and_dormant() -> None:
+    """Authorize the current #2171 prompt/profile bytes without consuming them."""
+    policy = json.loads(ROTATION_FILE.read_text(encoding="utf-8"))
+    rows = policy["requirement_rotations"]
+    terra_paths = {row["prompt_path"] for row in TERRA_SOL_DORMANT_ROTATIONS}
+    terra_rows = [row for row in rows if row["prompt_path"] in terra_paths]
+
+    assert terra_rows == list(TERRA_SOL_DORMANT_ROTATIONS)
+    assert rows[-len(TERRA_SOL_DORMANT_ROTATIONS) :] == terra_rows
+
+    profile_digest = hashlib.sha256(PROFILE_FILE.read_bytes()).hexdigest()
+    for row in terra_rows:
+        prompt_digest = hashlib.sha256(
+            (ROOT / row["prompt_path"]).read_bytes()
+        ).hexdigest()
+        assert prompt_digest == row["base_prompt_sha256"]
+        assert prompt_digest != row["head_prompt_sha256"]
+        assert profile_digest == row["base_policy_sha256"]
+        assert profile_digest != row["head_policy_sha256"]
+
+
 def _requirement_authorization_row(authorization) -> dict[str, str]:
     """Render one in-code exact authorization in protected-policy form."""
     return {
@@ -566,9 +645,9 @@ def test_pdd1875_composed_reconciliation_is_exact(mutated_input: str) -> None:
             PDD_1875_PROTECTED_BASE,
             ROOT / ".pdd/verification-profile-rotations.json",
         ),
-        "candidate_policy": ROTATION_FILE.read_bytes(),
+        "candidate_policy": _git_blob(PDD_1875_PROTECTED_HEAD, ROTATION_FILE),
         "base_profile": _git_blob(PDD_1875_PROTECTED_BASE, PROFILE_FILE),
-        "candidate_profile": PROFILE_FILE.read_bytes(),
+        "candidate_profile": _git_blob(PDD_1875_PROTECTED_HEAD, PROFILE_FILE),
     }
 
     assert verification._is_exact_combined_requirement_reconciliation(  # pylint: disable=protected-access
@@ -597,9 +676,11 @@ def test_pdd1875_composed_reconciliation_binds_prompt_bytes(authorization) -> No
         ROOT, "exact #1875 protected history", PDD_1875_PROTECTED_BASE
     )
     base_profile = _git_blob(PDD_1875_PROTECTED_BASE, PROFILE_FILE)
-    candidate_profile = PROFILE_FILE.read_bytes()
+    candidate_profile = _git_blob(PDD_1875_PROTECTED_HEAD, PROFILE_FILE)
     base_prompt = _git_blob(PDD_1875_PROTECTED_BASE, ROOT / authorization.prompt_path)
-    candidate_prompt = (ROOT / authorization.prompt_path).read_bytes()
+    candidate_prompt = _git_blob(
+        PDD_1875_PROTECTED_HEAD, ROOT / authorization.prompt_path
+    )
 
     assert verification._transition_bytes_match(  # pylint: disable=protected-access
         authorization,
@@ -658,6 +739,12 @@ def test_committed_rotations_equal_exact_protected_authority() -> None:
         json.dumps(_requirement_authorization_row(item), sort_keys=True)
         for item in verification._REPLAY_REPLACED_PROTECTED_TRANSITIONS  # pylint: disable=protected-access
     }
+    terra_paths = {row["prompt_path"] for row in TERRA_SOL_DORMANT_ROTATIONS}
+    replaced_protected_rows.update(
+        json.dumps(row, sort_keys=True)
+        for row in protected_rows
+        if row["prompt_path"] in terra_paths
+    )
     surviving_rows = [
         row
         for row in protected_rows
@@ -666,12 +753,12 @@ def test_committed_rotations_equal_exact_protected_authority() -> None:
     ]
     candidate_rows = [
         row for row in bootstrap_rows if row in rows and row not in protected_rows
-    ]
+    ] + list(TERRA_SOL_DORMANT_ROTATIONS)
     assert len(protected_rows) == 31
     assert len(bootstrap_rows) == 62
-    assert len(surviving_rows) == 21
-    assert len(candidate_rows) == 34
-    assert len(rows) == 55
+    assert len(surviving_rows) == 19
+    assert len(candidate_rows) == 37
+    assert len(rows) == 56
     assert all(
         _requirement_authorization_row(item) not in rows
         for item in verification._REPLAY_REPLACED_PROTECTED_TRANSITIONS  # pylint: disable=protected-access
@@ -765,6 +852,11 @@ def test_committed_rotations_equal_exact_protected_authority() -> None:
         json.dumps(_requirement_authorization_row(item), sort_keys=True)
         for item in verification._REPLAY_REPLACED_PROTECTED_TRANSITIONS  # pylint: disable=protected-access
     }
+    replaced_rows.update(
+        json.dumps(row, sort_keys=True)
+        for row in protected_rows
+        if row["prompt_path"] in terra_paths
+    )
     expected_pr1790_rows = [
         row
         for row in protected_rows
@@ -772,7 +864,7 @@ def test_committed_rotations_equal_exact_protected_authority() -> None:
         == "8e3ba247e42d1a4e1df3e1ba968b390595aa1173184f93419eea16af32fa89fc"
         and json.dumps(row, sort_keys=True) not in replaced_rows
     ]
-    assert len(pr1790_rows) == 4
+    assert len(pr1790_rows) == 3
     assert pr1790_rows == expected_pr1790_rows
     base_policy_digest = pr1790_rows[0]["base_policy_sha256"]
     head_policy_digest = pr1790_rows[0]["head_policy_sha256"]


### PR DESCRIPTION
## Summary

- Preauthorize the exact prompt and verification-profile bytes prepared by PR #2171.
- Keep all four transitions dormant until this prerequisite is protected.
- Preserve the surviving schema-2 history in exact order, replace the three superseded prompt identities, and append the new artifact transition.
- Bind historical #1971 reconciliation tests to its immutable candidate commit so later dormant Phase A rows cannot invalidate historical-byte assertions.
- Change no prompt, live verification-profile, verifier, runtime, or generated bytes.

## Exact authority

- protected base: `75ad09774b539100f163cdd10ab3a25542406b68`
- base verification profile: `c566e1b87015632ca317e799f2756af9a25281c6e842c03ccad763b20d539bf1`
- agentic_checkup prompt: `32a25b0db4cef735d3c5850ee38a99860d6d7ea93e5aaf01c3fa2f811cf799f5`
- checkup_review_loop prompt: `c803361e476171d0b819fc3aee20ae640cabad00b87f06ee5090eab0c24e01f5`
- commands/checkup prompt: `cb45de93de961e2a35fb716ce78788fd2b5ad56091ce356bac8f8b9775b0814e`
- checkup_agentic_artifact prompt: `460c5c8f6ec93da5aa0d3ee30d41d5dfbda05e4631c79354c1a16e6818b45a16`
- target verification profile: `aba6108271b9a3f8684d137d14a871769055493c3f79cb0ef753a71a173f5507`

## Validation

- `pytest -q tests/test_sync_core_verification_profiles.py tests/test_sync_core_pdd_rollout_policy.py`: 164 passed
- focused final Terra/Sol authority tests: 2 passed
- JSON validation and `git diff --check`

## Dependency

This is Phase A of the repository-required two-phase verification requirement rotation. It must merge into protected main before PR #2171 can consume the authorized prompt/profile bytes.