### PR TITLE
fix: scope verifiable-goal secret migration

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -6,8 +6,11 @@ name: auto-heal
 #
 # Compute runs in pdd_cloud's GCP project (prompt-driven-development-stg)
 # via Cloud Build using a pre-staged build-context tarball. This workflow
-# only dispatches the build and surfaces its status; no LLM or PEM
-# secrets ever land on a GitHub-Actions runner.
+# only dispatches the build and surfaces its status. For the normal auto-heal
+# path, no LLM or PEM secrets ever land on a GitHub-Actions runner. The
+# one-shot migration temporarily materializes the PEM only on the protected
+# pdd-cloud-read environment runner. Its cleanup job removes the temporary
+# App-secret copies and migration-token binding after verification succeeds.
 #
 # ---- Two distinct GitHub Apps ----
 # These MUST be different Apps (separation of duty):
@@ -189,12 +192,15 @@ jobs:
         if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
         id: app_token
         # SHA-pinned to v3.2.0 (https://github.com/actions/create-github-app-token/releases/tag/v3.2.0)
+        # Pin normal healing to Metadata:Read even if the externally managed
+        # App gains broader permissions later.
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           app-id: ${{ secrets.PDD_CLOUD_APP_ID }}
           private-key: ${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}
           owner: promptdriven
           repositories: pdd_cloud
+          permission-metadata: read
 
       - name: Authorize requester (must be pdd_cloud collaborator)
         if: steps.pf.outputs.skip != 'true' && steps.pf.outputs.fork == 'false'
@@ -350,26 +356,111 @@ jobs:
             -f "output[title]=auto-heal $conclusion" \
             -f "output[summary]=$summary"
 
-  # This is intentionally a one-shot, manually dispatched migration. It first
-  # copies the current values into the restricted environment and does not
-  # retire repository-level sources. The second job independently resolves the
-  # environment values and only retires sources after a fresh canary proof.
+  # This is intentionally a one-shot, manually dispatched migration. The App
+  # must be pdd-cloud-auth-reader (ID 3672994); requesting Contents:Read here
+  # cannot upgrade its externally managed permissions and therefore fails closed
+  # until that App is upgraded outside this workflow.
+  #
+  # PDD_SECRET_MIGRATION_TOKEN is a temporary, environment-only fine-grained
+  # credential scoped only to promptdriven/pdd with Environments read/write and
+  # Secrets read/write. Deleting its GitHub Environment binding does not revoke
+  # the credential; it must be revoked outside GitHub after the migration has
+  # completed.
   copy_pdd_cloud_app_secrets_to_environment:
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
-      github.repository == 'promptdriven/pdd'
+      github.repository == 'promptdriven/pdd' &&
+      github.ref_protected == true
     environment: pdd-cloud-read
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions: {}
+    outputs:
+      migration_state: ${{ steps.inspect_secret_provenance.outputs.migration_state }}
     env:
       PDD_CLOUD_APP_ID: ${{ secrets.PDD_CLOUD_APP_ID }}
       PDD_CLOUD_APP_PRIVATE_KEY: ${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}
-      GH_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
+      GH_TOKEN: ${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}
+      REPOSITORY: promptdriven/pdd
+      ENVIRONMENT: pdd-cloud-read
+      EXPECTED_PDD_CLOUD_APP_ID: "3672994"
     steps:
+      - name: Validate exact manual-dispatch context
+        id: validate_dispatch_context
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ] ||
+             [ "$GITHUB_REF" != "refs/heads/main" ] ||
+             [ "$GITHUB_REPOSITORY" != "promptdriven/pdd" ]; then
+            echo "::error::Secret migration must be manually dispatched from promptdriven/pdd main."
+            exit 1
+          fi
+
+      - name: Inspect App-secret provenance
+        id: inspect_secret_provenance
+        run: |
+          set -euo pipefail
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::The environment migration credential is empty; refusing to inspect secrets."
+            exit 1
+          fi
+
+          repository_secret_names=$(gh secret list --repo "$REPOSITORY" --json name --jq '.[].name')
+          environment_secret_names=$(gh secret list --env "$ENVIRONMENT" --repo "$REPOSITORY" --json name --jq '.[].name')
+
+          has_secret_name() {
+            local secret_names="$1"
+            local secret_name="$2"
+            printf '%s\n' "$secret_names" | grep -Fxq -- "$secret_name"
+          }
+
+          legacy_repository_pat_secret_name="PRIVATE_REPO""_TOKEN"
+          if has_secret_name "$repository_secret_names" "$legacy_repository_pat_secret_name"; then
+            echo "::error::The legacy repository credential must be removed before this migration can run."
+            exit 1
+          fi
+
+          repository_app_secret_count=0
+          environment_app_secret_count=0
+          for secret_name in PDD_CLOUD_APP_ID PDD_CLOUD_APP_PRIVATE_KEY; do
+            if has_secret_name "$repository_secret_names" "$secret_name"; then
+              repository_app_secret_count=$((repository_app_secret_count + 1))
+            fi
+            if has_secret_name "$environment_secret_names" "$secret_name"; then
+              environment_app_secret_count=$((environment_app_secret_count + 1))
+            fi
+          done
+
+          case "$repository_app_secret_count:$environment_app_secret_count" in
+            2:0)
+              migration_state=copy_from_repository
+              ;;
+            0:2)
+              migration_state=already_migrated
+              ;;
+            *)
+              echo "::error::App-secret provenance is partial or ambiguous; refusing to continue."
+              exit 1
+              ;;
+          esac
+
+          if [ -z "$PDD_CLOUD_APP_ID" ] ||
+             [ "$PDD_CLOUD_APP_ID" != "$EXPECTED_PDD_CLOUD_APP_ID" ]; then
+            echo "::error::Resolved App ID is not the expected pdd-cloud-auth-reader App."
+            exit 1
+          fi
+          if [ -z "$PDD_CLOUD_APP_PRIVATE_KEY" ]; then
+            echo "::error::Resolved App private key is empty; refusing to continue."
+            exit 1
+          fi
+
+          printf 'migration_state=%s\n' "$migration_state" >> "$GITHUB_OUTPUT"
+          echo "Migration provenance validated: $migration_state"
+
       - name: Copy App secrets into the restricted environment
         id: copy_environment_secrets
+        if: steps.inspect_secret_provenance.outputs.migration_state == 'copy_from_repository'
         run: |
           set -euo pipefail
           if [ -z "$PDD_CLOUD_APP_ID" ] ||
@@ -387,7 +478,8 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
-      github.repository == 'promptdriven/pdd'
+      github.repository == 'promptdriven/pdd' &&
+      github.ref_protected == true
     environment: pdd-cloud-read
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -395,20 +487,57 @@ jobs:
     env:
       PDD_CLOUD_APP_ID: ${{ secrets.PDD_CLOUD_APP_ID }}
       PDD_CLOUD_APP_PRIVATE_KEY: ${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}
+      GH_TOKEN: ${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}
+      REPOSITORY: promptdriven/pdd
+      ENVIRONMENT: pdd-cloud-read
+      EXPECTED_PDD_CLOUD_APP_ID: "3672994"
     steps:
+      - name: Validate exact manual-dispatch context
+        id: validate_dispatch_context
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ] ||
+             [ "$GITHUB_REF" != "refs/heads/main" ] ||
+             [ "$GITHUB_REPOSITORY" != "promptdriven/pdd" ]; then
+            echo "::error::Secret migration must be manually dispatched from promptdriven/pdd main."
+            exit 1
+          fi
+
+      - name: Validate migration state handoff
+        id: validate_migration_state
+        env:
+          MIGRATION_STATE: ${{ needs.copy_pdd_cloud_app_secrets_to_environment.outputs.migration_state }}
+        run: |
+          set -euo pipefail
+          case "$MIGRATION_STATE" in
+            copy_from_repository|already_migrated)
+              ;;
+            *)
+              echo "::error::Migration provenance state is missing or invalid."
+              exit 1
+              ;;
+          esac
+
       - name: Require freshly resolved environment App secrets
         id: require_environment_app_secrets
         run: |
           set -euo pipefail
           if [ -z "$PDD_CLOUD_APP_ID" ] ||
-             [ -z "$PDD_CLOUD_APP_PRIVATE_KEY" ]; then
+             [ -z "$PDD_CLOUD_APP_PRIVATE_KEY" ] ||
+             [ -z "$GH_TOKEN" ]; then
             echo "::error::Required environment App secret is empty; refusing to continue."
+            exit 1
+          fi
+          if [ "$PDD_CLOUD_APP_ID" != "$EXPECTED_PDD_CLOUD_APP_ID" ]; then
+            echo "::error::Resolved App ID is not the expected pdd-cloud-auth-reader App."
             exit 1
           fi
 
       - name: Mint pdd_cloud contents-read App token
         id: pdd_cloud_contents_token
         # SHA-pinned to v3.2.0 (https://github.com/actions/create-github-app-token/releases/tag/v3.2.0)
+        # This request cannot grant Contents:Read; it fails closed until the
+        # externally managed App permission has been upgraded for migration.
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           app-id: ${{ env.PDD_CLOUD_APP_ID }}
@@ -444,11 +573,8 @@ jobs:
           gh api -X DELETE /installation/token
 
       - name: Retire repository-level App secret copies
-        id: retire_repository_secret_copies
+        id: retire_repository_app_secret_copies
         if: success() && steps.verify_canary.outcome == 'success' && steps.revoke_pdd_cloud_token.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
-          REPOSITORY: promptdriven/pdd
         run: |
           set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then
@@ -471,3 +597,22 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Remove temporary environment migration credential binding
+        id: delete_migration_token_secret
+        if: success() && steps.retire_repository_app_secret_copies.outcome == 'success'
+        run: |
+          set -euo pipefail
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::Environment migration credential is empty; refusing cleanup."
+            exit 1
+          fi
+
+          migration_token_secret_name=PDD_SECRET_MIGRATION_TOKEN
+          gh secret delete PDD_SECRET_MIGRATION_TOKEN --env "$ENVIRONMENT" --repo "$REPOSITORY"
+
+          remaining_environment_secret_names=$(gh secret list --env "$ENVIRONMENT" --repo "$REPOSITORY" --json name --jq '.[].name')
+          if printf '%s\n' "$remaining_environment_secret_names" | grep -Fxq -- "$migration_token_secret_name"; then
+            echo "::error::Temporary environment migration credential remains bound after cleanup."
+            exit 1
+          fi

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -40,6 +40,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
+  # One-shot secret migration. Its jobs are additionally fail-closed to the
+  # canonical repository and refs/heads/main below.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -346,3 +349,125 @@ jobs:
             -f conclusion="$conclusion" \
             -f "output[title]=auto-heal $conclusion" \
             -f "output[summary]=$summary"
+
+  # This is intentionally a one-shot, manually dispatched migration. It first
+  # copies the current values into the restricted environment and does not
+  # retire repository-level sources. The second job independently resolves the
+  # environment values and only retires sources after a fresh canary proof.
+  copy_pdd_cloud_app_secrets_to_environment:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'promptdriven/pdd'
+    environment: pdd-cloud-read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    env:
+      PDD_CLOUD_APP_ID: ${{ secrets.PDD_CLOUD_APP_ID }}
+      PDD_CLOUD_APP_PRIVATE_KEY: ${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}
+      GH_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
+    steps:
+      - name: Copy App secrets into the restricted environment
+        id: copy_environment_secrets
+        run: |
+          set -euo pipefail
+          if [ -z "$PDD_CLOUD_APP_ID" ] ||
+             [ -z "$PDD_CLOUD_APP_PRIVATE_KEY" ] ||
+             [ -z "$GH_TOKEN" ]; then
+            echo "::error::A required migration credential is empty; refusing to change secrets."
+            exit 1
+          fi
+
+          printf '%s' "$PDD_CLOUD_APP_ID" | gh secret set PDD_CLOUD_APP_ID --env pdd-cloud-read --repo promptdriven/pdd
+          printf '%s' "$PDD_CLOUD_APP_PRIVATE_KEY" | gh secret set PDD_CLOUD_APP_PRIVATE_KEY --env pdd-cloud-read --repo promptdriven/pdd
+
+  verify_pdd_cloud_and_retire_repository_app_secrets:
+    needs: copy_pdd_cloud_app_secrets_to_environment
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'promptdriven/pdd'
+    environment: pdd-cloud-read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    env:
+      PDD_CLOUD_APP_ID: ${{ secrets.PDD_CLOUD_APP_ID }}
+      PDD_CLOUD_APP_PRIVATE_KEY: ${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}
+    steps:
+      - name: Require freshly resolved environment App secrets
+        id: require_environment_app_secrets
+        run: |
+          set -euo pipefail
+          if [ -z "$PDD_CLOUD_APP_ID" ] ||
+             [ -z "$PDD_CLOUD_APP_PRIVATE_KEY" ]; then
+            echo "::error::Required environment App secret is empty; refusing to continue."
+            exit 1
+          fi
+
+      - name: Mint pdd_cloud contents-read App token
+        id: pdd_cloud_contents_token
+        # SHA-pinned to v3.2.0 (https://github.com/actions/create-github-app-token/releases/tag/v3.2.0)
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          app-id: ${{ env.PDD_CLOUD_APP_ID }}
+          private-key: ${{ env.PDD_CLOUD_APP_PRIVATE_KEY }}
+          owner: promptdriven
+          repositories: pdd_cloud
+          permission-contents: read
+          # A dedicated always-run cleanup below revokes the token before any
+          # repository-secret retirement step can receive the private token.
+          skip-token-revoke: "true"
+
+      - name: Verify the exact pdd_cloud canary commit
+        id: verify_canary
+        env:
+          GH_TOKEN: ${{ steps.pdd_cloud_contents_token.outputs.token }}
+          CANARY_REPOSITORY: promptdriven/pdd_cloud
+          CANARY_SHA: 09f9d3fea71c4c0ed6655f2acd5e95b14a32c3c8
+        run: |
+          set -euo pipefail
+          resolved_sha=$(gh api "repos/$CANARY_REPOSITORY/git/commits/$CANARY_SHA" --jq '.sha')
+          if [ "$resolved_sha" != "$CANARY_SHA" ]; then
+            echo "::error::The pdd_cloud canary did not resolve to the expected commit."
+            exit 1
+          fi
+
+      - name: Revoke pdd_cloud App token
+        id: revoke_pdd_cloud_token
+        if: always() && steps.pdd_cloud_contents_token.outputs.token != ''
+        env:
+          GH_TOKEN: ${{ steps.pdd_cloud_contents_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          gh api -X DELETE /installation/token
+
+      - name: Retire repository-level App secret copies
+        id: retire_repository_secret_copies
+        if: success() && steps.verify_canary.outcome == 'success' && steps.revoke_pdd_cloud_token.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
+          REPOSITORY: promptdriven/pdd
+        run: |
+          set -euo pipefail
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::Repository-management token is empty; refusing to retire secrets."
+            exit 1
+          fi
+
+          repository_secret_names=(PDD_CLOUD_APP_PRIVATE_KEY PDD_CLOUD_APP_ID)
+          current_secret_names=$(gh secret list --repo "$REPOSITORY" --json name --jq '.[].name')
+          for secret_name in "${repository_secret_names[@]}"; do
+            if printf '%s\n' "$current_secret_names" | grep -Fxq -- "$secret_name"; then
+              gh secret delete "$secret_name" --repo "$REPOSITORY"
+            fi
+          done
+
+          remaining_secret_names=$(gh secret list --repo "$REPOSITORY" --json name --jq '.[].name')
+          for secret_name in "${repository_secret_names[@]}"; do
+            if printf '%s\n' "$remaining_secret_names" | grep -Fxq -- "$secret_name"; then
+              echo "::error::Repository secret $secret_name remains after retirement."
+              exit 1
+            fi
+          done

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -6,11 +6,12 @@ name: auto-heal
 #
 # Compute runs in pdd_cloud's GCP project (prompt-driven-development-stg)
 # via Cloud Build using a pre-staged build-context tarball. This workflow
-# only dispatches the build and surfaces its status. For the normal auto-heal
-# path, no LLM or PEM secrets ever land on a GitHub-Actions runner. The
-# one-shot migration temporarily materializes the PEM only on the protected
-# pdd-cloud-read environment runner. Its cleanup job removes the temporary
-# App-secret copies and migration-token binding after verification succeeds.
+# only dispatches the build and surfaces its status. The normal protected,
+# SHA-pinned App-token mint action receives the PEM on its runner; candidate
+# code never does. The one-shot migration protected steps receive it only
+# through explicit per-step inputs. Its cleanup retires repository App sources
+# and the environment migration-token binding while retaining the environment
+# App secrets after verification succeeds.
 #
 # ---- Two distinct GitHub Apps ----
 # These MUST be different Apps (separation of duty):
@@ -379,9 +380,6 @@ jobs:
     outputs:
       migration_state: ${{ steps.inspect_secret_provenance.outputs.migration_state }}
     env:
-      PDD_CLOUD_APP_ID: ${{ secrets.PDD_CLOUD_APP_ID }}
-      PDD_CLOUD_APP_PRIVATE_KEY: ${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}
-      GH_TOKEN: ${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}
       REPOSITORY: promptdriven/pdd
       ENVIRONMENT: pdd-cloud-read
       EXPECTED_PDD_CLOUD_APP_ID: "3672994"
@@ -399,6 +397,10 @@ jobs:
 
       - name: Inspect App-secret provenance
         id: inspect_secret_provenance
+        env:
+          PDD_CLOUD_APP_ID: ${{ secrets.PDD_CLOUD_APP_ID }}
+          PDD_CLOUD_APP_PRIVATE_KEY: ${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}
+          GH_TOKEN: ${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}
         run: |
           set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then
@@ -414,6 +416,13 @@ jobs:
             local secret_name="$2"
             printf '%s\n' "$secret_names" | grep -Fxq -- "$secret_name"
           }
+
+          migration_token_secret_name=PDD_SECRET_MIGRATION_TOKEN
+          if ! has_secret_name "$environment_secret_names" "$migration_token_secret_name" ||
+             has_secret_name "$repository_secret_names" "$migration_token_secret_name"; then
+            echo "::error::The temporary migration credential must exist only in the protected environment."
+            exit 1
+          fi
 
           legacy_repository_pat_secret_name="PRIVATE_REPO""_TOKEN"
           if has_secret_name "$repository_secret_names" "$legacy_repository_pat_secret_name"; then
@@ -461,6 +470,10 @@ jobs:
       - name: Copy App secrets into the restricted environment
         id: copy_environment_secrets
         if: steps.inspect_secret_provenance.outputs.migration_state == 'copy_from_repository'
+        env:
+          PDD_CLOUD_APP_ID: ${{ secrets.PDD_CLOUD_APP_ID }}
+          PDD_CLOUD_APP_PRIVATE_KEY: ${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}
+          GH_TOKEN: ${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}
         run: |
           set -euo pipefail
           if [ -z "$PDD_CLOUD_APP_ID" ] ||
@@ -485,9 +498,6 @@ jobs:
     timeout-minutes: 10
     permissions: {}
     env:
-      PDD_CLOUD_APP_ID: ${{ secrets.PDD_CLOUD_APP_ID }}
-      PDD_CLOUD_APP_PRIVATE_KEY: ${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}
-      GH_TOKEN: ${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}
       REPOSITORY: promptdriven/pdd
       ENVIRONMENT: pdd-cloud-read
       EXPECTED_PDD_CLOUD_APP_ID: "3672994"
@@ -520,11 +530,13 @@ jobs:
 
       - name: Require freshly resolved environment App secrets
         id: require_environment_app_secrets
+        env:
+          PDD_CLOUD_APP_ID: ${{ secrets.PDD_CLOUD_APP_ID }}
+          PDD_CLOUD_APP_PRIVATE_KEY: ${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           if [ -z "$PDD_CLOUD_APP_ID" ] ||
-             [ -z "$PDD_CLOUD_APP_PRIVATE_KEY" ] ||
-             [ -z "$GH_TOKEN" ]; then
+             [ -z "$PDD_CLOUD_APP_PRIVATE_KEY" ]; then
             echo "::error::Required environment App secret is empty; refusing to continue."
             exit 1
           fi
@@ -540,13 +552,13 @@ jobs:
         # externally managed App permission has been upgraded for migration.
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          app-id: ${{ env.PDD_CLOUD_APP_ID }}
-          private-key: ${{ env.PDD_CLOUD_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PDD_CLOUD_APP_ID }}
+          private-key: ${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}
           owner: promptdriven
           repositories: pdd_cloud
           permission-contents: read
-          # A dedicated always-run cleanup below revokes the token before any
-          # repository-secret retirement step can receive the private token.
+          # A dedicated always-run cleanup below revokes this App token before
+          # the separate migration credential retires repository-secret copies.
           skip-token-revoke: "true"
 
       - name: Verify the exact pdd_cloud canary commit
@@ -575,6 +587,8 @@ jobs:
       - name: Retire repository-level App secret copies
         id: retire_repository_app_secret_copies
         if: success() && steps.verify_canary.outcome == 'success' && steps.revoke_pdd_cloud_token.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}
         run: |
           set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then
@@ -601,6 +615,8 @@ jobs:
       - name: Remove temporary environment migration credential binding
         id: delete_migration_token_secret
         if: success() && steps.retire_repository_app_secret_copies.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}
         run: |
           set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -2791,6 +2791,7 @@ def test_auto_heal_secret_migration_scopes_secrets_to_exact_steps() -> None:
         if job_name == SECRET_MIGRATION_COPY_JOB:
             assert paths == {
                 ("steps", 1, "env", "GH_TOKEN"),
+                ("steps", 1, "run"),
                 ("steps", 2, "env", "GH_TOKEN"),
             }
         elif job_name == SECRET_MIGRATION_RETIRE_JOB:
@@ -2913,7 +2914,10 @@ def test_auto_heal_header_scopes_temporary_pem_and_token_exception() -> None:
     assert "normal protected, SHA-pinned App-token mint action receives the PEM" in documentation
     assert "candidate code never does" in documentation
     assert "one-shot migration protected steps receive it only through explicit" in documentation
-    assert "cleanup retires repository App sources and the environment migration-token" in documentation
+    assert (
+        "cleanup retires repository App sources and the environment migration-token"
+        in documentation
+    )
     assert "retaining the environment App secrets" in documentation
     assert "temporary, environment-only fine-grained credential" in documentation
     assert "Environments read/write and Secrets read/write" in documentation

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -41,6 +41,21 @@ OWNERSHIP_PATH = ROOT / ".pdd" / "sync-ownership.json"
 PROFILE_FILE = ROOT / PROFILE_REL_PATH
 ROTATION_FILE = ROOT / ".pdd" / "verification-profile-rotations.json"
 AUTO_HEAL_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "auto-heal.yml"
+SECRET_MIGRATION_COPY_JOB = "copy_pdd_cloud_app_secrets_to_environment"
+SECRET_MIGRATION_RETIRE_JOB = "verify_pdd_cloud_and_retire_repository_app_secrets"
+SECRET_MIGRATION_JOB_GUARD = (
+    "github.event_name == 'workflow_dispatch' && "
+    "github.ref == 'refs/heads/main' && "
+    "github.repository == 'promptdriven/pdd'"
+)
+PDD_CLOUD_APP_TOKEN_ACTION = (
+    "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1"
+)
+PDD_CLOUD_CANARY_SHA = "09f9d3fea71c4c0ed6655f2acd5e95b14a32c3c8"
+PDD_CLOUD_APP_SECRET_NAMES = (
+    "PDD_CLOUD_APP_ID",
+    "PDD_CLOUD_APP_PRIVATE_KEY",
+)
 REPOSITORY_ID = "3b4d7b1c-d6cc-4752-ba93-6b98d1a710e0"
 EXPECTED_MANAGED_UNITS = 469
 # #1989's dormant-bootstrap assertions retain their original immutable base;
@@ -2341,7 +2356,7 @@ def _workflow_value_references_secret(value: object, secret_names: tuple[str, ..
 def _assert_auto_heal_app_secret_consumers_are_restricted(
     jobs: dict[str, dict[str, object]],
 ) -> None:
-    """Require the only App-secret consumer to be the restricted heal job."""
+    """Require every App-secret job to use the restricted environment."""
     app_secret_names = ("PDD_CLOUD_APP_ID", "PDD_CLOUD_APP_PRIVATE_KEY")
     consumer_jobs = {
         job_name
@@ -2350,7 +2365,11 @@ def _assert_auto_heal_app_secret_consumers_are_restricted(
     }
 
     assert consumer_jobs
-    assert consumer_jobs == {"heal"}
+    assert consumer_jobs == {
+        "heal",
+        SECRET_MIGRATION_COPY_JOB,
+        SECRET_MIGRATION_RETIRE_JOB,
+    }
     assert all(
         jobs[job_name].get("environment") == "pdd-cloud-read"
         for job_name in consumer_jobs
@@ -2387,6 +2406,223 @@ def test_auto_heal_rejects_second_job_with_alternate_app_secret_syntax(
 
     with pytest.raises(AssertionError):
         _assert_auto_heal_app_secret_consumers_are_restricted(jobs)
+
+
+def _load_auto_heal_workflow() -> dict[object, object]:
+    """Load the workflow safely, preserving its YAML rather than source text."""
+    workflow = yaml.safe_load(AUTO_HEAL_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def _auto_heal_triggers(workflow: dict[object, object]) -> dict[object, object]:
+    """Return parsed triggers, accounting for PyYAML's YAML 1.1 ``on`` quirk."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict)
+    return triggers
+
+
+def _auto_heal_job(
+    workflow: dict[object, object], job_name: str
+) -> dict[object, object]:
+    """Return one parsed job with a narrow type boundary for policy assertions."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict)
+    job = jobs.get(job_name)
+    assert isinstance(job, dict)
+    return job
+
+
+def _workflow_steps(job: dict[object, object]) -> list[dict[object, object]]:
+    """Return parsed job steps, rejecting malformed workflow structure."""
+    steps = job.get("steps")
+    assert isinstance(steps, list)
+    assert all(isinstance(step, dict) for step in steps)
+    return steps
+
+
+def _workflow_step(
+    job: dict[object, object], step_id: str
+) -> dict[object, object]:
+    """Find an exactly-one step by ID to make ordering policy explicit."""
+    matches = [step for step in _workflow_steps(job) if step.get("id") == step_id]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _workflow_run(step: dict[object, object]) -> str:
+    """Return one shell body, failing when the policy target is not a run step."""
+    run = step.get("run")
+    assert isinstance(run, str)
+    return run
+
+
+def test_auto_heal_secret_migration_is_dispatch_only_and_fresh() -> None:
+    """The one-shot migration can run only from main in the canonical repository."""
+    workflow = _load_auto_heal_workflow()
+    triggers = _auto_heal_triggers(workflow)
+    assert "workflow_dispatch" in triggers
+
+    copy_job = _auto_heal_job(workflow, SECRET_MIGRATION_COPY_JOB)
+    retire_job = _auto_heal_job(workflow, SECRET_MIGRATION_RETIRE_JOB)
+    for job in (copy_job, retire_job):
+        assert job.get("if") == SECRET_MIGRATION_JOB_GUARD
+        assert job.get("environment") == "pdd-cloud-read"
+        assert job.get("runs-on") == "ubuntu-latest"
+
+    assert "needs" not in copy_job
+    assert "outputs" not in copy_job
+    assert retire_job.get("needs") == SECRET_MIGRATION_COPY_JOB
+
+    retire_env = retire_job.get("env")
+    assert isinstance(retire_env, dict)
+    assert retire_env.get("PDD_CLOUD_APP_ID") == "${{ secrets.PDD_CLOUD_APP_ID }}"
+    assert retire_env.get("PDD_CLOUD_APP_PRIVATE_KEY") == (
+        "${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}"
+    )
+    assert "GH_TOKEN" not in retire_env
+    assert "needs." not in str(retire_job)
+
+
+def test_auto_heal_secret_migration_copy_is_stdin_only_and_non_destructive() -> None:
+    """Copy phase obtains values from env, writes stdin, and never deletes sources."""
+    workflow = _load_auto_heal_workflow()
+    copy_job = _auto_heal_job(workflow, SECRET_MIGRATION_COPY_JOB)
+    copy_env = copy_job.get("env")
+    assert isinstance(copy_env, dict)
+    assert copy_env.get("PDD_CLOUD_APP_ID") == "${{ secrets.PDD_CLOUD_APP_ID }}"
+    assert copy_env.get("PDD_CLOUD_APP_PRIVATE_KEY") == (
+        "${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}"
+    )
+    assert copy_env.get("GH_TOKEN") == "${{ secrets.PRIVATE_REPO_TOKEN }}"
+
+    copy_step = _workflow_step(copy_job, "copy_environment_secrets")
+    copy_run = _workflow_run(copy_step)
+    assert "set -euo pipefail" in copy_run
+    assert "gh secret delete" not in copy_run
+    assert "gh secret list" not in copy_run
+    assert "--body" not in copy_run
+    assert "${{" not in copy_run
+    assert "PRIVATE_REPO_TOKEN" not in copy_run
+    assert copy_run.count("gh secret set") == len(PDD_CLOUD_APP_SECRET_NAMES)
+    for secret_name in PDD_CLOUD_APP_SECRET_NAMES:
+        assert f'[ -z "${secret_name}" ]' in copy_run
+        assert (
+            f"printf '%s' \"${secret_name}\" | gh secret set {secret_name} "
+            "--env pdd-cloud-read --repo promptdriven/pdd"
+        ) in copy_run
+
+    migration_runs = "\n".join(
+        _workflow_run(step)
+        for step in _workflow_steps(copy_job)
+        if isinstance(step.get("run"), str)
+    )
+    assert "|| true" not in migration_runs
+
+
+def test_auto_heal_secret_migration_proves_canary_before_source_retirement() -> None:
+    """Retirement follows a scoped App-token proof, revocation, and absence check."""
+    workflow = _load_auto_heal_workflow()
+    retire_job = _auto_heal_job(workflow, SECRET_MIGRATION_RETIRE_JOB)
+    steps = _workflow_steps(retire_job)
+    step_ids = [step.get("id") for step in steps]
+
+    require_index = step_ids.index("require_environment_app_secrets")
+    token_index = step_ids.index("pdd_cloud_contents_token")
+    proof_index = step_ids.index("verify_canary")
+    revoke_index = step_ids.index("revoke_pdd_cloud_token")
+    delete_index = step_ids.index("retire_repository_secret_copies")
+    assert require_index < token_index < proof_index < revoke_index < delete_index
+
+    require_run = _workflow_run(
+        _workflow_step(retire_job, "require_environment_app_secrets")
+    )
+    assert "set -euo pipefail" in require_run
+    for secret_name in PDD_CLOUD_APP_SECRET_NAMES:
+        assert f'[ -z "${secret_name}" ]' in require_run
+    assert "${{" not in require_run
+
+    token_step = _workflow_step(retire_job, "pdd_cloud_contents_token")
+    assert token_step.get("uses") == PDD_CLOUD_APP_TOKEN_ACTION
+    token_with = token_step.get("with")
+    assert isinstance(token_with, dict)
+    assert token_with.get("app-id") == "${{ env.PDD_CLOUD_APP_ID }}"
+    assert token_with.get("private-key") == "${{ env.PDD_CLOUD_APP_PRIVATE_KEY }}"
+    assert token_with.get("owner") == "promptdriven"
+    assert token_with.get("repositories") == "pdd_cloud"
+    assert token_with.get("permission-contents") == "read"
+    assert token_with.get("skip-token-revoke") == "true"
+    assert {
+        name: value
+        for name, value in token_with.items()
+        if isinstance(name, str) and name.startswith("permission-")
+    } == {"permission-contents": "read"}
+
+    proof_step = _workflow_step(retire_job, "verify_canary")
+    proof_env = proof_step.get("env")
+    assert isinstance(proof_env, dict)
+    assert proof_env.get("GH_TOKEN") == "${{ steps.pdd_cloud_contents_token.outputs.token }}"
+    assert proof_env.get("CANARY_REPOSITORY") == "promptdriven/pdd_cloud"
+    assert proof_env.get("CANARY_SHA") == PDD_CLOUD_CANARY_SHA
+    proof_run = _workflow_run(proof_step)
+    assert "set -euo pipefail" in proof_run
+    assert 'gh api "repos/$CANARY_REPOSITORY/git/commits/$CANARY_SHA"' in proof_run
+    assert '"$resolved_sha" != "$CANARY_SHA"' in proof_run
+    assert "${{" not in proof_run
+    assert "--header" not in proof_run
+    assert "access_token" not in proof_run
+
+    revoke_step = _workflow_step(retire_job, "revoke_pdd_cloud_token")
+    assert revoke_step.get("if") == (
+        "always() && steps.pdd_cloud_contents_token.outputs.token != ''"
+    )
+    revoke_env = revoke_step.get("env")
+    assert isinstance(revoke_env, dict)
+    assert revoke_env.get("GH_TOKEN") == "${{ steps.pdd_cloud_contents_token.outputs.token }}"
+    revoke_run = _workflow_run(revoke_step)
+    assert "set -euo pipefail" in revoke_run
+    assert "gh api -X DELETE /installation/token" in revoke_run
+    assert "${{" not in revoke_run
+
+    delete_step = _workflow_step(retire_job, "retire_repository_secret_copies")
+    assert delete_step.get("if") == (
+        "success() && steps.verify_canary.outcome == 'success' && "
+        "steps.revoke_pdd_cloud_token.outcome == 'success'"
+    )
+    delete_env = delete_step.get("env")
+    assert isinstance(delete_env, dict)
+    assert delete_env.get("GH_TOKEN") == "${{ secrets.PRIVATE_REPO_TOKEN }}"
+    assert delete_env.get("REPOSITORY") == "promptdriven/pdd"
+    delete_run = _workflow_run(delete_step)
+    assert "set -euo pipefail" in delete_run
+    assert '[ -z "$GH_TOKEN" ]' in delete_run
+    assert "${{" not in delete_run
+    assert "|| true" not in delete_run
+    assert "repository_secret_names=(PDD_CLOUD_APP_PRIVATE_KEY PDD_CLOUD_APP_ID)" in (
+        delete_run
+    )
+    assert "current_secret_names=$(gh secret list --repo \"$REPOSITORY\"" in delete_run
+    assert "gh secret delete \"$secret_name\" --repo \"$REPOSITORY\"" in delete_run
+    assert "remaining_secret_names=$(gh secret list --repo \"$REPOSITORY\"" in (
+        delete_run
+    )
+    assert delete_run.index("current_secret_names=$(gh secret list") < delete_run.index(
+        "gh secret delete"
+    ) < delete_run.index("remaining_secret_names=$(gh secret list")
+    assert "grep -Fxq -- \"$secret_name\"" in delete_run
+
+    migration_runs = "\n".join(
+        _workflow_run(step)
+        for step in steps
+        if isinstance(step.get("run"), str)
+    )
+    assert "PRIVATE_REPO_TOKEN" not in migration_runs
+    assert "actions/checkout@" not in str(steps)
+    assert not re.search(
+        r"\b(?:git\s+(?:clone|checkout|fetch)|python(?:3(?:\.\d+)?)?\s|"
+        r"pdd\s|pytest\s|make\s|pip\s)",
+        migration_runs,
+    )
 
 
 def test_global_sync_runtime_lock_path_is_exactly_preauthorized() -> None:

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import os
 import re
 import subprocess
 import sys
@@ -46,12 +47,18 @@ SECRET_MIGRATION_RETIRE_JOB = "verify_pdd_cloud_and_retire_repository_app_secret
 SECRET_MIGRATION_JOB_GUARD = (
     "github.event_name == 'workflow_dispatch' && "
     "github.ref == 'refs/heads/main' && "
-    "github.repository == 'promptdriven/pdd'"
+    "github.repository == 'promptdriven/pdd' && "
+    "github.ref_protected == true"
 )
 PDD_CLOUD_APP_TOKEN_ACTION = (
     "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1"
 )
 PDD_CLOUD_CANARY_SHA = "09f9d3fea71c4c0ed6655f2acd5e95b14a32c3c8"
+PDD_CLOUD_MIGRATION_APP_ID = "3672994"
+MIGRATION_TOKEN_SECRET_NAME = "PDD_SECRET_MIGRATION_TOKEN"
+LEGACY_REPOSITORY_TOKEN_NAME = "PRIVATE_REPO_TOKEN"
+MIGRATION_CONTEXT_PRECHECK_STEP = "validate_dispatch_context"
+MIGRATION_PROVENANCE_STEP = "inspect_secret_provenance"
 PDD_CLOUD_APP_SECRET_NAMES = (
     "PDD_CLOUD_APP_ID",
     "PDD_CLOUD_APP_PRIVATE_KEY",
@@ -2457,6 +2464,89 @@ def _workflow_run(step: dict[object, object]) -> str:
     return run
 
 
+def _workflow_reference_paths(
+    value: object,
+    reference: str,
+    path: tuple[object, ...] = (),
+) -> set[tuple[object, ...]]:
+    """Return every recursively discovered, case-insensitive secret reference."""
+    if isinstance(value, dict):
+        return {
+            nested_path
+            for key, child in value.items()
+            for nested_path in _workflow_reference_paths(
+                child, reference, (*path, key)
+            )
+        }
+    if isinstance(value, list):
+        return {
+            nested_path
+            for index, child in enumerate(value)
+            for nested_path in _workflow_reference_paths(
+                child, reference, (*path, index)
+            )
+        }
+    if isinstance(value, str) and reference.casefold() in value.casefold():
+        return {path}
+    return set()
+
+
+def _run_secret_migration_provenance_preflight(
+    tmp_path: Path,
+    repository_secret_names: tuple[str, ...],
+    environment_secret_names: tuple[str, ...],
+    app_id: str = PDD_CLOUD_MIGRATION_APP_ID,
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    """Exercise the parsed provenance shell with a local list-only gh stub."""
+    workflow = _load_auto_heal_workflow()
+    copy_job = _auto_heal_job(workflow, SECRET_MIGRATION_COPY_JOB)
+    preflight = _workflow_step(copy_job, MIGRATION_PROVENANCE_STEP)
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    gh_stub = stub_dir / "gh"
+    gh_stub.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" != "secret" ] || [ "$2" != "list" ]; then
+  echo "unexpected gh invocation" >&2
+  exit 91
+fi
+for argument in "$@"; do
+  if [ "$argument" = "--env" ]; then
+    printf '%s\\n' "$MOCK_ENVIRONMENT_SECRET_NAMES"
+    exit 0
+  fi
+done
+printf '%s\\n' "$MOCK_REPOSITORY_SECRET_NAMES"
+""",
+        encoding="utf-8",
+    )
+    gh_stub.chmod(0o700)
+    output_path = tmp_path / "github-output"
+    output_path.write_text("", encoding="utf-8")
+    environment = os.environ | {
+        "PATH": f"{stub_dir}{os.pathsep}{os.environ['PATH']}",
+        "GITHUB_OUTPUT": str(output_path),
+        "GH_TOKEN": "migration-test-token",
+        "PDD_CLOUD_APP_ID": app_id,
+        "PDD_CLOUD_APP_PRIVATE_KEY": "migration-test-private-key",
+        "REPOSITORY": "promptdriven/pdd",
+        "ENVIRONMENT": "pdd-cloud-read",
+        "EXPECTED_PDD_CLOUD_APP_ID": PDD_CLOUD_MIGRATION_APP_ID,
+        "MOCK_REPOSITORY_SECRET_NAMES": "\n".join(repository_secret_names),
+        "MOCK_ENVIRONMENT_SECRET_NAMES": "\n".join(environment_secret_names),
+    }
+    result = subprocess.run(
+        ["bash", "-c", _workflow_run(preflight)],
+        check=False,
+        capture_output=True,
+        cwd=tmp_path,
+        env=environment,
+        text=True,
+    )
+    return result, output_path.read_text(encoding="utf-8")
+
+
 def test_auto_heal_secret_migration_is_dispatch_only_and_fresh() -> None:
     """The one-shot migration can run only from main in the canonical repository."""
     workflow = _load_auto_heal_workflow()
@@ -2472,7 +2562,9 @@ def test_auto_heal_secret_migration_is_dispatch_only_and_fresh() -> None:
         assert job.get("permissions") == {}
 
     assert "needs" not in copy_job
-    assert "outputs" not in copy_job
+    assert copy_job.get("outputs") == {
+        "migration_state": "${{ steps.inspect_secret_provenance.outputs.migration_state }}"
+    }
     assert retire_job.get("needs") == SECRET_MIGRATION_COPY_JOB
 
     retire_env = retire_job.get("env")
@@ -2481,9 +2573,17 @@ def test_auto_heal_secret_migration_is_dispatch_only_and_fresh() -> None:
     assert retire_env.get("PDD_CLOUD_APP_PRIVATE_KEY") == (
         "${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}"
     )
-    assert "GH_TOKEN" not in retire_env
+    assert retire_env.get("GH_TOKEN") == (
+        "${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}"
+    )
     assert "needs." not in str(retire_job)
-    assert str(retire_job).count("PRIVATE_REPO_TOKEN") == 1
+    for job in (copy_job, retire_job):
+        job_env = job.get("env")
+        assert isinstance(job_env, dict)
+        assert job_env.get("EXPECTED_PDD_CLOUD_APP_ID") == PDD_CLOUD_MIGRATION_APP_ID
+        assert job_env.get("GH_TOKEN") == (
+            "${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}"
+        )
 
 
 def test_auto_heal_secret_migration_copy_is_stdin_only_and_non_destructive() -> None:
@@ -2496,8 +2596,7 @@ def test_auto_heal_secret_migration_copy_is_stdin_only_and_non_destructive() -> 
     assert copy_env.get("PDD_CLOUD_APP_PRIVATE_KEY") == (
         "${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}"
     )
-    assert copy_env.get("GH_TOKEN") == "${{ secrets.PRIVATE_REPO_TOKEN }}"
-    assert str(copy_job).count("PRIVATE_REPO_TOKEN") == 1
+    assert copy_env.get("GH_TOKEN") == "${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}"
 
     copy_step = _workflow_step(copy_job, "copy_environment_secrets")
     copy_run = _workflow_run(copy_step)
@@ -2531,6 +2630,160 @@ def test_auto_heal_secret_migration_copy_is_stdin_only_and_non_destructive() -> 
     )
 
 
+def test_auto_heal_normal_app_token_is_explicitly_metadata_only() -> None:
+    """A future App permission upgrade cannot broaden the normal heal token."""
+    workflow = _load_auto_heal_workflow()
+    heal_job = _auto_heal_job(workflow, "heal")
+    token_step = _workflow_step(heal_job, "app_token")
+    token_with = token_step.get("with")
+    assert isinstance(token_with, dict)
+    assert token_with.get("permission-metadata") == "read"
+    assert {
+        name: value
+        for name, value in token_with.items()
+        if isinstance(name, str) and name.startswith("permission-")
+    } == {"permission-metadata": "read"}
+
+
+def test_auto_heal_secret_migration_preflights_exact_dispatch_context() -> None:
+    """Both migration jobs shell-check exact case-sensitive dispatch values first."""
+    workflow = _load_auto_heal_workflow()
+    for job_name in (SECRET_MIGRATION_COPY_JOB, SECRET_MIGRATION_RETIRE_JOB):
+        job = _auto_heal_job(workflow, job_name)
+        steps = _workflow_steps(job)
+        assert steps[0].get("id") == MIGRATION_CONTEXT_PRECHECK_STEP
+        context_run = _workflow_run(steps[0])
+        assert '[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]' in context_run
+        assert '[ "$GITHUB_REF" != "refs/heads/main" ]' in context_run
+        assert '[ "$GITHUB_REPOSITORY" != "promptdriven/pdd" ]' in context_run
+        assert "${{" not in context_run
+        assert "gh secret set" not in context_run
+        assert "gh secret delete" not in context_run
+
+    copy_steps = _workflow_steps(_auto_heal_job(workflow, SECRET_MIGRATION_COPY_JOB))
+    assert [step.get("id") for step in copy_steps] == [
+        MIGRATION_CONTEXT_PRECHECK_STEP,
+        MIGRATION_PROVENANCE_STEP,
+        "copy_environment_secrets",
+    ]
+    assert not any("uses" in step for step in copy_steps)
+
+    retire_steps = _workflow_steps(
+        _auto_heal_job(workflow, SECRET_MIGRATION_RETIRE_JOB)
+    )
+    assert [step.get("id") for step in retire_steps] == [
+        MIGRATION_CONTEXT_PRECHECK_STEP,
+        "validate_migration_state",
+        "require_environment_app_secrets",
+        "pdd_cloud_contents_token",
+        "verify_canary",
+        "revoke_pdd_cloud_token",
+        "retire_repository_app_secret_copies",
+        "delete_migration_token_secret",
+    ]
+    assert {
+        step.get("id"): step.get("uses")
+        for step in retire_steps
+        if "uses" in step
+    } == {"pdd_cloud_contents_token": PDD_CLOUD_APP_TOKEN_ACTION}
+
+
+def test_auto_heal_secret_migration_uses_only_environment_migration_token() -> None:
+    """The temporary token is scoped to the two guarded environment jobs only."""
+    workflow_text = AUTO_HEAL_WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert LEGACY_REPOSITORY_TOKEN_NAME.casefold() not in workflow_text.casefold()
+
+    workflow = _load_auto_heal_workflow()
+    all_jobs = workflow.get("jobs")
+    assert isinstance(all_jobs, dict)
+    for job_name, job in all_jobs.items():
+        assert isinstance(job, dict)
+        paths = _workflow_reference_paths(job, MIGRATION_TOKEN_SECRET_NAME)
+        if job_name == SECRET_MIGRATION_COPY_JOB:
+            assert paths == {("env", "GH_TOKEN")}
+        elif job_name == SECRET_MIGRATION_RETIRE_JOB:
+            steps = _workflow_steps(job)
+            self_delete_index = next(
+                index
+                for index, step in enumerate(steps)
+                if step.get("id") == "delete_migration_token_secret"
+            )
+            assert paths == {
+                ("env", "GH_TOKEN"),
+                ("steps", self_delete_index, "run"),
+            }
+        else:
+            assert not paths
+
+    assert _workflow_reference_paths(
+        {"env": {"GH_TOKEN": "${{ secrets.pdd_secret_migration_token }}"}},
+        MIGRATION_TOKEN_SECRET_NAME,
+    ) == {("env", "GH_TOKEN")}
+
+
+@pytest.mark.parametrize(
+    ("repository_secret_names", "environment_secret_names", "app_id", "state"),
+    (
+        (PDD_CLOUD_APP_SECRET_NAMES, (), PDD_CLOUD_MIGRATION_APP_ID, "copy_from_repository"),
+        ((), PDD_CLOUD_APP_SECRET_NAMES, PDD_CLOUD_MIGRATION_APP_ID, "already_migrated"),
+        (
+            PDD_CLOUD_APP_SECRET_NAMES,
+            PDD_CLOUD_APP_SECRET_NAMES,
+            PDD_CLOUD_MIGRATION_APP_ID,
+            None,
+        ),
+        (("PDD_CLOUD_APP_ID",), (), PDD_CLOUD_MIGRATION_APP_ID, None),
+        ((), ("PDD_CLOUD_APP_PRIVATE_KEY",), PDD_CLOUD_MIGRATION_APP_ID, None),
+        (
+            ("PDD_CLOUD_APP_ID",),
+            PDD_CLOUD_APP_SECRET_NAMES,
+            PDD_CLOUD_MIGRATION_APP_ID,
+            None,
+        ),
+        (
+            (LEGACY_REPOSITORY_TOKEN_NAME, *PDD_CLOUD_APP_SECRET_NAMES),
+            (),
+            PDD_CLOUD_MIGRATION_APP_ID,
+            None,
+        ),
+        (PDD_CLOUD_APP_SECRET_NAMES, (), "9999999", None),
+    ),
+)
+def test_auto_heal_secret_migration_provenance_state_machine(
+    tmp_path: Path,
+    repository_secret_names: tuple[str, ...],
+    environment_secret_names: tuple[str, ...],
+    app_id: str,
+    state: str | None,
+) -> None:
+    """Only exact source/destination states may progress to the copy phase."""
+    result, output = _run_secret_migration_provenance_preflight(
+        tmp_path,
+        repository_secret_names,
+        environment_secret_names,
+        app_id,
+    )
+
+    if state is None:
+        assert result.returncode != 0
+        assert not output
+    else:
+        assert result.returncode == 0, result.stderr
+        assert output == f"migration_state={state}\n"
+    assert app_id not in result.stdout
+    assert "migration-test-private-key" not in result.stdout
+
+
+def test_auto_heal_header_scopes_temporary_pem_and_token_exception() -> None:
+    """Documentation distinguishes normal healing from the one-shot exception."""
+    workflow_text = AUTO_HEAL_WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "For the normal auto-heal path, no LLM or PEM secrets ever land" in workflow_text
+    assert "one-shot migration temporarily materializes the PEM only" in workflow_text
+    assert "temporary, environment-only fine-grained credential" in workflow_text
+    assert "Environments read/write and Secrets read/write" in workflow_text
+    assert "must be revoked outside GitHub" in workflow_text
+
+
 def test_auto_heal_secret_migration_mints_and_verifies_bound_canary() -> None:
     """A fresh environment secret resolves to one scoped, exact canary proof."""
     workflow = _load_auto_heal_workflow()
@@ -2538,10 +2791,12 @@ def test_auto_heal_secret_migration_mints_and_verifies_bound_canary() -> None:
     steps = _workflow_steps(retire_job)
     step_ids = [step.get("id") for step in steps]
 
+    context_index = step_ids.index(MIGRATION_CONTEXT_PRECHECK_STEP)
+    state_index = step_ids.index("validate_migration_state")
     require_index = step_ids.index("require_environment_app_secrets")
     token_index = step_ids.index("pdd_cloud_contents_token")
     proof_index = step_ids.index("verify_canary")
-    assert require_index < token_index < proof_index
+    assert context_index < state_index < require_index < token_index < proof_index
 
     require_run = _workflow_run(
         _workflow_step(retire_job, "require_environment_app_secrets")
@@ -2549,6 +2804,7 @@ def test_auto_heal_secret_migration_mints_and_verifies_bound_canary() -> None:
     assert "set -euo pipefail" in require_run
     for secret_name in PDD_CLOUD_APP_SECRET_NAMES:
         assert f'[ -z "${secret_name}" ]' in require_run
+    assert '[ "$PDD_CLOUD_APP_ID" != "$EXPECTED_PDD_CLOUD_APP_ID" ]' in require_run
     assert "${{" not in require_run
 
     token_step = _workflow_step(retire_job, "pdd_cloud_contents_token")
@@ -2590,8 +2846,9 @@ def test_auto_heal_secret_migration_revokes_before_idempotent_retirement() -> No
     step_ids = [step.get("id") for step in steps]
     proof_index = step_ids.index("verify_canary")
     revoke_index = step_ids.index("revoke_pdd_cloud_token")
-    delete_index = step_ids.index("retire_repository_secret_copies")
-    assert proof_index < revoke_index < delete_index
+    delete_index = step_ids.index("retire_repository_app_secret_copies")
+    self_delete_index = step_ids.index("delete_migration_token_secret")
+    assert proof_index < revoke_index < delete_index < self_delete_index
 
     revoke_step = _workflow_step(retire_job, "revoke_pdd_cloud_token")
     assert revoke_step.get("if") == (
@@ -2605,15 +2862,12 @@ def test_auto_heal_secret_migration_revokes_before_idempotent_retirement() -> No
     assert "gh api -X DELETE /installation/token" in revoke_run
     assert "${{" not in revoke_run
 
-    delete_step = _workflow_step(retire_job, "retire_repository_secret_copies")
+    delete_step = _workflow_step(retire_job, "retire_repository_app_secret_copies")
     assert delete_step.get("if") == (
         "success() && steps.verify_canary.outcome == 'success' && "
         "steps.revoke_pdd_cloud_token.outcome == 'success'"
     )
-    delete_env = delete_step.get("env")
-    assert isinstance(delete_env, dict)
-    assert delete_env.get("GH_TOKEN") == "${{ secrets.PRIVATE_REPO_TOKEN }}"
-    assert delete_env.get("REPOSITORY") == "promptdriven/pdd"
+    assert delete_step.get("env") is None
     delete_run = _workflow_run(delete_step)
     assert "set -euo pipefail" in delete_run
     assert '[ -z "$GH_TOKEN" ]' in delete_run
@@ -2631,6 +2885,23 @@ def test_auto_heal_secret_migration_revokes_before_idempotent_retirement() -> No
         "gh secret delete"
     ) < delete_run.index("remaining_secret_names=$(gh secret list")
     assert "grep -Fxq -- \"$secret_name\"" in delete_run
+
+    self_delete_step = _workflow_step(retire_job, "delete_migration_token_secret")
+    assert self_delete_step == steps[-1]
+    assert self_delete_step.get("if") == (
+        "success() && steps.retire_repository_app_secret_copies.outcome == 'success'"
+    )
+    self_delete_run = _workflow_run(self_delete_step)
+    assert "set -euo pipefail" in self_delete_run
+    assert (
+        "gh secret delete PDD_SECRET_MIGRATION_TOKEN --env \"$ENVIRONMENT\" "
+        "--repo \"$REPOSITORY\""
+    ) in self_delete_run
+    assert (
+        "remaining_environment_secret_names=$(gh secret list --env "
+        "\"$ENVIRONMENT\" --repo \"$REPOSITORY\""
+    ) in self_delete_run
+    assert "grep -Fxq -- \"$migration_token_secret_name\"" in self_delete_run
 
     migration_runs = "\n".join(
         _workflow_run(step)

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -59,6 +59,19 @@ MIGRATION_TOKEN_SECRET_NAME = "PDD_SECRET_MIGRATION_TOKEN"
 LEGACY_REPOSITORY_TOKEN_NAME = "PRIVATE_REPO_TOKEN"
 MIGRATION_CONTEXT_PRECHECK_STEP = "validate_dispatch_context"
 MIGRATION_PROVENANCE_STEP = "inspect_secret_provenance"
+PDD_CLOUD_APP_SECRET_REFERENCES = {
+    "PDD_CLOUD_APP_ID": "${{ secrets.PDD_CLOUD_APP_ID }}",
+    "PDD_CLOUD_APP_PRIVATE_KEY": "${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}",
+}
+MIGRATION_TOKEN_REFERENCE = "${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}"
+MIGRATION_JOB_NON_SECRET_ENV = {
+    "REPOSITORY": "promptdriven/pdd",
+    "ENVIRONMENT": "pdd-cloud-read",
+    "EXPECTED_PDD_CLOUD_APP_ID": PDD_CLOUD_MIGRATION_APP_ID,
+}
+WORKFLOW_SECRET_EXPRESSION = re.compile(
+    r"\$\{\{\s*secrets(?:\s*\.|\s*\[)", re.IGNORECASE
+)
 PDD_CLOUD_APP_SECRET_NAMES = (
     "PDD_CLOUD_APP_ID",
     "PDD_CLOUD_APP_PRIVATE_KEY",
@@ -2491,6 +2504,28 @@ def _workflow_reference_paths(
     return set()
 
 
+def _workflow_secret_expression_paths(
+    value: object,
+    path: tuple[object, ...] = (),
+) -> set[tuple[object, ...]]:
+    """Return every recursively discovered GitHub Actions secret expression."""
+    if isinstance(value, dict):
+        return {
+            nested_path
+            for key, child in value.items()
+            for nested_path in _workflow_secret_expression_paths(child, (*path, key))
+        }
+    if isinstance(value, list):
+        return {
+            nested_path
+            for index, child in enumerate(value)
+            for nested_path in _workflow_secret_expression_paths(child, (*path, index))
+        }
+    if isinstance(value, str) and WORKFLOW_SECRET_EXPRESSION.search(value):
+        return {path}
+    return set()
+
+
 def _run_secret_migration_provenance_preflight(
     tmp_path: Path,
     repository_secret_names: tuple[str, ...],
@@ -2567,15 +2602,6 @@ def test_auto_heal_secret_migration_is_dispatch_only_and_fresh() -> None:
     }
     assert retire_job.get("needs") == SECRET_MIGRATION_COPY_JOB
 
-    retire_env = retire_job.get("env")
-    assert isinstance(retire_env, dict)
-    assert retire_env.get("PDD_CLOUD_APP_ID") == "${{ secrets.PDD_CLOUD_APP_ID }}"
-    assert retire_env.get("PDD_CLOUD_APP_PRIVATE_KEY") == (
-        "${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}"
-    )
-    assert retire_env.get("GH_TOKEN") == (
-        "${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}"
-    )
     migration_state_step = _workflow_step(retire_job, "validate_migration_state")
     assert migration_state_step.get("env") == {
         "MIGRATION_STATE": (
@@ -2585,26 +2611,14 @@ def test_auto_heal_secret_migration_is_dispatch_only_and_fresh() -> None:
     }
     assert str(retire_job).count("needs.") == 1
     for job in (copy_job, retire_job):
-        job_env = job.get("env")
-        assert isinstance(job_env, dict)
-        assert job_env.get("EXPECTED_PDD_CLOUD_APP_ID") == PDD_CLOUD_MIGRATION_APP_ID
-        assert job_env.get("GH_TOKEN") == (
-            "${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}"
-        )
+        assert job.get("env") == MIGRATION_JOB_NON_SECRET_ENV
+        assert not _workflow_secret_expression_paths(job.get("env"))
 
 
 def test_auto_heal_secret_migration_copy_is_stdin_only_and_non_destructive() -> None:
     """Copy phase obtains values from env, writes stdin, and never deletes sources."""
     workflow = _load_auto_heal_workflow()
     copy_job = _auto_heal_job(workflow, SECRET_MIGRATION_COPY_JOB)
-    copy_env = copy_job.get("env")
-    assert isinstance(copy_env, dict)
-    assert copy_env.get("PDD_CLOUD_APP_ID") == "${{ secrets.PDD_CLOUD_APP_ID }}"
-    assert copy_env.get("PDD_CLOUD_APP_PRIVATE_KEY") == (
-        "${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}"
-    )
-    assert copy_env.get("GH_TOKEN") == "${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}"
-
     copy_step = _workflow_step(copy_job, "copy_environment_secrets")
     copy_run = _workflow_run(copy_step)
     assert "set -euo pipefail" in copy_run
@@ -2695,19 +2709,90 @@ def test_auto_heal_secret_migration_preflights_exact_dispatch_context() -> None:
     } == {"pdd_cloud_contents_token": PDD_CLOUD_APP_TOKEN_ACTION}
 
 
-def test_auto_heal_secret_migration_uses_only_environment_migration_token() -> None:
-    """The temporary token is scoped to the two guarded environment jobs only."""
+def test_auto_heal_secret_migration_scopes_secrets_to_exact_steps() -> None:
+    """Migration secrets are exposed only to the smallest required step set."""
     workflow_text = AUTO_HEAL_WORKFLOW_PATH.read_text(encoding="utf-8")
     assert LEGACY_REPOSITORY_TOKEN_NAME.casefold() not in workflow_text.casefold()
 
     workflow = _load_auto_heal_workflow()
+    copy_job = _auto_heal_job(workflow, SECRET_MIGRATION_COPY_JOB)
+    retire_job = _auto_heal_job(workflow, SECRET_MIGRATION_RETIRE_JOB)
+    app_and_migration_token_env = {
+        **PDD_CLOUD_APP_SECRET_REFERENCES,
+        "GH_TOKEN": MIGRATION_TOKEN_REFERENCE,
+    }
+
+    assert _workflow_step(copy_job, MIGRATION_CONTEXT_PRECHECK_STEP).get("env") is None
+    assert _workflow_step(copy_job, MIGRATION_PROVENANCE_STEP).get("env") == (
+        app_and_migration_token_env
+    )
+    assert _workflow_step(copy_job, "copy_environment_secrets").get("env") == (
+        app_and_migration_token_env
+    )
+
+    assert _workflow_step(retire_job, MIGRATION_CONTEXT_PRECHECK_STEP).get("env") is None
+    assert _workflow_step(retire_job, "validate_migration_state").get("env") == {
+        "MIGRATION_STATE": (
+            "${{ needs.copy_pdd_cloud_app_secrets_to_environment.outputs."
+            "migration_state }}"
+        )
+    }
+    assert _workflow_step(retire_job, "require_environment_app_secrets").get(
+        "env"
+    ) == PDD_CLOUD_APP_SECRET_REFERENCES
+    token_step = _workflow_step(retire_job, "pdd_cloud_contents_token")
+    assert token_step.get("env") is None
+    assert token_step.get("with") == {
+        "app-id": "${{ secrets.PDD_CLOUD_APP_ID }}",
+        "private-key": "${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}",
+        "owner": "promptdriven",
+        "repositories": "pdd_cloud",
+        "permission-contents": "read",
+        "skip-token-revoke": "true",
+    }
+    assert _workflow_step(retire_job, "verify_canary").get("env") == {
+        "GH_TOKEN": "${{ steps.pdd_cloud_contents_token.outputs.token }}",
+        "CANARY_REPOSITORY": "promptdriven/pdd_cloud",
+        "CANARY_SHA": PDD_CLOUD_CANARY_SHA,
+    }
+    assert _workflow_step(retire_job, "revoke_pdd_cloud_token").get("env") == {
+        "GH_TOKEN": "${{ steps.pdd_cloud_contents_token.outputs.token }}"
+    }
+    for step_id in (
+        "retire_repository_app_secret_copies",
+        "delete_migration_token_secret",
+    ):
+        assert _workflow_step(retire_job, step_id).get("env") == {
+            "GH_TOKEN": MIGRATION_TOKEN_REFERENCE
+        }
+
+    assert _workflow_secret_expression_paths(copy_job) == {
+        ("steps", 1, "env", "PDD_CLOUD_APP_ID"),
+        ("steps", 1, "env", "PDD_CLOUD_APP_PRIVATE_KEY"),
+        ("steps", 1, "env", "GH_TOKEN"),
+        ("steps", 2, "env", "PDD_CLOUD_APP_ID"),
+        ("steps", 2, "env", "PDD_CLOUD_APP_PRIVATE_KEY"),
+        ("steps", 2, "env", "GH_TOKEN"),
+    }
+    assert _workflow_secret_expression_paths(retire_job) == {
+        ("steps", 2, "env", "PDD_CLOUD_APP_ID"),
+        ("steps", 2, "env", "PDD_CLOUD_APP_PRIVATE_KEY"),
+        ("steps", 3, "with", "app-id"),
+        ("steps", 3, "with", "private-key"),
+        ("steps", 6, "env", "GH_TOKEN"),
+        ("steps", 7, "env", "GH_TOKEN"),
+    }
+
     all_jobs = workflow.get("jobs")
     assert isinstance(all_jobs, dict)
     for job_name, job in all_jobs.items():
         assert isinstance(job, dict)
         paths = _workflow_reference_paths(job, MIGRATION_TOKEN_SECRET_NAME)
         if job_name == SECRET_MIGRATION_COPY_JOB:
-            assert paths == {("env", "GH_TOKEN")}
+            assert paths == {
+                ("steps", 1, "env", "GH_TOKEN"),
+                ("steps", 2, "env", "GH_TOKEN"),
+            }
         elif job_name == SECRET_MIGRATION_RETIRE_JOB:
             steps = _workflow_steps(job)
             self_delete_index = next(
@@ -2716,7 +2801,8 @@ def test_auto_heal_secret_migration_uses_only_environment_migration_token() -> N
                 if step.get("id") == "delete_migration_token_secret"
             )
             assert paths == {
-                ("env", "GH_TOKEN"),
+                ("steps", 6, "env", "GH_TOKEN"),
+                ("steps", self_delete_index, "env", "GH_TOKEN"),
                 ("steps", self_delete_index, "run"),
             }
         else:
@@ -2731,29 +2817,67 @@ def test_auto_heal_secret_migration_uses_only_environment_migration_token() -> N
 @pytest.mark.parametrize(
     ("repository_secret_names", "environment_secret_names", "app_id", "state"),
     (
-        (PDD_CLOUD_APP_SECRET_NAMES, (), PDD_CLOUD_MIGRATION_APP_ID, "copy_from_repository"),
-        ((), PDD_CLOUD_APP_SECRET_NAMES, PDD_CLOUD_MIGRATION_APP_ID, "already_migrated"),
         (
             PDD_CLOUD_APP_SECRET_NAMES,
-            PDD_CLOUD_APP_SECRET_NAMES,
+            (MIGRATION_TOKEN_SECRET_NAME,),
+            PDD_CLOUD_MIGRATION_APP_ID,
+            "copy_from_repository",
+        ),
+        (
+            (),
+            (*PDD_CLOUD_APP_SECRET_NAMES, MIGRATION_TOKEN_SECRET_NAME),
+            PDD_CLOUD_MIGRATION_APP_ID,
+            "already_migrated",
+        ),
+        (PDD_CLOUD_APP_SECRET_NAMES, (), PDD_CLOUD_MIGRATION_APP_ID, None),
+        (
+            (*PDD_CLOUD_APP_SECRET_NAMES, MIGRATION_TOKEN_SECRET_NAME),
+            (),
             PDD_CLOUD_MIGRATION_APP_ID,
             None,
         ),
-        (("PDD_CLOUD_APP_ID",), (), PDD_CLOUD_MIGRATION_APP_ID, None),
-        ((), ("PDD_CLOUD_APP_PRIVATE_KEY",), PDD_CLOUD_MIGRATION_APP_ID, None),
+        (
+            (*PDD_CLOUD_APP_SECRET_NAMES, MIGRATION_TOKEN_SECRET_NAME),
+            (MIGRATION_TOKEN_SECRET_NAME,),
+            PDD_CLOUD_MIGRATION_APP_ID,
+            None,
+        ),
+        (
+            PDD_CLOUD_APP_SECRET_NAMES,
+            (*PDD_CLOUD_APP_SECRET_NAMES, MIGRATION_TOKEN_SECRET_NAME),
+            PDD_CLOUD_MIGRATION_APP_ID,
+            None,
+        ),
         (
             ("PDD_CLOUD_APP_ID",),
-            PDD_CLOUD_APP_SECRET_NAMES,
+            (MIGRATION_TOKEN_SECRET_NAME,),
+            PDD_CLOUD_MIGRATION_APP_ID,
+            None,
+        ),
+        (
+            (),
+            ("PDD_CLOUD_APP_PRIVATE_KEY", MIGRATION_TOKEN_SECRET_NAME),
+            PDD_CLOUD_MIGRATION_APP_ID,
+            None,
+        ),
+        (
+            ("PDD_CLOUD_APP_ID",),
+            (*PDD_CLOUD_APP_SECRET_NAMES, MIGRATION_TOKEN_SECRET_NAME),
             PDD_CLOUD_MIGRATION_APP_ID,
             None,
         ),
         (
             (LEGACY_REPOSITORY_TOKEN_NAME, *PDD_CLOUD_APP_SECRET_NAMES),
-            (),
+            (MIGRATION_TOKEN_SECRET_NAME,),
             PDD_CLOUD_MIGRATION_APP_ID,
             None,
         ),
-        (PDD_CLOUD_APP_SECRET_NAMES, (), "9999999", None),
+        (
+            PDD_CLOUD_APP_SECRET_NAMES,
+            (MIGRATION_TOKEN_SECRET_NAME,),
+            "9999999",
+            None,
+        ),
     ),
 )
 def test_auto_heal_secret_migration_provenance_state_machine(
@@ -2786,8 +2910,11 @@ def test_auto_heal_header_scopes_temporary_pem_and_token_exception() -> None:
     workflow_text = AUTO_HEAL_WORKFLOW_PATH.read_text(encoding="utf-8")
     documentation = re.sub(r"(?m)^\s*# ?", "", workflow_text)
     documentation = re.sub(r"\s+", " ", documentation)
-    assert "For the normal auto-heal path, no LLM or PEM secrets ever land" in documentation
-    assert "one-shot migration temporarily materializes the PEM only" in documentation
+    assert "normal protected, SHA-pinned App-token mint action receives the PEM" in documentation
+    assert "candidate code never does" in documentation
+    assert "one-shot migration protected steps receive it only through explicit" in documentation
+    assert "cleanup retires repository App sources and the environment migration-token" in documentation
+    assert "retaining the environment App secrets" in documentation
     assert "temporary, environment-only fine-grained credential" in documentation
     assert "Environments read/write and Secrets read/write" in documentation
     assert "must be revoked outside GitHub" in documentation
@@ -2824,8 +2951,9 @@ def test_auto_heal_secret_migration_mints_and_verifies_bound_canary() -> None:
     assert token_step.get("uses") == PDD_CLOUD_APP_TOKEN_ACTION
     token_with = token_step.get("with")
     assert isinstance(token_with, dict)
-    assert token_with.get("app-id") == "${{ env.PDD_CLOUD_APP_ID }}"
-    assert token_with.get("private-key") == "${{ env.PDD_CLOUD_APP_PRIVATE_KEY }}"
+    assert token_step.get("env") is None
+    assert token_with.get("app-id") == "${{ secrets.PDD_CLOUD_APP_ID }}"
+    assert token_with.get("private-key") == "${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}"
     assert token_with.get("owner") == "promptdriven"
     assert token_with.get("repositories") == "pdd_cloud"
     assert token_with.get("permission-contents") == "read"
@@ -2884,7 +3012,7 @@ def test_auto_heal_secret_migration_revokes_before_idempotent_retirement() -> No
         "success() && steps.verify_canary.outcome == 'success' && "
         "steps.revoke_pdd_cloud_token.outcome == 'success'"
     )
-    assert delete_step.get("env") is None
+    assert delete_step.get("env") == {"GH_TOKEN": MIGRATION_TOKEN_REFERENCE}
     delete_run = _workflow_run(delete_step)
     assert "set -euo pipefail" in delete_run
     assert '[ -z "$GH_TOKEN" ]' in delete_run
@@ -2909,6 +3037,7 @@ def test_auto_heal_secret_migration_revokes_before_idempotent_retirement() -> No
         "success() && steps.retire_repository_app_secret_copies.outcome == 'success'"
     )
     self_delete_run = _workflow_run(self_delete_step)
+    assert self_delete_step.get("env") == {"GH_TOKEN": MIGRATION_TOKEN_REFERENCE}
     assert "set -euo pipefail" in self_delete_run
     assert (
         "gh secret delete PDD_SECRET_MIGRATION_TOKEN --env \"$ENVIRONMENT\" "

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -2576,7 +2576,14 @@ def test_auto_heal_secret_migration_is_dispatch_only_and_fresh() -> None:
     assert retire_env.get("GH_TOKEN") == (
         "${{ secrets.PDD_SECRET_MIGRATION_TOKEN }}"
     )
-    assert "needs." not in str(retire_job)
+    migration_state_step = _workflow_step(retire_job, "validate_migration_state")
+    assert migration_state_step.get("env") == {
+        "MIGRATION_STATE": (
+            "${{ needs.copy_pdd_cloud_app_secrets_to_environment.outputs."
+            "migration_state }}"
+        )
+    }
+    assert str(retire_job).count("needs.") == 1
     for job in (copy_job, retire_job):
         job_env = job.get("env")
         assert isinstance(job_env, dict)
@@ -2777,11 +2784,13 @@ def test_auto_heal_secret_migration_provenance_state_machine(
 def test_auto_heal_header_scopes_temporary_pem_and_token_exception() -> None:
     """Documentation distinguishes normal healing from the one-shot exception."""
     workflow_text = AUTO_HEAL_WORKFLOW_PATH.read_text(encoding="utf-8")
-    assert "For the normal auto-heal path, no LLM or PEM secrets ever land" in workflow_text
-    assert "one-shot migration temporarily materializes the PEM only" in workflow_text
-    assert "temporary, environment-only fine-grained credential" in workflow_text
-    assert "Environments read/write and Secrets read/write" in workflow_text
-    assert "must be revoked outside GitHub" in workflow_text
+    documentation = re.sub(r"(?m)^\s*# ?", "", workflow_text)
+    documentation = re.sub(r"\s+", " ", documentation)
+    assert "For the normal auto-heal path, no LLM or PEM secrets ever land" in documentation
+    assert "one-shot migration temporarily materializes the PEM only" in documentation
+    assert "temporary, environment-only fine-grained credential" in documentation
+    assert "Environments read/write and Secrets read/write" in documentation
+    assert "must be revoked outside GitHub" in documentation
 
 
 def test_auto_heal_secret_migration_mints_and_verifies_bound_canary() -> None:
@@ -2791,12 +2800,16 @@ def test_auto_heal_secret_migration_mints_and_verifies_bound_canary() -> None:
     steps = _workflow_steps(retire_job)
     step_ids = [step.get("id") for step in steps]
 
-    context_index = step_ids.index(MIGRATION_CONTEXT_PRECHECK_STEP)
-    state_index = step_ids.index("validate_migration_state")
     require_index = step_ids.index("require_environment_app_secrets")
     token_index = step_ids.index("pdd_cloud_contents_token")
     proof_index = step_ids.index("verify_canary")
-    assert context_index < state_index < require_index < token_index < proof_index
+    assert (
+        step_ids.index(MIGRATION_CONTEXT_PRECHECK_STEP)
+        < step_ids.index("validate_migration_state")
+        < require_index
+        < token_index
+        < proof_index
+    )
 
     require_run = _workflow_run(
         _workflow_step(retire_job, "require_environment_app_secrets")
@@ -2847,8 +2860,12 @@ def test_auto_heal_secret_migration_revokes_before_idempotent_retirement() -> No
     proof_index = step_ids.index("verify_canary")
     revoke_index = step_ids.index("revoke_pdd_cloud_token")
     delete_index = step_ids.index("retire_repository_app_secret_copies")
-    self_delete_index = step_ids.index("delete_migration_token_secret")
-    assert proof_index < revoke_index < delete_index < self_delete_index
+    assert (
+        proof_index
+        < revoke_index
+        < delete_index
+        < step_ids.index("delete_migration_token_secret")
+    )
 
     revoke_step = _workflow_step(retire_job, "revoke_pdd_cloud_token")
     assert revoke_step.get("if") == (

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -2469,6 +2469,7 @@ def test_auto_heal_secret_migration_is_dispatch_only_and_fresh() -> None:
         assert job.get("if") == SECRET_MIGRATION_JOB_GUARD
         assert job.get("environment") == "pdd-cloud-read"
         assert job.get("runs-on") == "ubuntu-latest"
+        assert job.get("permissions") == {}
 
     assert "needs" not in copy_job
     assert "outputs" not in copy_job
@@ -2482,6 +2483,7 @@ def test_auto_heal_secret_migration_is_dispatch_only_and_fresh() -> None:
     )
     assert "GH_TOKEN" not in retire_env
     assert "needs." not in str(retire_job)
+    assert str(retire_job).count("PRIVATE_REPO_TOKEN") == 1
 
 
 def test_auto_heal_secret_migration_copy_is_stdin_only_and_non_destructive() -> None:
@@ -2495,6 +2497,7 @@ def test_auto_heal_secret_migration_copy_is_stdin_only_and_non_destructive() -> 
         "${{ secrets.PDD_CLOUD_APP_PRIVATE_KEY }}"
     )
     assert copy_env.get("GH_TOKEN") == "${{ secrets.PRIVATE_REPO_TOKEN }}"
+    assert str(copy_job).count("PRIVATE_REPO_TOKEN") == 1
 
     copy_step = _workflow_step(copy_job, "copy_environment_secrets")
     copy_run = _workflow_run(copy_step)
@@ -2518,10 +2521,18 @@ def test_auto_heal_secret_migration_copy_is_stdin_only_and_non_destructive() -> 
         if isinstance(step.get("run"), str)
     )
     assert "|| true" not in migration_runs
+    assert "${{ secrets." not in migration_runs
+    assert "actions/checkout@" not in str(_workflow_steps(copy_job))
+    assert not re.search(
+        r"(?:^|[;&|]\s*)(?:git\s+(?:clone|checkout|fetch)|"
+        r"python(?:3(?:\.\d+)?)?\s|pdd\s|pytest\s|make\s|pip\s)",
+        migration_runs,
+        re.MULTILINE,
+    )
 
 
-def test_auto_heal_secret_migration_proves_canary_before_source_retirement() -> None:
-    """Retirement follows a scoped App-token proof, revocation, and absence check."""
+def test_auto_heal_secret_migration_mints_and_verifies_bound_canary() -> None:
+    """A fresh environment secret resolves to one scoped, exact canary proof."""
     workflow = _load_auto_heal_workflow()
     retire_job = _auto_heal_job(workflow, SECRET_MIGRATION_RETIRE_JOB)
     steps = _workflow_steps(retire_job)
@@ -2530,9 +2541,7 @@ def test_auto_heal_secret_migration_proves_canary_before_source_retirement() -> 
     require_index = step_ids.index("require_environment_app_secrets")
     token_index = step_ids.index("pdd_cloud_contents_token")
     proof_index = step_ids.index("verify_canary")
-    revoke_index = step_ids.index("revoke_pdd_cloud_token")
-    delete_index = step_ids.index("retire_repository_secret_copies")
-    assert require_index < token_index < proof_index < revoke_index < delete_index
+    assert require_index < token_index < proof_index
 
     require_run = _workflow_run(
         _workflow_step(retire_job, "require_environment_app_secrets")
@@ -2571,6 +2580,18 @@ def test_auto_heal_secret_migration_proves_canary_before_source_retirement() -> 
     assert "${{" not in proof_run
     assert "--header" not in proof_run
     assert "access_token" not in proof_run
+
+
+def test_auto_heal_secret_migration_revokes_before_idempotent_retirement() -> None:
+    """Source copies retire only after proof, explicit revocation, and a re-list."""
+    workflow = _load_auto_heal_workflow()
+    retire_job = _auto_heal_job(workflow, SECRET_MIGRATION_RETIRE_JOB)
+    steps = _workflow_steps(retire_job)
+    step_ids = [step.get("id") for step in steps]
+    proof_index = step_ids.index("verify_canary")
+    revoke_index = step_ids.index("revoke_pdd_cloud_token")
+    delete_index = step_ids.index("retire_repository_secret_copies")
+    assert proof_index < revoke_index < delete_index
 
     revoke_step = _workflow_step(retire_job, "revoke_pdd_cloud_token")
     assert revoke_step.get("if") == (
@@ -2619,9 +2640,10 @@ def test_auto_heal_secret_migration_proves_canary_before_source_retirement() -> 
     assert "PRIVATE_REPO_TOKEN" not in migration_runs
     assert "actions/checkout@" not in str(steps)
     assert not re.search(
-        r"\b(?:git\s+(?:clone|checkout|fetch)|python(?:3(?:\.\d+)?)?\s|"
-        r"pdd\s|pytest\s|make\s|pip\s)",
+        r"(?:^|[;&|]\s*)(?:git\s+(?:clone|checkout|fetch)|"
+        r"python(?:3(?:\.\d+)?)?\s|pdd\s|pytest\s|make\s|pip\s)",
         migration_runs,
+        re.MULTILINE,
     )
 
 


### PR DESCRIPTION
## Summary

- Adds a guarded, one-shot migration from repository App secrets to the restricted environment.
- Limits every migration secret to its exact consuming workflow step and verifies provenance before copying or retiring anything.
- Merges current protected main (`349859fbd558f2cc8dfa76cfec2c186b635bbd85`) with no ownership delta.

## DO NOT MERGE / DO NOT DISPATCH

Do not merge this draft or manually dispatch the migration until security review confirms every external prerequisite:

- `pdd-cloud-auth-reader` (App ID `3672994`) has been granted `Contents: Read` externally; this workflow cannot grant that App permission.
- `pdd-cloud-read` contains `PDD_SECRET_MIGRATION_TOKEN` only as an environment secret (never a repository secret): a temporary fine-grained credential scoped only to `promptdriven/pdd` with Environments read/write and Secrets read/write.
- The legacy repository PAT is already absent; provenance intentionally fails closed when it is present.
- The environment remains branch-policy-gated and restricted to protected `main`; do not weaken those controls.
- Plan an out-of-band revocation of the temporary credential after successful cleanup.

This PR does not modify credentials, GitHub Apps, environment settings, dispatch state, or merge state.

## Validation

- `python -m pytest -q tests/test_sync_core_pdd_rollout_policy.py -k auto_heal` (22 passed)
- Parsed workflow YAML; `bash -n` and shellcheck passed for all 10 migration run blocks.
- Effective PR diff is limited to `.github/workflows/auto-heal.yml` and `tests/test_sync_core_pdd_rollout_policy.py`; `.pdd/sync-ownership.json` has no delta.
