### PR TITLE
fix(release): opt v0.0.310 out of video and repair gate-caught test bugs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,12 @@ jobs:
       HAS_CLAUDE_OAUTH: ${{ (secrets.CLAUDE_CODE_OAUTH_TOKEN_1 != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN_2 != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN_3 != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '') && 'true' || 'false' }}
       HAS_CLAUDE_OAUTH_SLOTS: ${{ (secrets.CLAUDE_CODE_OAUTH_TOKEN_1 != '' && secrets.CLAUDE_CODE_OAUTH_TOKEN_2 != '' && secrets.CLAUDE_CODE_OAUTH_TOKEN_3 != '') && 'true' || 'false' }}
       HAS_PDS: ${{ secrets.PDS_TOKEN != '' && 'true' || 'false' }}
-      # Exact release tag that must not create, upload, or distribute a video.
-      RELEASE_VIDEO_OPT_OUT_TAG: v0.0.309
+      # Exact release tags that must never create, upload, or distribute a
+      # video. A JSON array so the check is array membership, not substring
+      # matching -- `contains('v0.0.31', ...)` would also match v0.0.310.
+      # Overwriting a single tag to opt out a new release would silently
+      # re-enable video for the previous one; the guarantee is permanent.
+      RELEASE_VIDEO_OPT_OUT_TAGS: '["v0.0.309","v0.0.310"]'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -251,7 +255,7 @@ jobs:
       #                                notes artifact path to preserve exact
       #                                selected-project recovery metadata.
       - name: Create release video and prepend link to notes (best-effort)
-        if: env.HAS_PDS == 'true' && github.ref_name != env.RELEASE_VIDEO_OPT_OUT_TAG
+        if: env.HAS_PDS == 'true' && !contains(fromJSON(env.RELEASE_VIDEO_OPT_OUT_TAGS), github.ref_name)
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -341,7 +345,7 @@ jobs:
           esac
 
       - name: Upload release video recovery artifacts
-        if: env.HAS_PDS == 'true' && always() && github.ref_name != env.RELEASE_VIDEO_OPT_OUT_TAG
+        if: env.HAS_PDS == 'true' && always() && !contains(fromJSON(env.RELEASE_VIDEO_OPT_OUT_TAGS), github.ref_name)
         uses: actions/upload-artifact@v4
         with:
           name: release-video-${{ github.ref_name }}
@@ -349,7 +353,9 @@ jobs:
           if-no-files-found: ignore
 
       - name: Post release notes to Discord
-        if: github.ref_name != env.RELEASE_VIDEO_OPT_OUT_TAG
+        # Wrapped in ${{ }} because a bare `if:` value starting with `!` parses
+        # as a YAML tag rather than as an expression.
+        if: ${{ !contains(fromJSON(env.RELEASE_VIDEO_OPT_OUT_TAGS), github.ref_name) }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,12 @@ RELEASE_VIDEO_VEO_VALIDATION_RECOVERY_JOB_ID ?=
 RELEASE_VIDEO_STATUS_QUERY ?= 0
 RELEASE_VIDEO_YOUTUBE_URL ?=
 RELEASE_VIDEO_SKIP_REASON ?=
-RELEASE_VIDEO_OPT_OUT_TAG ?= v0.0.309
+# Exact release tags that must never create, upload, or distribute a video.
+# A set, not one tag: overwriting a single value to opt out a new release
+# silently re-enables video for the previous one, and the guarantee is
+# per-release and permanent. v0.0.309 carries no `pdd-release-video-skipped`
+# marker, so this list is the only thing keeping a backfill off it.
+RELEASE_VIDEO_OPT_OUT_TAGS ?= v0.0.309 v0.0.310
 RELEASE_VIDEO_PDS_CREATE_TIMEOUT ?= 1800
 RELEASE_VIDEO_CLAUDE_MODEL ?= claude-opus-4-8
 RELEASE_VIDEO_PDS_CLAUDE_MODEL ?= glm-5.2
@@ -956,7 +961,7 @@ release-infisical:
 	@$(MAKE) --no-print-directory release-sops
 
 release-video:
-	@if [ "$(RELEASE_TAG)" = "$(RELEASE_VIDEO_OPT_OUT_TAG)" ]; then \
+	@if printf '%s\n' $(RELEASE_VIDEO_OPT_OUT_TAGS) | grep -qxF "$(RELEASE_TAG)"; then \
 		echo "release-video: $(RELEASE_TAG) is opted out and must not create, upload, or distribute a video." >&2; \
 		exit 1; \
 	fi
@@ -1015,7 +1020,7 @@ release-video-status:
 		$$STATUS_QUERY_ARGS
 
 release-video-discord-backfill:
-	@if [ "$(RELEASE_TAG)" = "$(RELEASE_VIDEO_OPT_OUT_TAG)" ]; then \
+	@if printf '%s\n' $(RELEASE_VIDEO_OPT_OUT_TAGS) | grep -qxF "$(RELEASE_TAG)"; then \
 		echo "release-video-discord-backfill: $(RELEASE_TAG) is opted out and must not mutate a release or Discord." >&2; \
 		exit 1; \
 	fi
@@ -1025,7 +1030,7 @@ release-video-discord-backfill:
 		--repo "$${GITHUB_REPOSITORY:-promptdriven/pdd}"
 
 release-video-skip:
-	@if [ "$(RELEASE_TAG)" = "$(RELEASE_VIDEO_OPT_OUT_TAG)" ]; then \
+	@if printf '%s\n' $(RELEASE_VIDEO_OPT_OUT_TAGS) | grep -qxF "$(RELEASE_TAG)"; then \
 		echo "release-video-skip: $(RELEASE_TAG) is opted out and must not mutate a release or Discord." >&2; \
 		exit 1; \
 	fi
@@ -1080,7 +1085,7 @@ release: check-deps check-suspicious-files check-release-remote check-release-br
 			echo "Error: tag $$EXISTING_TAG on origin points at $$REMOTE_TAG_COMMIT, not HEAD ($$HEAD_SHA)."; \
 			exit 1; \
 		fi; \
-		if [ "$$EXISTING_TAG" = "$(RELEASE_VIDEO_OPT_OUT_TAG)" ]; then \
+		if printf '%s\n' $(RELEASE_VIDEO_OPT_OUT_TAGS) | grep -qxF "$$EXISTING_TAG"; then \
 			echo "Skipping release video for opted-out tag $$EXISTING_TAG."; \
 		else \
 			make --no-print-directory release-video RELEASE_TAG="$$EXISTING_TAG" RELEASE_GIT_SHA="$$HEAD_SHA"; \
@@ -1109,7 +1114,7 @@ release: check-deps check-suspicious-files check-release-remote check-release-br
 	git tag -a "$$NEW_TAG" -m "Release $$NEW_TAG"; \
 	git push origin "$$NEW_TAG"; \
 	echo "Tag $$NEW_TAG is on origin. GHA will request gltanaka approval, then publish."; \
-	if [ "$$NEW_TAG" = "$(RELEASE_VIDEO_OPT_OUT_TAG)" ]; then \
+	if printf '%s\n' $(RELEASE_VIDEO_OPT_OUT_TAGS) | grep -qxF "$$NEW_TAG"; then \
 		echo "Skipping release video for opted-out tag $$NEW_TAG."; \
 	else \
 		make --no-print-directory release-video RELEASE_TAG="$$NEW_TAG" RELEASE_GIT_SHA="$$HEAD_SHA"; \

--- a/scripts/release_video.py
+++ b/scripts/release_video.py
@@ -18,7 +18,14 @@ from typing import Any
 
 SEMVER_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
 YOUTUBE_URL_RE = re.compile(r"https?://(?:www\.)?(?:youtube\.com|youtu\.be)/[^\s\"'<>]+")
-RELEASE_VIDEO_OPT_OUT_TAG = "v0.0.309"
+# Exact release tags that must never create, upload, or distribute a video.
+#
+# A set rather than a single tag: opting a new release out by overwriting one
+# constant silently re-enables video for the previous one, and the guarantee is
+# per-release and permanent. v0.0.309 in particular carries no
+# `pdd-release-video-skipped` marker on its GitHub Release, so this set is the
+# only thing preventing a later backfill from attaching a video to it.
+RELEASE_VIDEO_OPT_OUT_TAGS = frozenset({"v0.0.309", "v0.0.310"})
 IDEMPOTENCY_PROVENANCE_RE = re.compile(r"[^a-z0-9._-]+")
 PDS_RUN_HANDLE_LINE_RE = re.compile(
     r"^\[pds\]\s+release-video run handle:\s+(?P<fields>.+)$",
@@ -464,8 +471,8 @@ class ReleaseVideoError(RuntimeError):
 
 
 def release_video_opt_out_reason(tag: str) -> str | None:
-    """Return the release-video denial reason for the exact excluded tag."""
-    if tag == RELEASE_VIDEO_OPT_OUT_TAG:
+    """Return the release-video denial reason for an exact excluded tag."""
+    if tag in RELEASE_VIDEO_OPT_OUT_TAGS:
         return (
             f"{tag} is opted out and release video operations must not create, "
             "upload, or distribute a video."

--- a/tests/test_check_cloud_green.py
+++ b/tests/test_check_cloud_green.py
@@ -40,8 +40,26 @@ OTHER = "b" * 40
 
 
 def run_payload(sha: str, hours_ago: float, url: str = "https://example/run") -> dict:
-    """Build one `gh run list --json headSha,updatedAt,url` entry."""
+    """Build one `gh run list --json headSha,updatedAt,url` entry, relative to NOW.
+
+    For in-process tests only, which pass ``NOW`` to the function under test.
+    Subprocess tests must use :func:`live_run_payload` instead — the script
+    reads the real clock, so a payload anchored to a frozen ``NOW`` silently
+    ages past the freshness bound and the test starts failing a day later.
+    """
     stamp = NOW - datetime.timedelta(hours=hours_ago)
+    return {
+        "headSha": sha,
+        "updatedAt": stamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "url": url,
+    }
+
+
+def live_run_payload(sha: str, hours_ago: float, url: str = "https://example/run") -> dict:
+    """Build an entry relative to the real clock, for subprocess invocations."""
+    stamp = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        hours=hours_ago
+    )
     return {
         "headSha": sha,
         "updatedAt": stamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -203,7 +221,7 @@ class TestAncestorSuggestion:
         result = subprocess.run(
             [sys.executable, str(SCRIPT), "--candidate-sha", tip,
              "--max-age-hours", "24", "--suggest-ancestor-of", "main"],
-            input=json.dumps([run_payload(proven, 2.0)]),
+            input=json.dumps([live_run_payload(proven, 2.0)]),
             cwd=tmp_path,
             capture_output=True,
             text=True,
@@ -252,7 +270,7 @@ class TestFreshnessBoundCannotBeDisabled:
         result = subprocess.run(
             [sys.executable, str(SCRIPT), "--candidate-sha", CANDIDATE,
              "--max-age-hours", bad],
-            input=json.dumps([run_payload(CANDIDATE, 8760.0)]),
+            input=json.dumps([live_run_payload(CANDIDATE, 8760.0)]),
             capture_output=True,
             text=True,
             check=False,
@@ -293,13 +311,13 @@ class TestScriptInvocation:
         )
 
     def test_exits_zero_and_reports_the_green(self):
-        result = self._run(json.dumps([run_payload(CANDIDATE, 1.0)]))
+        result = self._run(json.dumps([live_run_payload(CANDIDATE, 1.0)]))
         assert result.returncode == 0, result.stderr
         assert "Cloud gate green" in result.stdout
         assert CANDIDATE in result.stdout
 
     def test_exits_nonzero_on_refusal(self):
-        result = self._run(json.dumps([run_payload(OTHER, 1.0)]))
+        result = self._run(json.dumps([live_run_payload(OTHER, 1.0)]))
         assert result.returncode == 1
         assert "Error:" in result.stderr
 

--- a/tests/test_release_video.py
+++ b/tests/test_release_video.py
@@ -3033,8 +3033,10 @@ args = sys.argv[1:]
 with Path(os.environ["RELEASE_TEST_MAKE_LOG"]).open("a", encoding="utf8") as log:
     log.write(" ".join(args) + "\\n")
 
-if "release-video" in args and "RELEASE_TAG=v0.0.309" in args:
-    sys.stderr.write("release-video: v0.0.309 is opted out\\n")
+if "release-video" in args and any(
+    ("RELEASE_TAG=" + t) in args for t in ("v0.0.309", "v0.0.310")
+):
+    sys.stderr.write("release-video: tag is opted out\\n")
     raise SystemExit(1)
 raise SystemExit(0)
 """,
@@ -3047,8 +3049,8 @@ raise SystemExit(0)
     [
         ("existing", "v0.0.309", "", False),
         ("new", "v0.0.309", "v0.0.308", False),
-        ("existing", "v0.0.310", "", True),
-        ("new", "v0.0.310", "v0.0.309", True),
+        ("existing", "v0.0.311", "", True),
+        ("new", "v0.0.311", "v0.0.310", True),
     ],
 )
 def test_release_makefile_treats_only_opt_out_tag_as_successful_no_video_path(
@@ -3177,8 +3179,8 @@ raise SystemExit(0)
             "RELEASE_TEST_MAKE_LOG": str(tmp_path / "make.log"),
             "RELEASE_TEST_MAKEFILE": str(wrapper),
             "RELEASE_TEST_SCENARIO": "new",
-            "RELEASE_TEST_TAG": "v0.0.310",
-            "RELEASE_TEST_LATEST_TAG": "v0.0.309",
+            "RELEASE_TEST_TAG": "v0.0.311",
+            "RELEASE_TEST_LATEST_TAG": "v0.0.310",
             "SKIP_MAKEFILE_REGEN": "1",
         }
     )
@@ -3206,8 +3208,8 @@ raise SystemExit(0)
     assert "Skipping release video because RELEASE_VIDEO=0" in result.stdout
     assert not output_dir.exists()
     git_calls = (tmp_path / "git.log").read_text(encoding="utf8").splitlines()
-    assert "tag -a v0.0.310 -m Release v0.0.310" in git_calls
-    assert "push origin v0.0.310" in git_calls
+    assert "tag -a v0.0.311 -m Release v0.0.311" in git_calls
+    assert "push origin v0.0.311" in git_calls
 
 
 def test_release_video_makefile_empty_local_defaults_are_unset():
@@ -3270,9 +3272,16 @@ def test_release_video_workflow_explicitly_opts_out_v0_0_309():
     )
     publish_job = workflow["jobs"]["publish-pypi"]
     steps = {step["name"]: step for step in publish_job["steps"] if "name" in step}
-    opt_out_condition = "github.ref_name != env.RELEASE_VIDEO_OPT_OUT_TAG"
+    opt_out_condition = (
+        "!contains(fromJSON(env.RELEASE_VIDEO_OPT_OUT_TAGS), github.ref_name)"
+    )
 
-    assert publish_job["env"]["RELEASE_VIDEO_OPT_OUT_TAG"] == "v0.0.309"
+    # A JSON array checked by array membership. Plain substring `contains`
+    # would make the tag v0.0.31 match the entry v0.0.310.
+    assert json.loads(publish_job["env"]["RELEASE_VIDEO_OPT_OUT_TAGS"]) == [
+        "v0.0.309",
+        "v0.0.310",
+    ]
     for step_name in (
         "Create release video and prepend link to notes (best-effort)",
         "Upload release video recovery artifacts",
@@ -8509,3 +8518,58 @@ def test_backfill_workflow_behavior_preserves_release_on_validation_failure(
     assert result.returncode != 0
     assert release_state == "Existing GitHub-generated notes\n"
     assert all(not call.startswith("release edit") for call in gh_calls)
+
+
+def test_release_video_opt_out_is_a_set_covering_every_opted_out_tag() -> None:
+    """Opting a new release out must not re-enable video for an earlier one.
+
+    The opt-out used to be one tag, so opting out a new release meant
+    overwriting the previous value. The guarantee is per-release and permanent:
+    v0.0.309 carries no ``pdd-release-video-skipped`` marker on its GitHub
+    Release, so this set is the only thing keeping a later backfill from
+    attaching a video to it.
+    """
+    from scripts.release_video import (  # noqa: PLC0415
+        RELEASE_VIDEO_OPT_OUT_TAGS,
+        release_video_opt_out_reason,
+    )
+
+    assert {"v0.0.309", "v0.0.310"} <= RELEASE_VIDEO_OPT_OUT_TAGS
+
+    for tag in sorted(RELEASE_VIDEO_OPT_OUT_TAGS):
+        reason = release_video_opt_out_reason(tag)
+        assert reason is not None and tag in reason
+
+    # Exact membership, never prefix or substring.
+    assert release_video_opt_out_reason("v0.0.31") is None
+    assert release_video_opt_out_reason("v0.0.3100") is None
+    assert release_video_opt_out_reason("v0.0.311") is None
+
+
+def test_release_video_opt_out_sources_agree() -> None:
+    """Makefile, workflow, and script must name the same opted-out tags.
+
+    Three independent copies gate three different execution paths (local make,
+    the tag-triggered workflow, and the script). A tag opted out in only some
+    of them is silently opted in via the others.
+    """
+    from scripts.release_video import RELEASE_VIDEO_OPT_OUT_TAGS  # noqa: PLC0415
+
+    makefile = (ROOT / "Makefile").read_text(encoding="utf8")
+    make_line = next(
+        line
+        for line in makefile.splitlines()
+        if line.startswith("RELEASE_VIDEO_OPT_OUT_TAGS")
+    )
+    make_tags = set(make_line.split("?=", 1)[1].split())
+
+    workflow = yaml.safe_load(
+        (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf8")
+    )
+    workflow_tags = set(
+        json.loads(
+            workflow["jobs"]["publish-pypi"]["env"]["RELEASE_VIDEO_OPT_OUT_TAGS"]
+        )
+    )
+
+    assert make_tags == workflow_tags == set(RELEASE_VIDEO_OPT_OUT_TAGS)

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -3370,6 +3370,14 @@ def test_post_base_addition_filter_ignores_only_paths_added_after_the_base() -> 
     those out keeps the pinned-base guards meaningful without making the
     repository unable to accept new files.
     """
+    # Cloud Batch shards run from an extracted source tarball with no git
+    # history, so `git diff <pinned base>` exits 128 there. Skip exactly as the
+    # sibling pinned-base regressions do rather than failing the release gate.
+    skip_if_authenticated_candidate_lacks_refs(
+        ROOT,
+        "exact sync-rollout protected history",
+        SYNC_ROLLOUT_PROTECTED_BASE,
+    )
     base = SYNC_ROLLOUT_PROTECTED_BASE
     added = _paths_added_since(base)
     assert added, "expected at least one path added since the pinned base"


### PR DESCRIPTION
The cloud gate ran on main (`f971b3871`) and went **red**: 75 passed, 2 failed of 77 tasks. Both pytest failures were mine, introduced in #2328, and neither was reachable from a local run or from CI on the day they were written. This is the gate doing precisely the job it was built for — finding these before a release rather than during one.

## Bug 1 — time-dependent tests (would have failed CI every day from now on)

`tests/test_check_cloud_green.py` anchored its fixtures to a frozen `NOW = 2026-07-26`, while the subprocess under test reads the real clock. On 2026-07-26 a "1 hour old" fixture really was 1 hour old. A day later the same fixture is 28.7h old, past `CLOUD_GREEN_MAX_AGE_HOURS=24`, so the script correctly refuses and the test fails:

```
Error: green for aaaa... is 28.7h old, older than CLOUD_GREEN_MAX_AGE_HOURS=24.
```

Subprocess payloads now come from `live_run_payload`, anchored to the real clock. In-process tests keep the frozen `NOW` — they pass it explicitly to the function under test, so they are deterministic by construction. Both helpers document which is which.

## Bug 2 — missing environment guard

`test_post_base_addition_filter_*` shells out to `git diff <pinned base> HEAD`, which exits 128 on the Cloud Batch shards: they run from an extracted source tarball with no git history. It now uses the same `skip_if_authenticated_candidate_lacks_refs` guard every sibling pinned-base regression already had — I added the helper in #2328 but did not guard its own test.

## Video opt-out for v0.0.310

The opt-out was a **single tag** duplicated in three places, so opting out a new release meant overwriting the previous one. That matters concretely: v0.0.309 carries no `pdd-release-video-skipped` marker on its GitHub Release, so this constant is the only thing keeping a later backfill from attaching a video to it.

Converted to a set across all three sources, each with an exact-match check:

| source | representation | match |
| --- | --- | --- |
| `scripts/release_video.py` | `frozenset` | `in` |
| `Makefile` | space-separated list | `grep -qxF` (whole-line, fixed-string) |
| `.github/workflows/release.yml` | JSON array | `contains(fromJSON(...), ...)` |

Exact matching throughout is deliberate: substring `contains` would make the tag `v0.0.31` match the entry `v0.0.310`. Verified functionally — `v0.0.309` and `v0.0.310` refuse, `v0.0.311` and `v0.0.31` proceed.

The Discord step needed `${{ }}` wrapping: a bare `if:` value starting with `!` parses as a YAML tag, not an expression, and made the workflow file unloadable.

A new test asserts all three sources name the same tags, since they gate three different execution paths and a tag opted out in only some of them is silently opted in via the others.

## Verification

659 tests pass across the affected suites (`check_cloud_green`, `release_video`, `release_video_discord_backfill`, `release_process_runbook`, `prose_judge_advisory_lane`, `pr_loop_risk_tiers`), plus the 6 sync guards. Workflow YAML parses and the opt-out array round-trips.

## Not fixed here

The gate also failed `cloud_regression case_3` (cloud `test` command, exit 2). That is unrelated to these changes and needs separate triage — it is a genuine failure on main, and it is exactly the kind of thing that used to surface mid-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)