### PR TITLE
feat: add build_dependency_graph_from_architecture() to sync_order

### DIFF
--- a/pdd/prompts/agentic_change_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_change_orchestrator_python.prompt
@@ -321,14 +321,16 @@ Before the step loop begins, load `.pddrc` configuration to provide context keys
 - Step 13 receives: issue_content, step8_output, worktree_path, files_to_stage, issue_title, sync_order_script, sync_order_list, impacted_tests, base_branch, **head_branch** (the worktree's actual current branch, derived from its HEAD and defaulting to `change/issue-{N}`; it is a `change/issue-{N}-job-*` fallback when the canonical branch was locked under clean restart — Step 13 pushes and opens/updates the PR on this branch rather than a hardcoded `change/issue-{N}`. The existing-PR guard also matches `change/issue-{N}-job-*` heads so a later normal run does not open a duplicate), **user_story_summary** (literal `None` when no story was generated/attempted, otherwise a PR-body markdown section naming generated `user_stories/story__*.md` artifacts and linked prompts), **manual_review_lines** (aggregated `MANUAL_REVIEW:` lines from Step 9 JSON/prose, Step 10 synthesized `associated_docs_conflicts`, and Step 11/12 review-loop JSON/prose manual-review entries; rendered in the PR body's "Manual Review Required" section. The Step 12.5 gate no longer contributes here — a gate failure now hard-blocks before Step 13 rather than surfacing as an advisory line), **clean_restart** (`"true"` or `"false"`) — Step 13 uses this to decide whether to force-push (`--force-with-lease`) and whether to look for an existing open PR to update in place rather than creating a new one
 
 % Dependency Context (Before Step 6)
-Before Step 6 runs, build a formatted dependency graph to help identify transitively affected modules:
+Before Step 6 runs, build a formatted dependency graph to help identify transitively affected modules. This must reflect declared architectural dependencies (`<pdd-dependency>` tags, as recorded in architecture.json), not the `<include>` context graph — see issue #1807: `<include>` tags are LLM context and are not a reliable signal of "what needs updating if this module changes."
 
-Helper: `_build_dependency_context(prompts_dir: Path, quiet: bool = False) -> str`:
-- Build dependency graph using `build_dependency_graph(prompts_dir)`
+Helper: `_build_dependency_context(architecture_path: Path, quiet: bool = False) -> str`:
+- Build dependency graph using `build_dependency_graph_from_architecture(architecture_path)` — NOT `build_dependency_graph(prompts_dir)`.
 - Compute reverse dependencies (module → modules that depend on it)
 - Format as "## Module Dependency Graph" with sections showing modules sorted by number of dependents (limit top 30, max 10 dependents shown per module)
 - Add to `context["dependency_context"]`
-- Return empty string if prompts_dir doesn't exist or on any error
+- Return empty string if architecture_path doesn't exist or on any error
+
+Call site: before Step 6 runs, set `architecture_path = cwd / "architecture.json"` and call `_build_dependency_context(architecture_path, quiet=quiet)` when it exists; otherwise set `context["dependency_context"] = ""`. (Previously this passed `prompts_dir = cwd / "prompts"` to the include-based `build_dependency_graph()` — that call site is now architecture.json-based instead.)
 
 % Files to Stage
 After Step 9 parses FILES_CREATED/FILES_MODIFIED/DIRECT_EDITS, pass the extracted file list to subsequent steps:
@@ -632,7 +634,7 @@ Import from `pdd.pre_checkup_gate`: `run_pre_checkup_gate` (Step 12.5 build/smok
 Note: `CHANGE_STEP_TIMEOUTS` is defined locally in this module (see Per-Step Timeouts section)
 <pdd.agentic_common><include select="def:run_agentic_task,def:load_workflow_state,def:save_workflow_state,def:clear_workflow_state,def:substitute_template_variables,def:validate_cached_state,def:post_step_comment,def:set_agentic_progress,def:clear_agentic_progress">pdd/agentic_common.py</include></pdd.agentic_common>
 <pdd.load_prompt_template><include>context/load_prompt_template_example.py</include></pdd.load_prompt_template>
-<pdd.sync_order><include select="def:build_dependency_graph,def:topological_sort,def:get_affected_modules,def:generate_sync_order_script,def:extract_module_from_include,def:discover_associated_documents">pdd/sync_order.py</include></pdd.sync_order>
+<pdd.sync_order><include select="def:build_dependency_graph,def:build_dependency_graph_from_architecture,def:topological_sort,def:get_affected_modules,def:generate_sync_order_script,def:extract_module_from_include,def:discover_associated_documents">pdd/sync_order.py</include></pdd.sync_order>
 <pdd.construct_paths><include>context/construct_paths_example.py</include></pdd.construct_paths>
 <pdd.get_extension><include>context/get_extension_example.py</include></pdd.get_extension>
 <pdd.preprocess><include select="def:preprocess">pdd/preprocess.py</include></pdd.preprocess>

--- a/pdd/prompts/agentic_change_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_change_orchestrator_python.prompt
@@ -321,7 +321,7 @@ Before the step loop begins, load `.pddrc` configuration to provide context keys
 - Step 13 receives: issue_content, step8_output, worktree_path, files_to_stage, issue_title, sync_order_script, sync_order_list, impacted_tests, base_branch, **head_branch** (the worktree's actual current branch, derived from its HEAD and defaulting to `change/issue-{N}`; it is a `change/issue-{N}-job-*` fallback when the canonical branch was locked under clean restart — Step 13 pushes and opens/updates the PR on this branch rather than a hardcoded `change/issue-{N}`. The existing-PR guard also matches `change/issue-{N}-job-*` heads so a later normal run does not open a duplicate), **user_story_summary** (literal `None` when no story was generated/attempted, otherwise a PR-body markdown section naming generated `user_stories/story__*.md` artifacts and linked prompts), **manual_review_lines** (aggregated `MANUAL_REVIEW:` lines from Step 9 JSON/prose, Step 10 synthesized `associated_docs_conflicts`, and Step 11/12 review-loop JSON/prose manual-review entries; rendered in the PR body's "Manual Review Required" section. The Step 12.5 gate no longer contributes here — a gate failure now hard-blocks before Step 13 rather than surfacing as an advisory line), **clean_restart** (`"true"` or `"false"`) — Step 13 uses this to decide whether to force-push (`--force-with-lease`) and whether to look for an existing open PR to update in place rather than creating a new one
 
 % Dependency Context (Before Step 6)
-Before Step 6 runs, build a formatted dependency graph to help identify transitively affected modules. This must reflect declared architectural dependencies (`<pdd-dependency>` tags, as recorded in architecture.json), not the `<include>` context graph — see issue #1807: `<include>` tags are LLM context and are not a reliable signal of "what needs updating if this module changes."
+Before Step 6 runs, build a formatted dependency graph to help identify transitively affected modules. This must reflect declared architectural dependencies (`<pdd-dependency>` tags, as recorded in architecture.json), not the `<include>` context graph.
 
 Helper: `_build_dependency_context(architecture_path: Path, quiet: bool = False) -> str`:
 - Build dependency graph using `build_dependency_graph_from_architecture(architecture_path)` — NOT `build_dependency_graph(prompts_dir)`.
@@ -330,7 +330,7 @@ Helper: `_build_dependency_context(architecture_path: Path, quiet: bool = False)
 - Add to `context["dependency_context"]`
 - Return empty string if architecture_path doesn't exist or on any error
 
-Call site: before Step 6 runs, set `architecture_path = cwd / "architecture.json"` and call `_build_dependency_context(architecture_path, quiet=quiet)` when it exists; otherwise set `context["dependency_context"] = ""`. (Previously this passed `prompts_dir = cwd / "prompts"` to the include-based `build_dependency_graph()` — that call site is now architecture.json-based instead.)
+Call site: before Step 6 runs, set `architecture_path = cwd / "architecture.json"` and call `_build_dependency_context(architecture_path, quiet=quiet)` when it exists; otherwise set `context["dependency_context"] = ""`.
 
 % Files to Stage
 After Step 9 parses FILES_CREATED/FILES_MODIFIED/DIRECT_EDITS, pass the extracted file list to subsequent steps:

--- a/pdd/prompts/agentic_change_orchestrator_python.prompt
+++ b/pdd/prompts/agentic_change_orchestrator_python.prompt
@@ -321,16 +321,11 @@ Before the step loop begins, load `.pddrc` configuration to provide context keys
 - Step 13 receives: issue_content, step8_output, worktree_path, files_to_stage, issue_title, sync_order_script, sync_order_list, impacted_tests, base_branch, **head_branch** (the worktree's actual current branch, derived from its HEAD and defaulting to `change/issue-{N}`; it is a `change/issue-{N}-job-*` fallback when the canonical branch was locked under clean restart — Step 13 pushes and opens/updates the PR on this branch rather than a hardcoded `change/issue-{N}`. The existing-PR guard also matches `change/issue-{N}-job-*` heads so a later normal run does not open a duplicate), **user_story_summary** (literal `None` when no story was generated/attempted, otherwise a PR-body markdown section naming generated `user_stories/story__*.md` artifacts and linked prompts), **manual_review_lines** (aggregated `MANUAL_REVIEW:` lines from Step 9 JSON/prose, Step 10 synthesized `associated_docs_conflicts`, and Step 11/12 review-loop JSON/prose manual-review entries; rendered in the PR body's "Manual Review Required" section. The Step 12.5 gate no longer contributes here — a gate failure now hard-blocks before Step 13 rather than surfacing as an advisory line), **clean_restart** (`"true"` or `"false"`) — Step 13 uses this to decide whether to force-push (`--force-with-lease`) and whether to look for an existing open PR to update in place rather than creating a new one
 
 % Dependency Context (Before Step 6)
-Before Step 6 runs, build a formatted dependency graph to help identify transitively affected modules. This must reflect declared architectural dependencies (`<pdd-dependency>` tags, as recorded in architecture.json), not the `<include>` context graph.
+Before Step 6 runs, build a formatted module-dependency summary so the step can identify transitively affected modules. The graph must reflect declared architectural dependencies (`<pdd-dependency>` tags, as recorded in architecture.json) rather than the `<include>` context graph.
 
-Helper: `_build_dependency_context(architecture_path: Path, quiet: bool = False) -> str`:
-- Build dependency graph using `build_dependency_graph_from_architecture(architecture_path)` — NOT `build_dependency_graph(prompts_dir)`.
-- Compute reverse dependencies (module → modules that depend on it)
-- Format as "## Module Dependency Graph" with sections showing modules sorted by number of dependents (limit top 30, max 10 dependents shown per module)
-- Add to `context["dependency_context"]`
-- Return empty string if architecture_path doesn't exist or on any error
+`_build_dependency_context(architecture_path: Path, quiet: bool = False) -> str` builds this summary from `build_dependency_graph_from_architecture(architecture_path)` (not the include-based `build_dependency_graph(prompts_dir)`), computing each module's reverse dependents and formatting them as a "## Module Dependency Graph" section — modules ordered by dependent count, top 30 shown, at most 10 dependents listed per module. The result is stored in `context["dependency_context"]`; it's an empty string when `architecture_path` doesn't exist or on any error.
 
-Call site: before Step 6 runs, set `architecture_path = cwd / "architecture.json"` and call `_build_dependency_context(architecture_path, quiet=quiet)` when it exists; otherwise set `context["dependency_context"] = ""`.
+Before Step 6 runs, set `architecture_path = cwd / "architecture.json"` and call `_build_dependency_context(architecture_path, quiet=quiet)` when it exists; otherwise leave `context["dependency_context"]` empty.
 
 % Files to Stage
 After Step 9 parses FILES_CREATED/FILES_MODIFIED/DIRECT_EDITS, pass the extracted file list to subsequent steps:

--- a/pdd/prompts/sync_order_python.prompt
+++ b/pdd/prompts/sync_order_python.prompt
@@ -40,6 +40,16 @@ A utility module that parses `<include>` tags from prompt files, builds a depend
    - Skip self-references (module including its own example)
    - Return empty dict if prompts_dir doesn't exist
 
+3a. Function: build_dependency_graph_from_architecture(architecture_path: Path) -> Dict[str, List[str]]
+   - Build the same `module_name -> [dependency module names]` adjacency-list shape as `build_dependency_graph()`, but sourced from architecture.json's `dependencies` field (populated by `architecture_sync.py` from `<pdd-dependency>` tags) instead of scanning `<include>` tags.
+   - Rationale (issue #1807): `<include>` tags give the LLM context and are not architectural dependencies — a module that `<include>`s another module's example file purely for style reference is not really coupled to it, and a module that truly depends on another via `<pdd-dependency>` may never `<include>` it at all. Callers that need "what will need updating if I change this module" (e.g. `pdd change` Step 6) must read the declared dependency, not the include graph.
+   - Return `{}` if `architecture_path` doesn't exist, can't be read, or contains invalid JSON (log a warning via the module logger, never raise).
+   - Parse module entries tolerantly via `pdd.architecture_registry.extract_modules()` (accepts both the bare-array and `{"modules": [...]}` architecture.json formats, mirrors `discover_associated_documents()`'s handling). Return `{}` if no entries are found.
+   - For each entry, read its `filename` and `dependencies` (default to `[]` when `dependencies` is absent or not a list) and map both through `extract_module_from_include()` to get module names — the same normalization `build_dependency_graph()` applies to include paths. Skip entries whose `filename` doesn't map to a module name.
+   - Ensure every discovered module is a key in the returned graph even when its dependency list is empty (mirrors `build_dependency_graph()`'s "ensure module exists in graph" behavior).
+   - Skip self-references and any dependency that fails to map to a module name.
+   - This is an independent, architecture.json-only view — it does not need to agree with `build_dependency_graph()`'s include-based graph, and callers should not mix the two graphs together.
+
 4. Function: topological_sort(graph: Dict[str, List[str]]) -> Tuple[List[str], List[List[str]]]
    - Implement Kahn's algorithm for topological sorting
    - Return tuple of (sorted_list, cycles_detected)

--- a/pdd/prompts/sync_order_python.prompt
+++ b/pdd/prompts/sync_order_python.prompt
@@ -41,14 +41,13 @@ A utility module that parses `<include>` tags from prompt files, builds a depend
    - Return empty dict if prompts_dir doesn't exist
 
 3a. Function: build_dependency_graph_from_architecture(architecture_path: Path) -> Dict[str, List[str]]
-   - Build the same `module_name -> [dependency module names]` adjacency-list shape as `build_dependency_graph()`, but sourced from architecture.json's `dependencies` field (populated by `architecture_sync.py` from `<pdd-dependency>` tags) instead of scanning `<include>` tags.
-   - Rationale (issue #1807): `<include>` tags give the LLM context and are not architectural dependencies — a module that `<include>`s another module's example file purely for style reference is not really coupled to it, and a module that truly depends on another via `<pdd-dependency>` may never `<include>` it at all. Callers that need "what will need updating if I change this module" (e.g. `pdd change` Step 6) must read the declared dependency, not the include graph.
-   - Return `{}` if `architecture_path` doesn't exist, can't be read, or contains invalid JSON (log a warning via the module logger, never raise).
-   - Parse module entries tolerantly via `pdd.architecture_registry.extract_modules()` (accepts both the bare-array and `{"modules": [...]}` architecture.json formats, mirrors `discover_associated_documents()`'s handling). Return `{}` if no entries are found.
-   - For each entry, read its `filename` and `dependencies` (default to `[]` when `dependencies` is absent or not a list) and map both through `extract_module_from_include()` to get module names — the same normalization `build_dependency_graph()` applies to include paths. Skip entries whose `filename` doesn't map to a module name.
-   - Ensure every discovered module is a key in the returned graph even when its dependency list is empty (mirrors `build_dependency_graph()`'s "ensure module exists in graph" behavior).
-   - Skip self-references and any dependency that fails to map to a module name.
-   - This is an independent, architecture.json-only view — it does not need to agree with `build_dependency_graph()`'s include-based graph, and callers should not mix the two graphs together.
+   - Read architecture.json via pdd.architecture_registry.extract_modules() (accepts bare-array or {"modules": [...]} formats)
+   - For each module entry, extract module name from its `filename` field (e.g., "foo_python.prompt" -> "foo") using extract_module_from_include()
+   - Map each entry's `dependencies` list (default [] if missing or not a list) to module names using extract_module_from_include()
+   - Build graph: module_name -> list of dependency module names, sourced from architecture.json's `dependencies` field instead of `<include>` tags
+   - Skip self-references and dependencies that don't map to a module name
+   - Return empty dict if architecture_path doesn't exist, can't be read, or contains invalid JSON
+
 
 4. Function: topological_sort(graph: Dict[str, List[str]]) -> Tuple[List[str], List[List[str]]]
    - Implement Kahn's algorithm for topological sorting

--- a/pdd/prompts/sync_order_python.prompt
+++ b/pdd/prompts/sync_order_python.prompt
@@ -41,12 +41,11 @@ A utility module that parses `<include>` tags from prompt files, builds a depend
    - Return empty dict if prompts_dir doesn't exist
 
 3a. Function: build_dependency_graph_from_architecture(architecture_path: Path) -> Dict[str, List[str]]
-   - Read architecture.json via pdd.architecture_registry.extract_modules() (accepts bare-array or {"modules": [...]} formats)
-   - For each module entry, extract module name from its `filename` field (e.g., "foo_python.prompt" -> "foo") using extract_module_from_include()
-   - Map each entry's `dependencies` list (default [] if missing or not a list) to module names using extract_module_from_include()
-   - Build graph: module_name -> list of dependency module names, sourced from architecture.json's `dependencies` field instead of `<include>` tags
-   - Skip self-references and dependencies that don't map to a module name
-   - Return empty dict if architecture_path doesn't exist, can't be read, or contains invalid JSON
+   - Builds the same `module_name -> [dependency module names]` shape as `build_dependency_graph()`, but sourced from architecture.json's `dependencies` field (populated from `<pdd-dependency>` tags) instead of `<include>` tags.
+   - Accepts architecture.json as either a bare array or an object with a `"modules"` key.
+   - Every module present in architecture.json is a key in the result, even with no dependencies; self-dependencies are excluded.
+   - Module names are derived from filenames the same way `build_dependency_graph()` does.
+   - Missing file, unreadable file, or invalid JSON returns an empty dict rather than raising.
 
 
 4. Function: topological_sort(graph: Dict[str, List[str]]) -> Tuple[List[str], List[List[str]]]
@@ -97,11 +96,14 @@ Helper: `_is_document_include(include_path: str) -> bool`
 <include select="def:main">context/auto_include_example.py</include>
 </auto_include_example>
 <utils.architecture_sync>
-    <include select="def:example_sync_all,def:example_validate_dependencies">context/architecture_sync_example.py</include>
+    <include select="def:run_example">context/architecture_sync_example.py</include>
 </utils.architecture_sync>
 <pdd.agentic_common>
     <include select="def:example_run_agentic_task">context/agentic_common_example.py</include>
 </pdd.agentic_common>
+<utils.architecture_registry>
+    <include>context/architecture_registry_example.py</include>
+</utils.architecture_registry>
 
 % Instructions
 - Reuse regex pattern from auto_include.py for parsing `<include>` tags

--- a/pdd/sync_order.py
+++ b/pdd/sync_order.py
@@ -155,6 +155,68 @@ def build_dependency_graph(prompts_dir: Path) -> Dict[str, List[str]]:
     return {k: list(v) for k, v in dependency_graph.items()}
 
 
+def build_dependency_graph_from_architecture(architecture_path: Path) -> Dict[str, List[str]]:
+    """
+    Builds a dependency graph from architecture.json based on declared dependencies.
+
+    Args:
+        architecture_path: Path to architecture.json.
+
+    Returns:
+        Dictionary mapping module_name -> list of dependencies (module names).
+    """
+    if not architecture_path.exists() or not architecture_path.is_file():
+        logger.warning(f"Architecture file not found: {architecture_path}")
+        return {}
+
+    try:
+        arch_data = json.loads(architecture_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.warning(f"Failed to read or parse architecture.json at {architecture_path}: {e}")
+        return {}
+
+    try:
+        from pdd.architecture_registry import extract_modules
+        arch_entries = extract_modules(arch_data)
+    except Exception as exc:
+        logger.warning(f"extract_modules failed on {architecture_path}: {exc}")
+        arch_entries = arch_data if isinstance(arch_data, list) else []
+
+    if not arch_entries:
+        return {}
+
+    dependency_graph: Dict[str, Set[str]] = {}
+
+    for entry in arch_entries:
+        if not isinstance(entry, dict):
+            continue
+        filename = entry.get("filename")
+        if not filename:
+            continue
+
+        current_module = extract_module_from_include(filename)
+        if not current_module:
+            continue
+
+        if current_module not in dependency_graph:
+            dependency_graph[current_module] = set()
+
+        deps = entry.get("dependencies")
+        if not isinstance(deps, list):
+            continue
+
+        for dep in deps:
+            if not isinstance(dep, str):
+                continue
+            dep_module = extract_module_from_include(dep)
+            if dep_module and dep_module != current_module:
+                dependency_graph[current_module].add(dep_module)
+                if dep_module not in dependency_graph:
+                    dependency_graph[dep_module] = set()
+
+    return {k: sorted(list(v)) for k, v in dependency_graph.items()}
+
+
 def topological_sort(graph: Dict[str, List[str]]) -> Tuple[List[str], List[List[str]]]:
     """
     Performs topological sort using Kahn's algorithm.
@@ -439,7 +501,7 @@ def generate_sync_order_script(modules: List[str], output_path: Path, worktree_p
 
     script_content = "\n".join(lines)
 
-    try:
+    try: 
         output_path.write_text(script_content, encoding="utf-8")
 
         # Make executable (chmod +x)
@@ -498,7 +560,7 @@ def discover_associated_documents(
     results: List[str] = []
     seen: Set[str] = set()
 
-    def _add(path: str) -> None:
+    def _add(path: str) -> None: 
         if path and path not in seen:
             seen.add(path)
             results.append(path)
@@ -514,7 +576,7 @@ def discover_associated_documents(
 
     # Phase 2: BFS traversal via architecture.json for transitive dependents
     if architecture_path is not None and architecture_path.exists():
-        try:
+        try: 
             arch_data = json.loads(architecture_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             logger.warning(f"Failed to read architecture.json at {architecture_path}: {exc}")
@@ -526,7 +588,7 @@ def discover_associated_documents(
         # tolerance (architecture_registry.py:21); rejecting non-list
         # data here means object-format repos silently fall out of #739's
         # transitive-doc safety net.
-        try:
+        try: 
             from pdd.architecture_registry import extract_modules
             arch_entries = extract_modules(arch_data)
         except Exception as exc:
@@ -567,7 +629,7 @@ def discover_associated_documents(
         # match a basename-only seed and the dependent doc would be missed.
         modified_filenames: Set[str] = set()
         for p in modified_prompts:
-            try:
+            try: 
                 rel = p.relative_to(prompts_dir).as_posix()
             except ValueError:
                 rel = ""

--- a/tests/test_sync_order.py
+++ b/tests/test_sync_order.py
@@ -1,3 +1,4 @@
+import json
 import os
 import stat
 import pytest
@@ -783,3 +784,61 @@ def test_issue_1048_mixed_modules_quoting_preserved(tmp_path):
         expected_quoted = shlex.quote(module)
         assert expected_quoted in content, \
             f"Bug #1048: Module {module!r} not shell-quoted. Expected {expected_quoted} in script."
+
+
+
+def test_build_dependency_graph_from_architecture_valid_array(tmp_path):
+    """Test building a dependency graph from a bare array architecture.json."""
+    arch_file = tmp_path / "architecture.json"
+    arch_content = [
+        {
+            "filename": "auth_python.prompt",
+            "dependencies": ["log_python.prompt"]
+        },
+        {
+            "filename": "log_python.prompt",
+            "dependencies": []
+        }
+    ]
+    arch_file.write_text(json.dumps(arch_content), encoding="utf-8")
+    
+    graph = sync_order.build_dependency_graph_from_architecture(arch_file)
+    assert "auth" in graph
+    assert "log" in graph
+    assert graph["auth"] == ["log"]
+    assert graph["log"] == []
+
+
+def test_build_dependency_graph_from_architecture_valid_object(tmp_path):
+    """Test building a dependency graph from an object format with 'modules' key."""
+    arch_file = tmp_path / "architecture.json"
+    arch_content = {
+        "modules": [
+            {
+                "filename": "auth_python.prompt",
+                "dependencies": ["log_python.prompt", "db_python.prompt"]
+            },
+            {
+                "filename": "log_python.prompt",
+                "dependencies": []
+            }
+        ]
+    }
+    arch_file.write_text(json.dumps(arch_content), encoding="utf-8")
+    
+    graph = sync_order.build_dependency_graph_from_architecture(arch_file)
+    assert "auth" in graph
+    assert "log" in graph
+    assert "db" in graph  # Discovered as dependency
+    assert sorted(graph["auth"]) == ["db", "log"]
+
+
+def test_build_dependency_graph_from_architecture_missing_or_invalid(tmp_path, mock_logger):
+    """Test behavior when architecture file is missing, can't be parsed, or is invalid."""
+    missing_file = tmp_path / "missing_architecture.json"
+    assert sync_order.build_dependency_graph_from_architecture(missing_file) == {}
+    
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("{invalid json", encoding="utf-8")
+    assert sync_order.build_dependency_graph_from_architecture(bad_file) == {}
+    mock_logger.warning.assert_called()


### PR DESCRIPTION
## Summary
- Follow-up to #2373 (prompts-only). Implements `build_dependency_graph_from_architecture(architecture_path: Path) -> Dict[str, List[str]]` in `pdd/sync_order.py`, exactly as specified in `pdd/prompts/sync_order_python.prompt`.
- Builds the module dependency graph from `architecture.json`'s `dependencies` field (populated from `<pdd-dependency>` tags) instead of scanning `<include>` tags -- this is the data source `pdd change` Step 6 needs per #1807.
- Generated via `pdd generate --incremental` from the prompt, not hand-written.
- Adds 3 unit tests covering: bare-array `architecture.json`, object format with a `"modules"` key, and missing/unreadable/invalid-JSON handling.

**Stacks on #2373** -- this branch includes those prompt commits since #2373 isn't merged yet; the diff will shrink to just this PR's content once #2373 lands.

**Not included yet:** wiring `pdd/agentic_change_orchestrator.py`'s `_build_dependency_context()` to call this new function (Step 6's actual bug fix). That file is ~4000 lines and `pdd generate --incremental` currently can't complete it -- Anthropic API access is blocked by a billing issue, and the fallback Gemini model hits its ~65k output-token ceiling trying to re-emit the whole file. Will follow up once that's resolved.

Fixes (partially) #1807

## Test plan
- [x] `pytest tests/test_sync_order.py` -- 52 passed
- [ ] Follow-up PR wires `_build_dependency_context()` in `agentic_change_orchestrator.py` to this function and adds its own tests
- [ ] Manual repro (see `/Users/ishaanagarwal/Desktop/Code/pdd-issue-1807-repro/`): confirms `build_dependency_graph_from_architecture()` correctly surfaces `<pdd-dependency>`-declared dependencies that `<include>`-based scanning misses