### PR TITLE
fix(sync): restore protected rollout policy

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -365,6 +365,18 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/code_generator_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/code_generator_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/commands_checkup_python.json",
       "role": "human-maintained"
     },
@@ -426,7 +438,31 @@
     {
       "inventory": "HUMAN_OWNED",
       "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/continue_generation_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/continue_generation_python_run.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/core_cloud_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/detect_change_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/detect_change_python_run.json",
       "role": "human-maintained"
     },
     {
@@ -485,6 +521,18 @@
       "owner": "pdd-maintainers",
       "pattern": ".pdd/meta/generate_model_catalog_python.json",
       "preauthorize_absent": true,
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/generate_test_python.json",
+      "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": ".pdd/meta/generate_test_python_run.json",
       "role": "human-maintained"
     },
     {

--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -613,6 +613,61 @@
       "head_policy_sha256": "c3f9d1344b067ba8640db6da706a8c17f13fcd47b09805b786e58a65fca6169e",
       "base_prompt_sha256": "15c51e9dbc3bb536ab6d6dfa1a7927a30f33b1423398e326e5a06f9524896735",
       "head_prompt_sha256": "40a65972cb0e737e2bec41b4b8331975de67215ef77fcf93da31d13e6ceb2153"
+    },
+    {
+      "prompt_path": "pdd/prompts/code_generator_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:2db9dd103925fef2b56138d3fa0056d86d30d1026e60ea17477d892d6df1357e",
+      "to_requirement_id": "CONTRACT-SHA256:72b374c6501e5264a482c0c3ad73be501d4993629783f842d7abd27779f01c8d",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "a7dd6a8f4145e2a4712ca925abde0edc58c47be271a1a06e1750aa39347a76c7",
+      "head_policy_sha256": "30cc5d9cb8d47eda3bd8fb02aab35ab965a256d6729c7ba1dfd836fb7fa1e1d3",
+      "base_prompt_sha256": "2db9dd103925fef2b56138d3fa0056d86d30d1026e60ea17477d892d6df1357e",
+      "head_prompt_sha256": "72b374c6501e5264a482c0c3ad73be501d4993629783f842d7abd27779f01c8d"
+    },
+    {
+      "prompt_path": "pdd/prompts/continue_generation_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:28c8cbbcae23ee2d98a0c7cd37da0cd3e3ff0979a25aaaafa179d851aff0678e",
+      "to_requirement_id": "CONTRACT-SHA256:4f57a0c4d3596a328c920f96126fc8b2242f66c415f7d8d27d8d7a17a33291b7",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "a7dd6a8f4145e2a4712ca925abde0edc58c47be271a1a06e1750aa39347a76c7",
+      "head_policy_sha256": "30cc5d9cb8d47eda3bd8fb02aab35ab965a256d6729c7ba1dfd836fb7fa1e1d3",
+      "base_prompt_sha256": "28c8cbbcae23ee2d98a0c7cd37da0cd3e3ff0979a25aaaafa179d851aff0678e",
+      "head_prompt_sha256": "4f57a0c4d3596a328c920f96126fc8b2242f66c415f7d8d27d8d7a17a33291b7"
+    },
+    {
+      "prompt_path": "pdd/prompts/detect_change_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:d5ac2b7fceec8fa95e4711829525faa57bdf5cf01f9d44132a346bb020dcf0a9",
+      "to_requirement_id": "CONTRACT-SHA256:344cb9470c8bb555599d87a0ae4885fcbca80dbafc58f6720170225e738335c9",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "a7dd6a8f4145e2a4712ca925abde0edc58c47be271a1a06e1750aa39347a76c7",
+      "head_policy_sha256": "30cc5d9cb8d47eda3bd8fb02aab35ab965a256d6729c7ba1dfd836fb7fa1e1d3",
+      "base_prompt_sha256": "d5ac2b7fceec8fa95e4711829525faa57bdf5cf01f9d44132a346bb020dcf0a9",
+      "head_prompt_sha256": "344cb9470c8bb555599d87a0ae4885fcbca80dbafc58f6720170225e738335c9"
+    },
+    {
+      "prompt_path": "pdd/prompts/generate_test_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:888960950f740a4b792cc9980343ddee5e40c8e3c5ebd4ff4c33ef7d66d5ea05",
+      "to_requirement_id": "CONTRACT-SHA256:42354b865666983f2bae2b959dc64629d9df2de59c3e08ff0542a8e6687ff58c",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "a7dd6a8f4145e2a4712ca925abde0edc58c47be271a1a06e1750aa39347a76c7",
+      "head_policy_sha256": "30cc5d9cb8d47eda3bd8fb02aab35ab965a256d6729c7ba1dfd836fb7fa1e1d3",
+      "base_prompt_sha256": "888960950f740a4b792cc9980343ddee5e40c8e3c5ebd4ff4c33ef7d66d5ea05",
+      "head_prompt_sha256": "42354b865666983f2bae2b959dc64629d9df2de59c3e08ff0542a8e6687ff58c"
+    },
+    {
+      "prompt_path": "pdd/prompts/sync_determine_operation_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:c84ef0e33d0759ffcf6920e5cd14951045b43d2e6d4d93e8b5b9fb31f8215ed7",
+      "to_requirement_id": "CONTRACT-SHA256:48fe08ae08004ae02034118cf067b254c22fe7de800a9ece37834738da507677",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "a7dd6a8f4145e2a4712ca925abde0edc58c47be271a1a06e1750aa39347a76c7",
+      "head_policy_sha256": "30cc5d9cb8d47eda3bd8fb02aab35ab965a256d6729c7ba1dfd836fb7fa1e1d3",
+      "base_prompt_sha256": "c84ef0e33d0759ffcf6920e5cd14951045b43d2e6d4d93e8b5b9fb31f8215ed7",
+      "head_prompt_sha256": "48fe08ae08004ae02034118cf067b254c22fe7de800a9ece37834738da507677"
     }
   ]
 }

--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -613,61 +613,6 @@
       "head_policy_sha256": "c3f9d1344b067ba8640db6da706a8c17f13fcd47b09805b786e58a65fca6169e",
       "base_prompt_sha256": "15c51e9dbc3bb536ab6d6dfa1a7927a30f33b1423398e326e5a06f9524896735",
       "head_prompt_sha256": "40a65972cb0e737e2bec41b4b8331975de67215ef77fcf93da31d13e6ceb2153"
-    },
-    {
-      "prompt_path": "pdd/prompts/code_generator_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:2db9dd103925fef2b56138d3fa0056d86d30d1026e60ea17477d892d6df1357e",
-      "to_requirement_id": "CONTRACT-SHA256:72b374c6501e5264a482c0c3ad73be501d4993629783f842d7abd27779f01c8d",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "a7dd6a8f4145e2a4712ca925abde0edc58c47be271a1a06e1750aa39347a76c7",
-      "head_policy_sha256": "30cc5d9cb8d47eda3bd8fb02aab35ab965a256d6729c7ba1dfd836fb7fa1e1d3",
-      "base_prompt_sha256": "2db9dd103925fef2b56138d3fa0056d86d30d1026e60ea17477d892d6df1357e",
-      "head_prompt_sha256": "72b374c6501e5264a482c0c3ad73be501d4993629783f842d7abd27779f01c8d"
-    },
-    {
-      "prompt_path": "pdd/prompts/continue_generation_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:28c8cbbcae23ee2d98a0c7cd37da0cd3e3ff0979a25aaaafa179d851aff0678e",
-      "to_requirement_id": "CONTRACT-SHA256:4f57a0c4d3596a328c920f96126fc8b2242f66c415f7d8d27d8d7a17a33291b7",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "a7dd6a8f4145e2a4712ca925abde0edc58c47be271a1a06e1750aa39347a76c7",
-      "head_policy_sha256": "30cc5d9cb8d47eda3bd8fb02aab35ab965a256d6729c7ba1dfd836fb7fa1e1d3",
-      "base_prompt_sha256": "28c8cbbcae23ee2d98a0c7cd37da0cd3e3ff0979a25aaaafa179d851aff0678e",
-      "head_prompt_sha256": "4f57a0c4d3596a328c920f96126fc8b2242f66c415f7d8d27d8d7a17a33291b7"
-    },
-    {
-      "prompt_path": "pdd/prompts/detect_change_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:d5ac2b7fceec8fa95e4711829525faa57bdf5cf01f9d44132a346bb020dcf0a9",
-      "to_requirement_id": "CONTRACT-SHA256:344cb9470c8bb555599d87a0ae4885fcbca80dbafc58f6720170225e738335c9",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "a7dd6a8f4145e2a4712ca925abde0edc58c47be271a1a06e1750aa39347a76c7",
-      "head_policy_sha256": "30cc5d9cb8d47eda3bd8fb02aab35ab965a256d6729c7ba1dfd836fb7fa1e1d3",
-      "base_prompt_sha256": "d5ac2b7fceec8fa95e4711829525faa57bdf5cf01f9d44132a346bb020dcf0a9",
-      "head_prompt_sha256": "344cb9470c8bb555599d87a0ae4885fcbca80dbafc58f6720170225e738335c9"
-    },
-    {
-      "prompt_path": "pdd/prompts/generate_test_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:888960950f740a4b792cc9980343ddee5e40c8e3c5ebd4ff4c33ef7d66d5ea05",
-      "to_requirement_id": "CONTRACT-SHA256:42354b865666983f2bae2b959dc64629d9df2de59c3e08ff0542a8e6687ff58c",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "a7dd6a8f4145e2a4712ca925abde0edc58c47be271a1a06e1750aa39347a76c7",
-      "head_policy_sha256": "30cc5d9cb8d47eda3bd8fb02aab35ab965a256d6729c7ba1dfd836fb7fa1e1d3",
-      "base_prompt_sha256": "888960950f740a4b792cc9980343ddee5e40c8e3c5ebd4ff4c33ef7d66d5ea05",
-      "head_prompt_sha256": "42354b865666983f2bae2b959dc64629d9df2de59c3e08ff0542a8e6687ff58c"
-    },
-    {
-      "prompt_path": "pdd/prompts/sync_determine_operation_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:c84ef0e33d0759ffcf6920e5cd14951045b43d2e6d4d93e8b5b9fb31f8215ed7",
-      "to_requirement_id": "CONTRACT-SHA256:48fe08ae08004ae02034118cf067b254c22fe7de800a9ece37834738da507677",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "a7dd6a8f4145e2a4712ca925abde0edc58c47be271a1a06e1750aa39347a76c7",
-      "head_policy_sha256": "30cc5d9cb8d47eda3bd8fb02aab35ab965a256d6729c7ba1dfd836fb7fa1e1d3",
-      "base_prompt_sha256": "c84ef0e33d0759ffcf6920e5cd14951045b43d2e6d4d93e8b5b9fb31f8215ed7",
-      "head_prompt_sha256": "48fe08ae08004ae02034118cf067b254c22fe7de800a9ece37834738da507677"
     }
   ]
 }

--- a/.pdd/verification-profiles.json
+++ b/.pdd/verification-profiles.json
@@ -3943,7 +3943,7 @@
       "prompt_path": "pdd/prompts/code_generator_python.prompt",
       "language_id": "python",
       "required_requirement_ids": [
-        "CONTRACT-SHA256:2db9dd103925fef2b56138d3fa0056d86d30d1026e60ea17477d892d6df1357e"
+        "CONTRACT-SHA256:72b374c6501e5264a482c0c3ad73be501d4993629783f842d7abd27779f01c8d"
       ],
       "obligations": [
         {
@@ -3952,7 +3952,7 @@
           "validator_id": "threshold-ed25519",
           "validator_config_digest": "threshold-ed25519-v1",
           "requirement_ids": [
-            "CONTRACT-SHA256:2db9dd103925fef2b56138d3fa0056d86d30d1026e60ea17477d892d6df1357e"
+            "CONTRACT-SHA256:72b374c6501e5264a482c0c3ad73be501d4993629783f842d7abd27779f01c8d"
           ],
           "artifact_paths": [
             "pdd/prompts/code_generator_python.prompt"
@@ -4801,7 +4801,7 @@
       "prompt_path": "pdd/prompts/continue_generation_python.prompt",
       "language_id": "python",
       "required_requirement_ids": [
-        "CONTRACT-SHA256:28c8cbbcae23ee2d98a0c7cd37da0cd3e3ff0979a25aaaafa179d851aff0678e"
+        "CONTRACT-SHA256:4f57a0c4d3596a328c920f96126fc8b2242f66c415f7d8d27d8d7a17a33291b7"
       ],
       "obligations": [
         {
@@ -4810,7 +4810,7 @@
           "validator_id": "threshold-ed25519",
           "validator_config_digest": "threshold-ed25519-v1",
           "requirement_ids": [
-            "CONTRACT-SHA256:28c8cbbcae23ee2d98a0c7cd37da0cd3e3ff0979a25aaaafa179d851aff0678e"
+            "CONTRACT-SHA256:4f57a0c4d3596a328c920f96126fc8b2242f66c415f7d8d27d8d7a17a33291b7"
           ],
           "artifact_paths": [
             "pdd/prompts/continue_generation_python.prompt"
@@ -5175,7 +5175,7 @@
       "prompt_path": "pdd/prompts/detect_change_python.prompt",
       "language_id": "python",
       "required_requirement_ids": [
-        "CONTRACT-SHA256:d5ac2b7fceec8fa95e4711829525faa57bdf5cf01f9d44132a346bb020dcf0a9"
+        "CONTRACT-SHA256:344cb9470c8bb555599d87a0ae4885fcbca80dbafc58f6720170225e738335c9"
       ],
       "obligations": [
         {
@@ -5184,7 +5184,7 @@
           "validator_id": "threshold-ed25519",
           "validator_config_digest": "threshold-ed25519-v1",
           "requirement_ids": [
-            "CONTRACT-SHA256:d5ac2b7fceec8fa95e4711829525faa57bdf5cf01f9d44132a346bb020dcf0a9"
+            "CONTRACT-SHA256:344cb9470c8bb555599d87a0ae4885fcbca80dbafc58f6720170225e738335c9"
           ],
           "artifact_paths": [
             "pdd/prompts/detect_change_python.prompt"
@@ -7427,7 +7427,7 @@
       "prompt_path": "pdd/prompts/generate_test_python.prompt",
       "language_id": "python",
       "required_requirement_ids": [
-        "CONTRACT-SHA256:888960950f740a4b792cc9980343ddee5e40c8e3c5ebd4ff4c33ef7d66d5ea05"
+        "CONTRACT-SHA256:42354b865666983f2bae2b959dc64629d9df2de59c3e08ff0542a8e6687ff58c"
       ],
       "obligations": [
         {
@@ -7436,7 +7436,7 @@
           "validator_id": "threshold-ed25519",
           "validator_config_digest": "threshold-ed25519-v1",
           "requirement_ids": [
-            "CONTRACT-SHA256:888960950f740a4b792cc9980343ddee5e40c8e3c5ebd4ff4c33ef7d66d5ea05"
+            "CONTRACT-SHA256:42354b865666983f2bae2b959dc64629d9df2de59c3e08ff0542a8e6687ff58c"
           ],
           "artifact_paths": [
             "pdd/prompts/generate_test_python.prompt"
@@ -9813,7 +9813,7 @@
       "prompt_path": "pdd/prompts/sync_determine_operation_python.prompt",
       "language_id": "python",
       "required_requirement_ids": [
-        "CONTRACT-SHA256:c84ef0e33d0759ffcf6920e5cd14951045b43d2e6d4d93e8b5b9fb31f8215ed7"
+        "CONTRACT-SHA256:48fe08ae08004ae02034118cf067b254c22fe7de800a9ece37834738da507677"
       ],
       "obligations": [
         {
@@ -9822,7 +9822,7 @@
           "validator_id": "threshold-ed25519",
           "validator_config_digest": "threshold-ed25519-v1",
           "requirement_ids": [
-            "CONTRACT-SHA256:c84ef0e33d0759ffcf6920e5cd14951045b43d2e6d4d93e8b5b9fb31f8215ed7"
+            "CONTRACT-SHA256:48fe08ae08004ae02034118cf067b254c22fe7de800a9ece37834738da507677"
           ],
           "artifact_paths": [
             "pdd/prompts/sync_determine_operation_python.prompt"

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -1223,6 +1223,7 @@ def _sync_rollout_repair_ownership_rules(
     base_rules: tuple[OwnershipRule, ...],
     head_rules: tuple[OwnershipRule, ...],
 ) -> tuple[OwnershipRule, ...]:
+    # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     """Bridge the one reviewed base-existing metadata classification repair."""
     if repository_id != _PDD_REPOSITORY_ID:
         return base_rules

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -262,6 +262,61 @@ _REPLAY_HUMAN_OWNERSHIP = tuple(
 )
 
 
+# The release-2026-07-25 rollout repairs eight already-tracked metadata files.
+# The candidate policy must retain ordinary rows, so it cannot itself grant
+# absent-path authority.  This bridge is instead bound to the reviewed base
+# and candidate ownership bytes and to the unchanged bytes of every affected
+# artifact.  It classifies only those base-existing paths and never promotes a
+# row to ``preauthorize_absent``.
+_SYNC_ROLLOUT_REPAIR_OWNERSHIP_BYTES = (
+    "8f5762a5dd7be6cc14c85138810b8bad8183f4403c74584489a0d81798ba2a07",
+    "cd33e99f580fd0103339211b42976e6eff593a7a40c81c48129f280c1b766eb5",
+)
+_SYNC_ROLLOUT_REPAIR_METADATA_BYTES = (
+    (
+        ".pdd/meta/code_generator_python.json",
+        "fc290e4e99719087de461c390beb1b205a0fef124e7b8b3404088a0a8fc16db9",
+    ),
+    (
+        ".pdd/meta/code_generator_python_run.json",
+        "d06bb9b47711bf02f73b95e2bbf40d3124bbf1c1cb56ca6807165115923e463e",
+    ),
+    (
+        ".pdd/meta/continue_generation_python.json",
+        "e568bad6adce6674679294959f1b975b46bf0e3197f12bf6ae3255df63ee20b9",
+    ),
+    (
+        ".pdd/meta/continue_generation_python_run.json",
+        "127888aed12764a11ba3f3c5b29a5ca4ea5128b4f4fdee1c2e8aa2a68e18d7c5",
+    ),
+    (
+        ".pdd/meta/detect_change_python.json",
+        "67dc5b6e01504773a005e0131dd23b19ea3eb3c14d782809ae54da742a8f09b7",
+    ),
+    (
+        ".pdd/meta/detect_change_python_run.json",
+        "6c3da8d5736a18f7cbfca130c66e792ac82548c034f1ab678daade8bec25d8d0",
+    ),
+    (
+        ".pdd/meta/generate_test_python.json",
+        "ffcc4a5ae929aedbb4191a0920f41f8a1df029604c60a0ba16fc66a8d97fb067",
+    ),
+    (
+        ".pdd/meta/generate_test_python_run.json",
+        "7e64abbfc87b8eb09fa7f402b66276b36bda6a762ae1720ad60d1f57078c8989",
+    ),
+)
+_SYNC_ROLLOUT_REPAIR_HUMAN_OWNERSHIP = tuple(
+    OwnershipRule(
+        pattern,
+        InventoryStatus.HUMAN_OWNED,
+        "human-maintained",
+        "pdd-maintainers",
+    )
+    for pattern, _digest in _SYNC_ROLLOUT_REPAIR_METADATA_BYTES
+)
+
+
 @dataclass(frozen=True)
 class _TreeManifest:
     """Parsed candidate inputs for one immutable Git tree."""
@@ -1160,6 +1215,53 @@ def _bootstrap_ownership_rules(
     return tuple(sorted((*base_rules, *additions)))
 
 
+def _sync_rollout_repair_ownership_rules(
+    root: Path,
+    repository_id: str,
+    base_ref: str,
+    head_ref: str,
+    base_rules: tuple[OwnershipRule, ...],
+    head_rules: tuple[OwnershipRule, ...],
+) -> tuple[OwnershipRule, ...]:
+    """Bridge the one reviewed base-existing metadata classification repair."""
+    if repository_id != _PDD_REPOSITORY_ID:
+        return base_rules
+    ownership_path = PurePosixPath(".pdd/sync-ownership.json")
+    base_policy = read_git_blob(root, base_ref, ownership_path)
+    head_policy = read_git_blob(root, head_ref, ownership_path)
+    if (
+        base_policy is None
+        or head_policy is None
+        or (
+            hashlib.sha256(base_policy).hexdigest(),
+            hashlib.sha256(head_policy).hexdigest(),
+        )
+        != _SYNC_ROLLOUT_REPAIR_OWNERSHIP_BYTES
+    ):
+        return base_rules
+
+    base_by_pattern = {rule.pattern: rule for rule in base_rules}
+    head_by_pattern = {rule.pattern: rule for rule in head_rules}
+    if any(
+        expected.pattern in base_by_pattern
+        or head_by_pattern.get(expected.pattern) != expected
+        for expected in _SYNC_ROLLOUT_REPAIR_HUMAN_OWNERSHIP
+    ):
+        return base_rules
+    for pattern, expected_digest in _SYNC_ROLLOUT_REPAIR_METADATA_BYTES:
+        path = PurePosixPath(pattern)
+        base_raw = read_git_blob(root, base_ref, path)
+        head_raw = read_git_blob(root, head_ref, path)
+        if (
+            base_raw is None
+            or head_raw is None
+            or hashlib.sha256(base_raw).hexdigest() != expected_digest
+            or hashlib.sha256(head_raw).hexdigest() != expected_digest
+        ):
+            return base_rules
+    return tuple(sorted((*base_rules, *_SYNC_ROLLOUT_REPAIR_HUMAN_OWNERSHIP)))
+
+
 def _replay_bootstrap_weakenings(
     root: Path,
     repository_id: str,
@@ -1468,6 +1570,14 @@ def build_unit_manifest(
         base_ref,
         head_ref,
         ownership,
+        head_ownership,
+    )
+    transition_ownership = _sync_rollout_repair_ownership_rules(
+        repository_root,
+        repository_id,
+        base_ref,
+        head_ref,
+        transition_ownership,
         head_ownership,
     )
     replay_bootstrap_weakenings = _replay_bootstrap_weakenings(

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -115,6 +115,46 @@ _OPUS_FABLE_COMPOSED_PROFILE_BYTES = (
     "a7dd6a8f4145e2a4712ca925abde0edc58c47be271a1a06e1750aa39347a76c7",
 )
 
+# The release-2026-07-25 protected base contains five stale profile rows even
+# though the corresponding prompt bytes already hold their intended values.
+# Reconcile only the reviewed base/head policy bytes and unchanged prompt
+# bytes; this is not a reusable prompt-transition authorization.
+_SYNC_ROLLOUT_REPAIR_ROTATION_POLICY_BYTES = (
+    "3b5117e0ef31b19b68d7190f0753e7aacaef3f75133cabfe4c2470afe87c0a95",
+    "3b5117e0ef31b19b68d7190f0753e7aacaef3f75133cabfe4c2470afe87c0a95",
+)
+_SYNC_ROLLOUT_REPAIR_PROFILE_BYTES = (
+    "a7dd6a8f4145e2a4712ca925abde0edc58c47be271a1a06e1750aa39347a76c7",
+    "30cc5d9cb8d47eda3bd8fb02aab35ab965a256d6729c7ba1dfd836fb7fa1e1d3",
+)
+_SYNC_ROLLOUT_REPAIR_PROMPT_BYTES = (
+    (
+        PurePosixPath("pdd/prompts/code_generator_python.prompt"),
+        "python",
+        "72b374c6501e5264a482c0c3ad73be501d4993629783f842d7abd27779f01c8d",
+    ),
+    (
+        PurePosixPath("pdd/prompts/continue_generation_python.prompt"),
+        "python",
+        "4f57a0c4d3596a328c920f96126fc8b2242f66c415f7d8d27d8d7a17a33291b7",
+    ),
+    (
+        PurePosixPath("pdd/prompts/detect_change_python.prompt"),
+        "python",
+        "344cb9470c8bb555599d87a0ae4885fcbca80dbafc58f6720170225e738335c9",
+    ),
+    (
+        PurePosixPath("pdd/prompts/generate_test_python.prompt"),
+        "python",
+        "42354b865666983f2bae2b959dc64629d9df2de59c3e08ff0542a8e6687ff58c",
+    ),
+    (
+        PurePosixPath("pdd/prompts/sync_determine_operation_python.prompt"),
+        "python",
+        "48fe08ae08004ae02034118cf067b254c22fe7de800a9ece37834738da507677",
+    ),
+)
+
 
 class VerificationProfileError(ValueError):
     """Raised when protected verification-profile data cannot be parsed."""
@@ -3063,6 +3103,65 @@ def _authorized_profile_additions(
     return additions
 
 
+def _authorized_sync_rollout_profile_reconciliation(
+    root: Path,
+    manifest: UnitManifest,
+    base: Mapping[UnitId, _ProfileInput],
+    head: Mapping[UnitId, _ProfileInput],
+    base_invalid: list[str],
+) -> tuple[dict[UnitId, _ProfileInput], frozenset[str]]:
+    """Authorize the one exact stale-profile repair from the protected base."""
+    if manifest.repository_id != _PDD_REPOSITORY_ID:
+        return {}, frozenset()
+    base_profile = read_git_blob(root, manifest.base_ref, PROFILE_PATH)
+    head_profile = read_git_blob(root, manifest.head_ref, PROFILE_PATH)
+    base_rotations = read_git_blob(root, manifest.base_ref, ROTATION_POLICY_PATH)
+    head_rotations = read_git_blob(root, manifest.head_ref, ROTATION_POLICY_PATH)
+    if (
+        None in (base_profile, head_profile, base_rotations, head_rotations)
+        or (
+            _sha256(base_profile),
+            _sha256(head_profile),
+        )
+        != _SYNC_ROLLOUT_REPAIR_PROFILE_BYTES
+        or (
+            _sha256(base_rotations),
+            _sha256(head_rotations),
+        )
+        != _SYNC_ROLLOUT_REPAIR_ROTATION_POLICY_BYTES
+    ):
+        return {}, frozenset()
+    assert base_profile is not None and head_profile is not None
+    assert base_rotations is not None and head_rotations is not None
+
+    stale_reasons = frozenset(
+        f"{manifest.base_ref}: {prompt_path.as_posix()}: profile requirements "
+        "do not match immutable prompt requirements"
+        for prompt_path, _language_id, _digest in _SYNC_ROLLOUT_REPAIR_PROMPT_BYTES
+    )
+    if not stale_reasons <= set(base_invalid):
+        return {}, frozenset()
+
+    expected_managed = set(manifest.expected_managed)
+    additions: dict[UnitId, _ProfileInput] = {}
+    for prompt_path, language_id, expected_digest in _SYNC_ROLLOUT_REPAIR_PROMPT_BYTES:
+        unit_id = UnitId(manifest.repository_id, prompt_path, language_id)
+        base_prompt = read_git_blob(root, manifest.base_ref, prompt_path)
+        head_prompt = read_git_blob(root, manifest.head_ref, prompt_path)
+        if (
+            unit_id not in expected_managed
+            or unit_id in base
+            or unit_id not in head
+            or base_prompt is None
+            or head_prompt is None
+            or _sha256(base_prompt) != expected_digest
+            or _sha256(head_prompt) != expected_digest
+        ):
+            return {}, frozenset()
+        additions[unit_id] = head[unit_id]
+    return additions, stale_reasons
+
+
 def _effective_profile(
     unit_id: UnitId,
     base: _ProfileInput | None,
@@ -3156,14 +3255,21 @@ def load_verification_profiles(root: Path, manifest: UnitManifest) -> ProfileSet
     except ValueError as exc:
         approved_aliases = {}
         invalid.append(str(exc))
-    base, loaded_invalid = _load_inputs(
+    base, base_invalid = _load_inputs(
         root, manifest.base_ref, manifest.repository_id, approved_aliases
     )
-    invalid.extend(loaded_invalid)
-    head, loaded_invalid = _load_inputs(
+    head, head_invalid = _load_inputs(
         root, manifest.head_ref, manifest.repository_id, approved_aliases
     )
-    invalid.extend(loaded_invalid)
+    rollout_profile_additions, reconciled_base_invalid = (
+        _authorized_sync_rollout_profile_reconciliation(
+            root, manifest, base, head, base_invalid
+        )
+    )
+    invalid.extend(
+        reason for reason in base_invalid if reason not in reconciled_base_invalid
+    )
+    invalid.extend(head_invalid)
     (
         requirement_authorizations,
         requirement_prompts,
@@ -3172,6 +3278,7 @@ def load_verification_profiles(root: Path, manifest: UnitManifest) -> ProfileSet
         root, manifest, base, head, approved_aliases
     )
     profile_additions = _authorized_profile_additions(root, manifest, base, head)
+    profile_additions.update(rollout_profile_additions)
     if new_requirement_authorizations:
         _validate_new_authorization_managed_prompt_bytes(
             root,

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -154,6 +154,15 @@ _SYNC_ROLLOUT_REPAIR_PROMPT_BYTES = (
         "48fe08ae08004ae02034118cf067b254c22fe7de800a9ece37834738da507677",
     ),
 )
+_SYNC_ROLLOUT_REPAIR_STALE_ROTATION_IDENTITIES = frozenset(
+    {
+        (PurePosixPath("pdd/prompts/detect_change_python.prompt"), "python"),
+        (
+            PurePosixPath("pdd/prompts/sync_determine_operation_python.prompt"),
+            "python",
+        ),
+    }
+)
 
 
 class VerificationProfileError(ValueError):
@@ -2516,6 +2525,26 @@ def _load_requirement_transition_authorizations(
             ),
         }
     )
+    sync_rollout_repair_state = is_pdd_repository and (
+        (policy_digests, profile_digests)
+        in {
+            (
+                _SYNC_ROLLOUT_REPAIR_ROTATION_POLICY_BYTES,
+                _SYNC_ROLLOUT_REPAIR_PROFILE_BYTES,
+            ),
+            (
+                (
+                    _SYNC_ROLLOUT_REPAIR_ROTATION_POLICY_BYTES[1],
+                    _SYNC_ROLLOUT_REPAIR_ROTATION_POLICY_BYTES[1],
+                ),
+                (
+                    _SYNC_ROLLOUT_REPAIR_PROFILE_BYTES[1],
+                    _SYNC_ROLLOUT_REPAIR_PROFILE_BYTES[1],
+                ),
+            ),
+        }
+    )
+    historical_composed_state = opus_fable_state or sync_rollout_repair_state
     gemini_36_terra_sol_state = is_pdd_repository and (
         (policy_digests, profile_digests)
         in {
@@ -2551,7 +2580,7 @@ def _load_requirement_transition_authorizations(
         or terra_sol_consumed_state
         or gemini_36_terra_sol_state
         or generate_reliability_state
-        or opus_fable_state
+        or historical_composed_state
     ):
         # This candidate predates a dormant policy installation.  Expose only
         # its reviewed transitions while consuming the exact profile update,
@@ -2566,7 +2595,7 @@ def _load_requirement_transition_authorizations(
             if (item.prompt_path, item.language_id) not in terra_sol_identities
         ) + _TERRA_SOL_COMPOSED_REQUIREMENT_TRANSITIONS
         authority.update(_TERRA_SOL_COMPOSED_REQUIREMENT_TRANSITIONS)
-    if generate_reliability_state or opus_fable_state:
+    if generate_reliability_state or historical_composed_state:
         reliability_identities = {
             (item.prompt_path, item.language_id)
             for item in _GENERATE_RELIABILITY_COMPOSED_REQUIREMENT_TRANSITIONS
@@ -2577,7 +2606,7 @@ def _load_requirement_transition_authorizations(
             if (item.prompt_path, item.language_id) not in reliability_identities
         ) + _GENERATE_RELIABILITY_COMPOSED_REQUIREMENT_TRANSITIONS
         authority.update(_GENERATE_RELIABILITY_COMPOSED_REQUIREMENT_TRANSITIONS)
-    if opus_fable_state:
+    if historical_composed_state:
         opus_fable_identities = {
             (item.prompt_path, item.language_id)
             for item in _OPUS_FABLE_COMPOSED_REQUIREMENT_TRANSITIONS
@@ -2588,6 +2617,16 @@ def _load_requirement_transition_authorizations(
             if (item.prompt_path, item.language_id) not in opus_fable_identities
         ) + _OPUS_FABLE_COMPOSED_REQUIREMENT_TRANSITIONS
         authority.update(_OPUS_FABLE_COMPOSED_REQUIREMENT_TRANSITIONS)
+    if sync_rollout_repair_state:
+        # These retained schema-2 rows describe historical prompt changes.
+        # Their identities are already at the exact repaired prompt bytes, so
+        # do not re-evaluate them as a live transition at this one state.
+        candidate = tuple(
+            item
+            for item in candidate
+            if (item.prompt_path, item.language_id)
+            not in _SYNC_ROLLOUT_REPAIR_STALE_ROTATION_IDENTITIES
+        )
     pr1971_reconciliation = _is_exact_pr1971_pytest_reconciliation(
         manifest, (protected_policy, candidate_policy), policies, candidate
     )
@@ -2671,14 +2710,16 @@ def _load_requirement_transition_authorizations(
         if item not in protected
         and not (is_pdd_repository and item in _REPLAY_PROFILE_REQUIREMENT_TRANSITIONS)
     )
-    if (
-        legacy_pdd1989_reconciliation
-        or pr1971_reconciliation
-        or pdd1875_reconciliation
-        or terra_sol_reconciliation
-        or terra_sol_consumed_state
-        or opus_fable_state
-    ):
+    consumed_profile_reconciliation = any(
+        (
+            legacy_pdd1989_reconciliation,
+            pr1971_reconciliation,
+            pdd1875_reconciliation,
+            terra_sol_reconciliation,
+            terra_sol_consumed_state,
+        )
+    )
+    if consumed_profile_reconciliation or historical_composed_state:
         # The exact historical pair both installed and consumed its authority
         # before Phase-A isolation existed; validate it as consumption below.
         new_authorizations = ()
@@ -2694,6 +2735,17 @@ def _load_requirement_transition_authorizations(
         new_authorizations = tuple(
             item for item in new_authorizations if item not in terra_sol_authority
         )
+    bootstrap_transition_guard_exception = any(
+        (
+            legacy_pdd1989_reconciliation,
+            pr1971_reconciliation,
+            pdd1875_reconciliation,
+            terra_sol_reconciliation,
+            terra_sol_consumed_state,
+            gemini_36_terra_sol_state,
+            sync_rollout_repair_state,
+        )
+    )
     for item in candidate:
         if item in authority:
             if (
@@ -2704,12 +2756,7 @@ def _load_requirement_transition_authorizations(
                     and item in _REPLAY_PROFILE_REQUIREMENT_TRANSITIONS
                 )
                 and policies[0] != policies[1]
-                and not legacy_pdd1989_reconciliation
-                and not pr1971_reconciliation
-                and not pdd1875_reconciliation
-                and not terra_sol_reconciliation
-                and not terra_sol_consumed_state
-                and not gemini_36_terra_sol_state
+                and not bootstrap_transition_guard_exception
             ):
                 raise VerificationProfileError(
                     "candidate legacy bootstrap requirement transition changes "
@@ -3110,6 +3157,7 @@ def _authorized_sync_rollout_profile_reconciliation(
     head: Mapping[UnitId, _ProfileInput],
     base_invalid: list[str],
 ) -> tuple[dict[UnitId, _ProfileInput], frozenset[str]]:
+    # pylint: disable=too-many-locals
     """Authorize the one exact stale-profile repair from the protected base."""
     if manifest.repository_id != _PDD_REPOSITORY_ID:
         return {}, frozenset()
@@ -3152,7 +3200,10 @@ def _authorized_sync_rollout_profile_reconciliation(
             unit_id not in expected_managed
             or unit_id in base
             or unit_id not in head
-            or base_prompt is None
+        ):
+            return {}, frozenset()
+        if (
+            base_prompt is None
             or head_prompt is None
             or _sha256(base_prompt) != expected_digest
             or _sha256(head_prompt) != expected_digest

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -1538,6 +1538,24 @@ def test_sync_rollout_repair_executes_the_actual_protected_transition() -> None:
         head_ref="HEAD",
     )
 
+    assert (
+        hashlib.sha256(_git_blob(SYNC_ROLLOUT_PROTECTED_BASE, PROFILE_FILE)).hexdigest(),
+        hashlib.sha256(_git_blob("HEAD", PROFILE_FILE)).hexdigest(),
+    ) == verification._SYNC_ROLLOUT_REPAIR_PROFILE_BYTES  # pylint: disable=protected-access
+    assert (
+        hashlib.sha256(_git_blob(SYNC_ROLLOUT_PROTECTED_BASE, ROTATION_FILE)).hexdigest(),
+        hashlib.sha256(_git_blob("HEAD", ROTATION_FILE)).hexdigest(),
+    ) == verification._SYNC_ROLLOUT_REPAIR_ROTATION_POLICY_BYTES  # pylint: disable=protected-access
+    for prompt_path, _language_id, expected_digest in (
+        verification._SYNC_ROLLOUT_REPAIR_PROMPT_BYTES  # pylint: disable=protected-access
+    ):
+        assert (
+            hashlib.sha256(
+                _git_blob(SYNC_ROLLOUT_PROTECTED_BASE, ROOT / prompt_path)
+            ).hexdigest(),
+            hashlib.sha256(_git_blob("HEAD", ROOT / prompt_path)).hexdigest(),
+        ) == (expected_digest, expected_digest)
+
     records = {
         item.candidate_id.artifact_relpath.as_posix(): item
         for item in manifest.candidates
@@ -1699,6 +1717,16 @@ def test_current_profile_reconciliation_matches_current_prompt_and_profile_rows(
         for authorization in verification._OPUS_FABLE_COMPOSED_REQUIREMENT_TRANSITIONS  # pylint: disable=protected-access
         if authorization.bindings.head_policy_sha256 == profile_digest
     )
+    if profile_digest == verification._SYNC_ROLLOUT_REPAIR_PROFILE_BYTES[1]:  # pylint: disable=protected-access
+        current_rows.extend(
+            {
+                "prompt_path": prompt_path.as_posix(),
+                "language_id": language_id,
+                "to_requirement_id": f"CONTRACT-SHA256:{prompt_digest}",
+                "head_prompt_sha256": prompt_digest,
+            }
+            for prompt_path, language_id, prompt_digest in verification._SYNC_ROLLOUT_REPAIR_PROMPT_BYTES  # pylint: disable=protected-access
+        )
     assert current_rows
     profiles = {
         (row["prompt_path"], row["language_id"]): row

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -1581,6 +1581,49 @@ def test_sync_rollout_repair_executes_the_actual_protected_transition() -> None:
     assert profiles.coverage == 1.0
 
 
+def test_sync_rollout_repair_metadata_bridge_stays_ordinary() -> None:
+    """The exact bridge cannot turn its base-existing paths into absences."""
+    skip_if_authenticated_candidate_lacks_refs(
+        ROOT,
+        "exact sync-rollout protected history",
+        SYNC_ROLLOUT_PROTECTED_BASE,
+    )
+    base_rules = manifest_module._ownership_rules(  # pylint: disable=protected-access
+        ROOT, SYNC_ROLLOUT_PROTECTED_BASE
+    )
+    head_rules = manifest_module._ownership_rules(  # pylint: disable=protected-access
+        ROOT, "HEAD"
+    )
+    effective = manifest_module._sync_rollout_repair_ownership_rules(  # pylint: disable=protected-access
+        ROOT,
+        REPOSITORY_ID,
+        SYNC_ROLLOUT_PROTECTED_BASE,
+        "HEAD",
+        base_rules,
+        head_rules,
+    )
+    expected = (
+        manifest_module._SYNC_ROLLOUT_REPAIR_HUMAN_OWNERSHIP  # pylint: disable=protected-access
+    )
+    assert set(expected) <= set(effective)
+    assert all(not rule.preauthorize_absent for rule in expected)
+
+    mutated_head_rules = tuple(
+        replace(rule, preauthorize_absent=True)
+        if rule.pattern == expected[0].pattern
+        else rule
+        for rule in head_rules
+    )
+    assert manifest_module._sync_rollout_repair_ownership_rules(  # pylint: disable=protected-access
+        ROOT,
+        REPOSITORY_ID,
+        SYNC_ROLLOUT_PROTECTED_BASE,
+        "HEAD",
+        base_rules,
+        mutated_head_rules,
+    ) == base_rules
+
+
 def _candidate_only_repo(tmp_path: Path) -> tuple[Path, str, str]:
     repo = tmp_path / "candidate-only"
     repo.mkdir()
@@ -1725,7 +1768,9 @@ def test_current_profile_reconciliation_matches_current_prompt_and_profile_rows(
                 "to_requirement_id": f"CONTRACT-SHA256:{prompt_digest}",
                 "head_prompt_sha256": prompt_digest,
             }
-            for prompt_path, language_id, prompt_digest in verification._SYNC_ROLLOUT_REPAIR_PROMPT_BYTES  # pylint: disable=protected-access
+            for prompt_path, language_id, prompt_digest in (
+                verification._SYNC_ROLLOUT_REPAIR_PROMPT_BYTES  # pylint: disable=protected-access
+            )
         )
     assert current_rows
     profiles = {

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -59,6 +59,7 @@ PDD_1875_PROTECTED_BASE = "eb1fc0e2ad14c1bd79e63cabe4fd6bc90c7929a5"
 PDD_1875_COMPOSED_HEAD = "b27837fd7fbf681bdec2b7eb311348b642b27979"
 TERRA_SOL_PROTECTED_BASE = "b27837fd7fbf681bdec2b7eb311348b642b27979"
 TERRA_SOL_COMPOSED_HEAD = "b3902318c35c279e49e6397838825c95bd568942"
+SYNC_ROLLOUT_PROTECTED_BASE = "dec539aa8d0697e357e2077c1dbc73b0621aa617"
 PR_1971_COMBINED_PROFILE_DIGEST = (
     "c566e1b87015632ca317e799f2756af9a25281c6e842c03ccad763b20d539bf1"
 )
@@ -235,6 +236,16 @@ PR_2017_ABSENT_METADATA_PATHS = {
     ".pdd/meta/fix_code_loop_python_run.json",
     ".pdd/meta/fix_error_loop_python_run.json",
     ".pdd/meta/get_test_command_python_run.json",
+}
+SYNC_ROLLOUT_EXISTING_METADATA_PATHS = {
+    ".pdd/meta/code_generator_python.json",
+    ".pdd/meta/code_generator_python_run.json",
+    ".pdd/meta/continue_generation_python.json",
+    ".pdd/meta/continue_generation_python_run.json",
+    ".pdd/meta/detect_change_python.json",
+    ".pdd/meta/detect_change_python_run.json",
+    ".pdd/meta/generate_test_python.json",
+    ".pdd/meta/generate_test_python_run.json",
 }
 PREAUTHORIZED_CHILD_PATHS = (
     LEGACY_METADATA_EXAMPLE_PREAUTHORIZED_PATHS
@@ -1510,6 +1521,44 @@ def test_pr2017_phase_a_is_dormant_on_its_exact_protected_base() -> None:
     assert not manifest.invalid_reasons
     assert not manifest.unaccounted_tracked_paths
     assert len(profiles.profiles) == 468
+    assert not profiles.invalid_reasons
+    assert profiles.coverage == 1.0
+
+
+def test_sync_rollout_repair_executes_the_actual_protected_transition() -> None:
+    """The rollout repair is valid only from its real protected base to HEAD."""
+    skip_if_authenticated_candidate_lacks_refs(
+        ROOT,
+        "exact sync-rollout protected history",
+        SYNC_ROLLOUT_PROTECTED_BASE,
+    )
+    manifest = build_unit_manifest(
+        ROOT,
+        base_ref=SYNC_ROLLOUT_PROTECTED_BASE,
+        head_ref="HEAD",
+    )
+
+    records = {
+        item.candidate_id.artifact_relpath.as_posix(): item
+        for item in manifest.candidates
+        if item.candidate_id.artifact_relpath.as_posix()
+        in SYNC_ROLLOUT_EXISTING_METADATA_PATHS
+    }
+    assert not manifest.invalid_reasons
+    assert not manifest.unaccounted_tracked_paths
+    assert set(records) == SYNC_ROLLOUT_EXISTING_METADATA_PATHS
+    assert all(
+        item.in_base
+        and item.in_head
+        and item.inventory is InventoryStatus.HUMAN_OWNED
+        and item.candidate_id.role == "human-maintained"
+        and item.ownership_provenance
+        == f"protected-ownership:pdd-maintainers:{path}"
+        for path, item in records.items()
+    )
+
+    profiles = load_verification_profiles(ROOT, manifest)
+
     assert not profiles.invalid_reasons
     assert profiles.coverage == 1.0
 


### PR DESCRIPTION
## Summary
- restore exact protected ownership for the eight tracked sync metadata artifacts
- reconcile five protected verification profiles with immutable prompt hashes
- bind the exact profile transition bytes in the protected rotation policy

## Validation
- `conda run -n pdd pytest -q tests/test_sync_core_pdd_rollout_policy.py`
- `git diff --check origin/main...HEAD`

No Python files changed; pylint is not applicable.