### PR TITLE
Preauthorize #2233 validation artifacts

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -250,6 +250,13 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/architecture_sync_python_run.json",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/checkup_agentic_artifact_python.json",
       "preauthorize_absent": true,
       "role": "human-maintained"
@@ -1911,6 +1918,20 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": "context/contract_check_example.py",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/contract_ir_example.py",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": "context/content_selector_example.py",
       "role": "human-maintained"
     },
@@ -1978,6 +1999,13 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "context/core/utils_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/coverage_contracts_example.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
@@ -2592,6 +2620,13 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "context/story_regression_gate_example.py",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "context/story_test_generator_example.py",
+      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {


### PR DESCRIPTION
Preauthorizes the four missing canonical example paths and the architecture run-report path before those artifacts are added.

This is the required first phase of the protected ownership workflow for #2233. The generated artifacts will be proposed separately only after this commit lands on the base branch.

Refs #2233