### PR TITLE
Preauthorize #2246 context generator metadata

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -379,6 +379,13 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/context_generator_main_python.json",
+      "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/context_snapshot_python.json",
       "role": "human-maintained"
     },

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -181,6 +181,7 @@ PREAUTHORIZED_CHILD_PATHS = (
         "pdd/sync_core/human_attestation.py",
         "tests/test_sync_core_human_attestation.py",
         ".pdd/meta/ci_detect_changed_modules_python.json",
+        ".pdd/meta/context_generator_main_python.json",
         ".pdd/meta/evidence_manifest_python.json",
         ".pdd/meta/story_detection_result_python.json",
         "pdd/schemas/story_detection_result.schema.json",


### PR DESCRIPTION
Preauthorizes the previously absent managed fingerprint for `context_generator_main` before the #2246 prompt/runtime repair creates it.

This is the ownership-first phase; the functional and metadata commit will follow separately after this lands.

Refs #2246
Refs #2233