### PR TITLE
test(sync): stabilize legacy v1 dependency fixture

### DIFF
--- a/tests/test_sync_determine_operation.py
+++ b/tests/test_sync_determine_operation.py
@@ -7145,11 +7145,17 @@ class TestFingerprintIncludeDependencies:
         prompt = pdd_test_environment / "prompts" / f"{BASENAME}_{LANGUAGE}.prompt"
         first = pdd_test_environment / "a.py"
         second = pdd_test_environment / "b.py"
-        create_file(prompt, "No includes.\n")
-        create_file(first, "A = 1\n")
-        create_file(second, "B = 1\n")
-        stored = {str(second): "old", str(pdd_test_environment / "missing.py"): "old", str(first): "old"}
-        expected = hashlib.sha256(prompt.read_bytes() + first.read_bytes() + second.read_bytes()).hexdigest()
+        prompt.write_text("No includes.\n", encoding="utf-8")
+        first.write_text("A = 1\n", encoding="utf-8")
+        second.write_text("B = 1\n", encoding="utf-8")
+        stored = {
+            str(second): "old",
+            str(pdd_test_environment / "missing.py"): "old",
+            str(first): "old",
+        }
+        expected = hashlib.sha256(
+            prompt.read_bytes() + first.read_bytes() + second.read_bytes()
+        ).hexdigest()
         assert calculate_prompt_hash(prompt, stored_deps=stored, hash_version=1) == expected
 
     def test_calculate_prompt_hash_detects_dep_change_via_stored_deps(self, pdd_test_environment):


### PR DESCRIPTION
## Summary

- materialize the legacy v1 prompt and both stored dependency files before the first rooted cache lookup
- preserve stored dependency insertion order, expected digest, and the existing behavioral assertion
- test-only release stabilization; this does **not** fix the production trusted-directory cache behavior tracked in #2276

## Cloud evidence

Release run `run-20260722-033259-765b65cc7`, pytest `task_16`, failed `TestFingerprintIncludeDependencies::test_legacy_v1_stored_dependencies_skip_missing_and_keep_key_order` because the helper hashed `a.py` before creating `b.py`, allowing a coalesced parent-directory mtime to retain an incomplete cached listing. This follows the fixture-order corrections in #2277 and #2273.

## Validation

- exact test: 1 passed (also 5/5 fresh processes before rebase)
- `TestFingerprintIncludeDependencies`: 25 passed
- whole file before byte-identical rebase: 510 passed, 2 skipped
- Ruff critical selectors: passed
- `git diff --check`: passed
- deterministic forced coalesced-mtime control: old order reproduced cloud digest `856cab...`; raw pre-materialization produced expected `70661a...`

## Scope

Only `tests/test_sync_determine_operation.py` changes. No production behavior, cache policy, or neighboring tests are modified.

Related: #2276, #2277.