### PR TITLE
feat(intent): local ordinary-language planning front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Also see the Prompt‑Driven Development Doctrine for core principles and practi
 
 For a step-by-step methodology on turning a GitHub issue into a durable, human-verified user story, see [docs/generating_user_stories.md](docs/generating_user_stories.md).
 
+For the ordinary-language human surface, the four standalone/monorepo adoption
+scenarios, and a precise explanation of versioned prompts, tests, and
+agent-drafted stories, see [docs/intent.md](docs/intent.md).
+
 For pre-merge prompt and user-story quality (vague terms, vocabulary, optional LLM review), see [docs/prompt_lint.md](docs/prompt_lint.md).
 
 For deterministic contract-section lint (`<contract_rules>`, `<coverage>`, waivers, story `## Covers`), see [docs/contract_check.md](docs/contract_check.md).
@@ -193,7 +197,20 @@ This opens a browser-based interface where you can:
 - **Browse Files**: View and edit prompts, code, and tests in your project
 - **Remote Access**: Access your session from any browser via PDD Cloud (use `--local-only` to disable)
 
-### Option 2: Issue-Driven CLI
+### Option 2: Local intent planning
+
+Plan an ordinary-language request against local repository evidence without a
+GitHub issue, model call, or project-file changes:
+
+```bash
+pdd intent plan --text "Add offline report export. Never upload the report."
+```
+
+Use `--json` when an AI harness will consume the plan. This first release is
+planning-only; see [docs/intent.md](docs/intent.md) for its exact capabilities
+and the agent-assisted workflow it is designed to support.
+
+### Option 3: Issue-Driven CLI
 
 For CLI enthusiasts, implement GitHub issues directly:
 
@@ -220,7 +237,7 @@ pdd bug https://github.com/owner/repo/issues/456
 pdd fix https://github.com/owner/repo/issues/456
 ```
 
-### Option 3: Manual Prompt Workflow
+### Option 4: Manual Prompt Workflow
 
 For learning PDD fundamentals or working with existing prompt files:
 

--- a/architecture.json
+++ b/architecture.json
@@ -8670,7 +8670,9 @@
     "dependencies": [
       "commands/replay_python.prompt",
       "commands/context_python.prompt",
-      "commands/contracts_python.prompt"
+      "commands/contracts_python.prompt",
+      "commands/story_python.prompt",
+      "commands/intent_cli_python.prompt"
     ],
     "priority": 70,
     "filename": "commands/__init___python.prompt",
@@ -12448,5 +12450,74 @@
         ]
       }
     }
+  },
+  {
+    "reason": "Plans ordinary-language product intent against local repository evidence without requiring GitHub or exposing PDD file mechanics to the human.",
+    "description": "Deterministic, read-only intent planning core that preserves the request, distinguishes standalone and monorepo subproject adoption scenarios, classifies greenfield/brownfield/existing-PDD scope, proposes prompt-owned targets conservatively, recommends selective story coverage, and renders human and structured review output.",
+    "dependencies": [
+      "architecture_registry_python.prompt"
+    ],
+    "priority": 243,
+    "filename": "intent_python.prompt",
+    "filepath": "pdd/intent.py",
+    "tags": [
+      "intent",
+      "pdd-intent",
+      "planning",
+      "local",
+      "python"
+    ],
+    "interface": {
+      "type": "module",
+      "module": {
+        "functions": [
+          {
+            "name": "build_intent_plan",
+            "signature": "(request: str, project_root: Path, *, title: Optional[str] = None, source_kind: str = 'inline', source_ref: Optional[str] = None) -> IntentPlan",
+            "returns": "IntentPlan"
+          },
+          {
+            "name": "intent_plan_to_dict",
+            "signature": "(plan: IntentPlan) -> Dict[str, Any]",
+            "returns": "Dict[str, Any]"
+          },
+          {
+            "name": "render_review_card",
+            "signature": "(plan: IntentPlan) -> str",
+            "returns": "str"
+          }
+        ]
+      }
+    },
+    "position": null
+  },
+  {
+    "reason": "Provides the beginner- and agent-facing local `pdd intent plan` CLI without requiring GitHub, prompt paths, or dev-unit names.",
+    "description": "Thin Click command group that accepts ordinary-language product intent from inline text, a local file, or stdin and emits either a human review card or stable JSON while guaranteeing no project writes, model calls, or application side effects.",
+    "dependencies": [
+      "intent_python.prompt"
+    ],
+    "priority": 244,
+    "filename": "commands/intent_cli_python.prompt",
+    "filepath": "pdd/commands/intent.py",
+    "tags": [
+      "intent",
+      "pdd-intent",
+      "commands",
+      "cli",
+      "python"
+    ],
+    "interface": {
+      "type": "cli",
+      "cli": {
+        "commands": [
+          {
+            "name": "intent plan",
+            "description": "Plan an ordinary-language request against local project evidence without changing files or requiring GitHub"
+          }
+        ]
+      }
+    },
+    "position": null
   }
 ]

--- a/docs/generating_user_stories.md
+++ b/docs/generating_user_stories.md
@@ -35,7 +35,7 @@ A story lives in **two files with different owners**:
 
 | File | Owner | Holds | Edited by |
 | --- | --- | --- | --- |
-| `user_stories/story__<slug>.md` | **Human** (source of truth) | One plain-language `## Story` sentence | A person, by hand |
+| `user_stories/story__<slug>.md` | **Human-authoritative** (source of truth) | One plain-language `## Story` sentence | A person or an agent acting on the person's correction/approval |
 | `user_stories/contracts/<slug>.contract.md` | **Tooling** (generated) | `## Covers`, `## Acceptance Criteria`, `## Oracle`, `## Non-Oracle`, `## Negative Cases`, `## Non-Goals`, `## Candidate Prompts` | Regenerated, never hand-edited |
 
 The human file is deliberately tiny so a person can read it, decide *"yes, that
@@ -43,6 +43,12 @@ is the behavior I want"*, and verify it by using the product. The machine-checka
 contract is **derived** from that Story plus the original issue, and is
 re-derived whenever the Story changes. A `story-hash` in the contract header
 tracks alignment.
+
+Human-authoritative describes who controls the meaning, not who performs the
+keystrokes. In an agent-assisted workflow, the agent may draft and edit this
+small file from the independently preserved request, present the sentence to
+the human, and apply the human's correction. The human does not need to know
+the story filename, directory, metadata, or CLI command.
 
 > **Edit the Story, not the contract.** Hand-editing the contract is overwritten
 > the next time it is regenerated.

--- a/docs/intent.md
+++ b/docs/intent.md
@@ -1,0 +1,289 @@
+# Natural-language intent: the human surface of PDD
+
+PDD has many implementation artifacts and commands. A product/domain user
+should not have to maintain them.
+
+The human-facing contract is:
+
+1. describe what should happen, stop happening, or change;
+2. give corrections, examples, and `MUST` / `MUST NOT` constraints;
+3. confirm or correct the agent's interpretation;
+4. decide whether the reported evidence proves the product works.
+
+The AI agent and PDD maintain the file formats, mappings, generated artifacts,
+command selection, synchronization, and verification.
+
+Human control means authority over meaning and acceptable evidence. It does not
+mean the human must perform every file edit.
+
+## The first `pdd intent` release
+
+The first safe vertical slice is read-only:
+
+```bash
+pdd intent plan --text \
+  "Highlight pressure intervals outside the permitted band. Never alter the uploaded samples."
+```
+
+It also accepts a local file or piped input:
+
+```bash
+pdd intent plan docs/request.md
+printf '%s\n' "Add offline PDF export." | pdd intent plan
+```
+
+For an AI harness:
+
+```bash
+pdd intent plan --text "Add offline PDF export." --json
+```
+
+`pdd intent plan`:
+
+- requires no GitHub issue;
+- classifies the selected project scope;
+- discovers candidate prompt-owned product areas conservatively;
+- extracts stated examples and preservation constraints;
+- recommends independent story coverage selectively;
+- emits one human review card or stable JSON;
+- does not call a model;
+- does not change project files;
+- does not yet apply the plan.
+
+The command is primarily an agent-facing primitive. A human using an AI coding
+harness should be able to speak normally while the harness selects the command
+and project scope.
+
+## The four adoption scenarios
+
+The human interaction remains the same in every scenario. The agent changes its
+internal route.
+
+### 1. Existing standalone project without PDD
+
+The agent scopes planning to the project root, inventories existing behavior,
+and runs characterization tests before assigning PDD ownership. It then
+proposes bounded prompt-owned product areas. Existing code does not become
+generated output merely because `.pddrc` was added.
+
+Planner classification:
+
+```text
+project_kind: conventional_brownfield
+adoption_scenario: existing_project_adoption
+workflow: characterize_then_adopt
+```
+
+### 2. Completely new standalone project
+
+The agent consolidates the ordinary-language request into product intent,
+proposes technology and architecture decisions, generates the prompt graph,
+and verifies one small end-to-end slice before broad generation.
+
+The proposed project directory may be absent during planning; `pdd intent plan`
+does not create it.
+
+Planner classification:
+
+```text
+project_kind: greenfield
+adoption_scenario: new_project_design
+workflow: design_greenfield
+```
+
+### 3. Existing monorepo subproject without PDD
+
+The agent passes the subproject—not the entire repository—as the PDD project
+scope. Discovery stays inside that boundary, so unrelated sibling projects are
+not silently converted. The agent also identifies build and integration checks
+at the containing repository boundary.
+
+Planner classification:
+
+```text
+scope_kind: subproject
+project_kind: conventional_brownfield
+adoption_scenario: existing_subproject_adoption
+workflow: characterize_then_adopt
+```
+
+### 4. New monorepo subproject
+
+The agent may plan against a proposed subdirectory that does not exist yet. It
+designs that subproject's product intent, technology, architecture, prompts,
+and local tests while also planning integration checks with the monorepo.
+
+Planner classification:
+
+```text
+scope_kind: subproject
+project_kind: greenfield
+adoption_scenario: new_subproject_design
+workflow: design_greenfield
+```
+
+An already-PDD-managed standalone project or subproject is classified as an
+existing PDD change instead.
+
+## Two meanings of “prompt”
+
+The word *prompt* is overloaded.
+
+### Conversational prompts
+
+These are the messages a person types or dictates:
+
+> Add offline report export. Never send the report to a remote service.
+
+They are sufficient input to start. They may be rough, corrected later, or
+spread across several messages. Chat history is not a durable project source by
+itself, so an agent must preserve accepted meaning in repository artifacts.
+
+### PDD `.prompt` files
+
+A PDD `.prompt` file is a versioned technical specification used to generate or
+synchronize an implementation artifact. It contains durable behavior,
+interfaces, dependencies, constraints, examples, and PDD metadata.
+
+The prompt files collectively form a **prompt graph** that governs the
+PDD-managed project or subproject. They are not one giant transcript and should
+not be confused with every message the human has ever sent.
+
+Normally:
+
+- prompt files use the `.prompt` suffix;
+- they live under a configured prompt root, conventionally `prompts/`;
+- `architecture.json` maps them to generated outputs and dependencies;
+- `.pddrc` defines relevant paths and defaults;
+- the prompt files are committed and versioned in Git;
+- an AI agent may draft and edit them;
+- a human approves consequential behavior, while a technical owner reviews
+  important interfaces, dependencies, and constraints.
+
+The exact filename and directory matter to PDD, but should not be decisions the
+product user must make.
+
+## What “tests” means
+
+Tests are executable programs that check observable behavior. They are not
+another collection of chat prompts.
+
+Depending on the project, they may be:
+
+- unit tests for one component;
+- integration tests between components;
+- end-to-end or UI tests;
+- regression tests preserving a previously broken behavior;
+- negative tests proving a `MUST NOT`;
+- compile, link, schema, security, performance, or hardware-in-the-loop checks.
+
+They normally live in the repository's established test layout—such as
+`tests/`, Rust test modules, JavaScript test directories, or a CMake/CTest
+tree—and are committed to Git. `.pddrc` and project conventions tell PDD and
+the agent where applicable tests belong.
+
+The product/domain human supplies important examples and decides what outcomes
+would be convincing. The agent or PDD writes and runs the test code. A
+technical owner reviews critical coverage. The human should not have to know
+pytest, Jest, Cargo, CTest, filenames, or test markers merely to describe the
+product.
+
+## What happens to user stories
+
+User stories are selective independent acceptance checks, not mandatory input
+syntax and not the primary compiler source.
+
+The human does not have to:
+
+- begin with `As a ... I want ... so that ...`;
+- run `pdd story add`;
+- choose a prompt or “dev unit”;
+- invent a story slug;
+- create `user_stories/`;
+- write story metadata;
+- edit the generated contract;
+- choose a regression-test path.
+
+When an independent story is useful, the agent drafts it from the preserved
+original request and presents its meaning in the review card. The human says
+whether it is right or supplies a correction. The agent performs the file edit.
+
+The conventional implementation layout is:
+
+```text
+user_stories/story__<slug>.md
+user_stories/contracts/<slug>.contract.md
+tests/story_regression/test_story_<slug>.py
+```
+
+The small story is human-authoritative, which means a person approves its
+meaning. It does not require the person to type the file by hand. The contract
+is generated and must not be hand-edited.
+
+Use a story when independent acceptance intent can catch prompt drift—for
+example user-visible, cross-part, regression, security/privacy, data-loss, or
+critical `MUST` / `MUST NOT` behavior. Do not generate one as paperwork for
+every spelling correction or internal refactor.
+
+## Where the artifacts live
+
+A conventional standalone project looks like:
+
+```text
+project/
+├── .pddrc
+├── architecture.json
+├── prompts/
+│   └── <product-part>_<language>.prompt
+├── user_stories/
+│   ├── story__<slug>.md
+│   └── contracts/
+├── tests/
+└── generated source directories
+```
+
+A scoped monorepo subproject may use:
+
+```text
+repository/
+├── AGENTS.md
+├── packages/
+│   └── pressure-analyzer/
+│       ├── .pddrc
+│       ├── architecture.json
+│       ├── prompts/
+│       ├── user_stories/
+│       ├── tests/
+│       └── generated source
+└── integration-tests/
+```
+
+These are conventions, not requirements the human must memorize. Established
+project configuration is authoritative. Relative paths must resolve from the
+applicable PDD project/subproject scope, and agents must avoid accidentally
+mixing nested scopes.
+
+The source and verification artifacts—`.pddrc`, `architecture.json`, `.prompt`
+files, approved stories, generated contracts, tests, and normally generated
+source—should be committed when they are part of the product. Operational
+cache, temporary worktrees, resumable state, and some evidence under `.pdd/`
+follow separate repository policy and are not automatically product source.
+
+## The intended end state
+
+After the planning-only release, the next command layer should apply an
+approved plan:
+
+```text
+ordinary request
+-> review card
+-> human correction/approval
+-> agent-managed PDD source changes
+-> scoped synchronization
+-> tests and evidence
+```
+
+Until that application layer exists, `pdd intent plan` must remain explicit
+that it changed nothing. Existing advanced `pdd change`, `pdd generate`,
+`pdd story`, and `pdd sync` commands remain available to agents and experienced
+operators.

--- a/pdd/commands/__init__.py
+++ b/pdd/commands/__init__.py
@@ -23,6 +23,7 @@ from .utility import install_completion_cmd, verify
 from .which import which
 from .firecrawl import firecrawl_cache
 from .story import story_cli
+from .intent import intent_cli
 from .reconcile import install_hooks, reconcile
 from .sync_core import baseline, certify, recover, validate
 
@@ -71,3 +72,4 @@ def register_commands(cli: click.Group) -> None:
     cli.add_command(sessions)
     cli.add_command(firecrawl_cache)
     cli.add_command(story_cli)
+    cli.add_command(intent_cli)

--- a/pdd/commands/intent.py
+++ b/pdd/commands/intent.py
@@ -1,0 +1,99 @@
+"""`pdd intent` command group for local ordinary-language intent planning."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from ..intent import build_intent_plan, intent_plan_to_dict, render_review_card
+
+_MAX_INTENT_CHARS = 100_000
+
+
+def _read_intent_source(
+    source: Optional[Path], inline_text: Optional[str]
+) -> tuple[str, str, Optional[str]]:
+    if source is not None and inline_text is not None:
+        raise click.ClickException("Use either SOURCE or --text, not both.")
+
+    if inline_text is not None:
+        request = inline_text
+        source_kind = "inline"
+        source_ref = None
+    elif source is not None:
+        if not source.is_file():
+            raise click.ClickException(f"Intent source is not a file: {source}")
+        try:
+            request = source.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise click.ClickException(f"Could not read intent source {source}: {exc}") from exc
+        source_kind = "file"
+        source_ref = str(source.resolve())
+    elif not sys.stdin.isatty():
+        request = click.get_text_stream("stdin").read()
+        source_kind = "stdin"
+        source_ref = "<stdin>"
+    else:
+        raise click.ClickException(
+            "Provide a local SOURCE file, pass --text, or pipe the request on standard input."
+        )
+
+    if not request.strip():
+        raise click.ClickException("Intent request must not be empty.")
+    if len(request) > _MAX_INTENT_CHARS:
+        raise click.ClickException(
+            f"Intent request exceeds the {_MAX_INTENT_CHARS:,}-character planning limit."
+        )
+    return request, source_kind, source_ref
+
+
+@click.group(name="intent")
+def intent() -> None:
+    """Accept ordinary product intent and determine the appropriate PDD route."""
+
+
+@intent.command("plan")
+@click.argument(
+    "source",
+    required=False,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option("--text", "inline_text", default=None, help="Ordinary-language request.")
+@click.option("--title", default=None, help="Optional human-readable intent title.")
+@click.option(
+    "--project-root",
+    default=".",
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Existing or proposed project scope. Defaults to the current directory.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit structured agent output.")
+def plan_intent(
+    source: Optional[Path],
+    inline_text: Optional[str],
+    title: Optional[str],
+    project_root: Path,
+    as_json: bool,
+) -> None:
+    """Plan local product intent without GitHub, model calls, or file changes."""
+    request, source_kind, source_ref = _read_intent_source(source, inline_text)
+    try:
+        plan = build_intent_plan(
+            request,
+            project_root,
+            title=title,
+            source_kind=source_kind,
+            source_ref=source_ref,
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if as_json:
+        click.echo(json.dumps(intent_plan_to_dict(plan), indent=2, sort_keys=True))
+    else:
+        click.echo(render_review_card(plan))
+
+
+intent_cli = intent

--- a/pdd/intent.py
+++ b/pdd/intent.py
@@ -1,0 +1,761 @@
+"""Deterministic local planning for ordinary-language product intent."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from .architecture_registry import extract_modules, find_architecture_for_project
+
+INTENT_PLAN_SCHEMA_VERSION = "pdd.intent.plan.v1"
+_MAX_TARGETS = 5
+_MAX_SCANNED_FILES = 10_000
+_MAX_SCAN_DEPTH = 5
+_EXCLUDED_DIRS = {
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".pdd",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "coverage",
+    "dist",
+    "env",
+    "node_modules",
+    "target",
+    "vendor",
+    "venv",
+}
+_SOURCE_SUFFIXES = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cs",
+    ".cxx",
+    ".go",
+    ".h",
+    ".hpp",
+    ".java",
+    ".js",
+    ".jsx",
+    ".kt",
+    ".m",
+    ".php",
+    ".py",
+    ".rb",
+    ".rs",
+    ".scala",
+    ".sh",
+    ".swift",
+    ".ts",
+    ".tsx",
+}
+_STOP_WORDS = {
+    "about",
+    "after",
+    "agent",
+    "also",
+    "and",
+    "are",
+    "before",
+    "but",
+    "can",
+    "change",
+    "code",
+    "does",
+    "during",
+    "file",
+    "files",
+    "for",
+    "from",
+    "github",
+    "have",
+    "into",
+    "issue",
+    "just",
+    "language",
+    "let",
+    "local",
+    "make",
+    "module",
+    "need",
+    "never",
+    "ordinary",
+    "pdd",
+    "plan",
+    "planning",
+    "prompt",
+    "project",
+    "product",
+    "should",
+    "that",
+    "the",
+    "their",
+    "then",
+    "this",
+    "use",
+    "user",
+    "want",
+    "when",
+    "where",
+    "with",
+    "without",
+}
+_NEGATIVE_OR_INVARIANT_MARKERS = (
+    "must ",
+    "must not",
+    "never",
+    "always",
+    "do not",
+    "don't",
+    "without",
+    "unchanged",
+)
+_EXAMPLE_MARKERS = ("for example", "e.g.", "such as", "when ")
+
+
+@dataclass(frozen=True)
+class IntentTarget:
+    """A conservatively discovered product area that may own the request."""
+
+    product_area: str
+    prompt_path: Optional[str]
+    output_path: Optional[str]
+    architecture_path: Optional[str]
+    score: int
+    matched_terms: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class IntentPlan:
+    """Read-only plan for routing one preserved product-intent request."""
+
+    schema_version: str
+    intent_id: str
+    title: str
+    original_request: str
+    original_request_sha256: str
+    source_kind: str
+    source_ref: Optional[str]
+    project_root: str
+    project_exists: bool
+    repository_root: Optional[str]
+    scope_kind: str
+    adoption_scenario: str
+    project_kind: str
+    pdd_signals: Tuple[str, ...]
+    candidate_targets: Tuple[IntentTarget, ...]
+    must_preserve: Tuple[str, ...]
+    examples: Tuple[str, ...]
+    story_recommended: bool
+    story_reasons: Tuple[str, ...]
+    recommended_workflow: str
+    open_decisions: Tuple[str, ...]
+    warnings: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _InventoryTarget:
+    """Internal searchable representation of an architecture/prompt entry."""
+
+    product_area: str
+    prompt_path: Optional[str]
+    output_path: Optional[str]
+    architecture_path: Optional[str]
+    identity_text: str
+    prose_text: str
+
+
+def _relative_display(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _walk_project(root: Path) -> Tuple[List[Path], bool, List[Path], bool]:
+    """Return prompt files, source presence, pddrc files, and truncation state."""
+    prompts: List[Path] = []
+    pddrc_files: List[Path] = []
+    source_found = False
+    scanned = 0
+    truncated = False
+
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        current = Path(dirpath)
+        try:
+            depth = len(current.relative_to(root).parts)
+        except ValueError:
+            continue
+        dirnames[:] = sorted(
+            name
+            for name in dirnames
+            if name not in _EXCLUDED_DIRS and not name.startswith(".venv")
+        )
+        if depth >= _MAX_SCAN_DEPTH:
+            dirnames[:] = []
+
+        for filename in sorted(filenames):
+            scanned += 1
+            if scanned > _MAX_SCANNED_FILES:
+                truncated = True
+                return prompts, source_found, pddrc_files, truncated
+            path = current / filename
+            if filename == ".pddrc":
+                pddrc_files.append(path)
+            if path.suffix == ".prompt":
+                prompts.append(path)
+            if path.suffix.lower() in _SOURCE_SUFFIXES:
+                source_found = True
+
+    return prompts, source_found, pddrc_files, truncated
+
+
+def _containing_repository_root(project_root: Path) -> Optional[Path]:
+    """Find the nearest lexical ancestor containing a Git worktree marker."""
+    candidate = project_root
+    while not candidate.exists() and candidate != candidate.parent:
+        candidate = candidate.parent
+    if candidate.is_file():
+        candidate = candidate.parent
+    for current in (candidate, *candidate.parents):
+        if (current / ".git").exists():
+            return current.resolve()
+    return None
+
+
+def _adoption_scenario(
+    project_kind: str, scope_kind: str, project_exists: bool
+) -> str:
+    if project_kind == "existing_pdd":
+        return (
+            "existing_pdd_subproject_change"
+            if scope_kind == "subproject"
+            else "existing_pdd_change"
+        )
+    if project_kind == "conventional_brownfield":
+        return (
+            "existing_subproject_adoption"
+            if scope_kind == "subproject"
+            else "existing_project_adoption"
+        )
+    if scope_kind == "subproject":
+        return "new_subproject_design"
+    if not project_exists:
+        return "new_project_design"
+    return "new_project_design"
+
+
+def _load_architecture_targets(
+    root: Path, architecture_paths: Sequence[Path]
+) -> Tuple[List[_InventoryTarget], List[str], set[str]]:
+    targets: List[_InventoryTarget] = []
+    warnings: List[str] = []
+    represented_prompts: set[str] = set()
+
+    for architecture_path in architecture_paths:
+        display_architecture = _relative_display(architecture_path, root)
+        try:
+            data = json.loads(architecture_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            warnings.append(
+                f"Could not read {display_architecture} as architecture JSON: {exc}"
+            )
+            continue
+
+        modules = extract_modules(data)
+        if not modules and data not in ([], {"modules": []}):
+            warnings.append(
+                f"{display_architecture} contains no recognized architecture modules."
+            )
+        for entry in modules:
+            filename = str(entry.get("filename") or "").strip()
+            filepath = str(entry.get("filepath") or "").strip()
+            description = str(entry.get("description") or "").strip()
+            reason = str(entry.get("reason") or "").strip()
+            tags_value = entry.get("tags")
+            tags = (
+                [str(tag) for tag in tags_value if isinstance(tag, (str, int, float))]
+                if isinstance(tags_value, list)
+                else []
+            )
+            interface_value = entry.get("interface")
+            interface_text = (
+                json.dumps(interface_value, sort_keys=True)
+                if isinstance(interface_value, dict)
+                else ""
+            )
+            prompt_path = _resolve_declared_prompt(root, architecture_path, filename)
+            if prompt_path:
+                represented_prompts.add(prompt_path)
+            product_area = _product_area(description, filepath, filename)
+            targets.append(
+                _InventoryTarget(
+                    product_area=product_area,
+                    prompt_path=prompt_path,
+                    output_path=filepath or None,
+                    architecture_path=display_architecture,
+                    identity_text=" ".join((filename, filepath, " ".join(tags))),
+                    prose_text=" ".join((description, reason, interface_text)),
+                )
+            )
+    return targets, warnings, represented_prompts
+
+
+def _resolve_declared_prompt(
+    root: Path, architecture_path: Path, filename: str
+) -> Optional[str]:
+    if not filename:
+        return None
+    declared = Path(filename)
+    candidates = [
+        architecture_path.parent / "prompts" / declared,
+        root / "prompts" / declared,
+        architecture_path.parent / declared,
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return _relative_display(candidate, root)
+    conventional = root / "prompts" / declared
+    return _relative_display(conventional, root)
+
+
+def _product_area(description: str, filepath: str, filename: str) -> str:
+    if description:
+        first_sentence = re.split(r"(?<=[.!?])\s+", description, maxsplit=1)[0]
+        return textwrap.shorten(first_sentence, width=140, placeholder="...")
+    seed = filepath or filename or "Unnamed product area"
+    stem = Path(seed).stem
+    stem = re.sub(
+        r"_(python|typescript|javascript|rust|cpp|java|go|llm)$",
+        "",
+        stem,
+        flags=re.IGNORECASE,
+    )
+    return re.sub(r"[_-]+", " ", stem).strip().title() or "Unnamed product area"
+
+
+def _prompt_only_targets(
+    root: Path, prompt_paths: Iterable[Path], represented: set[str]
+) -> List[_InventoryTarget]:
+    targets: List[_InventoryTarget] = []
+    seen: set[str] = set()
+    for prompt_path in prompt_paths:
+        display = _relative_display(prompt_path, root)
+        identity = display.casefold()
+        if identity in seen or display in represented:
+            continue
+        seen.add(identity)
+        targets.append(
+            _InventoryTarget(
+                product_area=_product_area("", "", prompt_path.name),
+                prompt_path=display,
+                output_path=None,
+                architecture_path=None,
+                identity_text=display,
+                prose_text="",
+            )
+        )
+    return targets
+
+
+def _tokens(text: str) -> set[str]:
+    values = set(_lexemes(text))
+    return {
+        token
+        for token in values
+        if (len(token) >= 3 or token in {"ai", "api", "ui"}) and token not in _STOP_WORDS
+    }
+
+
+def _lexemes(text: str) -> List[str]:
+    return [
+        token.casefold()
+        for token in re.findall(
+            r"[A-Za-z0-9]+", text.replace("_", " ").replace("-", " ")
+        )
+    ]
+
+
+def _meaningful_phrases(text: str) -> set[str]:
+    """Return adjacent two-word phrases with at least one target-specific word."""
+    values = _lexemes(text)
+    return {
+        f"{first} {second}"
+        for first, second in zip(values, values[1:])
+        if (len(first) >= 3 or first in {"ai", "api", "ui"})
+        and (len(second) >= 3 or second in {"ai", "api", "ui"})
+        and not (first in _STOP_WORDS and second in _STOP_WORDS)
+    }
+
+
+def _candidate_targets(
+    request: str, inventory: Sequence[_InventoryTarget]
+) -> Tuple[IntentTarget, ...]:
+    request_tokens = _tokens(request)
+    request_phrases = _meaningful_phrases(request)
+    candidates: List[IntentTarget] = []
+    for item in inventory:
+        identity_matches = request_tokens & _tokens(item.identity_text)
+        prose_matches = request_tokens & _tokens(item.prose_text)
+        identity_phrase_matches = request_phrases & _meaningful_phrases(
+            item.identity_text
+        )
+        prose_phrase_matches = request_phrases & _meaningful_phrases(item.prose_text)
+        matched = (
+            identity_matches
+            | prose_matches
+            | identity_phrase_matches
+            | prose_phrase_matches
+        )
+        score = (
+            8 * len(identity_phrase_matches)
+            + 6 * len(prose_phrase_matches)
+            + 5 * len(identity_matches)
+            + 2 * len(prose_matches)
+        )
+        if score <= 0 or (not identity_matches and len(prose_matches) < 2):
+            continue
+        candidates.append(
+            IntentTarget(
+                product_area=item.product_area,
+                prompt_path=item.prompt_path,
+                output_path=item.output_path,
+                architecture_path=item.architecture_path,
+                score=score,
+                matched_terms=tuple(sorted(matched)),
+            )
+        )
+    candidates.sort(
+        key=lambda target: (
+            -target.score,
+            target.product_area.casefold(),
+            target.prompt_path or "",
+        )
+    )
+    if not candidates:
+        return ()
+    relative_cutoff = max(5, (candidates[0].score * 3 + 4) // 5)
+    return tuple(
+        candidate
+        for candidate in candidates
+        if candidate.score >= relative_cutoff
+    )[:_MAX_TARGETS]
+
+
+def _sentences(request: str) -> List[str]:
+    return [
+        sentence.strip()
+        for sentence in re.split(r"(?<=[.!?])\s+|\n+", request)
+        if sentence.strip()
+    ]
+
+
+def _marked_sentences(request: str, markers: Sequence[str]) -> Tuple[str, ...]:
+    found: List[str] = []
+    for sentence in _sentences(request):
+        lowered = sentence.casefold()
+        if any(marker in lowered for marker in markers):
+            found.append(sentence)
+        if len(found) == 5:
+            break
+    return tuple(found)
+
+
+def _story_recommendation(request: str) -> Tuple[bool, Tuple[str, ...]]:
+    lowered = request.casefold()
+    reasons: List[str] = []
+    if any(term in lowered for term in ("user", "customer", "operator", "engineer")):
+        reasons.append("user-visible behavior")
+    if any(term in lowered for term in ("end-to-end", "across ", "workflow", "multiple parts")):
+        reasons.append("cross-part behavior")
+    if any(term in lowered for term in ("regression", "used to", "must never return")):
+        reasons.append("regression protection")
+    if any(
+        term in lowered
+        for term in (
+            "must not",
+            "never",
+            "security",
+            "privacy",
+            "data loss",
+            "delete",
+            "payment",
+        )
+    ):
+        reasons.append("critical boundary")
+    return bool(reasons), tuple(reasons)
+
+
+def _infer_title(request: str) -> str:
+    first = next((line.strip() for line in request.splitlines() if line.strip()), "Intent")
+    first = re.sub(r"^[#*>\-\s]+", "", first).strip()
+    return textwrap.shorten(first, width=72, placeholder="...") or "Intent"
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.casefold()).strip("-")
+    return slug[:48] or "intent"
+
+
+def build_intent_plan(
+    request: str,
+    project_root: Path,
+    *,
+    title: Optional[str] = None,
+    source_kind: str = "inline",
+    source_ref: Optional[str] = None,
+) -> IntentPlan:
+    """Build a deterministic, read-only intent plan from local project evidence."""
+    retained_request = request.strip()
+    if not retained_request:
+        raise ValueError("Intent request must not be empty.")
+    root = Path(project_root).expanduser().resolve()
+    project_exists = root.exists()
+    if project_exists and not root.is_dir():
+        raise ValueError(f"Project root is not a directory: {project_root}")
+
+    digest = hashlib.sha256(retained_request.encode("utf-8")).hexdigest()
+    resolved_title = (title or "").strip() or _infer_title(retained_request)
+    intent_id = f"{_slugify(resolved_title)}-{digest[:8]}"
+
+    repository_root = _containing_repository_root(root)
+    scope_kind = (
+        "subproject"
+        if repository_root is not None and repository_root != root
+        else "repository"
+    )
+    architecture_paths = find_architecture_for_project(root) if project_exists else []
+    if project_exists:
+        prompt_paths, source_found, pddrc_paths, scan_truncated = _walk_project(root)
+    else:
+        prompt_paths, source_found, pddrc_paths, scan_truncated = [], False, [], False
+    architecture_targets, warnings, represented = _load_architecture_targets(
+        root, architecture_paths
+    )
+    inventory = architecture_targets + _prompt_only_targets(
+        root, prompt_paths, represented
+    )
+    candidates = _candidate_targets(retained_request, inventory)
+
+    signals: List[str] = []
+    signals.extend(_relative_display(path, root) for path in pddrc_paths)
+    signals.extend(_relative_display(path, root) for path in architecture_paths)
+    if prompt_paths:
+        signals.append(f"{len(prompt_paths)} prompt file(s)")
+    signals = list(dict.fromkeys(signals))
+    if scan_truncated:
+        warnings.append(
+            f"Project scan stopped after {_MAX_SCANNED_FILES} files; evidence may be incomplete."
+        )
+
+    if signals:
+        project_kind = "existing_pdd"
+        workflow = "change_existing_pdd"
+    elif source_found:
+        project_kind = "conventional_brownfield"
+        workflow = "characterize_then_adopt"
+    else:
+        project_kind = "greenfield"
+        workflow = "design_greenfield"
+    scenario = _adoption_scenario(project_kind, scope_kind, project_exists)
+
+    constraints = _marked_sentences(retained_request, _NEGATIVE_OR_INVARIANT_MARKERS)
+    examples = _marked_sentences(retained_request, _EXAMPLE_MARKERS)
+    story_recommended, story_reasons = _story_recommendation(retained_request)
+
+    open_decisions: List[str] = []
+    if project_kind == "existing_pdd" and not candidates:
+        open_decisions.append(
+            "No affected product area could be identified confidently; the agent must "
+            "inspect the prompt graph or propose a new area."
+        )
+    elif project_kind == "conventional_brownfield":
+        open_decisions.append(
+            "Decide which existing behavior must be characterized before PDD "
+            "ownership is introduced."
+        )
+    elif project_kind == "greenfield":
+        open_decisions.append(
+            "Review the proposed technology choices and architecture before prompt generation."
+        )
+    if scope_kind == "subproject":
+        open_decisions.append(
+            "Confirm the subproject boundary and the integration checks required "
+            "at the containing repository boundary."
+        )
+    if not examples:
+        open_decisions.append(
+            "No concrete example was stated; add one if different interpretations are possible."
+        )
+
+    return IntentPlan(
+        schema_version=INTENT_PLAN_SCHEMA_VERSION,
+        intent_id=intent_id,
+        title=resolved_title,
+        original_request=retained_request,
+        original_request_sha256=digest,
+        source_kind=source_kind,
+        source_ref=source_ref,
+        project_root=str(root),
+        project_exists=project_exists,
+        repository_root=str(repository_root) if repository_root else None,
+        scope_kind=scope_kind,
+        adoption_scenario=scenario,
+        project_kind=project_kind,
+        pdd_signals=tuple(signals),
+        candidate_targets=candidates,
+        must_preserve=constraints,
+        examples=examples,
+        story_recommended=story_recommended,
+        story_reasons=story_reasons,
+        recommended_workflow=workflow,
+        open_decisions=tuple(open_decisions),
+        warnings=tuple(warnings),
+    )
+
+
+def intent_plan_to_dict(plan: IntentPlan) -> Dict[str, Any]:
+    """Return the stable JSON-serializable representation of an intent plan."""
+    return {
+        "schema_version": plan.schema_version,
+        "intent_id": plan.intent_id,
+        "title": plan.title,
+        "original_request": plan.original_request,
+        "original_request_sha256": plan.original_request_sha256,
+        "source": {"kind": plan.source_kind, "ref": plan.source_ref},
+        "project": {
+            "root": plan.project_root,
+            "exists": plan.project_exists,
+            "kind": plan.project_kind,
+            "repository_root": plan.repository_root,
+            "scope_kind": plan.scope_kind,
+            "adoption_scenario": plan.adoption_scenario,
+            "pdd_signals": list(plan.pdd_signals),
+        },
+        "candidate_targets": [
+            {
+                "product_area": target.product_area,
+                "prompt_path": target.prompt_path,
+                "output_path": target.output_path,
+                "architecture_path": target.architecture_path,
+                "score": target.score,
+                "matched_terms": list(target.matched_terms),
+            }
+            for target in plan.candidate_targets
+        ],
+        "review": {
+            "must_preserve": list(plan.must_preserve),
+            "examples": list(plan.examples),
+            "open_decisions": list(plan.open_decisions),
+        },
+        "story": {
+            "recommended": plan.story_recommended,
+            "reasons": list(plan.story_reasons),
+        },
+        "recommended_workflow": plan.recommended_workflow,
+        "warnings": list(plan.warnings),
+        "capabilities": {
+            "planning": True,
+            "apply": False,
+            "writes_project_files": False,
+            "requires_github": False,
+            "invokes_llm": False,
+        },
+    }
+
+
+def _section_lines(items: Sequence[str], empty_message: str) -> List[str]:
+    if not items:
+        return [f"- {empty_message}"]
+    return [f"- {item}" for item in items]
+
+
+def render_review_card(plan: IntentPlan) -> str:
+    """Render one plain-language review card for the product/domain human."""
+    if plan.candidate_targets:
+        change_lines = [
+            "- Candidate impact: "
+            + ", ".join(target.product_area for target in plan.candidate_targets)
+        ]
+        area_lines = [
+            f"- {target.product_area} (candidate; matched: "
+            f"{', '.join(target.matched_terms)})"
+            for target in plan.candidate_targets
+        ]
+    elif plan.project_kind == "greenfield":
+        change_lines = ["- A product architecture and prompt graph need to be proposed."]
+        area_lines = ["- No product areas exist yet; architecture review comes first."]
+    elif plan.project_kind == "conventional_brownfield":
+        change_lines = [
+            "- Existing behavior must be characterized before assigning PDD ownership."
+        ]
+        area_lines = ["- No PDD-owned product area has been established."]
+    else:
+        change_lines = [
+            "- The affected PDD-owned area still needs repository inspection; none was guessed."
+        ]
+        area_lines = ["- No confident candidate yet."]
+
+    proof_lines = [
+        "- Preserve and run relevant existing tests before applying the change.",
+        "- Add focused behavioral tests for accepted behavior and examples.",
+    ]
+    if plan.must_preserve:
+        proof_lines.append("- Add negative checks for every accepted MUST/MUST-NOT boundary.")
+    if plan.project_kind == "greenfield":
+        proof_lines.append("- Verify one small end-to-end slice before broad generation.")
+
+    story_text = (
+        "Recommended because " + ", ".join(plan.story_reasons) + "."
+        if plan.story_recommended
+        else "Not automatically recommended from the current wording."
+    )
+    lines = [
+        f"Intent plan: {plan.title}",
+        f"Project state: {plan.project_kind}",
+        f"Project scope: {plan.scope_kind} ({plan.adoption_scenario})",
+        "",
+        "What I heard:",
+        plan.original_request,
+        "",
+        "What will change:",
+        *change_lines,
+        "",
+        "What must stay unchanged:",
+        *_section_lines(plan.must_preserve, "No explicit invariant was stated."),
+        "",
+        "Important examples:",
+        *_section_lines(plan.examples, "No concrete example was stated."),
+        "",
+        "How we will prove it:",
+        *proof_lines,
+        "",
+        "Affected product areas:",
+        *area_lines,
+        "",
+        "Open decisions:",
+        *_section_lines(plan.open_decisions, "None identified by deterministic planning."),
+        "",
+        "Story coverage:",
+        f"- {story_text}",
+    ]
+    if plan.warnings:
+        lines.extend(("", "Warnings:", *_section_lines(plan.warnings, "")))
+    lines.extend(
+        (
+            "",
+            "Planning only: no project files were changed, no GitHub access was used, "
+            "and no model was invoked.",
+        )
+    )
+    return "\n".join(lines)

--- a/pdd/intent.py
+++ b/pdd/intent.py
@@ -152,6 +152,67 @@ _NEGATIVE_OR_INVARIANT_MARKERS = (
     "unchanged",
 )
 _EXAMPLE_MARKERS = ("for example", "e.g.", "such as", "when ")
+# Deliberately excludes ambiguous ordinary words such as "go", "c", and "r":
+# a missed technology only costs an explicit assertion, while a false match
+# lets greenfield generation start against an undecided stack.
+_TECHNOLOGY_TERMS = frozenset(
+    {
+        "angular",
+        "bash",
+        "bun",
+        "cargo",
+        "clojure",
+        "cmake",
+        "cpp",
+        "csharp",
+        "deno",
+        "django",
+        "docker",
+        "dotnet",
+        "elixir",
+        "erlang",
+        "fastapi",
+        "flask",
+        "fortran",
+        "golang",
+        "haskell",
+        "java",
+        "javascript",
+        "julia",
+        "kotlin",
+        "kubernetes",
+        "lua",
+        "matlab",
+        "mongodb",
+        "mysql",
+        "node",
+        "nodejs",
+        "perl",
+        "php",
+        "pnpm",
+        "poetry",
+        "postgres",
+        "postgresql",
+        "powershell",
+        "python",
+        "python3",
+        "rails",
+        "react",
+        "ruby",
+        "rust",
+        "scala",
+        "spring",
+        "sqlite",
+        "svelte",
+        "swift",
+        "terraform",
+        "typescript",
+        "vue",
+        "wasm",
+        "webassembly",
+        "zig",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -541,6 +602,17 @@ def _story_recommendation(request: str) -> Tuple[bool, Tuple[str, ...]]:
     return bool(reasons), tuple(reasons)
 
 
+def detected_technology_terms(request: str) -> Tuple[str, ...]:
+    """Return technology names stated in the request, in stable order.
+
+    Greenfield generation must pick a language and runtime. When the request
+    names none, an agent should decide explicitly rather than let the
+    architecture workflow guess at cost.
+    """
+    found = {term for term in _lexemes(request) if term in _TECHNOLOGY_TERMS}
+    return tuple(sorted(found))
+
+
 def _infer_title(request: str) -> str:
     first = next((line.strip() for line in request.splitlines() if line.strip()), "Intent")
     first = re.sub(r"^[#*>\-\s]+", "", first).strip()
@@ -640,6 +712,15 @@ def build_intent_plan(
         open_decisions.append(
             "Review the proposed technology choices and architecture before prompt generation."
         )
+        if not detected_technology_terms(retained_request):
+            open_decisions.append(
+                "No language or runtime was named; decide the technology before any "
+                "greenfield generation is attempted."
+            )
+            warnings.append(
+                "Greenfield generation cannot select a technology on its own. Apply "
+                "will refuse until the request names one or the agent asserts it."
+            )
         if project_exists and other_content_found:
             open_decisions.append(
                 "This existing directory holds files but no recognized source; confirm "

--- a/pdd/intent.py
+++ b/pdd/intent.py
@@ -66,49 +66,80 @@ _STOP_WORDS = {
     "also",
     "and",
     "are",
+    "been",
     "before",
+    "being",
+    "both",
     "but",
     "can",
     "change",
     "code",
+    "could",
     "does",
     "during",
+    "each",
+    "every",
     "file",
     "files",
     "for",
     "from",
     "github",
+    "had",
+    "has",
     "have",
     "into",
     "issue",
+    "its",
     "just",
     "language",
     "let",
     "local",
     "make",
     "module",
+    "more",
+    "most",
     "need",
     "never",
+    "only",
     "ordinary",
+    "other",
+    "over",
     "pdd",
     "plan",
     "planning",
-    "prompt",
-    "project",
     "product",
+    "project",
+    "prompt",
+    "same",
     "should",
+    "some",
+    "such",
+    "than",
     "that",
     "the",
     "their",
+    "them",
     "then",
+    "there",
+    "these",
     "this",
+    "those",
     "use",
     "user",
+    "very",
     "want",
+    "was",
+    "were",
+    "what",
     "when",
     "where",
+    "which",
+    "while",
+    "who",
+    "will",
     "with",
     "without",
+    "would",
 }
 _NEGATIVE_OR_INVARIANT_MARKERS = (
     "must ",
@@ -182,11 +213,17 @@ def _relative_display(path: Path, root: Path) -> str:
         return str(path)
 
 
-def _walk_project(root: Path) -> Tuple[List[Path], bool, List[Path], bool]:
-    """Return prompt files, source presence, pddrc files, and truncation state."""
+def _walk_project(root: Path) -> Tuple[List[Path], bool, List[Path], bool, bool]:
+    """Return prompts, source presence, pddrc files, truncation, other content.
+
+    "Other content" means visible files that are neither recognized source nor
+    prompts. A directory full of documentation is not an empty greenfield
+    project root, and treating it as one invites scaffolding into it.
+    """
     prompts: List[Path] = []
     pddrc_files: List[Path] = []
     source_found = False
+    other_content_found = False
     scanned = 0
     truncated = False
 
@@ -208,7 +245,13 @@ def _walk_project(root: Path) -> Tuple[List[Path], bool, List[Path], bool]:
             scanned += 1
             if scanned > _MAX_SCANNED_FILES:
                 truncated = True
-                return prompts, source_found, pddrc_files, truncated
+                return (
+                    prompts,
+                    source_found,
+                    pddrc_files,
+                    truncated,
+                    other_content_found,
+                )
             path = current / filename
             if filename == ".pddrc":
                 pddrc_files.append(path)
@@ -216,8 +259,10 @@ def _walk_project(root: Path) -> Tuple[List[Path], bool, List[Path], bool]:
                 prompts.append(path)
             if path.suffix.lower() in _SOURCE_SUFFIXES:
                 source_found = True
+            elif path.suffix != ".prompt" and not filename.startswith("."):
+                other_content_found = True
 
-    return prompts, source_found, pddrc_files, truncated
+    return prompts, source_found, pddrc_files, truncated, other_content_found
 
 
 def _containing_repository_root(project_root: Path) -> Optional[Path]:
@@ -536,9 +581,16 @@ def build_intent_plan(
     )
     architecture_paths = find_architecture_for_project(root) if project_exists else []
     if project_exists:
-        prompt_paths, source_found, pddrc_paths, scan_truncated = _walk_project(root)
+        (
+            prompt_paths,
+            source_found,
+            pddrc_paths,
+            scan_truncated,
+            other_content_found,
+        ) = _walk_project(root)
     else:
-        prompt_paths, source_found, pddrc_paths, scan_truncated = [], False, [], False
+        prompt_paths, source_found, pddrc_paths = [], False, []
+        scan_truncated, other_content_found = False, False
     architecture_targets, warnings, represented = _load_architecture_targets(
         root, architecture_paths
     )
@@ -588,6 +640,15 @@ def build_intent_plan(
         open_decisions.append(
             "Review the proposed technology choices and architecture before prompt generation."
         )
+        if project_exists and other_content_found:
+            open_decisions.append(
+                "This existing directory holds files but no recognized source; confirm "
+                "it is the intended project root before anything is generated into it."
+            )
+            warnings.append(
+                "Project root already contains non-source files such as documentation. "
+                "It is classified greenfield only because no recognized source was found."
+            )
     if scope_kind == "subproject":
         open_decisions.append(
             "Confirm the subproject boundary and the integration checks required "

--- a/pdd/prompts/commands/__init___python.prompt
+++ b/pdd/prompts/commands/__init___python.prompt
@@ -14,6 +14,7 @@
 <pdd-dependency>commands/context_python.prompt</pdd-dependency>
 <pdd-dependency>commands/contracts_python.prompt</pdd-dependency>
 <pdd-dependency>commands/story_python.prompt</pdd-dependency>
+<pdd-dependency>commands/intent_cli_python.prompt</pdd-dependency>
 
 % You are an expert Python engineer. Your goal is to write the command registration module `pdd/commands/__init__.py`.
 
@@ -32,7 +33,6 @@
     - `sync`, `sync_architecture` (from `.maintenance`)
     - `checkup` (from `.checkup`)
     - `contracts_cli` (from `.contracts`)
-    - `story_cli` (from `.story`)
     - `auto_deps`, `setup` (from `.maintenance`)
     - `detect_change`, `conflicts`, `bug`, `crash`, `trace` (from `.analysis`)
     - `preprocess` (from `.misc`)
@@ -47,6 +47,8 @@
     - `auth_group` (from `.auth`)
     - `sessions` (from `.sessions`)
     - `firecrawl_cache` (from `.firecrawl`)
+    - `story_cli` (from `.story`)
+    - `intent_cli` (from `.intent`)
 
 % Deliverables
   - Code: `pdd/commands/__init__.py`

--- a/pdd/prompts/commands/intent_cli_python.prompt
+++ b/pdd/prompts/commands/intent_cli_python.prompt
@@ -1,0 +1,65 @@
+<pdd-reason>Exposes local ordinary-language intent planning as a safe `pdd intent plan` command for humans and AI harnesses.</pdd-reason>
+
+<pdd-interface>
+{
+  "type": "cli",
+  "cli": {
+    "commands": [
+      {
+        "name": "intent plan",
+        "description": "Plan an ordinary-language request against local project evidence without changing files or requiring GitHub"
+      }
+    ]
+  }
+}
+</pdd-interface>
+
+<pdd-dependency>intent_python.prompt</pdd-dependency>
+
+% You are an expert Python engineer. Write `pdd/commands/intent.py`.
+
+<include>context/python_preamble.prompt</include>
+
+% Role & Scope
+  Implement a thin Click command group over `pdd.intent`. The command is an
+  agent-facing front door, although it must also be understandable when a human
+  runs it. The first release is planning-only and deliberately has no `apply`
+  subcommand.
+
+<contract_rules>
+R1 - Command surface
+Expose a `@click.group(name="intent")` named `intent_cli` with a `plan`
+subcommand. `pdd intent --help` MUST state that the group accepts ordinary
+product intent and handles PDD routing. `pdd intent plan --help` MUST state
+that planning is local, requires no GitHub issue, and changes no project files.
+
+R2 - Input forms
+`intent plan` MUST accept exactly one input form: `--text
+<ordinary-language request>`, positional `SOURCE` naming an existing local text
+file, or piped standard input when neither `SOURCE` nor `--text` is supplied.
+Reject simultaneous `SOURCE` and `--text`, missing interactive input,
+unreadable/non-file sources, empty input, and input larger than 100,000
+characters with clear Click errors.
+
+R3 - Project and title options
+Support optional `--project-root <directory>` (default current directory) and
+`--title <human title>`. `--project-root` MAY name a proposed new directory
+that does not exist yet; planning MUST NOT create it. Resolve the project root
+before calling `build_intent_plan`. Do not require a GitHub URL, prompt path,
+internal target name, story slug, output path, or PDD configuration knowledge.
+
+R4 - Output modes
+Default output MUST be `render_review_card(plan)`. `--json` MUST instead emit
+only deterministic JSON from `intent_plan_to_dict(plan)`, with indentation and
+sorted object keys suitable for an AI harness. Do not mix status prose into
+JSON stdout.
+
+R5 - Planning-only truthfulness
+The command MUST NOT write any project files, call GitHub, invoke an LLM,
+generate stories/tests/code, or run synchronization. It MUST never imply that
+the request was applied. Errors exit non-zero.
+</contract_rules>
+
+% Deliverables
+- Code: `pdd/commands/intent.py`
+- Tests: `tests/commands/test_pdd_commands_intent.py`

--- a/pdd/prompts/intent_python.prompt
+++ b/pdd/prompts/intent_python.prompt
@@ -1,0 +1,180 @@
+<pdd-reason>Plans an ordinary-language product request against local repository evidence without requiring GitHub, mutating project files, or invoking an LLM.</pdd-reason>
+
+<pdd-interface>
+{
+  "type": "module",
+  "module": {
+    "dataclasses": [
+      {
+        "name": "IntentTarget",
+        "fields": [
+          {"name": "product_area", "type": "str"},
+          {"name": "prompt_path", "type": "Optional[str]"},
+          {"name": "output_path", "type": "Optional[str]"},
+          {"name": "architecture_path", "type": "Optional[str]"},
+          {"name": "score", "type": "int"},
+          {"name": "matched_terms", "type": "Tuple[str, ...]"}
+        ]
+      },
+      {
+        "name": "IntentPlan",
+        "fields": [
+          {"name": "schema_version", "type": "str"},
+          {"name": "intent_id", "type": "str"},
+          {"name": "title", "type": "str"},
+          {"name": "original_request", "type": "str"},
+          {"name": "original_request_sha256", "type": "str"},
+          {"name": "source_kind", "type": "str"},
+          {"name": "source_ref", "type": "Optional[str]"},
+          {"name": "project_root", "type": "str"},
+          {"name": "project_exists", "type": "bool"},
+          {"name": "repository_root", "type": "Optional[str]"},
+          {"name": "scope_kind", "type": "str"},
+          {"name": "adoption_scenario", "type": "str"},
+          {"name": "project_kind", "type": "str"},
+          {"name": "pdd_signals", "type": "Tuple[str, ...]"},
+          {"name": "candidate_targets", "type": "Tuple[IntentTarget, ...]"},
+          {"name": "must_preserve", "type": "Tuple[str, ...]"},
+          {"name": "examples", "type": "Tuple[str, ...]"},
+          {"name": "story_recommended", "type": "bool"},
+          {"name": "story_reasons", "type": "Tuple[str, ...]"},
+          {"name": "recommended_workflow", "type": "str"},
+          {"name": "open_decisions", "type": "Tuple[str, ...]"},
+          {"name": "warnings", "type": "Tuple[str, ...]"}
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "build_intent_plan",
+        "signature": "(request: str, project_root: Path, *, title: Optional[str] = None, source_kind: str = 'inline', source_ref: Optional[str] = None) -> IntentPlan",
+        "returns": "IntentPlan"
+      },
+      {
+        "name": "intent_plan_to_dict",
+        "signature": "(plan: IntentPlan) -> Dict[str, Any]",
+        "returns": "Dict[str, Any]"
+      },
+      {
+        "name": "render_review_card",
+        "signature": "(plan: IntentPlan) -> str",
+        "returns": "str"
+      }
+    ]
+  }
+}
+</pdd-interface>
+
+<pdd-dependency>architecture_registry_python.prompt</pdd-dependency>
+
+% You are an expert Python engineer. Write `pdd/intent.py`.
+
+<include>context/python_preamble.prompt</include>
+
+% Role & Scope
+  Implement the deterministic, local planning core for the beginner-facing
+  `pdd intent` workflow. This first vertical slice preserves an ordinary-language
+  request, classifies the project, discovers candidate prompt-owned product
+  areas, and renders a plain-language review card. It MUST NOT mutate the project,
+  call GitHub, invoke an LLM, run generation, or claim that it applied the plan.
+
+<contract_rules>
+R1 - Immutable request representation
+`build_intent_plan` MUST reject empty/whitespace-only requests, normalize only
+outer whitespace, retain the request text otherwise byte-for-byte, and include
+a SHA-256 digest of the retained request. It MUST derive a deterministic,
+lowercase intent ID containing only ASCII letters, digits, and hyphens, with no
+leading/trailing hyphen and a maximum length of 57 characters, from the
+supplied/inferred title plus the digest.
+
+R2 - Project classification
+Classify the project as `existing_pdd` when local PDD evidence exists
+(`.pddrc`, one or more `architecture.json` files, or `.prompt` files);
+otherwise classify it as `conventional_brownfield` when ordinary source files
+exist, and `greenfield` when neither PDD evidence nor ordinary source exists.
+Permit a proposed project root that does not exist yet and classify it as
+greenfield without creating it. Discover the nearest containing Git repository
+from `.git` evidence and distinguish `repository` from `subproject` scope.
+Return an adoption scenario that distinguishes an existing standalone project,
+a new standalone project, an existing monorepo subproject, a new monorepo
+subproject, and already-PDD-managed variants.
+Discovery MUST ignore `.git`, `.pdd`, virtual environments, dependency/vendor
+trees, caches, and build outputs. It MUST be bounded and deterministic.
+
+R3 - Tolerant architecture discovery
+Use `pdd.architecture_registry.find_architecture_for_project` and
+`extract_modules` to read bare-array and `{modules: [...]}` architecture files.
+An architecture file that raises `OSError` or `JSONDecodeError` MUST produce a
+warning instead of crashing.
+Architecture discovery MUST retain the declaring architecture path, prompt
+filename, generated output path, description/reason, and tags needed for
+candidate scoring.
+
+R4 - Conservative candidate discovery
+Discover candidate targets by deterministic token overlap between the request
+and architecture/prompt inventory. Identity fields (prompt filename, output
+path, tags) MUST carry more weight than description/reason prose. Return at
+most five stable, score-sorted candidates. A candidate MUST match at least one
+meaningful request token in an identity field or at least two meaningful
+request tokens in description/reason prose. Common workflow terms such as
+`agent`, `GitHub`, `issue`, `project`, `planning`, `prompt`, and `PDD` MUST NOT
+count as meaningful standalone target tokens. Give additional weight to
+matching adjacent two-word phrases, including phrases containing one workflow
+term and one target-specific term (for example, `pdd intent`). After sorting,
+retain only candidates scoring at least 60 percent of the highest score, up to
+the five-candidate limit. Never fabricate a target and never claim a candidate
+is authoritative; when no qualifying match exists, return no candidate and add
+an open decision that an agent must inspect the architecture or propose a new
+product part.
+
+R5 - Human intent extraction
+Extract explicit preservation constraints from sentences containing language
+such as `must`, `must not`, `never`, `always`, `do not`, or `without`.
+Extract example-bearing sentences using markers such as `for example`, `e.g.`,
+`such as`, or `when`. Preserve their original wording and cap each list at five.
+Absence is honest and MUST NOT cause invented constraints/examples.
+
+R6 - Selective story recommendation
+Recommend independent story coverage only when deterministic request evidence
+suggests user-visible behavior, cross-part/end-to-end behavior, a regression,
+or a critical MUST/MUST-NOT/security/privacy/data-loss boundary. Return the
+reason categories. This is a recommendation only: planning MUST NOT write story
+files or invoke `pdd story`.
+
+R7 - Workflow routing
+The plan MUST return exactly one stable workflow identifier. It MUST return
+`change_existing_pdd` for `existing_pdd`, `characterize_then_adopt` for
+`conventional_brownfield`, and `design_greenfield` for `greenfield`.
+The plan MUST distinguish these routes without requiring the caller to know a
+prompt path or “dev unit.”
+
+R7b - Scoped ownership
+All discovery MUST be anchored to the selected project root, not automatically
+expanded to the containing Git repository. This permits a monorepo subproject
+to own its own `.pddrc`, `architecture.json`, prompt graph, and generated
+outputs without converting unrelated siblings. The plan MUST report the
+containing repository separately and MUST add an open decision asking the
+agent to confirm the subproject boundary and its required integration checks.
+
+R8 - Stable structured output
+`intent_plan_to_dict` MUST emit JSON-serializable data with schema version
+`pdd.intent.plan.v1`, preserve list ordering, and include a capabilities object
+that truthfully reports `planning: true`, `apply: false`, `writes_project_files:
+false`, `requires_github: false`, and `invokes_llm: false`.
+
+R9 - Human review card
+`render_review_card` MUST show: What I heard, What will change, What must stay
+unchanged, Important examples, How we will prove it, Affected product areas,
+Open decisions, and Story coverage. It MUST describe technical candidates as
+proposals, avoid requiring PDD jargon from the human, and end by stating that
+this is planning only and no project files were changed.
+
+R10 - No side effects
+All public functions in this module MUST be deterministic and read-only with
+respect to the project. They MUST NOT create `.pdd/`, intent files, logs,
+branches, worktrees, issues, comments, prompts, tests, or generated code.
+</contract_rules>
+
+% Deliverables
+- Code: `pdd/intent.py`
+- Tests: `tests/test_pdd_intent.py`

--- a/pdd/prompts/intent_python.prompt
+++ b/pdd/prompts/intent_python.prompt
@@ -59,6 +59,11 @@
         "name": "render_review_card",
         "signature": "(plan: IntentPlan) -> str",
         "returns": "str"
+      },
+      {
+        "name": "detected_technology_terms",
+        "signature": "(request: str) -> Tuple[str, ...]",
+        "returns": "Tuple[str, ...]"
       }
     ]
   }
@@ -135,6 +140,16 @@ the five-candidate limit. Never fabricate a target and never claim a candidate
 is authoritative; when no qualifying match exists, return no candidate and add
 an open decision that an agent must inspect the architecture or propose a new
 product part.
+
+R4a - Technology detection for greenfield work
+`detected_technology_terms` MUST deterministically return the language,
+runtime, framework, and tooling names stated in the request, in stable sorted
+order. It MUST exclude ordinary English words that merely coincide with
+technology names, such as `go`, `c`, and `r`, because a false positive lets
+greenfield generation begin against an undecided stack while a false negative
+only costs one explicit assertion. When a greenfield plan names no technology,
+planning MUST add both an open decision to decide it and a warning that apply
+will refuse until it is stated or asserted.
 
 R5 - Human intent extraction
 Extract explicit preservation constraints from sentences containing language

--- a/pdd/prompts/intent_python.prompt
+++ b/pdd/prompts/intent_python.prompt
@@ -93,7 +93,12 @@ Classify the project as `existing_pdd` when local PDD evidence exists
 otherwise classify it as `conventional_brownfield` when ordinary source files
 exist, and `greenfield` when neither PDD evidence nor ordinary source exists.
 Permit a proposed project root that does not exist yet and classify it as
-greenfield without creating it. Discover the nearest containing Git repository
+greenfield without creating it. When an existing project root holds visible
+files that are neither recognized source nor prompts, such as a documentation
+directory, it MUST still classify as greenfield but MUST also emit a warning
+and an open decision that the root be confirmed before anything is generated
+into it. A genuinely empty root MUST NOT trigger that warning.
+Discover the nearest containing Git repository
 from `.git` evidence and distinguish `repository` from `subproject` scope.
 Return an adoption scenario that distinguishes an existing standalone project,
 a new standalone project, an existing monorepo subproject, a new monorepo
@@ -118,7 +123,11 @@ most five stable, score-sorted candidates. A candidate MUST match at least one
 meaningful request token in an identity field or at least two meaningful
 request tokens in description/reason prose. Common workflow terms such as
 `agent`, `GitHub`, `issue`, `project`, `planning`, `prompt`, and `PDD` MUST NOT
-count as meaningful standalone target tokens. Give additional weight to
+count as meaningful standalone target tokens. Ordinary English function words,
+such as `each`, `every`, `while`, `same`, `other`, `them`, and `what`, MUST NOT
+count either, and a two-word phrase composed only of such words, such as
+`for each`, MUST NOT count as a phrase match. A request that overlaps a product
+area on nothing but function words MUST yield no candidate. Give additional weight to
 matching adjacent two-word phrases, including phrases containing one workflow
 term and one target-specific term (for example, `pdd intent`). After sorting,
 retain only candidates scoring at least 60 percent of the highest score, up to

--- a/tests/commands/test_pdd_commands_intent.py
+++ b/tests/commands/test_pdd_commands_intent.py
@@ -1,0 +1,188 @@
+"""Tests for the `pdd intent` planning command."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+from click.testing import CliRunner
+
+from pdd.commands import register_commands
+from pdd.commands.intent import intent
+
+
+def test_help_describes_local_planning() -> None:
+    runner = CliRunner()
+
+    group_help = runner.invoke(intent, ["--help"])
+    plan_help = runner.invoke(intent, ["plan", "--help"])
+
+    assert group_help.exit_code == 0
+    assert "ordinary product intent" in group_help.output
+    assert plan_help.exit_code == 0
+    assert "without GitHub" in plan_help.output
+    assert "file changes" in plan_help.output
+
+
+def test_inline_text_renders_review_card_without_writes(tmp_path: Path) -> None:
+    runner = CliRunner()
+    before = set(tmp_path.iterdir())
+
+    result = runner.invoke(
+        intent,
+        [
+            "plan",
+            "--text",
+            "Add a calculator. Never send inputs over the network.",
+            "--project-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "What I heard:" in result.output
+    assert "Never send inputs over the network." in result.output
+    assert "Planning only" in result.output
+    assert set(tmp_path.iterdir()) == before
+
+
+def test_json_output_is_machine_readable_and_has_no_status_prose(
+    tmp_path: Path,
+) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        intent,
+        [
+            "plan",
+            "--text",
+            "Create a calculator.",
+            "--project-root",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["schema_version"] == "pdd.intent.plan.v1"
+    assert payload["capabilities"]["apply"] is False
+    assert "Planning only" not in result.output
+
+
+def test_local_file_source_is_recorded(tmp_path: Path) -> None:
+    runner = CliRunner()
+    source = tmp_path / "request.md"
+    source.write_text("# Export\n\nAdd PDF export.\n", encoding="utf-8")
+
+    result = runner.invoke(
+        intent,
+        [
+            "plan",
+            str(source),
+            "--project-root",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["source"] == {"kind": "file", "ref": str(source.resolve())}
+    assert payload["original_request"] == "# Export\n\nAdd PDF export."
+
+
+def test_piped_stdin_is_supported(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        intent,
+        ["plan", "--project-root", str(tmp_path), "--json"],
+        input="Create an offline report viewer.\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["source"] == {"kind": "stdin", "ref": "<stdin>"}
+
+
+def test_source_and_text_are_mutually_exclusive(tmp_path: Path) -> None:
+    runner = CliRunner()
+    source = tmp_path / "request.md"
+    source.write_text("Add export.", encoding="utf-8")
+
+    result = runner.invoke(
+        intent,
+        [
+            "plan",
+            str(source),
+            "--text",
+            "Different request",
+            "--project-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "either SOURCE or --text" in result.output
+
+
+def test_empty_input_is_rejected(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        intent,
+        ["plan", "--project-root", str(tmp_path)],
+        input="",
+    )
+
+    assert result.exit_code != 0
+    assert "must not be empty" in result.output
+
+
+def test_oversized_input_is_rejected(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        intent,
+        [
+            "plan",
+            "--text",
+            "x" * 100_001,
+            "--project-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "100,000-character" in result.output
+
+
+def test_proposed_project_root_may_not_exist(tmp_path: Path) -> None:
+    runner = CliRunner()
+    proposed = tmp_path / "packages" / "new_tool"
+
+    result = runner.invoke(
+        intent,
+        [
+            "plan",
+            "--text",
+            "Create a new tool.",
+            "--project-root",
+            str(proposed),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["project"]["exists"] is False
+    assert not proposed.exists()
+
+
+def test_command_is_registered_at_top_level() -> None:
+    cli = click.Group()
+
+    register_commands(cli)
+
+    assert "intent" in cli.commands

--- a/tests/test_pdd_intent.py
+++ b/tests/test_pdd_intent.py
@@ -258,3 +258,55 @@ def test_existing_file_cannot_be_project_root(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="not a directory"):
         build_intent_plan("Do something.", path)
+
+
+def test_function_words_do_not_manufacture_candidates(tmp_path: Path) -> None:
+    """Filler words must not link a request to an unrelated product area."""
+    prompts = tmp_path / "prompts"
+    prompts.mkdir(parents=True)
+    (prompts / "billing_totals_python.prompt").write_text("x", encoding="utf-8")
+    (tmp_path / ".pddrc").write_text("version: '1.0'\n", encoding="utf-8")
+    (tmp_path / "architecture.json").write_text(
+        json.dumps(
+            [
+                {
+                    "reason": "Step 11 of the workflow runs for each queued item.",
+                    "description": "Handles every other retry while the queue drains.",
+                    "filename": "billing_totals_python.prompt",
+                    "filepath": "src/billing_totals.py",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    plan = build_intent_plan(
+        "Show a chart for each visitor so that every one of them has what they "
+        "want, while the same layout is what it was before.",
+        tmp_path,
+    )
+
+    assert plan.candidate_targets == ()
+
+
+def test_docs_only_directory_warns_before_greenfield_generation(
+    tmp_path: Path,
+) -> None:
+    """An existing directory holding only prose is not a blank project root."""
+    (tmp_path / "notes.md").write_text("# Design notes\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# Overview\n", encoding="utf-8")
+
+    plan = build_intent_plan("Add offline PDF export.", tmp_path)
+
+    assert plan.project_kind == "greenfield"
+    assert any("no recognized source" in item for item in plan.open_decisions)
+    assert any("non-source files" in item for item in plan.warnings)
+
+
+def test_empty_greenfield_root_stays_unwarned(tmp_path: Path) -> None:
+    """The guard must not fire for a genuinely empty project root."""
+    plan = build_intent_plan("Add offline PDF export.", tmp_path)
+
+    assert plan.project_kind == "greenfield"
+    assert not any("no recognized source" in item for item in plan.open_decisions)
+    assert not any("non-source files" in item for item in plan.warnings)

--- a/tests/test_pdd_intent.py
+++ b/tests/test_pdd_intent.py
@@ -9,6 +9,7 @@ import pytest
 from pdd.intent import (
     INTENT_PLAN_SCHEMA_VERSION,
     build_intent_plan,
+    detected_technology_terms,
     intent_plan_to_dict,
     render_review_card,
 )
@@ -310,3 +311,28 @@ def test_empty_greenfield_root_stays_unwarned(tmp_path: Path) -> None:
     assert plan.project_kind == "greenfield"
     assert not any("no recognized source" in item for item in plan.open_decisions)
     assert not any("non-source files" in item for item in plan.warnings)
+
+
+def test_greenfield_without_a_named_technology_is_flagged(tmp_path: Path) -> None:
+    """Planning must surface the undecided stack before apply is attempted."""
+    plan = build_intent_plan("Create a calculator.", tmp_path / "new_project")
+
+    assert plan.project_kind == "greenfield"
+    assert detected_technology_terms(plan.original_request) == ()
+    assert any("No language or runtime" in item for item in plan.open_decisions)
+    assert any("cannot select a technology" in item for item in plan.warnings)
+
+
+def test_named_technology_is_detected_and_not_flagged(tmp_path: Path) -> None:
+    plan = build_intent_plan(
+        "Create a calculator in Python using poetry.", tmp_path / "new_project"
+    )
+
+    assert detected_technology_terms(plan.original_request) == ("poetry", "python")
+    assert not any("No language or runtime" in item for item in plan.open_decisions)
+    assert not any("cannot select a technology" in item for item in plan.warnings)
+
+
+def test_ambiguous_english_is_not_mistaken_for_a_technology() -> None:
+    """A false positive would let generation start on an undecided stack."""
+    assert detected_technology_terms("Go through the c and r columns.") == ()

--- a/tests/test_pdd_intent.py
+++ b/tests/test_pdd_intent.py
@@ -1,0 +1,260 @@
+"""Tests for deterministic local intent planning."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pdd.intent import (
+    INTENT_PLAN_SCHEMA_VERSION,
+    build_intent_plan,
+    intent_plan_to_dict,
+    render_review_card,
+)
+
+
+def _write_pressure_architecture(root: Path) -> None:
+    prompts = root / "prompts"
+    prompts.mkdir(parents=True)
+    (prompts / "pressure_trace_analyzer_python.prompt").write_text(
+        "Analyze uploaded pressure traces.",
+        encoding="utf-8",
+    )
+    (root / ".pddrc").write_text("version: '1.0'\n", encoding="utf-8")
+    (root / "architecture.json").write_text(
+        json.dumps(
+            [
+                {
+                    "reason": "Detect pressure excursions for valve diagnosis.",
+                    "description": "Highlights out-of-limit pressure intervals for test engineers.",
+                    "dependencies": [],
+                    "priority": 1,
+                    "filename": "pressure_trace_analyzer_python.prompt",
+                    "filepath": "src/pressure_trace_analyzer.py",
+                    "tags": ["pressure", "trace", "diagnostics"],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _file_inventory(root: Path) -> set[str]:
+    return {
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_existing_pdd_plan_preserves_request_and_finds_candidate(tmp_path: Path) -> None:
+    _write_pressure_architecture(tmp_path)
+    request = (
+        "As a test engineer, highlight pressure intervals outside the permitted band. "
+        "Never modify the uploaded samples. For example, show when a valve spike begins."
+    )
+
+    before = _file_inventory(tmp_path)
+    plan = build_intent_plan(request, tmp_path, title="Pressure limits")
+
+    assert plan.schema_version == INTENT_PLAN_SCHEMA_VERSION
+    assert plan.project_kind == "existing_pdd"
+    assert plan.scope_kind == "repository"
+    assert plan.adoption_scenario == "existing_pdd_change"
+    assert plan.recommended_workflow == "change_existing_pdd"
+    assert plan.original_request == request
+    assert len(plan.original_request_sha256) == 64
+    assert plan.intent_id.startswith("pressure-limits-")
+    assert plan.candidate_targets
+    assert plan.candidate_targets[0].prompt_path == (
+        "prompts/pressure_trace_analyzer_python.prompt"
+    )
+    assert "pressure" in plan.candidate_targets[0].matched_terms
+    assert plan.must_preserve == ("Never modify the uploaded samples.",)
+    assert plan.examples == (
+        "For example, show when a valve spike begins.",
+    )
+    assert plan.story_recommended is True
+    assert _file_inventory(tmp_path) == before
+
+
+def test_structured_plan_reports_truthful_capabilities(tmp_path: Path) -> None:
+    plan = build_intent_plan("Create a local calculator.", tmp_path)
+    payload = intent_plan_to_dict(plan)
+
+    assert payload["schema_version"] == "pdd.intent.plan.v1"
+    assert payload["project"]["kind"] == "greenfield"
+    assert payload["project"]["adoption_scenario"] == "new_project_design"
+    assert payload["capabilities"] == {
+        "planning": True,
+        "apply": False,
+        "writes_project_files": False,
+        "requires_github": False,
+        "invokes_llm": False,
+    }
+
+
+def test_conventional_project_routes_through_characterization(tmp_path: Path) -> None:
+    (tmp_path / "app.py").write_text("print('existing')\n", encoding="utf-8")
+
+    plan = build_intent_plan("Add CSV export.", tmp_path)
+
+    assert plan.project_kind == "conventional_brownfield"
+    assert plan.adoption_scenario == "existing_project_adoption"
+    assert plan.recommended_workflow == "characterize_then_adopt"
+    assert "characterized" in plan.open_decisions[0]
+
+
+def test_existing_monorepo_subproject_is_scoped_locally(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    subproject = tmp_path / "services" / "billing"
+    subproject.mkdir(parents=True)
+    (subproject / "service.py").write_text("def charge(): ...\n", encoding="utf-8")
+    sibling = tmp_path / "services" / "unrelated"
+    sibling.mkdir(parents=True)
+    (sibling / ".pddrc").write_text("version: '1.0'\n", encoding="utf-8")
+
+    plan = build_intent_plan("Add invoice reconciliation.", subproject)
+
+    assert plan.scope_kind == "subproject"
+    assert plan.repository_root == str(tmp_path.resolve())
+    assert plan.project_kind == "conventional_brownfield"
+    assert plan.adoption_scenario == "existing_subproject_adoption"
+    assert plan.pdd_signals == ()
+    assert any("repository boundary" in item for item in plan.open_decisions)
+
+
+def test_proposed_new_monorepo_subproject_need_not_exist(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    proposed = tmp_path / "services" / "new_analyzer"
+
+    plan = build_intent_plan("Create a pressure analyzer.", proposed)
+
+    assert plan.project_exists is False
+    assert plan.scope_kind == "subproject"
+    assert plan.project_kind == "greenfield"
+    assert plan.adoption_scenario == "new_subproject_design"
+    assert not proposed.exists()
+
+
+def test_invalid_architecture_is_warning_not_crash(tmp_path: Path) -> None:
+    (tmp_path / "architecture.json").write_text("{not-json", encoding="utf-8")
+
+    plan = build_intent_plan("Improve checkout.", tmp_path)
+
+    assert plan.project_kind == "existing_pdd"
+    assert plan.candidate_targets == ()
+    assert any("Could not read architecture.json" in warning for warning in plan.warnings)
+
+
+def test_prompt_only_project_can_propose_candidate(tmp_path: Path) -> None:
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    (prompts / "invoice_reconciliation_python.prompt").write_text(
+        "Reconcile invoices.", encoding="utf-8"
+    )
+
+    plan = build_intent_plan("Improve invoice reconciliation.", tmp_path)
+
+    assert plan.project_kind == "existing_pdd"
+    assert plan.candidate_targets[0].product_area == "Invoice Reconciliation"
+    assert plan.candidate_targets[0].output_path is None
+
+
+def test_no_token_match_does_not_fabricate_target(tmp_path: Path) -> None:
+    _write_pressure_architecture(tmp_path)
+
+    plan = build_intent_plan("Add multilingual checkout receipts.", tmp_path)
+
+    assert plan.candidate_targets == ()
+    assert any("No affected product area" in item for item in plan.open_decisions)
+
+
+def test_generic_workflow_terms_do_not_select_unrelated_modules(
+    tmp_path: Path,
+) -> None:
+    _write_pressure_architecture(tmp_path)
+
+    plan = build_intent_plan(
+        "Let an AI agent plan a project locally without a GitHub issue.",
+        tmp_path,
+    )
+
+    assert plan.candidate_targets == ()
+
+
+def test_multiword_product_intent_outranks_unrelated_internal_intent(
+    tmp_path: Path,
+) -> None:
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    for filename in ("intent_python.prompt", "agentic_split_step0_intent_LLM.prompt"):
+        (prompts / filename).write_text("Contract.", encoding="utf-8")
+    (tmp_path / "architecture.json").write_text(
+        json.dumps(
+            [
+                {
+                    "reason": "Plans ordinary-language product intent locally.",
+                    "description": "The PDD intent planning front door.",
+                    "dependencies": [],
+                    "priority": 1,
+                    "filename": "intent_python.prompt",
+                    "filepath": "pdd/intent.py",
+                    "tags": ["intent", "pdd-intent"],
+                },
+                {
+                    "reason": "Records intent for an internal agentic split step.",
+                    "description": "Step zero of the agentic split workflow.",
+                    "dependencies": [],
+                    "priority": 2,
+                    "filename": "agentic_split_step0_intent_LLM.prompt",
+                    "filepath": "pdd/agentic_split/step0_intent.py",
+                    "tags": ["intent", "agentic-split"],
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    plan = build_intent_plan(
+        "Use PDD intent to plan ordinary-language product intent.",
+        tmp_path,
+    )
+
+    assert [target.prompt_path for target in plan.candidate_targets] == [
+        "prompts/intent_python.prompt"
+    ]
+
+
+def test_review_card_uses_human_headings_and_disclaims_application(tmp_path: Path) -> None:
+    plan = build_intent_plan("Create a calculator.", tmp_path)
+
+    card = render_review_card(plan)
+
+    for heading in (
+        "What I heard:",
+        "What will change:",
+        "What must stay unchanged:",
+        "Important examples:",
+        "How we will prove it:",
+        "Affected product areas:",
+        "Open decisions:",
+        "Story coverage:",
+    ):
+        assert heading in card
+    assert "Planning only: no project files were changed" in card
+
+
+@pytest.mark.parametrize("intent_text", ["", " ", "\n\t"])
+def test_empty_intent_is_rejected(tmp_path: Path, intent_text: str) -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        build_intent_plan(intent_text, tmp_path)
+
+
+def test_existing_file_cannot_be_project_root(tmp_path: Path) -> None:
+    path = tmp_path / "not-a-project"
+    path.write_text("x", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="not a directory"):
+        build_intent_plan("Do something.", path)


### PR DESCRIPTION
Implements the read-only half of #2339: a local, ordinary-language planner that
needs no GitHub issue and no `--devunit`.

This PR deliberately contains **no mutating behavior**. `pdd intent apply` is a
follow-up so this one can be reviewed on its own. Please treat the shape
question in #2339 as still open — if you would rather this became a mode on
`pdd change`, that is a reasonable outcome and I would rather hear it now.

## What it adds

```bash
pdd intent plan --text "Highlight pressure intervals outside the permitted band."
pdd intent plan docs/request.md
printf '%s\n' "Add offline PDF export." | pdd intent plan
pdd intent plan --text "Add offline PDF export." --json
```

`pdd intent plan`:

- accepts inline text, a local file, or stdin;
- preserves the request byte-for-byte with a SHA-256 digest;
- classifies `existing_pdd` / `conventional_brownfield` / `greenfield` and
  `repository` / `subproject`, covering the four adoption layouts (existing and
  new standalone projects, existing and proposed monorepo subprojects);
- discovers candidate prompt-owned areas from `architecture.json` and the prompt
  graph, so the caller does not supply a dev unit;
- extracts stated MUST/MUST-NOT constraints and examples, capped and never
  invented;
- recommends independent story coverage selectively;
- emits one plain-language review card, or stable `pdd.intent.plan.v1` JSON.

It does not call a model, does not touch GitHub, and does not write project
files. A proposed project root may be absent and is not created.

## Dev unit

Following README-first: the README change came first, then the prompts, then the
code. Both modules ship their `.prompt` source with `architecture.json` entries,
plus a `<pdd-dependency>` edge on `commands/__init___python.prompt`, so these
are regenerable rather than hand-maintained code you would have to back-fit.

No example interface yet — I held those until the command shape is settled in
#2339, since they are the most shape-dependent artifact. Happy to add them
before merge if you would rather have them now.

## Tests

31 tests, passing in under a second with no network and no model calls. They
target guarantees rather than internals: capabilities reported truthfully, no
fabricated targets, invalid architecture warns instead of crashing, a proposed
root is not created, generic workflow terms do not select unrelated modules.

## Two fixes found by piloting this on real repositories

Both were caught by running the planner against this repo and others rather than
against fixtures, and both have red/green regression tests.

**Function words manufactured candidates.** A request could be linked to an
unrelated product area on nothing but filler — one real case matched a module on
`each`, `for each`, and `while` alone, scoring 18. I first tried a
document-frequency filter on the theory that these terms were simply common;
measurement disproved it, since on a 1013-entry inventory they appear in under
5% of entries. The actual cause was `each` missing from the stop-word set, which
also removes `for each`, because a two-word phrase of stop words is already
ignored. The dead end is recorded in the commit message so nobody retries it.

**A docs-only directory classified as bare greenfield.** Pointing
`--project-root` at a folder of markdown inside an existing repo returned
`greenfield / new_subproject_design` with no caveat, which would invite
generation into a documentation directory. It still classifies as greenfield,
since there is no source to own, but now carries a warning and an open decision;
a genuinely empty root stays unwarned.

## One doc change worth your explicit decision

`docs/generating_user_stories.md` describes the story file as **"Human (source
of truth) … edited by a person, by hand."** This PR changes that to
**"Human-authoritative … a person or an agent acting on the person's correction
or approval."**

The argument: human control should mean authority over meaning and acceptable
evidence, not possession of the keystrokes. A product or domain expert can
approve what a story means without knowing its filename, directory, or
`pdd story add`.

This is a doctrine question rather than a feature detail, and it is one file. If
you would rather not decide it here, say so and I will drop that file from this
PR — nothing else depends on it, and the follow-up `apply` PR enforces human
authority in code regardless of what the doc calls it.

## Not done, stated plainly

- The planner has been exercised on real repositories, but the wider intent
  workflow has not yet been piloted end-to-end on a real project.
- No example interface files, as noted above.
- No `pdd intent status`; reading the JSON is the only way to inspect state.

Ranking parameters were not involved — nothing here invokes a model.
