### PR TITLE
Consume #2233 artifact preauthorizations

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -251,7 +251,6 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/architecture_sync_python_run.json",
-      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
@@ -1919,14 +1918,12 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "context/contract_check_example.py",
-      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "context/contract_ir_example.py",
-      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
@@ -2005,7 +2002,6 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "context/coverage_contracts_example.py",
-      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {
@@ -2626,7 +2622,6 @@
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
       "pattern": "context/story_test_generator_example.py",
-      "preauthorize_absent": true,
       "role": "human-maintained"
     },
     {


### PR DESCRIPTION
Removes the temporary `preauthorize_absent` flags now that the four canonical examples and architecture run report have landed.

This completes the protected ownership two-phase rollout begun in #2247 and consumed by #2248.

Refs #2233