### PR TITLE
fix(release): sync regex requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ pytest==9.0.3
 pytest-cov==7.1.0
 python-dotenv==1.2.2
 rich==15.0.0
+regex>=2024.0.0
 semver==3.0.4
 setuptools
 starlette>=0.37.2


### PR DESCRIPTION
## Summary

- add the existing runtime `regex>=2024.0.0` dependency to `requirements.txt`
- restore release dependency parity after PR #1998

## Investigation

PR #1998 / merge `eb1fc0e2ad14c1bd79e63cabe4fd6bc90c7929a5` added `regex>=2024.0.0` to `pyproject.toml` for the timeout-capable selector regex engine but did not update `requirements.txt`. The release `check-deps` gate therefore failed before tag creation. No sibling mismatches were found. This follows prior release dependency-sync fixes such as #2033: pyproject remains the source of truth and the missing requirement is mirrored exactly.

## Validation

- `python scripts/check_deps.py`
- `git diff --check`
- `python -m build --sdist --wheel`

## Release impact

No tag or publication was created by the failed release attempt. Because `requirements.txt` participates in the cloud image dependency hash, the final merged SHA will receive a fresh full cloud release gate.