### PR TITLE
fix(test): recognize let-propagate fallback action

### DIFF
--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -799,6 +799,83 @@ class TestDeterministicChangeJudges:
 
         assert judgment.passed, judgment.reasoning
 
+    def test_retry_fallback_judge_accepts_cloud_let_propagate_output(self) -> None:
+        """The exact release-gate output states an explicit final action."""
+        guidance = """\
+Build a Python data-import pipeline with three steps:
+1. `fetch_data(url)` — downloads JSON from a URL.
+2. `parse_data(raw)` — parses the JSON into records.
+3. `load_data(records, db)` — inserts records into a database.
+
+The pipeline runner `run_pipeline(url, db)` calls these in sequence.
+
+If `fetch_data(url)` raises a connection error (such as a network-related
+exception), `run_pipeline(url, db)` must catch this exception and retry the
+entire pipeline from the beginning.
+- Implement a retry limit of up to 3 attempts in total.
+- If the 3rd attempt still fails with a connection error, `run_pipeline` must
+  let the connection exception propagate to the caller.
+"""
+
+        judgment = _judge_retry_fallback(guidance)
+
+        assert judgment.passed, judgment.reasoning
+
+    @pytest.mark.parametrize(
+        "guidance",
+        (
+            (
+                "Use at most 3 attempts. If the third attempt fails, let the "
+                "connection exception propagate to the caller."
+            ),
+            (
+                "Retry up to 3 times. If the 3rd attempt still fails, the "
+                "runner must let the final error propagate."
+            ),
+            (
+                "Use a maximum of 3 attempts. If the third attempt fails, "
+                "run_pipeline should explicitly let that exception propagate."
+            ),
+        ),
+    )
+    def test_retry_fallback_judge_accepts_let_error_propagate(
+        self, guidance: str
+    ) -> None:
+        """Explicitly letting an error propagate is affirmative fallback."""
+        judgment = _judge_retry_fallback(guidance)
+
+        assert judgment.passed, judgment.reasoning
+
+    @pytest.mark.parametrize(
+        "guidance",
+        (
+            "Use 3 attempts. If the third attempt fails, let it happen.",
+            (
+                "Use 3 attempts. If the third attempt fails, the runner must "
+                "not let the exception propagate."
+            ),
+            "Use 3 attempts. If the third attempt fails, let metrics propagate.",
+            "Use 3 attempts. If the third attempt fails, let success propagate.",
+            (
+                "Use 3 attempts. If the third attempt fails, let the exception "
+                "propagate and keep retrying."
+            ),
+            "If a connection error occurs, let the exception propagate.",
+            "Let the connection exception propagate to the caller.",
+            (
+                "Use 3 attempts. If validation fails, let the connection "
+                "exception propagate. If the third attempt fails."
+            ),
+        ),
+    )
+    def test_retry_fallback_judge_rejects_unsafe_let_forms(
+        self, guidance: str
+    ) -> None:
+        """Vague, negated, unrelated, or unbounded ``let`` is not fallback."""
+        judgment = _judge_retry_fallback(guidance)
+
+        assert not judgment.passed, guidance
+
     @pytest.mark.parametrize(
         "guidance",
         (

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -229,6 +229,11 @@ _CONNECTIVE_ONLY_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+_ACTION_LIST_PREFIX_PATTERN = re.compile(
+    r"^\s*(?:(?:[-*+]|\d+[.)])\s+)+",
+    re.IGNORECASE,
+)
+
 _ACTION_ADVERBS = (
     r"(?:(?:immediately|gracefully|clearly|explicitly|directly|finally)\s+)*"
 )
@@ -241,7 +246,10 @@ _DIRECT_ACTION_PATTERNS = tuple(
         r"(?:re[- ]?)?rais(?:e|ed)\b.{0,96}",
         r"(?:surface|propagate|abort|skip)\b.{0,96}",
         r"let\s+(?:(?:the|a|an|this|that)\s+)?"
-        r"(?:[\w-]+\s+){0,4}(?:errors?|exceptions?)\s+propagate\b.{0,64}",
+        r"(?:[\w-]+\s+){0,4}(?:errors?|exceptions?)\s+propagate"
+        r"(?:\s+upstream|\s+(?:back\s+)?to\s+"
+        r"(?:(?:the|a|an|its)\s+)?(?:caller|user|client|upstream|"
+        r"calling\s+(?:code|function)))?",
         r"return\b.{0,64}\b(?:error|exception|failure)\b.{0,32}",
         r"log\b.{0,64}\b(?:error|exception|failure)\b.{0,32}",
         r"fail\s+with\b.{0,64}\b(?:error|exception|failure)\b.{0,32}",
@@ -368,6 +376,7 @@ def _retry_units(prompt_output: str) -> tuple[str, ...]:
 def _fallback_action_state(text: str) -> tuple[bool, bool]:
     """Classify one self-contained action unit as affirmative or rejected."""
     text = text.strip(" ,;:.!?\t\r\n")
+    text = _ACTION_LIST_PREFIX_PATTERN.sub("", text)
     if _UNSUPPORTED_INVERSE_ORDINAL_PATTERN.search(text):
         return False, False
     if _RETRY_CONTINUATION_PATTERN.search(text):

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -229,10 +229,7 @@ _CONNECTIVE_ONLY_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-_ACTION_LIST_PREFIX_PATTERN = re.compile(
-    r"^\s*(?:(?:[-*+]|\d+[.)])\s+)+",
-    re.IGNORECASE,
-)
+_NESTED_LIST_ACTION_PATTERN = re.compile(r"^(?:[-*+]|\d+[.)])\s+")
 
 _ACTION_ADVERBS = (
     r"(?:(?:immediately|gracefully|clearly|explicitly|directly|finally)\s+)*"
@@ -376,7 +373,8 @@ def _retry_units(prompt_output: str) -> tuple[str, ...]:
 def _fallback_action_state(text: str) -> tuple[bool, bool]:
     """Classify one self-contained action unit as affirmative or rejected."""
     text = text.strip(" ,;:.!?\t\r\n")
-    text = _ACTION_LIST_PREFIX_PATTERN.sub("", text)
+    if _NESTED_LIST_ACTION_PATTERN.match(text):
+        return False, False
     if _UNSUPPORTED_INVERSE_ORDINAL_PATTERN.search(text):
         return False, False
     if _RETRY_CONTINUATION_PATTERN.search(text):
@@ -847,6 +845,11 @@ entire pipeline from the beginning.
                 "Use a maximum of 3 attempts. If the third attempt fails, "
                 "run_pipeline should explicitly let that exception propagate."
             ),
+            (
+                "Use at most 3 attempts.\n"
+                "- If the third attempt fails, `run_pipeline` must let the "
+                "connection exception propagate to the caller."
+            ),
         ),
     )
     def test_retry_fallback_judge_accepts_let_error_propagate(
@@ -909,29 +912,6 @@ entire pipeline from the beginning.
             (
                 "Use at most 3 attempts.\n"
                 "- If the third attempt fails:\n"
-                "  - let the connection exception propagate to the caller."
-            ),
-            (
-                "Use at most 3 attempts.\n"
-                "  * If the third attempt fails:\n"
-                "    * `run_pipeline` must let the final error propagate upstream."
-            ),
-        ),
-    )
-    def test_retry_fallback_judge_accepts_nested_markdown_let_action(
-        self, guidance: str
-    ) -> None:
-        """Nested list markers do not obscure a bounded terminal action."""
-        judgment = _judge_retry_fallback(guidance)
-
-        assert judgment.passed, judgment.reasoning
-
-    @pytest.mark.parametrize(
-        "guidance",
-        (
-            (
-                "Use at most 3 attempts.\n"
-                "- If the third attempt fails:\n"
                 "  - do not let the connection exception propagate to the caller."
             ),
             (
@@ -941,12 +921,36 @@ entire pipeline from the beginning.
                 "- If the third attempt fails:\n"
                 "  - log retry metrics."
             ),
+            (
+                "Use at most 3 attempts.\n"
+                "- If validation fails:\n"
+                "  - If the third attempt fails:\n"
+                "    - let the connection exception propagate to the caller."
+            ),
+            (
+                "Use at most 3 attempts.\n"
+                "- If authentication fails:\n"
+                "  - If the third attempt fails:\n"
+                "    - `run_pipeline` must let the final error propagate upstream."
+            ),
+            (
+                "Use at most 3 attempts.\n"
+                "- Unless validation succeeds:\n"
+                "  - If the third attempt fails:\n"
+                "    - let the connection exception propagate to the caller."
+            ),
+            (
+                "Use at most 3 attempts.\n"
+                "- Before validation completes:\n"
+                "  - If the third attempt fails:\n"
+                "    - `run_pipeline` must let the final error propagate upstream."
+            ),
         ),
     )
     def test_retry_fallback_judge_rejects_nested_markdown_sibling_actions(
         self, guidance: str
     ) -> None:
-        """List normalization does not cross negated or unrelated branches."""
+        """Unsupported nested list actions cannot weaken clause isolation."""
         judgment = _judge_retry_fallback(guidance)
 
         assert not judgment.passed, guidance

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -240,6 +240,8 @@ _DIRECT_ACTION_PATTERNS = tuple(
     for body in (
         r"(?:re[- ]?)?rais(?:e|ed)\b.{0,96}",
         r"(?:surface|propagate|abort|skip)\b.{0,96}",
+        r"let\s+(?:(?:the|a|an|this|that)\s+)?"
+        r"(?:[\w-]+\s+){0,4}(?:errors?|exceptions?)\s+propagate\b.{0,64}",
         r"return\b.{0,64}\b(?:error|exception|failure)\b.{0,32}",
         r"log\b.{0,64}\b(?:error|exception|failure)\b.{0,32}",
         r"fail\s+with\b.{0,64}\b(?:error|exception|failure)\b.{0,32}",

--- a/tests/test_change_call_site_and_retry.py
+++ b/tests/test_change_call_site_and_retry.py
@@ -862,6 +862,22 @@ entire pipeline from the beginning.
                 "Use 3 attempts. If the third attempt fails, let the exception "
                 "propagate and keep retrying."
             ),
+            (
+                "Use 3 attempts. If the third attempt fails, let the connection "
+                "exception propagate no further."
+            ),
+            (
+                "Use 3 attempts. If the third attempt fails, let the connection "
+                "exception propagate and swallow it before it reaches the caller."
+            ),
+            (
+                "Use 3 attempts. If the third attempt fails, let the connection "
+                "exception propagate only when debug mode is enabled."
+            ),
+            (
+                "Use 3 attempts. If the third attempt fails, let the connection "
+                "exception propagate to telemetry, not the caller."
+            ),
             "If a connection error occurs, let the exception propagate.",
             "Let the connection exception propagate to the caller.",
             (
@@ -874,6 +890,54 @@ entire pipeline from the beginning.
         self, guidance: str
     ) -> None:
         """Vague, negated, unrelated, or unbounded ``let`` is not fallback."""
+        judgment = _judge_retry_fallback(guidance)
+
+        assert not judgment.passed, guidance
+
+    @pytest.mark.parametrize(
+        "guidance",
+        (
+            (
+                "Use at most 3 attempts.\n"
+                "- If the third attempt fails:\n"
+                "  - let the connection exception propagate to the caller."
+            ),
+            (
+                "Use at most 3 attempts.\n"
+                "  * If the third attempt fails:\n"
+                "    * `run_pipeline` must let the final error propagate upstream."
+            ),
+        ),
+    )
+    def test_retry_fallback_judge_accepts_nested_markdown_let_action(
+        self, guidance: str
+    ) -> None:
+        """Nested list markers do not obscure a bounded terminal action."""
+        judgment = _judge_retry_fallback(guidance)
+
+        assert judgment.passed, judgment.reasoning
+
+    @pytest.mark.parametrize(
+        "guidance",
+        (
+            (
+                "Use at most 3 attempts.\n"
+                "- If the third attempt fails:\n"
+                "  - do not let the connection exception propagate to the caller."
+            ),
+            (
+                "Use at most 3 attempts.\n"
+                "- If validation fails:\n"
+                "  - let the connection exception propagate to the caller.\n"
+                "- If the third attempt fails:\n"
+                "  - log retry metrics."
+            ),
+        ),
+    )
+    def test_retry_fallback_judge_rejects_nested_markdown_sibling_actions(
+        self, guidance: str
+    ) -> None:
+        """List normalization does not cross negated or unrelated branches."""
         judgment = _judge_retry_fallback(guidance)
 
         assert not judgment.passed, guidance


### PR DESCRIPTION
## Context

Cloud Batch run `run-20260722-151736-2cf006b37` failed task 31 on explicit bounded fallback guidance:

> If the 3rd attempt still fails with a connection error, `run_pipeline` must let the connection exception propagate to the caller.

After #2283 recognized the ordinal exhaustion and cause tail, the deterministic fallback-action grammar still did not recognize this affirmative terminal action.

## Change

- Add a test-oracle-only action production for `let` + an explicit error/exception subject + terminal `propagate`.
- Accept either a bare terminal propagation or an explicit caller/user/client/upstream/calling-code destination.
- Preserve modal-subject handling, negation and continuation rejection, bound matching, and clause isolation.
- Explicitly leave nested Markdown action bullets unsupported; the exact Cloud form is a top-level bullet and is covered directly.
- Add the exact full Cloud output and focused positive, semantic-reversal, unrelated-condition, unbounded, and nested-isolation controls.
- No product, prompt, provider, runtime, or workflow changes.

## Validation at rebased head `989268742` on base `c5cb6dab5`

- Exact Cloud-output regression: 1 passed.
- Exact Cloud/top-level-bullet focused selection: 23 passed.
- Adjusted original reviewer matrix: 15/15 matched; the documented pre-existing unsupported inverse form is excluded.
- Nested scope/isolation matrix: 9/9 matched.
- Full module: 196 passed, 2 skipped.
- Ruff and `git diff --check`: passed.
- Rebase equivalence to approved head `9f4a79d92`: binary diff SHA-256 `679adf9cc0e16f433cd40efec2c4078692691696480ff41fafdd0c6ce3739e1f`; stable aggregate patch ID `8fbdade9b7017494383cc511925dc8d5002e54da`; changed-file blob `c6b39b9ce2d3333cad83504ace38fdfbf4b67f3a`.

TDD evidence: initial red commit before rebase had 4 expected failures and 8 passing controls. Correction red commit reproduced the four semantic false positives and two nested false negatives before nested support was explicitly removed from scope.

No paid/real LLM test was rerun locally. Fresh merged-main Cloud Batch remains the authoritative release gate.

## Risk

Natural-language grammars can false-negative novel equivalent wording. This production intentionally favors soundness: it requires literal `let`, an explicit error/exception subject, terminal `propagate`, and no restrictive or redirecting tail. Nested action bullets remain unsupported to avoid weakening conditional-ancestor isolation.