### PR TITLE
test(agentic): align issue 817 CLI failure exit contract

### DIFF
--- a/tests/test_e2e_issue_817_step5_degenerate_cli.py
+++ b/tests/test_e2e_issue_817_step5_degenerate_cli.py
@@ -78,7 +78,7 @@ def test_generate_issue_url_fails_fast_when_step5_returns_done(tmp_path, monkeyp
             obj={"verbose": False, "quiet": False},
         )
 
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 1, result.output
     assert step_calls == [
         "step1",
         "step1b",


### PR DESCRIPTION
## Summary
- update the issue #817 e2e assertion to expect exit code 1 when Step 5 fails fast
- preserve the existing diagnostics and no-Step-5b assertions

## Release blocker
Final Cloud Batch run `run-20260725-142638-8691065c9` task 28 exposed the stale assertion. Product behavior is correct: issue #817 requires a hard failure, `generate` marks the command failed, and the top-level CLI exits 1. The test predated commit `4830ef565` that made hosted-executor failures nonzero. Hosted unit CI excludes `@pytest.mark.e2e`; Cloud Batch correctly collects it.

## Evidence
- RED on exact main: focused test failed only because actual `SystemExit(1)` was compared with 0; all expected Step 5 diagnostics were present and Step 5b was absent.
- GREEN: `pytest -q tests/test_e2e_issue_817_step5_degenerate_cli.py` — 1 passed.
- Nearby orchestrator suite: 106 passed.
- `git diff --check` — passed.

No product code, infrastructure, or video behavior changes.