### PR TITLE
test(update): stabilize include dependency fixture

### DIFF
--- a/tests/test_update_main.py
+++ b/tests/test_update_main.py
@@ -2235,10 +2235,9 @@ class TestIsCodeChanged:
 
         code_file = tmp_path / "module.py"
         code_file.write_text("def foo(): pass\n")
-        current_hash = calculate_sha256(code_file, tmp_path)
-
         dep_file = tmp_path / "preamble.md"
         dep_file.write_text("updated preamble content\n")
+        current_hash = calculate_sha256(code_file, tmp_path)
 
         mock_fp = MagicMock()
         mock_fp.code_hash = current_hash


### PR DESCRIPTION
## Summary

- create the include dependency before rooted SHA256 cache priming
- preserve the changed=True behavior, reason assertion, and exact hash-call assertion
- avoid production hash/cache changes

## Release blocker

Cloud release run `run-20260721-232839-4597a4d1a` failed `tests/test_update_main.py::TestIsCodeChanged::test_fingerprint_include_deps_changed` because coalesced parent mtimes can reuse the directory listing cached before `preamble.md` exists.

## Validation

- exact failing test: 10/10 passed in fresh pytest processes
- `TestIsCodeChanged`: 6 passed
- `tests/test_update_main.py`: 136 passed
- Ruff critical selectors (`E9,F63,F7,F82`): passed
- `git diff --check`: passed

## Scope

Test-only fixture ordering change. No production behavior, assertions, skips, or unrelated formatting changed.