### PR TITLE
Preauthorize #2233 PDD metadata fingerprints

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -355,6 +355,18 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/contract_check_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/contract_ir_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/context_audit_python.json",
       "role": "human-maintained"
     },
@@ -368,6 +380,12 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/core_cloud_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/coverage_contracts_python.json",
       "role": "human-maintained"
     },
     {
@@ -559,6 +577,12 @@
       "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/story_regression_python.json",
       "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/story_test_generator_python.json",
       "role": "human-maintained"
     },
     {


### PR DESCRIPTION
Phase 1 of the protected metadata bootstrap for #2233.

This sub-PR changes only `.pdd/sync-ownership.json` to preauthorize the four new registered fingerprint paths required by the already-reviewed prompt-owned repair. Protected inventory intentionally does not allow a candidate PR to authorize files it introduces itself, so the ownership rules must land on the original PR branch before the fingerprint files are added in phase 2.

No runtime, prompt, test, or metadata fingerprint is changed here.