### PR TITLE
Fix ChatGPT subscription generation routing

### DIFF
--- a/.pdd/meta/llm_invoke_python.json
+++ b/.pdd/meta/llm_invoke_python.json
@@ -1,9 +1,9 @@
 {
-  "pdd_version": "0.0.309.dev0",
-  "timestamp": "2026-07-24T23:44:59+00:00",
-  "command": "test",
-  "prompt_hash": "34e03947c072722466560349d32bde6f285a797ad533cb8b049f59abc08a6ca7",
-  "code_hash": "c32efbee0533eddfa7e2f0776b033fe44c3b7117de0955846eb218eb16803ee3",
+  "pdd_version": "0.0.310.dev0",
+  "timestamp": "2026-07-28T16:11:20.872917+00:00",
+  "command": "fix",
+  "prompt_hash": "9e4ef520d92fda9138e300f399b918d217117daf35c906e552a94849e009928f",
+  "code_hash": "4865533bb177323ee5dde136f7c7e9081a56d7d5e03bc0daa1779021022b3be9",
   "example_hash": "3e66413118ec2f8e8940e7a835932920309aeeb775d23ce728d78299fb99e2ec",
   "test_hash": "c11062141398737eb949d11e117c14f7e82492d00c4ca4921ac227364a21d8c4",
   "test_files": {

--- a/.pdd/verification-profiles.json
+++ b/.pdd/verification-profiles.json
@@ -7955,7 +7955,7 @@
       "prompt_path": "pdd/prompts/llm_invoke_python.prompt",
       "language_id": "python",
       "required_requirement_ids": [
-        "CONTRACT-SHA256:09e5140c01bbf8136f4c487c873c816f8e75db75412c11794a8b7ea47259cf3c"
+        "CONTRACT-SHA256:10129606f47d4301052490b7767acc08d8fc713e48bcb2b867efadf2063f8d1e"
       ],
       "obligations": [
         {
@@ -7964,7 +7964,7 @@
           "validator_id": "threshold-ed25519",
           "validator_config_digest": "threshold-ed25519-v1",
           "requirement_ids": [
-            "CONTRACT-SHA256:09e5140c01bbf8136f4c487c873c816f8e75db75412c11794a8b7ea47259cf3c"
+            "CONTRACT-SHA256:10129606f47d4301052490b7767acc08d8fc713e48bcb2b867efadf2063f8d1e"
           ],
           "artifact_paths": [
             "pdd/prompts/llm_invoke_python.prompt"
@@ -8109,7 +8109,7 @@
       "prompt_path": "pdd/prompts/model_tester_python.prompt",
       "language_id": "python",
       "required_requirement_ids": [
-        "CONTRACT-SHA256:7c020d1e55839dfa7a962df32a3991952466bd3710afa3006122424f3d21c89b"
+        "CONTRACT-SHA256:4ab43d1625c4229c4088c6d71cdf92aadbe92b3467cde71b1f24d774b7cfc501"
       ],
       "obligations": [
         {
@@ -8118,7 +8118,7 @@
           "validator_id": "threshold-ed25519",
           "validator_config_digest": "threshold-ed25519-v1",
           "requirement_ids": [
-            "CONTRACT-SHA256:7c020d1e55839dfa7a962df32a3991952466bd3710afa3006122424f3d21c89b"
+            "CONTRACT-SHA256:4ab43d1625c4229c4088c6d71cdf92aadbe92b3467cde71b1f24d774b7cfc501"
           ],
           "artifact_paths": [
             "pdd/prompts/model_tester_python.prompt"

--- a/pdd/llm_invoke.py
+++ b/pdd/llm_invoke.py
@@ -5298,6 +5298,18 @@ def llm_invoke(
         api_key_name = model_info.get('api_key')
         provider = model_info.get('provider', '').lower()
 
+        # LiteLLM's ChatGPT subscription adapter only exposes the Codex
+        # Responses endpoint.  Its chat-completions batch endpoint is
+        # unsupported, so fail before credential setup or any provider call
+        # rather than silently routing chatgpt/* through batch_completion().
+        if use_batch_mode and str(model_name_litellm).lower().startswith("chatgpt/"):
+            raise ValueError(
+                "ChatGPT subscription models do not support batch invocations. "
+                "Set use_batch_mode=False and invoke each item individually; "
+                "PDD will not send chatgpt/* requests to LiteLLM's "
+                "chat-completions batch endpoint."
+            )
+
         # Record this candidate before any pre-call validation/skip logic so
         # models skipped mid-call (context window pre-check, missing api_key,
         # github_copilot OAuth missing, auth-error skip, etc.) are still
@@ -5820,9 +5832,23 @@ def llm_invoke(
                     raise EstimateOnlyResult(estimate_payload)
 
 
-                # Route OpenAI gpt-5* models through Responses API to support 'reasoning'
+                # Route OpenAI gpt-5* API models and ChatGPT subscription
+                # models through Responses.  LiteLLM's chatgpt provider is a
+                # Responses-only Codex backend; sending it through
+                # completion() targets /chat/completions and can return a
+                # browser-only Cloudflare challenge.
                 model_lower_for_call = str(model_name_litellm).lower()
                 provider_lower_for_call = str(provider).lower()
+                use_responses_api = (
+                    not use_batch_mode
+                    and (
+                        (
+                            provider_lower_for_call == "openai"
+                            and model_lower_for_call.startswith("gpt-5")
+                        )
+                        or is_chatgpt_subscription
+                    )
+                )
 
                 # Responses calls bypass the chat-completions admission block
                 # below, so perform the same context and hosted-budget checks
@@ -5830,11 +5856,7 @@ def llm_invoke(
                 # could send an uncapped request even when the story-stage
                 # adapter supplied PDD_COMMAND_MAX_* limits.
                 responses_budget_admitted = False
-                if (
-                    not use_batch_mode
-                    and provider_lower_for_call == "openai"
-                    and model_lower_for_call.startswith("gpt-5")
-                ):
+                if use_responses_api:
                     token_count_for_attribution = None
                     context_limit_for_attribution = None
                     try:
@@ -5937,20 +5959,85 @@ def llm_invoke(
                         provider_attempted_this_call = True
                     responses_budget_admitted = True
 
-                if (
-                    not use_batch_mode
-                    and provider_lower_for_call == 'openai'
-                    and model_lower_for_call.startswith('gpt-5')
-                ):
+                if use_responses_api:
                     if verbose:
                         logger.info(f"[INFO] Calling LiteLLM Responses API for {model_name_litellm}...")
                     try:
-                        # Build input text from messages
-                        if isinstance(formatted_messages, list) and formatted_messages and isinstance(formatted_messages[0], dict):
-                            input_text = "\n\n".join(f"{m.get('role','user')}: {m.get('content','')}" for m in formatted_messages)
+                        # Build input from the final messages, after any schema
+                        # instruction has been injected.  The ChatGPT/Codex
+                        # backend requires list-form Responses input.
+                        messages_for_responses = litellm_kwargs.get(
+                            "messages", formatted_messages
+                        )
+                        if is_chatgpt_subscription:
+                            input_text = []
+                            for message in messages_for_responses:
+                                if not isinstance(message, dict):
+                                    message = {"role": "user", "content": str(message)}
+                                content = message.get("content", "")
+                                if isinstance(content, list):
+                                    response_content = []
+                                    for part in content:
+                                        if not isinstance(part, dict):
+                                            response_content.append({
+                                                "type": "input_text",
+                                                "text": str(part),
+                                            })
+                                            continue
+                                        part_type = part.get("type")
+                                        if part_type in {"text", "input_text"}:
+                                            response_content.append({
+                                                "type": "input_text",
+                                                "text": str(part.get("text", "")),
+                                            })
+                                        elif part_type in {"image_url", "input_image"}:
+                                            image_data = part.get("image_url", "")
+                                            if isinstance(image_data, dict):
+                                                image_url = image_data.get("url", "")
+                                                detail = image_data.get("detail")
+                                            else:
+                                                image_url = image_data
+                                                detail = part.get("detail")
+                                            if isinstance(image_url, str) and image_url:
+                                                image_part = {
+                                                    "type": "input_image",
+                                                    "image_url": image_url,
+                                                }
+                                                if detail:
+                                                    image_part["detail"] = detail
+                                                response_content.append(image_part)
+                                        else:
+                                            response_content.append({
+                                                "type": "input_text",
+                                                "text": json.dumps(part, default=str),
+                                            })
+                                else:
+                                    response_content = [{
+                                        "type": "input_text",
+                                        "text": (
+                                            content
+                                            if isinstance(content, str)
+                                            else json.dumps(content, default=str)
+                                        ),
+                                    }]
+                                input_text.append(
+                                    {
+                                        "role": message.get("role", "user"),
+                                        "content": response_content,
+                                    }
+                                )
+                        elif (
+                            isinstance(messages_for_responses, list)
+                            and messages_for_responses
+                            and isinstance(messages_for_responses[0], dict)
+                        ):
+                            input_text = "\n\n".join(
+                                f"{m.get('role', 'user')}: {m.get('content', '')}"
+                                for m in messages_for_responses
+                            )
                         else:
                             # Fallback: string cast
-                            input_text = str(formatted_messages)
+                            input_text = str(messages_for_responses)
 
                         # Derive effort mapping already computed in time_kwargs
                         reasoning_param = time_kwargs.get("reasoning")
@@ -5993,8 +6080,12 @@ def llm_invoke(
                         responses_kwargs = {
                             "model": model_name_litellm,
                             "input": input_text,
-                            "text": text_block,
                         }
+                        # The subscription backend ignores/strips Responses
+                        # text.format. Its structured-output contract is the
+                        # schema instruction already included in input.
+                        if not is_chatgpt_subscription:
+                            responses_kwargs["text"] = text_block
                         if effective_output_cap is not None:
                             # Responses API names the hard completion ceiling
                             # differently from chat-completions.
@@ -6020,7 +6111,9 @@ def llm_invoke(
                                 "has_structured_text_format": text_block.get("format", {}).get("type") == "json_schema",
                             },
                         )
-                        resp = litellm.responses(**responses_kwargs)
+                        resp = litellm.responses(
+                            **responses_kwargs, timeout=LLM_CALL_TIMEOUT
+                        )
                         call_duration = time_module.time() - call_start
 
                         # Extract text result from response
@@ -6037,6 +6130,13 @@ def llm_invoke(
                                         break
                         except Exception:
                             result_text = None
+
+                        if not result_text:
+                            result_text = getattr(resp, "output_text", None)
+                        if not isinstance(result_text, str) or not result_text.strip():
+                            raise ValueError(
+                                "Responses API returned no non-empty text output"
+                            )
 
                         # Calculate cost using usage + CSV rates
                         total_cost = 0.0
@@ -6153,6 +6253,12 @@ def llm_invoke(
                         # reservation); terminate this candidate and let the
                         # outer single-attempt guard fail closed.
                         if responses_budget_admitted and command_single_attempt:
+                            break
+                        # Never retry a ChatGPT subscription request through
+                        # completion(): that is a different, unsupported
+                        # endpoint and produces the Cloudflare HTML seen by
+                        # users. Move directly to the next candidate model.
+                        if is_chatgpt_subscription:
                             break
                         # Remove 'reasoning' key to avoid OpenAI Chat API unknown param errors
                         if "reasoning" in litellm_kwargs:

--- a/pdd/model_tester.py
+++ b/pdd/model_tester.py
@@ -191,7 +191,7 @@ def _classify_error(exc: Exception) -> str:
 
 
 def _run_test(row: Dict[str, Any]) -> Dict[str, Any]:
-    """Run a single litellm.completion() test against the given model row.
+    """Run a single LiteLLM request against the given model row.
 
     Returns a dict with keys: success, duration_s, cost, error, tokens.
     """
@@ -202,6 +202,7 @@ def _run_test(row: Dict[str, Any]) -> Dict[str, Any]:
     model_name: str = str(row.get("model", ""))
     effective_model_name = canonicalize_claude_cli_model(model_name)
     base_url = _resolve_base_url(row)
+    is_chatgpt_subscription = model_name.lower().startswith("chatgpt/")
 
     kwargs: Dict[str, Any] = {
         "model": effective_model_name,
@@ -226,15 +227,59 @@ def _run_test(row: Dict[str, Any]) -> Dict[str, Any]:
         kwargs["base_url"] = base_url
         kwargs["api_base"] = base_url
 
+    if is_chatgpt_subscription:
+        from pdd.codex_subscription import (
+            apply_litellm_chatgpt_output_patch,
+            bridge_codex_auth_for_litellm,
+        )
+
+        bridge_codex_auth_for_litellm()
+        apply_litellm_chatgpt_output_patch()
+
     start = time_module.time()
     try:
-        response = litellm.completion(**kwargs)
+        if is_chatgpt_subscription:
+            response = litellm.responses(
+                model=model_name,
+                input=[{
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Say OK"}],
+                }],
+                timeout=8,
+            )
+            output_text = None
+            for item in getattr(response, "output", []) or []:
+                if getattr(item, "type", None) != "message":
+                    continue
+                for content in getattr(item, "content", []) or []:
+                    if getattr(content, "type", None) != "output_text":
+                        continue
+                    text = getattr(content, "text", None)
+                    if isinstance(text, str) and text.strip():
+                        output_text = text
+                        break
+                if output_text is not None:
+                    break
+            if output_text is None:
+                raise RuntimeError(
+                    "ChatGPT Responses smoke test returned no meaningful output"
+                )
+        else:
+            response = litellm.completion(**kwargs)
         duration = time_module.time() - start
 
         # Extract token usage
         usage = getattr(response, "usage", None)
-        prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
-        completion_tokens = getattr(usage, "completion_tokens", 0) or 0
+        prompt_tokens = (
+            getattr(usage, "prompt_tokens", 0)
+            or getattr(usage, "input_tokens", 0)
+            or 0
+        )
+        completion_tokens = (
+            getattr(usage, "completion_tokens", 0)
+            or getattr(usage, "output_tokens", 0)
+            or 0
+        )
 
         input_price = float(row.get("input", 0.0))
         output_price = float(row.get("output", 0.0))

--- a/pdd/prompts/llm_invoke_python.prompt
+++ b/pdd/prompts/llm_invoke_python.prompt
@@ -115,7 +115,7 @@
     - 'output_pydantic': Pydantic model class for structured output.
     - 'output_schema': Raw JSON schema dict (alternative to output_pydantic).
     - 'time': Thinking effort (0-1, default 0.25). Interpreted per model's reasoning_type in CSV.
-    - 'use_batch_mode': Use litellm.batch_completion if True.
+    - 'use_batch_mode': Use litellm.batch_completion if True, except that ChatGPT subscription (`chatgpt/*`) models must fail closed before any provider call because their Codex backend supports only the Responses endpoint, not chat-completions batching. Tell callers to set `use_batch_mode=False` and invoke items individually.
     - 'messages': Pre-formatted messages (ignores prompt/input_json if provided).
     - 'language': Language hint (e.g., "python", "javascript"). Skip Python-specific validation when not "python" or None.
     - 'use_cloud': None=auto-detect (cloud if enabled, local if PDD_FORCE_LOCAL=1), True=force cloud, False=force local.
@@ -182,7 +182,8 @@
     - 'none': No reasoning parameters.
 
 % LLM Invocation:
-    - For OpenAI gpt-5* models: Call litellm.responses() API to support 'reasoning' parameter. Build text.format block for structured output (type=json_schema when output_pydantic/output_schema, else type=text). Skip temperature for Responses API.
+    - For direct OpenAI gpt-5* API models: Call litellm.responses() to support the `reasoning` parameter. Build a `text.format` block for structured output (type=json_schema when output_pydantic/output_schema, else type=text). Skip temperature for Responses API.
+    - For ChatGPT subscription `chatgpt/*` models: always use `litellm.responses()` for single invocations. Build list-form Responses input from the final messages, preserving supported multimodal content: a text/input_text message part becomes `{"type":"input_text","text":...}`, and an OpenAI chat-completions `image_url` part (including a data URL from code_generator) becomes `{"type":"input_image","image_url":...}`. The subscription backend ignores Responses `text.format` and chat-completions `response_format`/`json_schema`; when structured output is requested, omit those fields and inject the JSON schema as an in-band system-message instruction. Never fall back to `litellm.completion()` after a Responses error. Batch invocation is unsupported: fail closed before auth/provider dispatch with an actionable error rather than calling `litellm.completion()` or `litellm.batch_completion()`.
     - For other models: Call litellm.completion() or litellm.batch_completion().
     - Pass: model, messages, temperature, num_retries=2, timeout=LLM_CALL_TIMEOUT (600s).
     - Claude Fable 5 and adaptive Claude Opus models reject `temperature`; remove that parameter before the provider call. Preserve Anthropic `stop_reason="refusal"` when LiteLLM would otherwise map it to generic `stop` with empty content. Treat that response as a provider refusal and continue to the next candidate, never as a corrupted-cache result that retries the same model with cache bypass.

--- a/pdd/prompts/model_tester_python.prompt
+++ b/pdd/prompts/model_tester_python.prompt
@@ -1,4 +1,4 @@
-<pdd-reason>Tests individual models via litellm.completion() with direct API key passing and diagnostics.</pdd-reason>
+<pdd-reason>Tests individual models with provider-appropriate LiteLLM calls, direct API key passing, and diagnostics.</pdd-reason>
 
 <pdd-interface>
 {
@@ -14,11 +14,11 @@
 % You are an expert Python engineer. Your goal is to write the pdd/model_tester.py module.
 
 % Role & Scope
-Tests a single configured model by making one `litellm.completion()` call with a minimal prompt. Only runs when the user explicitly chooses it — no surprise API costs. Uses `litellm.completion()` directly (not `llm_invoke`) because `llm_invoke` doesn't allow choosing a specific model or key.
+Tests a single configured model by making one provider-appropriate LiteLLM request with a minimal prompt. Only runs when the user explicitly chooses it — no surprise API costs. Uses LiteLLM directly (not `llm_invoke`) because `llm_invoke` doesn't allow choosing a specific model or key.
 
 % Requirements
 1. Function: `test_model_interactive()` — show models from `~/.pdd/llm_model.csv`, let user pick one, test it, loop until user exits (empty input or "q")
-2. Test call: `litellm.completion(model=..., messages=[...], timeout=8)`. Only pass `api_key=` for single-var providers. Preserve the exact `claude-opus-5` or `claude-fable-5` catalog model; they are distinct Anthropic API identifiers. Strip only an optional `anthropic/` provider prefix when required by the direct call.
+2. Test call: normally use `litellm.completion(model=..., messages=[...], timeout=8)`. For ChatGPT subscription `chatgpt/*` rows, bridge `codex login` credentials and apply the LiteLLM ChatGPT output patch, then use the Codex Responses smoke path: `litellm.responses(model=..., input=[{"role":"user","content":[{"type":"input_text","text":"Say OK"}]}], timeout=8)`. Treat the smoke test as successful only when the Responses payload contains a nonempty `output_text`; an empty or missing response output is a failure. Never send `chatgpt/*` smoke tests to chat-completions. Only pass `api_key=` for single-var providers. Preserve the exact `claude-opus-5` or `claude-fable-5` catalog model; they are distinct Anthropic API identifiers. Strip only an optional `anthropic/` provider prefix when required by the direct call.
 3. The CSV `api_key` column may be pipe-delimited (e.g. "VAR1|VAR2|VAR3"). Use `parse_api_key_vars()` from provider_manager and `resolve_api_key_from_env()` for single-var lookup so `GOOGLE_API_KEY` satisfies Gemini rows that still name `GEMINI_API_KEY`.
    - Single var: resolve from env including aliases, pass as api_key= to litellm.
    - Multi var: do NOT pass api_key= — litellm reads from os.environ (Bedrock, Azure, Vertex).

--- a/tests/test_codex_subscription.py
+++ b/tests/test_codex_subscription.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pandas as pd
@@ -202,30 +203,191 @@ def test_chatgpt_row_present_in_candidates():
 
 
 def test_fallback_reaches_chatgpt_when_anthropic_key_missing(monkeypatch):
-    """The load-bearing test: no ANTHROPIC_API_KEY, --force -> chatgpt is invoked."""
+    """No Anthropic key under --force reaches ChatGPT's Responses endpoint."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("PDD_LLM_INVOKE_ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("PDD_MODEL_DEFAULT", "claude-sonnet-4-6")
     monkeypatch.setenv("PDD_FORCE", "1")
     monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
 
     captured = {}
 
-    def fake_completion(**kwargs):
+    def fake_responses(**kwargs):
         captured["model"] = kwargs.get("model")
         raise RuntimeError("STOP_AFTER_CAPTURE")
 
     with patch("pdd.llm_invoke._load_model_data", return_value=_fake_model_df()), \
          patch("pdd.codex_subscription.has_codex_subscription_auth", return_value=True), \
          patch("pdd.codex_subscription.bridge_codex_auth_for_litellm", return_value=True), \
-         patch("pdd.llm_invoke.litellm.completion", side_effect=fake_completion):
+         patch("pdd.codex_subscription.apply_litellm_chatgpt_output_patch", return_value=True), \
+         patch("pdd.llm_invoke.litellm.responses", side_effect=fake_responses), \
+         patch("pdd.llm_invoke.litellm.completion") as completion:
         try:
             li.llm_invoke(prompt="hi {x}", input_json={"x": "there"}, strength=0.5, verbose=False)
         except Exception:
             pass
 
     # Anthropic row is skipped (missing key in --force); chatgpt is the first
-    # model that actually reaches litellm.completion.
+    # model that actually reaches LiteLLM.
     assert captured.get("model") == "chatgpt/gpt-5.3-codex"
+    completion.assert_not_called()
+
+
+def test_chatgpt_generation_uses_responses_api_with_list_input(monkeypatch):
+    """Generation must use the same Codex Responses endpoint proven by setup."""
+    monkeypatch.setenv("PDD_MODEL_DEFAULT", "chatgpt/gpt-5.3-codex")
+    monkeypatch.setenv("PDD_FORCE", "1")
+    monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+
+    output = SimpleNamespace(
+        type="message",
+        content=[SimpleNamespace(type="output_text", text="hello there")],
+    )
+    response = SimpleNamespace(
+        output=[output],
+        usage=SimpleNamespace(input_tokens=5, output_tokens=2),
+        status="completed",
+    )
+
+    with patch("pdd.llm_invoke._load_model_data", return_value=_fake_model_df()), \
+         patch("pdd.codex_subscription.has_codex_subscription_auth", return_value=True), \
+         patch("pdd.codex_subscription.bridge_codex_auth_for_litellm", return_value=True), \
+         patch("pdd.codex_subscription.apply_litellm_chatgpt_output_patch", return_value=True), \
+         patch("pdd.llm_invoke.litellm.responses", return_value=response) as responses, \
+         patch("pdd.llm_invoke.litellm.completion") as completion:
+        result = li.llm_invoke(
+            prompt="say hello to {name}",
+            input_json={"name": "there"},
+            strength=0.5,
+            verbose=False,
+        )
+
+    assert result["result"] == "hello there"
+    responses.assert_called_once()
+    completion.assert_not_called()
+    kwargs = responses.call_args.kwargs
+    assert kwargs["model"] == "chatgpt/gpt-5.3-codex"
+    assert isinstance(kwargs["input"], list)
+    assert kwargs["input"][0]["content"][0]["type"] == "input_text"
+    assert "say hello to there" in kwargs["input"][0]["content"][0]["text"]
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        [],
+        [SimpleNamespace(type="message", content=[])],
+        [
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text=None)],
+            )
+        ],
+        [
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text=" \n\t")],
+            )
+        ],
+    ],
+    ids=["no-output", "no-content", "non-string-text", "whitespace-text"],
+)
+def test_chatgpt_generation_rejects_empty_responses_output(monkeypatch, output):
+    """Empty Responses output must fail closed without using completion()."""
+    monkeypatch.setenv("PDD_MODEL_DEFAULT", "chatgpt/gpt-5.3-codex")
+    monkeypatch.setenv("PDD_FORCE", "1")
+    monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+
+    response = SimpleNamespace(
+        output=output,
+        usage=SimpleNamespace(input_tokens=5, output_tokens=0),
+        status="completed",
+    )
+
+    with patch("pdd.llm_invoke._load_model_data", return_value=_fake_model_df()), \
+         patch("pdd.codex_subscription.has_codex_subscription_auth", return_value=True), \
+         patch("pdd.codex_subscription.bridge_codex_auth_for_litellm", return_value=True), \
+         patch("pdd.codex_subscription.apply_litellm_chatgpt_output_patch", return_value=True), \
+         patch("pdd.llm_invoke.litellm.responses", return_value=response) as responses, \
+         patch("pdd.llm_invoke.litellm.completion") as completion:
+        with pytest.raises(
+            RuntimeError, match="Responses API returned no non-empty text output"
+        ):
+            li.llm_invoke(
+                prompt="say hello to {name}",
+                input_json={"name": "there"},
+                strength=0.5,
+                verbose=False,
+            )
+
+    responses.assert_called_once()
+    completion.assert_not_called()
+
+
+def test_chatgpt_generation_preserves_code_generator_multimodal_content(monkeypatch):
+    """Code-generator text/image messages retain their image in Responses input."""
+    monkeypatch.setenv("PDD_MODEL_DEFAULT", "chatgpt/gpt-5.3-codex")
+    monkeypatch.setenv("PDD_FORCE", "1")
+    monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+
+    response = SimpleNamespace(
+        output=[SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="looks good")],
+        )],
+        usage=SimpleNamespace(input_tokens=5, output_tokens=2),
+        status="completed",
+    )
+    image_url = "data:image/png;base64,AA=="
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this image."},
+            {"type": "image_url", "image_url": {"url": image_url}},
+        ],
+    }]
+
+    with patch("pdd.llm_invoke._load_model_data", return_value=_fake_model_df()), \
+         patch("pdd.codex_subscription.has_codex_subscription_auth", return_value=True), \
+         patch("pdd.codex_subscription.bridge_codex_auth_for_litellm", return_value=True), \
+         patch("pdd.codex_subscription.apply_litellm_chatgpt_output_patch", return_value=True), \
+         patch("pdd.llm_invoke.litellm.responses", return_value=response) as responses, \
+         patch("pdd.llm_invoke.litellm.completion") as completion:
+        result = li.llm_invoke(messages=messages, strength=0.5, verbose=False)
+
+    assert result["result"] == "looks good"
+    assert responses.call_args.kwargs["input"] == [{
+        "role": "user",
+        "content": [
+            {"type": "input_text", "text": "Describe this image."},
+            {"type": "input_image", "image_url": image_url},
+        ],
+    }]
+    completion.assert_not_called()
+
+
+def test_chatgpt_batch_fails_before_unsupported_litellm_endpoints(monkeypatch):
+    """The Responses-only subscription adapter must not hit batch completions."""
+    monkeypatch.setenv("PDD_MODEL_DEFAULT", "chatgpt/gpt-5.3-codex")
+    monkeypatch.setenv("PDD_FORCE", "1")
+    monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
+
+    with patch("pdd.llm_invoke._load_model_data", return_value=_fake_model_df()), \
+         patch("pdd.llm_invoke.litellm.responses") as responses, \
+         patch("pdd.llm_invoke.litellm.completion") as completion, \
+         patch("pdd.llm_invoke.litellm.batch_completion") as batch_completion:
+        with pytest.raises(ValueError, match="do not support batch invocations"):
+            li.llm_invoke(
+                prompt="say hello to {name}",
+                input_json=[{"name": "Ada"}, {"name": "Grace"}],
+                strength=0.5,
+                use_batch_mode=True,
+                verbose=False,
+            )
+
+    responses.assert_not_called()
+    completion.assert_not_called()
+    batch_completion.assert_not_called()
 
 
 def test_stale_catalog_reports_missing_exact_chatgpt_model(monkeypatch, caplog):
@@ -394,12 +556,9 @@ def test_anthropic_outranks_codex_so_default_unchanged():
 
 
 def test_chatgpt_structured_never_sends_response_format(monkeypatch):
-    """P1b (#1269, Greg review): EVERY chatgpt/ structured completion attempt —
-    the initial call AND the retry/repair calls — must (a) omit response_format
-    (the subscription backend ignores it) and (b) carry the in-prompt schema
-    instruction (the ONLY structured-output enforcement). Force non-JSON so the
-    repair retry fires, then assert both invariants on every recorded call."""
+    """ChatGPT Responses input carries the schema instead of text.format."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("PDD_MODEL_DEFAULT", "chatgpt/gpt-5.3-codex")
     monkeypatch.setenv("PDD_FORCE", "1")
     monkeypatch.setenv("PDD_FORCE_LOCAL", "1")
     from pydantic import BaseModel
@@ -419,39 +578,74 @@ def test_chatgpt_structured_never_sends_response_format(monkeypatch):
 
     # Marker from build_chatgpt_schema_instruction().
     SCHEMA_MARKER = "valid JSON object matching this schema"
-    seen = []  # one entry per attempt: {"rf": bool, "schema": bool}
+    seen = []
 
-    def fake_completion(**kwargs):
-        msgs = kwargs.get("messages") or []
+    def fake_responses(**kwargs):
+        msgs = kwargs.get("input") or []
         has_schema = any(
-            isinstance(m, dict) and SCHEMA_MARKER in (m.get("content") or "")
+            isinstance(m, dict)
+            and any(
+                SCHEMA_MARKER in (part.get("text") or "")
+                for part in (m.get("content") or [])
+                if isinstance(part, dict)
+            )
             for m in msgs
         )
-        seen.append({"rf": "response_format" in kwargs, "schema": has_schema})
-        # Return None content to force the cache-bypass retry path (one of the
-        # three retry sites), so we verify the retry call re-injects the schema.
-        msg = type("M", (), {"content": None, "role": "assistant"})()
-        choice = type("C", (), {"message": msg, "finish_reason": "stop"})()
-        usage = type("U", (), {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10})()
-        return type("R", (), {"choices": [choice], "usage": usage})()
+        seen.append({
+            "response_format": "response_format" in kwargs,
+            "text": "text" in kwargs,
+            "schema": has_schema,
+        })
+        return SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    content=[
+                        SimpleNamespace(
+                            type="output_text",
+                            text='{"country":"France","capital":"Paris"}',
+                        )
+                    ],
+                )
+            ],
+            usage=SimpleNamespace(input_tokens=5, output_tokens=5),
+            status="completed",
+        )
 
     with patch("pdd.llm_invoke._load_model_data", return_value=df), \
          patch("pdd.codex_subscription.has_codex_subscription_auth", return_value=True), \
          patch("pdd.codex_subscription.bridge_codex_auth_for_litellm", return_value=True), \
          patch("pdd.codex_subscription.apply_litellm_chatgpt_output_patch", return_value=True), \
-         patch("pdd.llm_invoke.litellm.completion", side_effect=fake_completion):
-        try:
-            li.llm_invoke(prompt="info about {c}", input_json={"c": "France"},
-                          strength=0.5, output_pydantic=Cap, verbose=False)
-        except Exception:
-            pass
+         patch("pdd.llm_invoke.litellm.responses", side_effect=fake_responses), \
+         patch("pdd.llm_invoke.litellm.completion") as completion:
+        result = li.llm_invoke(
+            prompt="info about {c}",
+            input_json={"c": "France"},
+            strength=0.5,
+            output_pydantic=Cap,
+            verbose=False,
+        )
 
-    assert seen, "litellm.completion was never called"
-    assert len(seen) >= 2, f"expected initial + at least one retry attempt, got {seen}"
-    assert not any(s["rf"] for s in seen), f"chatgpt/ call(s) sent response_format: {seen}"
-    assert all(s["schema"] for s in seen), (
-        f"a chatgpt/ structured attempt lacked the schema instruction (retry regressed): {seen}"
-    )
+    assert result["result"] == Cap(country="France", capital="Paris")
+    assert seen == [{"response_format": False, "text": False, "schema": True}]
+    completion.assert_not_called()
+
+
+def test_chatgpt_source_prompts_document_responses_contract():
+    """Mirrored source prompts preserve the subscription routing contract."""
+    root = Path(__file__).resolve().parents[1]
+    llm_prompt = (root / "prompts" / "llm_invoke_python.prompt").read_text()
+    mirrored_llm_prompt = (root / "pdd" / "prompts" / "llm_invoke_python.prompt").read_text()
+    tester_prompt = (root / "prompts" / "model_tester_python.prompt").read_text()
+    mirrored_tester_prompt = (root / "pdd" / "prompts" / "model_tester_python.prompt").read_text()
+
+    assert llm_prompt == mirrored_llm_prompt
+    assert tester_prompt == mirrored_tester_prompt
+    assert "list-form Responses input" in llm_prompt
+    assert "input_image" in llm_prompt
+    assert "inject the JSON schema as an in-band system-message instruction" in llm_prompt
+    assert "Batch invocation is unsupported: fail closed" in llm_prompt
+    assert "Codex Responses smoke path" in tester_prompt
 
 
 def test_splice_collapses_gpt54_multi_message_output():

--- a/tests/test_model_tester.py
+++ b/tests/test_model_tester.py
@@ -16,35 +16,38 @@
 #   10. test_successful_test_passes_api_key_for_single_var: Single api_key var → passed as api_key= to litellm.
 #   11. test_multi_var_provider_no_api_key_kwarg: Bedrock (pipe-delimited) → api_key= NOT passed to litellm.
 #   12. test_device_flow_no_api_key_kwarg: Empty api_key → api_key= NOT passed to litellm.
+#   13. test_chatgpt_subscription_uses_codex_responses_with_bridged_auth:
+#       chatgpt/* → Codex login is bridged and the Responses API is used.
 #
 # IV. Failed Model Test (end-to-end through test_model_interactive)
-#   13. test_auth_error_shows_classified_message: LLM raises 401 → output shows "Authentication error".
-#   14. test_connection_refused_shows_local_server_hint: LLM raises connection error → output suggests local server.
+#   14. test_auth_error_shows_classified_message: LLM raises 401 → output shows "Authentication error".
+#   15. test_connection_refused_shows_local_server_hint: LLM raises connection error → output suggests local server.
 #
 # V. Diagnostics Displayed Before Test
-#   15. test_diagnostics_show_key_found: API key in env → output includes "✓ Found".
-#   16. test_diagnostics_show_key_missing: API key not in env → output includes "✗ Not found".
-#   17. test_diagnostics_show_base_url_for_lm_studio: LM Studio model → base URL shown in output.
-#   18. test_diagnostics_bedrock_checks_all_vars: Bedrock model → all three env vars checked in output.
-#   19. test_diagnostics_vertex_bad_creds_file: GOOGLE_APPLICATION_CREDENTIALS path invalid → warns in output.
-#   20. test_diagnostics_device_flow_no_key_needed: Empty api_key → output indicates no key needed.
-#   21. test_diagnostics_show_base_url_for_zai: Z.AI row → base URL shown in diagnostics output.
-#   22. test_zai_kwargs_include_base_url_and_api_base: Z.AI general API → litellm gets base_url and api_base.
-#   23. test_zai_coding_plan_kwargs_use_coding_endpoint: Z.AI Coding Plan → coding endpoint in kwargs.
+#   16. test_diagnostics_show_key_found: API key in env → output includes "✓ Found".
+#   17. test_diagnostics_show_key_missing: API key not in env → output includes "✗ Not found".
+#   18. test_diagnostics_show_base_url_for_lm_studio: LM Studio model → base URL shown in output.
+#   19. test_diagnostics_bedrock_checks_all_vars: Bedrock model → all three env vars checked in output.
+#   20. test_diagnostics_vertex_bad_creds_file: GOOGLE_APPLICATION_CREDENTIALS path invalid → warns in output.
+#   21. test_diagnostics_device_flow_no_key_needed: Empty api_key → output indicates no key needed.
+#   22. test_diagnostics_show_base_url_for_zai: Z.AI row → base URL shown in diagnostics output.
+#   23. test_zai_kwargs_include_base_url_and_api_base: Z.AI general API → litellm gets base_url and api_base.
+#   24. test_zai_coding_plan_kwargs_use_coding_endpoint: Z.AI Coding Plan → coding endpoint in kwargs.
 #
 # VI. Session Persistence
-#   24. test_results_persist_across_picks: User tests model 1 then model 2 → both results shown in table.
+#   25. test_results_persist_across_picks: User tests model 1 then model 2 → both results shown in table.
 #
 # VII. CSV Loading Normalization
-#   25. test_csv_normalizes_nan_strings_and_bad_numerics: NaN strings → "", bad numbers → 0.0.
+#   26. test_csv_normalizes_nan_strings_and_bad_numerics: NaN strings → "", bad numbers → 0.0.
 #
 # VIII. Pure Function Contracts
-#   26-31. _classify_error: auth, connection refused, not found, timeout, rate limit, generic.
-#   32-33. _calculate_cost: basic math, zero tokens.
+#   27-32. _classify_error: auth, connection refused, not found, timeout, rate limit, generic.
+#   33-34. _calculate_cost: basic math, zero tokens.
 
 """Tests for model_tester.py — behavioral tests driven through test_model_interactive()."""
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from pdd import model_tester
@@ -156,6 +159,14 @@ DEVICE_FLOW_CSV = (
     "provider,model,api_key,input,output\n"
     "Github Copilot,github_copilot/gpt-5,,0.0,0.0\n"
 )
+
+CHATGPT_SUBSCRIPTION_ROW = {
+    "provider": "OpenAI ChatGPT",
+    "model": "chatgpt/gpt-5.6-sol",
+    "api_key": "",
+    "input": 0.0,
+    "output": 0.0,
+}
 
 LM_STUDIO_CSV = (
     "provider,model,api_key,input,output,base_url\n"
@@ -337,6 +348,72 @@ def test_device_flow_no_api_key_kwarg(tmp_path, monkeypatch):
     )
     call_kwargs = mock_comp.call_args[1]
     assert "api_key" not in call_kwargs
+
+
+def test_chatgpt_subscription_uses_codex_responses_with_bridged_auth():
+    """The setup/model smoke test must stage ``codex login`` credentials and
+    use the working Codex Responses route, not the legacy chat-completions route."""
+    bridge = MagicMock(return_value=True)
+
+    def responses_after_bridge(**_kwargs):
+        assert bridge.called, "Codex auth was not bridged before LiteLLM was called"
+        return SimpleNamespace(
+            output=[SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text="OK")],
+            )],
+            usage=SimpleNamespace(input_tokens=2, output_tokens=1),
+        )
+
+    with patch(
+        "pdd.codex_subscription.bridge_codex_auth_for_litellm", bridge
+    ), patch(
+        "pdd.codex_subscription.apply_litellm_chatgpt_output_patch"
+    ) as output_patch, patch(
+        "litellm.responses", side_effect=responses_after_bridge
+    ) as responses, patch(
+        "litellm.completion",
+        side_effect=AssertionError("legacy chat-completions route must not be used"),
+    ) as completion:
+        result = model_tester._run_test(CHATGPT_SUBSCRIPTION_ROW)
+
+    assert result["success"] is True
+    bridge.assert_called_once_with()
+    output_patch.assert_called_once_with()
+    responses.assert_called_once_with(
+        model="chatgpt/gpt-5.6-sol",
+        input=[{
+            "role": "user",
+            "content": [{"type": "input_text", "text": "Say OK"}],
+        }],
+        timeout=8,
+    )
+    completion.assert_not_called()
+
+
+def test_chatgpt_subscription_rejects_empty_responses_output():
+    """A transport-successful Responses call is not a valid smoke-test result."""
+    empty_response = SimpleNamespace(
+        output=[],
+        usage=SimpleNamespace(input_tokens=2, output_tokens=0),
+    )
+
+    with patch(
+        "pdd.codex_subscription.bridge_codex_auth_for_litellm", return_value=True
+    ), patch(
+        "pdd.codex_subscription.apply_litellm_chatgpt_output_patch"
+    ), patch(
+        "litellm.responses", return_value=empty_response
+    ) as responses, patch(
+        "litellm.completion",
+        side_effect=AssertionError("legacy chat-completions route must not be used"),
+    ) as completion:
+        result = model_tester._run_test(CHATGPT_SUBSCRIPTION_ROW)
+
+    assert result["success"] is False
+    assert "no meaningful output" in result["error"]
+    responses.assert_called_once()
+    completion.assert_not_called()
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- route `chatgpt/*` model smoke tests and normal generation through LiteLLM's Responses API
- bridge Codex login credentials and apply the existing ChatGPT SSE output patch before setup/model tests
- send ChatGPT Responses requests as list-form input built from the final messages, preserving schema-in-prompt instructions
- prevent failed ChatGPT Responses requests from falling through to the unsupported chat-completions endpoint
- retain the existing direct OpenAI GPT-5 Responses behavior and hosted-budget admission checks

## Root cause

`pdd setup` and `pdd generate` exercised different LiteLLM paths. The setup/model test could validate the Codex subscription, while generation called `litellm.completion()` for `chatgpt/gpt-5.6-sol`. That targeted `/backend-api/codex/chat/completions`, which returned a browser-only Cloudflare challenge. PDD then fell back to Gemini despite the ChatGPT subscription being valid.

The Codex subscription backend works through `litellm.responses()` and requires list-shaped `input`.

## Tests

- `pytest -q tests/test_model_tester.py tests/test_codex_subscription.py` — 71 passed
- focused ChatGPT/Codex/Responses regression selection — 43 passed
- existing OpenAI Responses API tests — 4 passed
- `python -m py_compile pdd/llm_invoke.py pdd/model_tester.py`
- `git diff --check`

## Live verification

Ran an editable install against an authenticated Codex subscription:

```bash
PDD_MODEL_DEFAULT=chatgpt/gpt-5.6-sol \
PDD_FORCE=1 \
pdd --local --strength 1.0 generate success_python.prompt \
  --output /home/glt/pdd/codex_responses_smoke.py
```

The command completed without the Cloudflare response or Gemini fallback:

```text
✓ Step 1 (generate): Cost: $0.000000, Model: chatgpt/gpt-5.6-sol
```
