### PR TITLE
ci: skip heavy checks for docs-only PRs

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -158,12 +158,65 @@ jobs:
             --jq .id)
           echo "check_id=$check_id" >> "$GITHUB_OUTPUT"
 
+      - name: Classify PR changes
+        if: steps.pf.outputs.skip != 'true'
+        id: changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pf.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          expected_count=$(gh api "repos/$REPO/pulls/$PR_NUMBER" \
+            --jq '.changed_files')
+          files=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
+            --jq '.[].filename')
+          if [ -z "$files" ]; then
+            echo "::error::PR file list is empty; refusing to skip auto-heal"
+            exit 1
+          fi
+          actual_count=$(printf '%s\n' "$files" |
+            awk 'NF { count++ } END { print count + 0 }')
+          if [ "$actual_count" != "$expected_count" ]; then
+            echo "::error::PR file list incomplete ($actual_count/$expected_count); refusing to skip auto-heal"
+            exit 1
+          fi
+          docs_only=true
+          while IFS= read -r path; do
+            case "$path" in
+              docs/*|*.md) ;;
+              *)
+                docs_only=false
+                break
+                ;;
+            esac
+          done <<< "$files"
+          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+
+      - name: Short-circuit documentation-only PRs
+        if: steps.pf.outputs.skip != 'true' && steps.changes.outputs.docs_only == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          CHECK_ID: ${{ steps.check_start.outputs.check_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh api -X PATCH "repos/$REPO/check-runs/$CHECK_ID" \
+            -f status='completed' \
+            -f conclusion='success' \
+            -f "output[title]=auto-heal skipped (documentation-only PR)" \
+            -f "output[summary]=No executable files changed; Cloud Build was not dispatched. [Workflow run]($RUN_URL)."
+
       # Short-circuit fork PRs BEFORE minting any App token. Auto-heal pushes
       # commits back to the PR branch which is impossible on a fork; "neutral"
       # is treated as passing by GitHub branch protection, so fork PRs are
       # not permanently blocked from merging.
       - name: Short-circuit fork PRs (neutral conclusion)
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'true'
+        if: |
+          steps.pf.outputs.skip != 'true' &&
+          steps.changes.outputs.docs_only != 'true' &&
+          steps.pf.outputs.fork == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -181,7 +234,10 @@ jobs:
             -f "output[summary]=Fork PRs are not auto-healed because the heal pushes commits to the PR branch (not possible across forks). [Workflow run]($RUN_URL)."
 
       - name: Mint pdd_cloud App token
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: |
+          steps.pf.outputs.skip != 'true' &&
+          steps.changes.outputs.docs_only != 'true' &&
+          steps.pf.outputs.fork == 'false'
         id: app_token
         # SHA-pinned to v3.2.0 (https://github.com/actions/create-github-app-token/releases/tag/v3.2.0)
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
@@ -192,7 +248,10 @@ jobs:
           repositories: pdd_cloud
 
       - name: Authorize requester (must be pdd_cloud collaborator)
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: |
+          steps.pf.outputs.skip != 'true' &&
+          steps.changes.outputs.docs_only != 'true' &&
+          steps.pf.outputs.fork == 'false'
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           REQUESTER: ${{ steps.pf.outputs.requester }}
@@ -238,7 +297,10 @@ jobs:
           esac
 
       - name: Authenticate to GCP via Workload Identity Federation
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: |
+          steps.pf.outputs.skip != 'true' &&
+          steps.changes.outputs.docs_only != 'true' &&
+          steps.pf.outputs.fork == 'false'
         # SHA-pinned to v3.0.0 (https://github.com/google-github-actions/auth/releases/tag/v3.0.0)
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
@@ -246,12 +308,18 @@ jobs:
           service_account: pdd-public-heal-dispatcher@prompt-driven-development-stg.iam.gserviceaccount.com
 
       - name: Set up gcloud
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: |
+          steps.pf.outputs.skip != 'true' &&
+          steps.changes.outputs.docs_only != 'true' &&
+          steps.pf.outputs.fork == 'false'
         # SHA-pinned to v3.0.1 (https://github.com/google-github-actions/setup-gcloud/releases/tag/v3.0.1)
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
 
       - name: Submit Cloud Build (async)
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: |
+          steps.pf.outputs.skip != 'true' &&
+          steps.changes.outputs.docs_only != 'true' &&
+          steps.pf.outputs.fork == 'false'
         id: gcb_submit
         env:
           PR_NUMBER: ${{ steps.pf.outputs.pr_number }}
@@ -285,7 +353,10 @@ jobs:
           echo "Cloud Build $build_id submitted; polling for completion."
 
       - name: Wait for Cloud Build to complete
-        if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
+        if: |
+          steps.pf.outputs.skip != 'true' &&
+          steps.changes.outputs.docs_only != 'true' &&
+          steps.pf.outputs.fork == 'false'
         env:
           BUILD_ID: ${{ steps.gcb_submit.outputs.build_id }}
         run: |
@@ -314,7 +385,11 @@ jobs:
           done
 
       - name: Finalize check_run
-        if: always() && steps.check_start.outputs.check_id && steps.pf.outputs.fork == 'false'
+        if: |
+          always() &&
+          steps.check_start.outputs.check_id &&
+          steps.changes.outputs.docs_only != 'true' &&
+          steps.pf.outputs.fork == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,9 +25,52 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 jobs:
-  unit-tests:
-    if: github.event.pull_request.draft != true
-    name: Run Unit Tests
+  changes:
+    name: Classify Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.classify.outputs.code_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Classify pull request paths
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "code_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          code_changed=false
+          paths_file=$(mktemp)
+          trap 'rm -f "$paths_file"' EXIT
+          git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" > "$paths_file"
+          while IFS= read -r -d '' path; do
+            case "$path" in
+              docs/*|*.md) ;;
+              *)
+                code_changed=true
+                break
+                ;;
+            esac
+          done < "$paths_file"
+          echo "code_changed=$code_changed" >> "$GITHUB_OUTPUT"
+
+  full-unit-tests:
+    needs: changes
+    if: |
+      needs.changes.outputs.code_changed == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft != true)
+    name: Full Unit Tests
     runs-on: ubuntu-latest
     # The broad protected suite reached 93% without an assertion failure at the
     # former 45-minute limit; retain bounded headroom for variable runner load.
@@ -236,7 +279,10 @@ jobs:
           --deselect=tests/test_setup_tool.py::test_create_api_env_script_with_common_problematic_characters
 
   public-cli-regression:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
+    needs: changes
+    if: |
+      needs.changes.outputs.code_changed == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft != true)
     name: Public CLI Regression
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -269,7 +315,10 @@ jobs:
         run: make regression-public
 
   story-regression:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
+    needs: changes
+    if: |
+      needs.changes.outputs.code_changed == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft != true)
     name: Story Regression
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -302,7 +351,10 @@ jobs:
         run: make regression-stories
 
   package-preprocess-smoke:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
+    needs: changes
+    if: |
+      needs.changes.outputs.code_changed == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft != true)
     name: Package Preprocess Smoke
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -532,7 +584,10 @@ jobs:
           grep -q "PDD Mental Model" preprocessed.txt
 
   repo-bloat-docker-e2e:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
+    needs: changes
+    if: |
+      needs.changes.outputs.code_changed == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft != true)
     name: Repo Bloat Docker E2E
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -567,3 +622,36 @@ jobs:
       - name: Stop hard-tier containers
         if: always()
         run: docker compose down -v
+
+  unit-tests:
+    name: Run Unit Tests
+    needs: [changes, full-unit-tests]
+    if: |
+      always() &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft != true)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve required unit-test check
+        env:
+          CODE_CHANGED: ${{ needs.changes.outputs.code_changed }}
+          CLASSIFY_RESULT: ${{ needs.changes.result }}
+          FULL_RESULT: ${{ needs.full-unit-tests.result }}
+        run: |
+          set -euo pipefail
+          if [ "$CLASSIFY_RESULT" != "success" ]; then
+            echo "::error::Change classification concluded: $CLASSIFY_RESULT"
+            exit 1
+          fi
+          if [ "$CODE_CHANGED" = "false" ]; then
+            echo "Documentation-only change; heavyweight test jobs skipped."
+            exit 0
+          fi
+          if [ "$CODE_CHANGED" != "true" ]; then
+            echo "::error::Change classification returned: $CODE_CHANGED"
+            exit 1
+          fi
+          if [ "$FULL_RESULT" != "success" ]; then
+            echo "::error::Full Unit Tests concluded: $FULL_RESULT"
+            exit 1
+          fi
+          echo "Full Unit Tests passed."

--- a/tests/test_auto_heal_workflow.py
+++ b/tests/test_auto_heal_workflow.py
@@ -117,6 +117,30 @@ def test_privileged_heal_steps_run_for_internal_generated_prs():
         assert "trusted_app_requester" not in condition, name
 
 
+def test_docs_only_prs_complete_required_check_without_privileged_heal():
+    classify = _step("Classify PR changes")
+    classify_script = classify["run"]
+    short_circuit = _step("Short-circuit documentation-only PRs")
+
+    assert 'docs/*|*.md)' in classify_script
+    assert "pulls/$PR_NUMBER/files" in classify_script
+    assert "steps.changes.outputs.docs_only == 'true'" in short_circuit["if"]
+    assert "-f conclusion='success'" in short_circuit["run"]
+    assert "Cloud Build was not dispatched" in short_circuit["run"]
+
+    privileged_steps = [
+        "Mint pdd_cloud App token",
+        "Authorize requester (must be pdd_cloud collaborator)",
+        "Authenticate to GCP via Workload Identity Federation",
+        "Set up gcloud",
+        "Submit Cloud Build (async)",
+        "Wait for Cloud Build to complete",
+        "Finalize check_run",
+    ]
+    for name in privileged_steps:
+        assert "steps.changes.outputs.docs_only != 'true'" in _step(name)["if"], name
+
+
 def test_workflow_does_not_allowlist_arbitrary_bot_identities():
     auth_script = _step("Authorize requester (must be pdd_cloud collaborator)")["run"]
     workflow_text = WORKFLOW_PATH.read_text()

--- a/tests/test_docs_only_ci_workflow.py
+++ b/tests/test_docs_only_ci_workflow.py
@@ -1,0 +1,52 @@
+"""Structural contracts for documentation-only CI fast paths."""
+
+from pathlib import Path
+
+import yaml
+
+
+UNIT_WORKFLOW = Path(".github/workflows/unit-tests.yml")
+
+
+def _unit_jobs() -> dict:
+    workflow = yaml.safe_load(UNIT_WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]
+
+
+def test_docs_only_prs_keep_required_check_without_heavy_jobs() -> None:
+    """Required status remains stable while expensive jobs skip documentation."""
+    jobs = _unit_jobs()
+    classifier = jobs["changes"]
+    required = jobs["unit-tests"]
+
+    assert classifier["outputs"]["code_changed"] == (
+        "${{ steps.classify.outputs.code_changed }}"
+    )
+    classify = next(
+        step for step in classifier["steps"]
+        if step.get("name") == "Classify pull request paths"
+    )
+    assert "docs/*|*.md)" in classify["run"]
+    assert 'git diff --name-only -z "$BASE_SHA" "$HEAD_SHA"' in classify["run"]
+
+    heavy_jobs = (
+        "full-unit-tests",
+        "public-cli-regression",
+        "story-regression",
+        "package-preprocess-smoke",
+        "repo-bloat-docker-e2e",
+    )
+    for job_id in heavy_jobs:
+        assert jobs[job_id]["needs"] == "changes"
+        assert "needs.changes.outputs.code_changed == 'true'" in jobs[job_id]["if"]
+
+    assert required["name"] == "Run Unit Tests"
+    assert required["needs"] == ["changes", "full-unit-tests"]
+    assert "always()" in required["if"]
+    gate = next(
+        step for step in required["steps"]
+        if step.get("name") == "Resolve required unit-test check"
+    )
+    assert 'if [ "$CLASSIFY_RESULT" != "success" ]' in gate["run"]
+    assert 'if [ "$CODE_CHANGED" = "false" ]' in gate["run"]
+    assert 'if [ "$FULL_RESULT" != "success" ]' in gate["run"]


### PR DESCRIPTION
## Summary
- classify pull requests as documentation-only when every path is under docs/ or is Markdown
- skip heavyweight unit, regression, package, and Docker jobs for documentation-only PRs
- preserve the required Run Unit Tests check through a lightweight fail-closed gate
- complete auto-heal successfully without credentials or Cloud Build for documentation-only PRs
- retain full CI for mixed or executable changes

## Validation
- 7 focused workflow contract tests passed on current main
- workflow YAML parsed successfully
- git diff --check passed