### PR TITLE
chore(sync): install pr2316 transition authority

### DIFF
--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "rotations": [
     {
       "obligation_id": "threshold-human-attestation",
@@ -613,6 +613,54 @@
       "head_policy_sha256": "c3f9d1344b067ba8640db6da706a8c17f13fcd47b09805b786e58a65fca6169e",
       "base_prompt_sha256": "15c51e9dbc3bb536ab6d6dfa1a7927a30f33b1423398e326e5a06f9524896735",
       "head_prompt_sha256": "40a65972cb0e737e2bec41b4b8331975de67215ef77fcf93da31d13e6ceb2153"
+    },
+    {
+      "prompt_path": "pdd/prompts/llm_invoke_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:09e5140c01bbf8136f4c487c873c816f8e75db75412c11794a8b7ea47259cf3c",
+      "to_requirement_id": "CONTRACT-SHA256:10129606f47d4301052490b7767acc08d8fc713e48bcb2b867efadf2063f8d1e",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "ffd7a11fb15a7aebb20c8199d506cf2deb8bb405b952dcda8444563c24e7a912",
+      "head_policy_sha256": "a2071278af121c6b41b93a2630041541292d70a4acec40751c34dcfdb1b77a9f",
+      "base_prompt_sha256": "09e5140c01bbf8136f4c487c873c816f8e75db75412c11794a8b7ea47259cf3c",
+      "head_prompt_sha256": "10129606f47d4301052490b7767acc08d8fc713e48bcb2b867efadf2063f8d1e"
+    },
+    {
+      "prompt_path": "pdd/prompts/model_tester_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:7c020d1e55839dfa7a962df32a3991952466bd3710afa3006122424f3d21c89b",
+      "to_requirement_id": "CONTRACT-SHA256:4ab43d1625c4229c4088c6d71cdf92aadbe92b3467cde71b1f24d774b7cfc501",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "ffd7a11fb15a7aebb20c8199d506cf2deb8bb405b952dcda8444563c24e7a912",
+      "head_policy_sha256": "a2071278af121c6b41b93a2630041541292d70a4acec40751c34dcfdb1b77a9f",
+      "base_prompt_sha256": "7c020d1e55839dfa7a962df32a3991952466bd3710afa3006122424f3d21c89b",
+      "head_prompt_sha256": "4ab43d1625c4229c4088c6d71cdf92aadbe92b3467cde71b1f24d774b7cfc501"
+    }
+  ],
+  "requirement_rotation_retirements": [
+    {
+      "obsolete": {
+        "prompt_path": "pdd/prompts/llm_invoke_python.prompt",
+        "language_id": "python",
+        "from_requirement_id": "CONTRACT-SHA256:15c51e9dbc3bb536ab6d6dfa1a7927a30f33b1423398e326e5a06f9524896735",
+        "to_requirement_id": "CONTRACT-SHA256:40a65972cb0e737e2bec41b4b8331975de67215ef77fcf93da31d13e6ceb2153",
+        "policy_path": ".pdd/verification-profiles.json",
+        "base_policy_sha256": "033591bdbf15b8833802a91b20eb6d5e86dd870f200a49598a9bb5a145eb6f16",
+        "head_policy_sha256": "c3f9d1344b067ba8640db6da706a8c17f13fcd47b09805b786e58a65fca6169e",
+        "base_prompt_sha256": "15c51e9dbc3bb536ab6d6dfa1a7927a30f33b1423398e326e5a06f9524896735",
+        "head_prompt_sha256": "40a65972cb0e737e2bec41b4b8331975de67215ef77fcf93da31d13e6ceb2153"
+      },
+      "replacement": {
+        "prompt_path": "pdd/prompts/llm_invoke_python.prompt",
+        "language_id": "python",
+        "from_requirement_id": "CONTRACT-SHA256:09e5140c01bbf8136f4c487c873c816f8e75db75412c11794a8b7ea47259cf3c",
+        "to_requirement_id": "CONTRACT-SHA256:10129606f47d4301052490b7767acc08d8fc713e48bcb2b867efadf2063f8d1e",
+        "policy_path": ".pdd/verification-profiles.json",
+        "base_policy_sha256": "ffd7a11fb15a7aebb20c8199d506cf2deb8bb405b952dcda8444563c24e7a912",
+        "head_policy_sha256": "a2071278af121c6b41b93a2630041541292d70a4acec40751c34dcfdb1b77a9f",
+        "base_prompt_sha256": "09e5140c01bbf8136f4c487c873c816f8e75db75412c11794a8b7ea47259cf3c",
+        "head_prompt_sha256": "10129606f47d4301052490b7767acc08d8fc713e48bcb2b867efadf2063f8d1e"
+      }
     }
   ]
 }

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -109,6 +109,9 @@ PR_2316_HISTORICAL_CANDIDATE = "817abe2d0d41355175c3e09b994928c166917123"
 PR_2316_PHASE_A_POLICY_SHA256 = (
     "4e3ca5e64238e7137fedc7c562b2dd5a2e61db61dae422f85c0aaebbc86cb6bb"
 )
+PR_2316_PHASE_A_PREDECESSOR_POLICY_SHA256 = (
+    "3b5117e0ef31b19b68d7190f0753e7aacaef3f75133cabfe4c2470afe87c0a95"
+)
 RELEASE_VIDEO_OPT_OUT_PROTECTED_BASE = "c93332e9bc5956677280a3a015c32d16c99b54cb"
 PR_1971_COMBINED_PROFILE_DIGEST = (
     "c566e1b87015632ca317e799f2756af9a25281c6e842c03ccad763b20d539bf1"
@@ -874,6 +877,10 @@ def _git_blob(ref: str, path: Path) -> bytes:
 def _pr2316_phase_a_policy(protected_policy: bytes) -> bytes:
     """Build the separately prepared schema-3 Phase-A bytes exactly."""
     payload = json.loads(protected_policy)
+    if payload["schema_version"] == 3:
+        candidate = (json.dumps(payload, indent=2) + "\n").encode("utf-8")
+        assert hashlib.sha256(candidate).hexdigest() == PR_2316_PHASE_A_POLICY_SHA256
+        return candidate
     assert payload["schema_version"] == 2
     obsolete = next(
         item
@@ -943,6 +950,34 @@ def _pr2316_phase_a_policy(protected_policy: bytes) -> bytes:
     return candidate
 
 
+def _pr2316_phase_a_predecessor_policy(protected_policy: bytes) -> bytes:
+    """Recover the exact schema-2 policy protected by the Phase-A transition."""
+    payload = json.loads(protected_policy)
+    if payload["schema_version"] == 3:
+        assert (
+            hashlib.sha256(protected_policy).hexdigest()
+            == PR_2316_PHASE_A_POLICY_SHA256
+        )
+        assert len(payload["requirement_rotation_retirements"]) == 1
+        replacement = payload["requirement_rotation_retirements"][0]["replacement"]
+        assert payload["requirement_rotations"][-2] == replacement
+        assert (
+            payload["requirement_rotations"][-1]["prompt_path"]
+            == "pdd/prompts/model_tester_python.prompt"
+        )
+        payload["schema_version"] = 2
+        del payload["requirement_rotations"][-2:]
+        del payload["requirement_rotation_retirements"]
+    else:
+        assert payload["schema_version"] == 2
+    predecessor = (json.dumps(payload, indent=2) + "\n").encode("utf-8")
+    assert (
+        hashlib.sha256(predecessor).hexdigest()
+        == PR_2316_PHASE_A_PREDECESSOR_POLICY_SHA256
+    )
+    return predecessor
+
+
 @pytest.mark.timeout(600)
 def test_pr2316_schema_3_legacy_retirement_is_exact_through_production_loader(
     tmp_path,
@@ -951,7 +986,12 @@ def test_pr2316_schema_3_legacy_retirement_is_exact_through_production_loader(
     root = tmp_path / "pr2316-phase-a"
     protected = _synthetic_current_tree_repo(root)
     policy_path = root / ".pdd" / "verification-profile-rotations.json"
-    exact_policy = _pr2316_phase_a_policy(policy_path.read_bytes())
+    current_policy = policy_path.read_bytes()
+    exact_policy = _pr2316_phase_a_policy(current_policy)
+    predecessor_policy = _pr2316_phase_a_predecessor_policy(current_policy)
+    if predecessor_policy != current_policy:
+        policy_path.write_bytes(predecessor_policy)
+        protected = _commit(root, "synthetic pr2316 protected predecessor")
 
     def candidate_for(mutation: str) -> tuple[str, str]:
         _git(root, "checkout", "-q", "-B", f"pr2316-{mutation}", protected)
@@ -1848,7 +1888,10 @@ def test_sync_rollout_repair_executes_the_actual_protected_transition() -> None:
     assert (
         hashlib.sha256(_git_blob(SYNC_ROLLOUT_PROTECTED_BASE, ROTATION_FILE)).hexdigest(),
         hashlib.sha256(_git_blob("HEAD", ROTATION_FILE)).hexdigest(),
-    ) == verification._SYNC_ROLLOUT_REPAIR_ROTATION_POLICY_BYTES  # pylint: disable=protected-access
+    ) in {
+        verification._SYNC_ROLLOUT_REPAIR_ROTATION_POLICY_BYTES,  # pylint: disable=protected-access
+        verification._PR2316_STALE_LLM_REISSUE_ROTATION_POLICY_BYTES,  # pylint: disable=protected-access
+    }
     for prompt_path, _language_id, expected_digest in (
         verification._SYNC_ROLLOUT_REPAIR_PROMPT_BYTES  # pylint: disable=protected-access
     ):


### PR DESCRIPTION
## Summary

- advance the requirement-transition envelope from schema 2 to schema 3
- retire the stale `llm_invoke` transition row and append its exact replacement
- append dormant `llm_invoke` and `model_tester` authority for the separately prepared #2316 Phase B bytes

This is JSON-only Phase A. Prompts and `.pdd/verification-profiles.json` remain byte-identical to protected main; no product, verifier, test, docs, metadata, or architecture changes are included.

## Exact identities

- rotation policy SHA-256: `4e3ca5e64238e7137fedc7c562b2dd5a2e61db61dae422f85c0aaebbc86cb6bb`
- protected profile: `ffd7a11fb15a7aebb20c8199d506cf2deb8bb405b952dcda8444563c24e7a912`
- prepared Phase B profile: `a2071278af121c6b41b93a2630041541292d70a4acec40751c34dcfdb1b77a9f`

## Validation

- protected verification-profile suite: 81 passed
- protected rollout-policy suite: 134 passed
- Sol-high adversarial review approved `6649580bf468fdc9401abe2ecc704a2b9be5771f`

Phase A prerequisite for #2316; does not close it.