### PR TITLE
test(sync): accept schema-3 retirement diagnostics

### DIFF
--- a/tests/test_sync_core_verification_profiles.py
+++ b/tests/test_sync_core_verification_profiles.py
@@ -2150,7 +2150,9 @@ def test_estimate_contract_rotations_reject_substitution(
                 "candidate (?:requirement transition "
                 "(?:lacks protected authorization|rules are duplicated or ambiguous)"
                 "|removed unconsumed protected requirement transition"
-                "|schema-2 history rewrites protected representation)"
+                "|schema-2 history rewrites protected representation"
+                "|retirement history is not append-only"
+                "|active requirement transition rules are ambiguous)"
             ),
         ):
             verification._load_requirement_transition_authorizations(  # pylint: disable=protected-access


### PR DESCRIPTION
## Summary

- extend the protected substitution-test regex with two exact schema-3 retirement diagnostics
- preserve the JSON-only boundary for the subsequent #2316 Phase A authority change

No production, verifier, policy, profile, prompt, metadata, or architecture bytes change.

## Validation

- protected verification-profile suite on current main: 81 passed
- same suite with exact JSON-only Phase A policy overlaid: 81 passed
- Sol-high adversarial review approved `ea0ebcaa95479bfaad4e707805f5b3e77192a0f4`

Test prerequisite for #2316; does not close it.