### PR TITLE
Add Kimi K3 to OpenRouter catalog

### DIFF
--- a/pdd/data/llm_model.csv
+++ b/pdd/data/llm_model.csv
@@ -184,6 +184,7 @@ OpenRouter,openrouter/anthropic/claude-opus-4.5,5.0,25.0,1468,1468,arena-elo-fal
 OpenRouter,openrouter/z-ai/glm-4.7,0.4,1.5,1440,1440,arena-elo-fallback,,OPENROUTER_API_KEY,0,True,effort,,False,
 OpenRouter,openrouter/google/gemini-3-pro-preview,2.0,12.0,1438,1438,arena-elo-fallback,,OPENROUTER_API_KEY,0,True,effort,,False,
 OpenRouter,openrouter/moonshotai/kimi-k2.5,0.6,3.0,1408,1408,arena-elo-fallback,,OPENROUTER_API_KEY,0,True,none,,False,
+OpenRouter,openrouter/moonshotai/kimi-k3,3.0,15.0,0,0,platform-default,,OPENROUTER_API_KEY,0,True,effort,,False,1048576
 OpenRouter,openrouter/openai/gpt-5.2,1.75,14.0,1404,1404,arena-elo-fallback,,OPENROUTER_API_KEY,0,True,effort,,False,
 OpenRouter,openrouter/openai/gpt-5,1.25,10.0,1393,1393,arena-elo-fallback,,OPENROUTER_API_KEY,0,False,effort,,False,
 OpenRouter,openrouter/minimax/minimax-m2.1,0.27,1.2,1392,1392,arena-elo-fallback,,OPENROUTER_API_KEY,0,True,effort,,False,

--- a/pdd/data/provider_catalog.v1.json
+++ b/pdd/data/provider_catalog.v1.json
@@ -6599,6 +6599,36 @@
           "order": 185,
           "csv": {
             "provider": "OpenRouter",
+            "model": "openrouter/moonshotai/kimi-k3",
+            "input": "3.0",
+            "output": "15.0",
+            "coding_arena_elo": "0",
+            "model_rank_score": "0",
+            "model_rank_source": "platform-default",
+            "base_url": "",
+            "api_key": "OPENROUTER_API_KEY",
+            "max_reasoning_tokens": "0",
+            "structured_output": "True",
+            "reasoning_type": "effort",
+            "location": "",
+            "interactive_only": "False",
+            "context_limit": "1048576"
+          },
+          "upstream_model": "moonshotai/kimi-k3",
+          "capabilities": [
+            "text_generation",
+            "streaming",
+            "tools",
+            "structured_output",
+            "reasoning_content",
+            "long_context"
+          ],
+          "byok_eligible": true
+        },
+        {
+          "order": 186,
+          "csv": {
+            "provider": "OpenRouter",
             "model": "openrouter/openai/gpt-5.2",
             "input": "1.75",
             "output": "14.0",
@@ -6623,7 +6653,7 @@
           "byok_eligible": true
         },
         {
-          "order": 186,
+          "order": 187,
           "csv": {
             "provider": "OpenRouter",
             "model": "openrouter/openai/gpt-5",
@@ -6650,7 +6680,7 @@
           "byok_eligible": true
         },
         {
-          "order": 187,
+          "order": 188,
           "csv": {
             "provider": "OpenRouter",
             "model": "openrouter/minimax/minimax-m2.1",
@@ -6677,7 +6707,7 @@
           "byok_eligible": true
         },
         {
-          "order": 188,
+          "order": 189,
           "csv": {
             "provider": "OpenRouter",
             "model": "openrouter/openai/gpt-5.1-codex-max",
@@ -6704,7 +6734,7 @@
           "byok_eligible": true
         },
         {
-          "order": 189,
+          "order": 190,
           "csv": {
             "provider": "OpenRouter",
             "model": "openrouter/anthropic/claude-sonnet-4.5",
@@ -6731,7 +6761,7 @@
           "byok_eligible": true
         },
         {
-          "order": 190,
+          "order": 191,
           "csv": {
             "provider": "OpenRouter",
             "model": "openrouter/minimax/minimax-m2.5",
@@ -6758,7 +6788,7 @@
           "byok_eligible": true
         },
         {
-          "order": 191,
+          "order": 192,
           "csv": {
             "provider": "OpenRouter",
             "model": "openrouter/deepseek/deepseek-r1-0528",
@@ -6785,7 +6815,7 @@
           "byok_eligible": true
         },
         {
-          "order": 192,
+          "order": 193,
           "csv": {
             "provider": "OpenRouter",
             "model": "openrouter/z-ai/glm-4.6",
@@ -6812,7 +6842,7 @@
           "byok_eligible": true
         },
         {
-          "order": 193,
+          "order": 194,
           "csv": {
             "provider": "OpenRouter",
             "model": "openrouter/openai/gpt-5.2-codex",
@@ -6839,7 +6869,7 @@
           "byok_eligible": true
         },
         {
-          "order": 194,
+          "order": 195,
           "csv": {
             "provider": "OpenRouter",
             "model": "openrouter/deepseek/deepseek-v3.2",
@@ -6866,7 +6896,7 @@
           "byok_eligible": true
         },
         {
-          "order": 195,
+          "order": 196,
           "csv": {
             "provider": "OpenRouter",
             "model": "openrouter/anthropic/claude-haiku-4.5",
@@ -6893,7 +6923,7 @@
           "byok_eligible": true
         },
         {
-          "order": 196,
+          "order": 197,
           "csv": {
             "provider": "OpenRouter",
             "model": "openrouter/minimax/minimax-m2",
@@ -6920,7 +6950,7 @@
           "byok_eligible": true
         },
         {
-          "order": 197,
+          "order": 198,
           "csv": {
             "provider": "OpenRouter",
             "model": "openrouter/deepseek/deepseek-chat",
@@ -7013,7 +7043,7 @@
       ],
       "models": [
         {
-          "order": 198,
+          "order": 199,
           "csv": {
             "provider": "Perplexity",
             "model": "perplexity/anthropic/claude-opus-4-7",
@@ -7040,7 +7070,7 @@
           "byok_eligible": true
         },
         {
-          "order": 199,
+          "order": 200,
           "csv": {
             "provider": "Perplexity",
             "model": "perplexity/google/gemini-3-flash-preview",
@@ -7067,7 +7097,7 @@
           "byok_eligible": true
         },
         {
-          "order": 200,
+          "order": 201,
           "csv": {
             "provider": "Perplexity",
             "model": "perplexity/anthropic/claude-opus-4-6",
@@ -7094,7 +7124,7 @@
           "byok_eligible": true
         },
         {
-          "order": 201,
+          "order": 202,
           "csv": {
             "provider": "Perplexity",
             "model": "perplexity/anthropic/claude-opus-4-5",
@@ -7121,7 +7151,7 @@
           "byok_eligible": true
         },
         {
-          "order": 202,
+          "order": 203,
           "csv": {
             "provider": "Perplexity",
             "model": "perplexity/google/gemini-3-pro-preview",
@@ -7148,7 +7178,7 @@
           "byok_eligible": true
         },
         {
-          "order": 203,
+          "order": 204,
           "csv": {
             "provider": "Perplexity",
             "model": "perplexity/openai/gpt-5.2",
@@ -7175,7 +7205,7 @@
           "byok_eligible": true
         },
         {
-          "order": 204,
+          "order": 205,
           "csv": {
             "provider": "Perplexity",
             "model": "perplexity/anthropic/claude-sonnet-4-5",
@@ -7202,7 +7232,7 @@
           "byok_eligible": true
         },
         {
-          "order": 205,
+          "order": 206,
           "csv": {
             "provider": "Perplexity",
             "model": "perplexity/xai/grok-4-1-fast-non-reasoning",
@@ -7229,7 +7259,7 @@
           "byok_eligible": true
         },
         {
-          "order": 206,
+          "order": 207,
           "csv": {
             "provider": "Perplexity",
             "model": "perplexity/openai/gpt-5.1",
@@ -7256,7 +7286,7 @@
           "byok_eligible": true
         },
         {
-          "order": 207,
+          "order": 208,
           "csv": {
             "provider": "Perplexity",
             "model": "perplexity/anthropic/claude-haiku-4-5",
@@ -7283,7 +7313,7 @@
           "byok_eligible": true
         },
         {
-          "order": 208,
+          "order": 209,
           "csv": {
             "provider": "Perplexity",
             "model": "perplexity/openai/gpt-5-mini",
@@ -7310,7 +7340,7 @@
           "byok_eligible": true
         },
         {
-          "order": 209,
+          "order": 210,
           "csv": {
             "provider": "Perplexity",
             "model": "perplexity/google/gemini-2.5-flash",
@@ -7395,7 +7425,7 @@
       ],
       "models": [
         {
-          "order": 210,
+          "order": 211,
           "csv": {
             "provider": "Replicate",
             "model": "replicate/google/gemini-3-pro",
@@ -7422,7 +7452,7 @@
           "byok_eligible": false
         },
         {
-          "order": 211,
+          "order": 212,
           "csv": {
             "provider": "Replicate",
             "model": "replicate/openai/gpt-5",
@@ -7449,7 +7479,7 @@
           "byok_eligible": false
         },
         {
-          "order": 212,
+          "order": 213,
           "csv": {
             "provider": "Replicate",
             "model": "replicate/openai/gpt-4.1",
@@ -7476,7 +7506,7 @@
           "byok_eligible": false
         },
         {
-          "order": 213,
+          "order": 214,
           "csv": {
             "provider": "Replicate",
             "model": "replicate/openai/o4-mini",
@@ -7503,7 +7533,7 @@
           "byok_eligible": false
         },
         {
-          "order": 214,
+          "order": 215,
           "csv": {
             "provider": "Replicate",
             "model": "replicate/openai/gpt-4.1-mini",
@@ -7530,7 +7560,7 @@
           "byok_eligible": false
         },
         {
-          "order": 215,
+          "order": 216,
           "csv": {
             "provider": "Replicate",
             "model": "replicate/openai/gpt-5-nano",
@@ -7623,7 +7653,7 @@
       ],
       "models": [
         {
-          "order": 216,
+          "order": 217,
           "csv": {
             "provider": "SambaNova",
             "model": "sambanova/DeepSeek-R1",
@@ -7650,7 +7680,7 @@
           "byok_eligible": true
         },
         {
-          "order": 217,
+          "order": 218,
           "csv": {
             "provider": "SambaNova",
             "model": "sambanova/DeepSeek-V3-0324",
@@ -7677,7 +7707,7 @@
           "byok_eligible": true
         },
         {
-          "order": 218,
+          "order": 219,
           "csv": {
             "provider": "SambaNova",
             "model": "sambanova/DeepSeek-V3.1",
@@ -7767,7 +7797,7 @@
       ],
       "models": [
         {
-          "order": 219,
+          "order": 220,
           "csv": {
             "provider": "Snowflake",
             "model": "snowflake/deepseek-r1",
@@ -7794,7 +7824,7 @@
           "byok_eligible": false
         },
         {
-          "order": 220,
+          "order": 221,
           "csv": {
             "provider": "Snowflake",
             "model": "snowflake/claude-3-5-sonnet",
@@ -7887,7 +7917,7 @@
       ],
       "models": [
         {
-          "order": 221,
+          "order": 222,
           "csv": {
             "provider": "Together AI",
             "model": "together_ai/zai-org/GLM-4.7",
@@ -7914,7 +7944,7 @@
           "byok_eligible": true
         },
         {
-          "order": 222,
+          "order": 223,
           "csv": {
             "provider": "Together AI",
             "model": "together_ai/moonshotai/Kimi-K2.5",
@@ -7941,7 +7971,7 @@
           "byok_eligible": true
         },
         {
-          "order": 223,
+          "order": 224,
           "csv": {
             "provider": "Together AI",
             "model": "together_ai/zai-org/GLM-4.6",
@@ -7968,7 +7998,7 @@
           "byok_eligible": true
         },
         {
-          "order": 224,
+          "order": 225,
           "csv": {
             "provider": "Together AI",
             "model": "together_ai/deepseek-ai/DeepSeek-R1",
@@ -7995,7 +8025,7 @@
           "byok_eligible": true
         },
         {
-          "order": 225,
+          "order": 226,
           "csv": {
             "provider": "Together AI",
             "model": "together_ai/moonshotai/Kimi-K2-Instruct",
@@ -8022,7 +8052,7 @@
           "byok_eligible": true
         },
         {
-          "order": 226,
+          "order": 227,
           "csv": {
             "provider": "Together AI",
             "model": "together_ai/deepseek-ai/DeepSeek-V3.1",
@@ -8115,7 +8145,7 @@
       ],
       "models": [
         {
-          "order": 227,
+          "order": 228,
           "csv": {
             "provider": "Vercel AI Gateway",
             "model": "vercel_ai_gateway/anthropic/claude-opus-4.6",
@@ -8142,7 +8172,7 @@
           "byok_eligible": true
         },
         {
-          "order": 228,
+          "order": 229,
           "csv": {
             "provider": "Vercel AI Gateway",
             "model": "vercel_ai_gateway/anthropic/claude-opus-4.5",
@@ -8169,7 +8199,7 @@
           "byok_eligible": true
         },
         {
-          "order": 229,
+          "order": 230,
           "csv": {
             "provider": "Vercel AI Gateway",
             "model": "vercel_ai_gateway/anthropic/claude-opus-4.1",
@@ -8196,7 +8226,7 @@
           "byok_eligible": true
         },
         {
-          "order": 230,
+          "order": 231,
           "csv": {
             "provider": "Vercel AI Gateway",
             "model": "vercel_ai_gateway/anthropic/claude-sonnet-4.5",
@@ -8223,7 +8253,7 @@
           "byok_eligible": true
         },
         {
-          "order": 231,
+          "order": 232,
           "csv": {
             "provider": "Vercel AI Gateway",
             "model": "vercel_ai_gateway/openai/o3",
@@ -8250,7 +8280,7 @@
           "byok_eligible": true
         },
         {
-          "order": 232,
+          "order": 233,
           "csv": {
             "provider": "Vercel AI Gateway",
             "model": "vercel_ai_gateway/zai/glm-4.6",
@@ -8277,7 +8307,7 @@
           "byok_eligible": true
         },
         {
-          "order": 233,
+          "order": 234,
           "csv": {
             "provider": "Vercel AI Gateway",
             "model": "vercel_ai_gateway/deepseek/deepseek-r1",
@@ -8304,7 +8334,7 @@
           "byok_eligible": true
         },
         {
-          "order": 234,
+          "order": 235,
           "csv": {
             "provider": "Vercel AI Gateway",
             "model": "vercel_ai_gateway/anthropic/claude-haiku-4.5",
@@ -8331,7 +8361,7 @@
           "byok_eligible": true
         },
         {
-          "order": 235,
+          "order": 236,
           "csv": {
             "provider": "Vercel AI Gateway",
             "model": "vercel_ai_gateway/openai/gpt-4.1-mini",
@@ -8358,7 +8388,7 @@
           "byok_eligible": true
         },
         {
-          "order": 236,
+          "order": 237,
           "csv": {
             "provider": "Vercel AI Gateway",
             "model": "vercel_ai_gateway/deepseek/deepseek-v3",
@@ -8451,7 +8481,7 @@
       ],
       "models": [
         {
-          "order": 237,
+          "order": 238,
           "csv": {
             "provider": "W&B Inference",
             "model": "wandb/moonshotai/Kimi-K2.5",
@@ -8478,7 +8508,7 @@
           "byok_eligible": true
         },
         {
-          "order": 238,
+          "order": 239,
           "csv": {
             "provider": "W&B Inference",
             "model": "wandb/MiniMaxAI/MiniMax-M2.5",
@@ -8505,7 +8535,7 @@
           "byok_eligible": true
         },
         {
-          "order": 239,
+          "order": 240,
           "csv": {
             "provider": "W&B Inference",
             "model": "wandb/deepseek-ai/DeepSeek-R1-0528",
@@ -8532,7 +8562,7 @@
           "byok_eligible": true
         },
         {
-          "order": 240,
+          "order": 241,
           "csv": {
             "provider": "W&B Inference",
             "model": "wandb/moonshotai/Kimi-K2-Instruct",
@@ -8559,7 +8589,7 @@
           "byok_eligible": true
         },
         {
-          "order": 241,
+          "order": 242,
           "csv": {
             "provider": "W&B Inference",
             "model": "wandb/Qwen/Qwen3-235B-A22B-Thinking-2507",
@@ -8653,7 +8683,7 @@
       ],
       "models": [
         {
-          "order": 242,
+          "order": 243,
           "csv": {
             "provider": "Z.AI",
             "model": "openai/glm-5.2",
@@ -8680,7 +8710,7 @@
           "byok_eligible": true
         },
         {
-          "order": 243,
+          "order": 244,
           "csv": {
             "provider": "Z.AI",
             "model": "openai/glm-5",
@@ -8707,7 +8737,7 @@
           "byok_eligible": true
         },
         {
-          "order": 244,
+          "order": 245,
           "csv": {
             "provider": "Z.AI",
             "model": "openai/glm-5-turbo",
@@ -8734,7 +8764,7 @@
           "byok_eligible": true
         },
         {
-          "order": 245,
+          "order": 246,
           "csv": {
             "provider": "Z.AI",
             "model": "openai/glm-4.7",
@@ -8761,7 +8791,7 @@
           "byok_eligible": true
         },
         {
-          "order": 246,
+          "order": 247,
           "csv": {
             "provider": "Z.AI",
             "model": "openai/glm-5.1",
@@ -8788,7 +8818,7 @@
           "byok_eligible": true
         },
         {
-          "order": 250,
+          "order": 251,
           "csv": {
             "provider": "Zai",
             "model": "zai/glm-5",
@@ -8815,7 +8845,7 @@
           "byok_eligible": true
         },
         {
-          "order": 251,
+          "order": 252,
           "csv": {
             "provider": "Zai",
             "model": "zai/glm-4.7",
@@ -8842,7 +8872,7 @@
           "byok_eligible": true
         },
         {
-          "order": 252,
+          "order": 253,
           "csv": {
             "provider": "Zai",
             "model": "zai/glm-4.6",
@@ -8936,7 +8966,7 @@
       ],
       "models": [
         {
-          "order": 247,
+          "order": 248,
           "csv": {
             "provider": "Z.AI Coding Plan",
             "model": "openai/glm-5.2",
@@ -8963,7 +8993,7 @@
           "byok_eligible": true
         },
         {
-          "order": 248,
+          "order": 249,
           "csv": {
             "provider": "Z.AI Coding Plan",
             "model": "openai/glm-5-turbo",
@@ -8990,7 +9020,7 @@
           "byok_eligible": true
         },
         {
-          "order": 249,
+          "order": 250,
           "csv": {
             "provider": "Z.AI Coding Plan",
             "model": "openai/glm-4.7",
@@ -9083,7 +9113,7 @@
       ],
       "models": [
         {
-          "order": 253,
+          "order": 254,
           "csv": {
             "provider": "lm_studio",
             "model": "lm_studio/qwen3-coder-next",
@@ -9176,7 +9206,7 @@
       ],
       "models": [
         {
-          "order": 254,
+          "order": 255,
           "csv": {
             "provider": "xAI",
             "model": "xai/grok-4-0709",
@@ -9203,7 +9233,7 @@
           "byok_eligible": true
         },
         {
-          "order": 255,
+          "order": 256,
           "csv": {
             "provider": "xAI",
             "model": "xai/grok-4-1-fast-reasoning",

--- a/pdd/data/provider_catalog.v1.json
+++ b/pdd/data/provider_catalog.v1.json
@@ -6290,6 +6290,9 @@
       },
       "github": {
         "label": "pdd-openrouter",
+        "model_labels": {
+          "pdd-openrouter-kimi": "openrouter/moonshotai/kimi-k3"
+        },
         "execution_profile": "opencode_openai_chat",
         "eligible": true,
         "reason": ""

--- a/tests/test_kimi_k3_integration.py
+++ b/tests/test_kimi_k3_integration.py
@@ -296,6 +296,7 @@ def test_k3_request_contract_maps_effort_and_endpoint(
 
 
 def test_openrouter_k3_uses_generic_openrouter_route(tmp_path, monkeypatch):
+    """OpenRouter K3 must not inherit direct Moonshot's .cn request contract."""
     assert llm_mod._is_kimi_k3_model(K3_MODEL) is True
     assert llm_mod._is_kimi_k3_model(OPENROUTER_K3_MODEL) is False
 

--- a/tests/test_kimi_k3_integration.py
+++ b/tests/test_kimi_k3_integration.py
@@ -20,6 +20,7 @@ from pdd import provider_manager
 
 K3_MODEL = "moonshot/kimi-k3"
 K3_BASE_URL = "https://api.moonshot.cn/v1"
+OPENROUTER_K3_MODEL = "openrouter/moonshotai/kimi-k3"
 
 
 def _response(content: str = "ok"):
@@ -48,6 +49,19 @@ def _write_k3_csv(path) -> None:
         "context_limit\n"
         "Moonshot AI,moonshot/kimi-k3,2.951594,14.757969,0,0,"
         "platform-default,https://api.moonshot.cn/v1,MOONSHOT_API_KEY,0,"
+        "True,effort,,False,1048576\n",
+        encoding="utf-8",
+    )
+
+
+def _write_openrouter_k3_csv(path) -> None:
+    path.write_text(
+        "provider,model,input,output,coding_arena_elo,model_rank_score,"
+        "model_rank_source,base_url,api_key,max_reasoning_tokens,"
+        "structured_output,reasoning_type,location,interactive_only,"
+        "context_limit\n"
+        "OpenRouter,openrouter/moonshotai/kimi-k3,3.0,15.0,0,0,"
+        "platform-default,,OPENROUTER_API_KEY,0,"
         "True,effort,,False,1048576\n",
         encoding="utf-8",
     )
@@ -82,6 +96,38 @@ def _invoke_k3(tmp_path, monkeypatch, *, time=0.5, output_schema=None):
             use_cloud=False,
         )
     return captured, result
+
+
+def _invoke_openrouter_k3(tmp_path, monkeypatch):
+    csv_path = tmp_path / "llm_model.csv"
+    _write_openrouter_k3_csv(csv_path)
+    monkeypatch.setattr(llm_mod, "LLM_MODEL_CSV_PATH", csv_path)
+    monkeypatch.setattr(llm_mod, "DEFAULT_BASE_MODEL", OPENROUTER_K3_MODEL)
+    monkeypatch.setenv("PDD_MODEL_DEFAULT", OPENROUTER_K3_MODEL)
+    monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-key")
+    monkeypatch.delenv("MOONSHOT_API_KEY", raising=False)
+    monkeypatch.delenv("PDD_REASONING_EFFORT", raising=False)
+    captured = {}
+
+    def capture(**kwargs):
+        captured.update(kwargs)
+        return _response()
+
+    with (
+        patch("litellm.caching.caching.Cache"),
+        patch("pdd.core.cloud.CloudConfig.is_cloud_enabled", return_value=False),
+        patch.object(llm_mod, "count_tokens_for_messages", return_value=10),
+        patch.object(llm_mod.litellm, "completion", side_effect=capture),
+    ):
+        llm_mod.llm_invoke(
+            prompt="Say {word}",
+            input_json={"word": "OK"},
+            strength=0.5,
+            time=0.5,
+            use_cloud=False,
+        )
+    return captured
 
 
 def test_k3_mandatory_row_and_packaged_catalog_are_durable():
@@ -247,6 +293,21 @@ def test_k3_request_contract_maps_effort_and_endpoint(
     assert "reasoning_effort" not in captured
     for parameter in llm_mod._KIMI_K3_FIXED_SAMPLING_PARAMETERS:
         assert parameter not in captured
+
+
+def test_openrouter_k3_uses_generic_openrouter_route(tmp_path, monkeypatch):
+    assert llm_mod._is_kimi_k3_model(K3_MODEL) is True
+    assert llm_mod._is_kimi_k3_model(OPENROUTER_K3_MODEL) is False
+
+    captured = _invoke_openrouter_k3(tmp_path, monkeypatch)
+
+    assert captured["model"] == OPENROUTER_K3_MODEL
+    assert captured["api_key"] == "openrouter-test-key"
+    assert captured["reasoning_effort"] == "medium"
+    assert "extra_body" not in captured
+    assert "base_url" not in captured
+    assert "api_base" not in captured
+    assert captured["temperature"] == 0.1
 
 
 @pytest.mark.parametrize("effort", ["low", "high", "max"])

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -133,6 +133,32 @@ def test_kimi_k3_model_route_and_strict_label_are_canonical() -> None:
     }
     assert "base_url" not in by_model["moonshot/kimi-k2.6"]
 
+    openrouter = next(
+        provider
+        for provider in metadata["providers"]
+        if provider["id"] == "openrouter"
+    )
+    openrouter_by_model = {
+        model["model"]: model for model in openrouter["models"]
+    }
+    assert openrouter_by_model["openrouter/moonshotai/kimi-k3"] == {
+        "model": "openrouter/moonshotai/kimi-k3",
+        "upstream_model": "moonshotai/kimi-k3",
+        "capabilities": [
+            "text_generation",
+            "streaming",
+            "tools",
+            "structured_output",
+            "reasoning_content",
+            "long_context",
+        ],
+        "context_limit": "1048576",
+        "input": "3.0",
+        "output": "15.0",
+        "reasoning_type": "effort",
+        "byok_eligible": True,
+    }
+
 
 @pytest.mark.parametrize(
     ("label", "target", "message"),

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -138,6 +138,9 @@ def test_kimi_k3_model_route_and_strict_label_are_canonical() -> None:
         for provider in metadata["providers"]
         if provider["id"] == "openrouter"
     )
+    assert openrouter["github"]["model_labels"] == {
+        "pdd-openrouter-kimi": "openrouter/moonshotai/kimi-k3"
+    }
     openrouter_by_model = {
         model["model"]: model for model in openrouter["models"]
     }
@@ -158,6 +161,20 @@ def test_kimi_k3_model_route_and_strict_label_are_canonical() -> None:
         "reasoning_type": "effort",
         "byok_eligible": True,
     }
+
+
+def test_openrouter_kimi_label_cannot_reuse_direct_kimi_label() -> None:
+    manifest, generator = _manifest_and_generator()
+    openrouter = next(
+        provider
+        for provider in manifest["providers"]
+        if provider["id"] == "openrouter"
+    )
+    openrouter["github"]["model_labels"] = {
+        "pdd-kimi": "openrouter/moonshotai/kimi-k3"
+    }
+    with pytest.raises(generator.CatalogError, match="Duplicate GitHub label"):
+        generator._validate_manifest(manifest)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add Kimi K3 to the existing OpenRouter provider as `openrouter/moonshotai/kimi-k3`
- add the unique strict model label `pdd-openrouter-kimi` without reusing direct Moonshot's `pdd-kimi`
- project the canonical upstream model `moonshotai/kimi-k3`, 1,048,576-token context, reasoning/tools/structured-output capabilities, and current OpenRouter pricing
- preserve the direct `moonshot/kimi-k3` route and its `.cn` endpoint behavior
- cover canonical metadata and mocked provider dispatch without a paid API call

OpenRouter model reference: https://openrouter.ai/moonshotai/kimi-k3-20260715

## Test plan

- `python -m pytest -q tests/test_kimi_k3_integration.py tests/test_provider_catalog.py tests/test_generate_model_catalog.py tests/test_provider_manager.py` (185 passed)
- canonical generator write + `--check` against an isolated temporary Cloud projection
- `python scripts/ci_detect_changed_modules.py --diff-base origin/main...HEAD`
- `git diff --check`

## Cloud generator implication

Once this public manifest is consumed by pdd_cloud, running the canonical generator with `--cloud-root` will project this OpenRouter BYOK model into the generated JSON, Python, and TypeScript provider metadata. It should not be added to `llm_model_cloud.csv`, which remains the system-owned fallback catalog.

This is an intentionally unmerged follow-up PR for manager review.
