### PR TITLE
fix: point pdd-change Step 6 dependency context at <pdd-dependency>, not <include>

### DIFF
--- a/pdd/prompts/agentic_change_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_change_orchestrator_python.prompt
@@ -321,14 +321,16 @@ Before the step loop begins, load `.pddrc` configuration to provide context keys
 - Step 13 receives: issue_content, step8_output, worktree_path, files_to_stage, issue_title, sync_order_script, sync_order_list, impacted_tests, base_branch, **head_branch** (the worktree's actual current branch, derived from its HEAD and defaulting to `change/issue-{N}`; it is a `change/issue-{N}-job-*` fallback when the canonical branch was locked under clean restart — Step 13 pushes and opens/updates the PR on this branch rather than a hardcoded `change/issue-{N}`. The existing-PR guard also matches `change/issue-{N}-job-*` heads so a later normal run does not open a duplicate), **user_story_summary** (literal `None` when no story was generated/attempted, otherwise a PR-body markdown section naming generated `user_stories/story__*.md` artifacts and linked prompts), **manual_review_lines** (aggregated `MANUAL_REVIEW:` lines from Step 9 JSON/prose, Step 10 synthesized `associated_docs_conflicts`, and Step 11/12 review-loop JSON/prose manual-review entries; rendered in the PR body's "Manual Review Required" section. The Step 12.5 gate no longer contributes here — a gate failure now hard-blocks before Step 13 rather than surfacing as an advisory line), **clean_restart** (`"true"` or `"false"`) — Step 13 uses this to decide whether to force-push (`--force-with-lease`) and whether to look for an existing open PR to update in place rather than creating a new one
 
 % Dependency Context (Before Step 6)
-Before Step 6 runs, build a formatted dependency graph to help identify transitively affected modules:
+Before Step 6 runs, build a formatted dependency graph to help identify transitively affected modules. This must reflect declared architectural dependencies (`<pdd-dependency>` tags, as recorded in architecture.json), not the `<include>` context graph — see issue #1807: `<include>` tags are LLM context and are not a reliable signal of "what needs updating if this module changes."
 
-Helper: `_build_dependency_context(prompts_dir: Path, quiet: bool = False) -> str`:
-- Build dependency graph using `build_dependency_graph(prompts_dir)`
+Helper: `_build_dependency_context(architecture_path: Path, quiet: bool = False) -> str`:
+- Build dependency graph using `build_dependency_graph_from_architecture(architecture_path)` — NOT `build_dependency_graph(prompts_dir)`.
 - Compute reverse dependencies (module → modules that depend on it)
 - Format as "## Module Dependency Graph" with sections showing modules sorted by number of dependents (limit top 30, max 10 dependents shown per module)
 - Add to `context["dependency_context"]`
-- Return empty string if prompts_dir doesn't exist or on any error
+- Return empty string if architecture_path doesn't exist or on any error
+
+Call site: before Step 6 runs, set `architecture_path = cwd / "architecture.json"` and call `_build_dependency_context(architecture_path, quiet=quiet)` when it exists; otherwise set `context["dependency_context"] = ""`. (Previously this passed `prompts_dir = cwd / "prompts"` to the include-based `build_dependency_graph()` — that call site is now architecture.json-based instead.)
 
 % Files to Stage
 After Step 9 parses FILES_CREATED/FILES_MODIFIED/DIRECT_EDITS, pass the extracted file list to subsequent steps:
@@ -632,7 +634,7 @@ Import from `pdd.pre_checkup_gate`: `run_pre_checkup_gate` (Step 12.5 build/smok
 Note: `CHANGE_STEP_TIMEOUTS` is defined locally in this module (see Per-Step Timeouts section)
 <pdd.agentic_common><include select="def:run_agentic_task,def:load_workflow_state,def:save_workflow_state,def:clear_workflow_state,def:substitute_template_variables,def:validate_cached_state,def:post_step_comment,def:set_agentic_progress,def:clear_agentic_progress">pdd/agentic_common.py</include></pdd.agentic_common>
 <pdd.load_prompt_template><include>context/load_prompt_template_example.py</include></pdd.load_prompt_template>
-<pdd.sync_order><include select="def:build_dependency_graph,def:topological_sort,def:get_affected_modules,def:generate_sync_order_script,def:extract_module_from_include,def:discover_associated_documents">pdd/sync_order.py</include></pdd.sync_order>
+<pdd.sync_order><include select="def:build_dependency_graph,def:build_dependency_graph_from_architecture,def:topological_sort,def:get_affected_modules,def:generate_sync_order_script,def:extract_module_from_include,def:discover_associated_documents">pdd/sync_order.py</include></pdd.sync_order>
 <pdd.construct_paths><include>context/construct_paths_example.py</include></pdd.construct_paths>
 <pdd.get_extension><include>context/get_extension_example.py</include></pdd.get_extension>
 <pdd.preprocess><include select="def:preprocess">pdd/preprocess.py</include></pdd.preprocess>

--- a/pdd/prompts/agentic_change_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_change_orchestrator_python.prompt
@@ -321,7 +321,7 @@ Before the step loop begins, load `.pddrc` configuration to provide context keys
 - Step 13 receives: issue_content, step8_output, worktree_path, files_to_stage, issue_title, sync_order_script, sync_order_list, impacted_tests, base_branch, **head_branch** (the worktree's actual current branch, derived from its HEAD and defaulting to `change/issue-{N}`; it is a `change/issue-{N}-job-*` fallback when the canonical branch was locked under clean restart — Step 13 pushes and opens/updates the PR on this branch rather than a hardcoded `change/issue-{N}`. The existing-PR guard also matches `change/issue-{N}-job-*` heads so a later normal run does not open a duplicate), **user_story_summary** (literal `None` when no story was generated/attempted, otherwise a PR-body markdown section naming generated `user_stories/story__*.md` artifacts and linked prompts), **manual_review_lines** (aggregated `MANUAL_REVIEW:` lines from Step 9 JSON/prose, Step 10 synthesized `associated_docs_conflicts`, and Step 11/12 review-loop JSON/prose manual-review entries; rendered in the PR body's "Manual Review Required" section. The Step 12.5 gate no longer contributes here — a gate failure now hard-blocks before Step 13 rather than surfacing as an advisory line), **clean_restart** (`"true"` or `"false"`) — Step 13 uses this to decide whether to force-push (`--force-with-lease`) and whether to look for an existing open PR to update in place rather than creating a new one
 
 % Dependency Context (Before Step 6)
-Before Step 6 runs, build a formatted dependency graph to help identify transitively affected modules. This must reflect declared architectural dependencies (`<pdd-dependency>` tags, as recorded in architecture.json), not the `<include>` context graph — see issue #1807: `<include>` tags are LLM context and are not a reliable signal of "what needs updating if this module changes."
+Before Step 6 runs, build a formatted dependency graph to help identify transitively affected modules. This must reflect declared architectural dependencies (`<pdd-dependency>` tags, as recorded in architecture.json), not the `<include>` context graph.
 
 Helper: `_build_dependency_context(architecture_path: Path, quiet: bool = False) -> str`:
 - Build dependency graph using `build_dependency_graph_from_architecture(architecture_path)` — NOT `build_dependency_graph(prompts_dir)`.
@@ -330,7 +330,7 @@ Helper: `_build_dependency_context(architecture_path: Path, quiet: bool = False)
 - Add to `context["dependency_context"]`
 - Return empty string if architecture_path doesn't exist or on any error
 
-Call site: before Step 6 runs, set `architecture_path = cwd / "architecture.json"` and call `_build_dependency_context(architecture_path, quiet=quiet)` when it exists; otherwise set `context["dependency_context"] = ""`. (Previously this passed `prompts_dir = cwd / "prompts"` to the include-based `build_dependency_graph()` — that call site is now architecture.json-based instead.)
+Call site: before Step 6 runs, set `architecture_path = cwd / "architecture.json"` and call `_build_dependency_context(architecture_path, quiet=quiet)` when it exists; otherwise set `context["dependency_context"] = ""`.
 
 % Files to Stage
 After Step 9 parses FILES_CREATED/FILES_MODIFIED/DIRECT_EDITS, pass the extracted file list to subsequent steps:

--- a/pdd/prompts/sync_order_python.prompt
+++ b/pdd/prompts/sync_order_python.prompt
@@ -40,6 +40,16 @@ A utility module that parses `<include>` tags from prompt files, builds a depend
    - Skip self-references (module including its own example)
    - Return empty dict if prompts_dir doesn't exist
 
+3a. Function: build_dependency_graph_from_architecture(architecture_path: Path) -> Dict[str, List[str]]
+   - Build the same `module_name -> [dependency module names]` adjacency-list shape as `build_dependency_graph()`, but sourced from architecture.json's `dependencies` field (populated by `architecture_sync.py` from `<pdd-dependency>` tags) instead of scanning `<include>` tags.
+   - Rationale (issue #1807): `<include>` tags give the LLM context and are not architectural dependencies — a module that `<include>`s another module's example file purely for style reference is not really coupled to it, and a module that truly depends on another via `<pdd-dependency>` may never `<include>` it at all. Callers that need "what will need updating if I change this module" (e.g. `pdd change` Step 6) must read the declared dependency, not the include graph.
+   - Return `{}` if `architecture_path` doesn't exist, can't be read, or contains invalid JSON (log a warning via the module logger, never raise).
+   - Parse module entries tolerantly via `pdd.architecture_registry.extract_modules()` (accepts both the bare-array and `{"modules": [...]}` architecture.json formats, mirrors `discover_associated_documents()`'s handling). Return `{}` if no entries are found.
+   - For each entry, read its `filename` and `dependencies` (default to `[]` when `dependencies` is absent or not a list) and map both through `extract_module_from_include()` to get module names — the same normalization `build_dependency_graph()` applies to include paths. Skip entries whose `filename` doesn't map to a module name.
+   - Ensure every discovered module is a key in the returned graph even when its dependency list is empty (mirrors `build_dependency_graph()`'s "ensure module exists in graph" behavior).
+   - Skip self-references and any dependency that fails to map to a module name.
+   - This is an independent, architecture.json-only view — it does not need to agree with `build_dependency_graph()`'s include-based graph, and callers should not mix the two graphs together.
+
 4. Function: topological_sort(graph: Dict[str, List[str]]) -> Tuple[List[str], List[List[str]]]
    - Implement Kahn's algorithm for topological sorting
    - Return tuple of (sorted_list, cycles_detected)

--- a/pdd/prompts/sync_order_python.prompt
+++ b/pdd/prompts/sync_order_python.prompt
@@ -41,14 +41,13 @@ A utility module that parses `<include>` tags from prompt files, builds a depend
    - Return empty dict if prompts_dir doesn't exist
 
 3a. Function: build_dependency_graph_from_architecture(architecture_path: Path) -> Dict[str, List[str]]
-   - Build the same `module_name -> [dependency module names]` adjacency-list shape as `build_dependency_graph()`, but sourced from architecture.json's `dependencies` field (populated by `architecture_sync.py` from `<pdd-dependency>` tags) instead of scanning `<include>` tags.
-   - Rationale (issue #1807): `<include>` tags give the LLM context and are not architectural dependencies — a module that `<include>`s another module's example file purely for style reference is not really coupled to it, and a module that truly depends on another via `<pdd-dependency>` may never `<include>` it at all. Callers that need "what will need updating if I change this module" (e.g. `pdd change` Step 6) must read the declared dependency, not the include graph.
-   - Return `{}` if `architecture_path` doesn't exist, can't be read, or contains invalid JSON (log a warning via the module logger, never raise).
-   - Parse module entries tolerantly via `pdd.architecture_registry.extract_modules()` (accepts both the bare-array and `{"modules": [...]}` architecture.json formats, mirrors `discover_associated_documents()`'s handling). Return `{}` if no entries are found.
-   - For each entry, read its `filename` and `dependencies` (default to `[]` when `dependencies` is absent or not a list) and map both through `extract_module_from_include()` to get module names — the same normalization `build_dependency_graph()` applies to include paths. Skip entries whose `filename` doesn't map to a module name.
-   - Ensure every discovered module is a key in the returned graph even when its dependency list is empty (mirrors `build_dependency_graph()`'s "ensure module exists in graph" behavior).
-   - Skip self-references and any dependency that fails to map to a module name.
-   - This is an independent, architecture.json-only view — it does not need to agree with `build_dependency_graph()`'s include-based graph, and callers should not mix the two graphs together.
+   - Read architecture.json via pdd.architecture_registry.extract_modules() (accepts bare-array or {"modules": [...]} formats)
+   - For each module entry, extract module name from its `filename` field (e.g., "foo_python.prompt" -> "foo") using extract_module_from_include()
+   - Map each entry's `dependencies` list (default [] if missing or not a list) to module names using extract_module_from_include()
+   - Build graph: module_name -> list of dependency module names, sourced from architecture.json's `dependencies` field instead of `<include>` tags
+   - Skip self-references and dependencies that don't map to a module name
+   - Return empty dict if architecture_path doesn't exist, can't be read, or contains invalid JSON
+
 
 4. Function: topological_sort(graph: Dict[str, List[str]]) -> Tuple[List[str], List[List[str]]]
    - Implement Kahn's algorithm for topological sorting


### PR DESCRIPTION
## Summary
- `pdd change` Step 6 builds its module-dependency context by scanning `<include>` tags (`build_dependency_graph()`), but `<include>` tags are LLM context, not declared architectural dependencies -- so the graph both misses real `<pdd-dependency>`-declared dependents and fabricates false ones from stylistic includes.
- Updates the source prompts to specify a new `sync_order.build_dependency_graph_from_architecture()` that reads `architecture.json`'s `dependencies` field (already populated from `<pdd-dependency>` tags by `architecture_sync.py`), and wires Step 6's `_build_dependency_context()` to use it instead.
- **Prompts only in this PR.** The corresponding code regeneration (`pdd generate --incremental` on `pdd/sync_order.py` and `pdd/agentic_change_orchestrator.py`) is pending in a follow-up PR -- Anthropic API access is currently blocked by a billing issue, and the fallback Gemini model hits its output-token ceiling trying to patch the ~4000-line orchestrator file. Once resolved, the code PR will implement exactly what's specified here.

Fixes #1807

## Test plan
- [ ] Follow-up PR regenerates `pdd/sync_order.py` and `pdd/agentic_change_orchestrator.py` from these prompts via `pdd generate --incremental`
- [ ] Unit tests for `build_dependency_graph_from_architecture()` and the updated `_build_dependency_context()`
- [ ] Manual repro: a module declaring `<pdd-dependency>` on another without `<include>`-ing it shows up correctly as a dependent; a module `<include>`-ing another purely for style context does not
