### PR TITLE
fix: support global options in Zsh completion

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Provision and verify protected Linux sandbox
         run: |
           sudo apt-get update
-          sudo apt-get install --yes bubblewrap
+          sudo apt-get install --yes bubblewrap zsh
           private_root="$(mktemp -d)"
           chmod 700 "$private_root"
           mkdir -m 700 "$private_root/scratch"

--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -14916,6 +14916,12 @@
       "owner": "pdd-maintainers",
       "pattern": "pdd/story_detection_result.py",
       "role": "human-maintained"
+    },
+    {
+      "inventory": "HUMAN_OWNED",
+      "owner": "pdd-maintainers",
+      "pattern": "tests/test_zsh_completion.py",
+      "role": "human-maintained"
     }
   ]
 }

--- a/.pdd/verification-profiles.json
+++ b/.pdd/verification-profiles.json
@@ -8279,7 +8279,7 @@
       "prompt_path": "pdd/prompts/pdd_completion_zsh.prompt",
       "language_id": "zsh",
       "required_requirement_ids": [
-        "CONTRACT-SHA256:5d05ee3fcc959bfba1312b3d2ded6c2329ef1f6df0f532e855ac5a345ec6a107"
+        "CONTRACT-SHA256:488cde2f0d55b75a1cafc4f3e8f0e5f3984d4c0c0b70076c0d61820a4974365f"
       ],
       "obligations": [
         {
@@ -8288,7 +8288,7 @@
           "validator_id": "threshold-ed25519",
           "validator_config_digest": "threshold-ed25519-v1",
           "requirement_ids": [
-            "CONTRACT-SHA256:5d05ee3fcc959bfba1312b3d2ded6c2329ef1f6df0f532e855ac5a345ec6a107"
+            "CONTRACT-SHA256:488cde2f0d55b75a1cafc4f3e8f0e5f3984d4c0c0b70076c0d61820a4974365f"
           ],
           "artifact_paths": [
             "pdd/prompts/pdd_completion_zsh.prompt"

--- a/pdd/pdd_completion.zsh
+++ b/pdd/pdd_completion.zsh
@@ -50,6 +50,7 @@ local -a _pdd_global_opts
 _pdd_global_opts=(
   '--force[Overwrite existing files without asking for confirmation.]'
   '--strength[Set the strength of the AI model (0.0 to 1.0, default: 0.5)]:strength:(0.0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0)'
+  '--model[Override the model for this invocation]:model:_guard'
   '--time[Controls the reasoning allocation for LLM models (0.0 to 1.0, default: 0.25)]:time:(0.0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0)'
   '--temperature[Set the temperature of the AI model (default: 0.0)]:temperature:(0.0 0.25 0.5 0.75 1.0)'
   '--verbose[Increase output verbosity for more detailed information.]'
@@ -62,6 +63,9 @@ _pdd_global_opts=(
   '--review-examples[Review and optionally exclude few-shot examples before command execution.]'
   '--local[Run commands locally instead of in the cloud.]'
   '--context[Override automatic .pddrc context]:context-name:_guard'
+  '--keep-core-dumps[Number of core dumps to retain]:count:'
+  '--context-compression[Set global context compression mode]:mode:(off test examples contracts all)'
+  '--compression-fallback[Set behavior when compression fails]:mode:(full error)'
   '--list-contexts[List available .pddrc contexts and exit]'
   '--core-dump[Write a JSON core dump.]'
   '--no-core-dump[Disable JSON core dumps.]'
@@ -486,11 +490,15 @@ _pdd_checkup_simplify() {
 # checkup
 # Usage: pdd [GLOBAL OPTIONS] checkup [OPTIONS]
 _pdd_checkup() {
-  if [[ $words[3] == gate ]]; then
+  local checkup_index
+  for (( checkup_index = 2; checkup_index <= CURRENT; checkup_index++ )); do
+    [[ $words[checkup_index] == checkup ]] && break
+  done
+  if (( checkup_index <= CURRENT )) && [[ ${words[checkup_index + 1]} == gate ]]; then
     _pdd_checkup_gate
     return
   fi
-  if [[ $words[3] == simplify ]]; then
+  if (( checkup_index <= CURRENT )) && [[ ${words[checkup_index + 1]} == simplify ]]; then
     _pdd_checkup_simplify
     return
   fi
@@ -555,7 +563,7 @@ _pdd_find_subcommand() {
           return 0
           ;;
       esac
-      continue
+      return 1
     fi
 
     case "$token" in
@@ -579,6 +587,9 @@ _pdd_find_subcommand() {
         print -r -- "$token"
         return 0
         ;;
+      *)
+        return 1
+        ;;
     esac
   done
 
@@ -594,10 +605,7 @@ _pdd_auth() {
     'token:Print an authentication token'
     'clear-cache:Clear cached authentication state'
   )
-  _arguments -C -s $_pdd_global_opts '1:auth command:->group_command' && return 0
-  case $state in
-    group_command) _describe -t commands 'auth command' commands ;;
-  esac
+  _pdd_group_commands auth 'auth command' commands
 }
 
 _pdd_templates() {
@@ -607,19 +615,13 @@ _pdd_templates() {
     'show:Show a template'
     'copy:Copy a template into the project'
   )
-  _arguments -C -s $_pdd_global_opts '1:templates command:->group_command' && return 0
-  case $state in
-    group_command) _describe -t commands 'templates command' commands ;;
-  esac
+  _pdd_group_commands templates 'templates command' commands
 }
 
 _pdd_contracts() {
   local -a commands
   commands=('check:Run deterministic contract checks')
-  _arguments -C -s $_pdd_global_opts '1:contracts command:->group_command' && return 0
-  case $state in
-    group_command) _describe -t commands 'contracts command' commands ;;
-  esac
+  _pdd_group_commands contracts 'contracts command' commands
 }
 
 _pdd_sessions() {
@@ -629,10 +631,7 @@ _pdd_sessions() {
     'info:Show remote session information'
     'cleanup:Clean up remote sessions'
   )
-  _arguments -C -s $_pdd_global_opts '1:sessions command:->group_command' && return 0
-  case $state in
-    group_command) _describe -t commands 'sessions command' commands ;;
-  esac
+  _pdd_group_commands sessions 'sessions command' commands
 }
 
 _pdd_story() {
@@ -642,10 +641,7 @@ _pdd_story() {
     'list:List user stories'
     'link:Link a user story'
   )
-  _arguments -C -s $_pdd_global_opts '1:story command:->group_command' && return 0
-  case $state in
-    group_command) _describe -t commands 'story command' commands ;;
-  esac
+  _pdd_group_commands story 'story command' commands
 }
 
 _pdd_firecrawl_cache() {
@@ -656,10 +652,20 @@ _pdd_firecrawl_cache() {
     'info:Show cache configuration'
     'check:Check whether a URL is cached'
   )
-  _arguments -C -s $_pdd_global_opts '1:firecrawl-cache command:->group_command' && return 0
-  case $state in
-    group_command) _describe -t commands 'firecrawl-cache command' commands ;;
-  esac
+  _pdd_group_commands firecrawl-cache 'firecrawl-cache command' commands
+}
+
+_pdd_group_commands() {
+  local command=$1 label=$2 array_name=$3 index
+  for (( index = 2; index <= CURRENT; index++ )); do
+    [[ $words[index] == "$command" ]] && break
+  done
+  # In a native completion frame, a trailing space does not add an empty item
+  # to `$words`: CURRENT still points at the group command.  Keep this
+  # relative to the located root command so preceding global options do not
+  # change the group grammar.
+  (( index <= CURRENT )) || return 1
+  _describe -t commands "$label" "$array_name"
 }
 
 _pdd() {

--- a/pdd/pdd_completion.zsh
+++ b/pdd/pdd_completion.zsh
@@ -529,8 +529,36 @@ _pdd_checkup() {
 ##
 # Main PDD completion dispatcher
 ##
+# Return the first PDD subcommand in the current invocation.  Global options
+# are valid before a command, so `$words[2]` cannot be assumed to be one.
+_pdd_find_subcommand() {
+  local token expect_value=0
+
+  for token in "${(@)words[2,CURRENT]}"; do
+    if (( expect_value )); then
+      expect_value=0
+      continue
+    fi
+
+    case "$token" in
+      --strength|--model|--temperature|--time|--output-cost|--context|--keep-core-dumps|--context-compression|--compression-fallback)
+        expect_value=1
+        ;;
+      --strength=*|--model=*|--temperature=*|--time=*|--output-cost=*|--context=*|--keep-core-dumps=*|--context-compression=*|--compression-fallback=*|--*)
+        ;;
+      generate|example|test|preprocess|fix|split|change|update|detect|conflicts|crash|trace|bug|auto-deps|verify|sync|checkup|setup|install_completion|pytest-output)
+        print -r -- "$token"
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
 _pdd() {
   local context="$curcontext" state line
+  local pdd_command
   typeset -A opt_args
 
   # List of known subcommands with descriptions
@@ -558,8 +586,10 @@ _pdd() {
     'pytest-output:Run pytest and capture structured output'
   )
 
-  # If there's no subcommand yet (i.e., user typed only "pdd " or "pdd -<Tab>"), offer global opts or subcommands.
-  if (( CURRENT == 2 )); then
+  pdd_command=$(_pdd_find_subcommand)
+
+  # If no subcommand has been entered, offer global options and subcommands.
+  if [[ -z "$pdd_command" ]]; then
     _arguments -s \
       $_pdd_global_opts \
       '1: :->subcmds' && return 0
@@ -568,8 +598,8 @@ _pdd() {
     return
   fi
 
-  # If the user typed a known subcommand, dispatch to that subcommand's completion function.
-  case $words[2] in
+  # Dispatch after resolving a subcommand past any preceding global options.
+  case $pdd_command in
     generate)
       _pdd_generate
       ;;

--- a/pdd/pdd_completion.zsh
+++ b/pdd/pdd_completion.zsh
@@ -54,13 +54,21 @@ _pdd_global_opts=(
   '--temperature[Set the temperature of the AI model (default: 0.0)]:temperature:(0.0 0.25 0.5 0.75 1.0)'
   '--verbose[Increase output verbosity for more detailed information.]'
   '--quiet[Decrease output verbosity (minimal information).]'
+  '--color[Force colored output.]'
+  '--no-color[Disable colored output.]'
   '--output-cost[Enable cost tracking and output a CSV file with usage details.]:filename:_files'
+  '(--estimate --dry-run-cost)'{'--estimate','--dry-run-cost'}'[Preview token usage and estimated cost without running.]'
+  '--estimate-json[Emit the estimate as JSON.]'
   '--review-examples[Review and optionally exclude few-shot examples before command execution.]'
   '--local[Run commands locally instead of in the cloud.]'
   '--context[Override automatic .pddrc context]:context-name:_guard'
   '--list-contexts[List available .pddrc contexts and exit]'
+  '--core-dump[Write a JSON core dump.]'
+  '--no-core-dump[Disable JSON core dumps.]'
   '--help[Show help message and exit.]'
   '--version[Show version and exit.]'
+  '--compress-examples[Compress example code in context.]'
+  '--compress-test-context[Compress test context.]'
 )
 
 ##
@@ -544,9 +552,14 @@ _pdd_find_subcommand() {
       --strength|--model|--temperature|--time|--output-cost|--context|--keep-core-dumps|--context-compression|--compression-fallback)
         expect_value=1
         ;;
-      --strength=*|--model=*|--temperature=*|--time=*|--output-cost=*|--context=*|--keep-core-dumps=*|--context-compression=*|--compression-fallback=*|--*)
+      --strength=*|--model=*|--temperature=*|--time=*|--output-cost=*|--context=*|--keep-core-dumps=*|--context-compression=*|--compression-fallback=*)
         ;;
-      generate|example|test|preprocess|fix|split|change|update|detect|conflicts|crash|trace|bug|auto-deps|verify|sync|checkup|setup|install_completion|pytest-output)
+      --force|--verbose|--quiet|--color|--no-color|--estimate|--dry-run-cost|--estimate-json|--review-examples|--local|--list-contexts|--core-dump|--no-core-dump|--compress-examples|--compress-test-context|--help|--version)
+        ;;
+      --*)
+        return 1
+        ;;
+      generate|example|test|preprocess|fix|split|change|update|detect|conflicts|crash|trace|bug|auto-deps|verify|sync|sync-architecture|checkup|contracts|extracts|report-core|replay|context|which|reconcile|install-hooks|certify|recover|baseline|validate|templates|connect|auth|sessions|firecrawl-cache|story|setup|install_completion|pytest-output)
         print -r -- "$token"
         return 0
         ;;
@@ -580,7 +593,26 @@ _pdd() {
     'auto-deps:Analyze a prompt and include deps from a directory or glob'
     'verify:Verify functional correctness using LLM judgment and iteratively fix'
     'sync:Synchronize prompt, code, examples, tests with analysis'
+    'sync-architecture:Synchronize architecture documentation'
     'checkup:Run architecture/PR review loop with optional reviewer fallback'
+    'contracts:Run deterministic prompt contract checks'
+    'extracts:Manage prompt extraction artifacts'
+    'report-core:Display a saved core dump'
+    'replay:Replay a saved command run'
+    'context:Generate prompt context'
+    'which:Show the installed PDD executable'
+    'reconcile:Reconcile project artifacts'
+    'install-hooks:Install Git hooks'
+    'certify:Create a sync certificate'
+    'recover:Recover a sync transaction'
+    'baseline:Create a sync baseline'
+    'validate:Validate a sync module'
+    'templates:Manage project templates'
+    'connect:Connect to PDD Cloud'
+    'auth:Manage PDD Cloud authentication'
+    'sessions:Manage remote PDD sessions'
+    'firecrawl-cache:Manage Firecrawl cache'
+    'story:Manage regression-suite user stories'
     'setup:Interactive setup and completion install'
     'install_completion:Install shell completion for current shell'
     'pytest-output:Run pytest and capture structured output'
@@ -660,9 +692,12 @@ _pdd() {
     pytest-output)
       _pdd_pytest_output
       ;;
-    # If the subcommand is unknown or not typed yet, fall back to showing the list of subcommands.
+    # Commands without a dedicated completion function still accept global
+    # options and complete positional arguments as paths.
     *)
-      _describe -t subcommands 'pdd subcommand' _pdd_subcommands
+      _arguments -s \
+        $_pdd_global_opts \
+        '*:argument:_files'
       ;;
   esac
 }

--- a/pdd/pdd_completion.zsh
+++ b/pdd/pdd_completion.zsh
@@ -490,10 +490,7 @@ _pdd_checkup_simplify() {
 # checkup
 # Usage: pdd [GLOBAL OPTIONS] checkup [OPTIONS]
 _pdd_checkup() {
-  local checkup_index
-  for (( checkup_index = 2; checkup_index <= CURRENT; checkup_index++ )); do
-    [[ $words[checkup_index] == checkup ]] && break
-  done
+  local checkup_index=$1
   if (( checkup_index <= CURRENT )) && [[ ${words[checkup_index + 1]} == gate ]]; then
     _pdd_checkup_gate
     return
@@ -545,12 +542,15 @@ _pdd_checkup() {
 ##
 # Main PDD completion dispatcher
 ##
-# Return the first PDD subcommand in the current invocation.  Global options
-# are valid before a command, so `$words[2]` cannot be assumed to be one.
-_pdd_find_subcommand() {
-  local token expect_value=0 options_ended=0
+# Resolve the first PDD subcommand and its absolute index. Global options are
+# valid before a command, so `$words[2]` cannot be assumed to be one. The
+# caller receives `<index>:<command>` in REPLY.
+_pdd_resolve_subcommand() {
+  local token index expect_value=0 options_ended=0
+  REPLY=
 
-  for token in "${(@)words[2,CURRENT]}"; do
+  for (( index = 2; index <= CURRENT; index++ )); do
+    token=$words[index]
     if (( expect_value )); then
       expect_value=0
       continue
@@ -559,7 +559,7 @@ _pdd_find_subcommand() {
     if (( options_ended )); then
       case "$token" in
         generate|example|test|preprocess|fix|split|change|update|detect|conflicts|crash|trace|bug|auto-deps|verify|sync|sync-architecture|checkup|contracts|extracts|report-core|replay|context|which|reconcile|install-hooks|certify|recover|baseline|validate|templates|connect|auth|sessions|firecrawl-cache|story|setup|install_completion|pytest-output)
-          print -r -- "$token"
+          REPLY="$index:$token"
           return 0
           ;;
       esac
@@ -584,7 +584,7 @@ _pdd_find_subcommand() {
         return 1
         ;;
       generate|example|test|preprocess|fix|split|change|update|detect|conflicts|crash|trace|bug|auto-deps|verify|sync|sync-architecture|checkup|contracts|extracts|report-core|replay|context|which|reconcile|install-hooks|certify|recover|baseline|validate|templates|connect|auth|sessions|firecrawl-cache|story|setup|install_completion|pytest-output)
-        print -r -- "$token"
+        REPLY="$index:$token"
         return 0
         ;;
       *)
@@ -594,6 +594,12 @@ _pdd_find_subcommand() {
   done
 
   return 1
+}
+
+# Return the first PDD subcommand for callers that only need its name.
+_pdd_find_subcommand() {
+  _pdd_resolve_subcommand || return 1
+  print -r -- "${REPLY#*:}"
 }
 
 _pdd_auth() {
@@ -717,7 +723,12 @@ _pdd() {
     'pytest-output:Run pytest and capture structured output'
   )
 
-  pdd_command=$(_pdd_find_subcommand)
+  local pdd_command_index
+  _pdd_resolve_subcommand
+  if [[ -n "$REPLY" ]]; then
+    pdd_command_index=${REPLY%%:*}
+    pdd_command=${REPLY#*:}
+  fi
 
   # If no subcommand has been entered, offer global options and subcommands.
   if [[ -z "$pdd_command" ]]; then
@@ -780,7 +791,7 @@ _pdd() {
       _pdd_sync
       ;;
     checkup)
-      _pdd_checkup
+      _pdd_checkup "$pdd_command_index"
       ;;
     auth)
       _pdd_auth

--- a/pdd/pdd_completion.zsh
+++ b/pdd/pdd_completion.zsh
@@ -540,11 +540,21 @@ _pdd_checkup() {
 # Return the first PDD subcommand in the current invocation.  Global options
 # are valid before a command, so `$words[2]` cannot be assumed to be one.
 _pdd_find_subcommand() {
-  local token expect_value=0
+  local token expect_value=0 options_ended=0
 
   for token in "${(@)words[2,CURRENT]}"; do
     if (( expect_value )); then
       expect_value=0
+      continue
+    fi
+
+    if (( options_ended )); then
+      case "$token" in
+        generate|example|test|preprocess|fix|split|change|update|detect|conflicts|crash|trace|bug|auto-deps|verify|sync|sync-architecture|checkup|contracts|extracts|report-core|replay|context|which|reconcile|install-hooks|certify|recover|baseline|validate|templates|connect|auth|sessions|firecrawl-cache|story|setup|install_completion|pytest-output)
+          print -r -- "$token"
+          return 0
+          ;;
+      esac
       continue
     fi
 
@@ -554,7 +564,13 @@ _pdd_find_subcommand() {
         ;;
       --strength=*|--model=*|--temperature=*|--time=*|--output-cost=*|--context=*|--keep-core-dumps=*|--context-compression=*|--compression-fallback=*)
         ;;
-      --force|--verbose|--quiet|--color|--no-color|--estimate|--dry-run-cost|--estimate-json|--review-examples|--local|--list-contexts|--core-dump|--no-core-dump|--compress-examples|--compress-test-context|--help|--version)
+      --)
+        options_ended=1
+        ;;
+      --help|--version|--list-contexts)
+        return 1
+        ;;
+      --force|--verbose|--quiet|--color|--no-color|--estimate|--dry-run-cost|--estimate-json|--review-examples|--local|--core-dump|--no-core-dump|--compress-examples|--compress-test-context)
         ;;
       --*)
         return 1
@@ -567,6 +583,83 @@ _pdd_find_subcommand() {
   done
 
   return 1
+}
+
+_pdd_auth() {
+  local -a commands
+  commands=(
+    'login:Authenticate with PDD Cloud'
+    'status:Show authentication status'
+    'logout:Sign out of PDD Cloud'
+    'token:Print an authentication token'
+    'clear-cache:Clear cached authentication state'
+  )
+  _arguments -C -s $_pdd_global_opts '1:auth command:->group_command' && return 0
+  case $state in
+    group_command) _describe -t commands 'auth command' commands ;;
+  esac
+}
+
+_pdd_templates() {
+  local -a commands
+  commands=(
+    'list:List available templates'
+    'show:Show a template'
+    'copy:Copy a template into the project'
+  )
+  _arguments -C -s $_pdd_global_opts '1:templates command:->group_command' && return 0
+  case $state in
+    group_command) _describe -t commands 'templates command' commands ;;
+  esac
+}
+
+_pdd_contracts() {
+  local -a commands
+  commands=('check:Run deterministic contract checks')
+  _arguments -C -s $_pdd_global_opts '1:contracts command:->group_command' && return 0
+  case $state in
+    group_command) _describe -t commands 'contracts command' commands ;;
+  esac
+}
+
+_pdd_sessions() {
+  local -a commands
+  commands=(
+    'list:List remote sessions'
+    'info:Show remote session information'
+    'cleanup:Clean up remote sessions'
+  )
+  _arguments -C -s $_pdd_global_opts '1:sessions command:->group_command' && return 0
+  case $state in
+    group_command) _describe -t commands 'sessions command' commands ;;
+  esac
+}
+
+_pdd_story() {
+  local -a commands
+  commands=(
+    'add:Add a user story'
+    'list:List user stories'
+    'link:Link a user story'
+  )
+  _arguments -C -s $_pdd_global_opts '1:story command:->group_command' && return 0
+  case $state in
+    group_command) _describe -t commands 'story command' commands ;;
+  esac
+}
+
+_pdd_firecrawl_cache() {
+  local -a commands
+  commands=(
+    'stats:Show cache statistics'
+    'clear:Clear cached entries'
+    'info:Show cache configuration'
+    'check:Check whether a URL is cached'
+  )
+  _arguments -C -s $_pdd_global_opts '1:firecrawl-cache command:->group_command' && return 0
+  case $state in
+    group_command) _describe -t commands 'firecrawl-cache command' commands ;;
+  esac
 }
 
 _pdd() {
@@ -682,6 +775,24 @@ _pdd() {
       ;;
     checkup)
       _pdd_checkup
+      ;;
+    auth)
+      _pdd_auth
+      ;;
+    templates)
+      _pdd_templates
+      ;;
+    contracts)
+      _pdd_contracts
+      ;;
+    sessions)
+      _pdd_sessions
+      ;;
+    story)
+      _pdd_story
+      ;;
+    firecrawl-cache)
+      _pdd_firecrawl_cache
       ;;
     setup)
       _pdd_setup

--- a/pdd/prompts/pdd_completion_zsh.prompt
+++ b/pdd/prompts/pdd_completion_zsh.prompt
@@ -26,3 +26,10 @@
 % The generated script must also include the `checkup` subcommand and its README-documented options, including recovery (`--start-step`), PR mode (`--pr`, `--issue`, `--test-scope` with `full`|`targeted`, `--full-suite-source` with `local`|`github-checks`), review-loop mode (`--review-loop`, `--review-only`, `--reviewers`, `--reviewer`, `--fixer`, `--reviewer-fallback`, `--fixer-fallback`, `--allow-same-reviewer-fixer`), bounded Codex-only `--terra-sol` (hard five-round default, overridden by `--max-review-rounds`; clean-only success; conflicts with final/review/agentic-review/report-only/prompt-repair modes), the canonical final PR gate (`--final-gate`, issue #1406; requires both `--pr` and `--issue`), review budget/limit flags, reviewer-status compatibility flags (`--continue-on-reviewer-limit`, `--fallback-reviewer-on-failure`), `--blocking-severities`, `--clean-reviewer-states`, and the issue #1092 deterministic-gate flags `--no-gates`, `--gate-timeout`, and the repeatable `--gate-allow`.
 %
 % Define `_pdd_checkup` exactly once. zsh autoload resolves duplicate function definitions by overwriting earlier ones, so do not emit a second `_pdd_checkup()` block alongside or below the canonical definition — every flag must live inside a single function.
+%
+% Global options may appear before the subcommand. The main dispatcher MUST find
+% the first known subcommand after skipping global flags and the values consumed
+% by global value options. In particular, `pdd --local sync <TAB>` must dispatch
+% to `_pdd_sync`, rather than treating `--local` as the command and falling back
+% to the generic subcommand list. Support both `--option value` and
+% `--option=value` forms for global options that consume a value.

--- a/pdd/prompts/pdd_completion_zsh.prompt
+++ b/pdd/prompts/pdd_completion_zsh.prompt
@@ -26,10 +26,3 @@
 % The generated script must also include the `checkup` subcommand and its README-documented options, including recovery (`--start-step`), PR mode (`--pr`, `--issue`, `--test-scope` with `full`|`targeted`, `--full-suite-source` with `local`|`github-checks`), review-loop mode (`--review-loop`, `--review-only`, `--reviewers`, `--reviewer`, `--fixer`, `--reviewer-fallback`, `--fixer-fallback`, `--allow-same-reviewer-fixer`), bounded Codex-only `--terra-sol` (hard five-round default, overridden by `--max-review-rounds`; clean-only success; conflicts with final/review/agentic-review/report-only/prompt-repair modes), the canonical final PR gate (`--final-gate`, issue #1406; requires both `--pr` and `--issue`), review budget/limit flags, reviewer-status compatibility flags (`--continue-on-reviewer-limit`, `--fallback-reviewer-on-failure`), `--blocking-severities`, `--clean-reviewer-states`, and the issue #1092 deterministic-gate flags `--no-gates`, `--gate-timeout`, and the repeatable `--gate-allow`.
 %
 % Define `_pdd_checkup` exactly once. zsh autoload resolves duplicate function definitions by overwriting earlier ones, so do not emit a second `_pdd_checkup()` block alongside or below the canonical definition — every flag must live inside a single function.
-%
-% Global options may appear before the subcommand. The main dispatcher MUST find
-% the first known subcommand after skipping global flags and the values consumed
-% by global value options. In particular, `pdd --local sync <TAB>` must dispatch
-% to `_pdd_sync`, rather than treating `--local` as the command and falling back
-% to the generic subcommand list. Support both `--option value` and
-% `--option=value` forms for global options that consume a value.

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -288,6 +288,15 @@ _REPLAY_HUMAN_OWNERSHIP = tuple(
 # lose their repaired ownership, and they resurface as unowned tracked paths.
 _SYNC_ROLLOUT_REPAIR_OWNERSHIP_BYTES = (
     "8f5762a5dd7be6cc14c85138810b8bad8183f4403c74584489a0d81798ba2a07",
+    "8ff5fb357321c85d827c8be4cb9b1ee06ad0a4a15b91bd5bf5db418e74067f20",
+)
+# Re-pinning above only tracks the current head. The repair is also replayed
+# across its own protected range, whose head predates every later edit to the
+# ownership policy, so that exact historical pair stays valid authority too.
+# Both are bound to the same reviewed base, and each still has to clear the
+# unchanged-artifact and ordinary-row checks below.
+_SYNC_ROLLOUT_REPAIR_PROTECTED_OWNERSHIP_BYTES = (
+    "8f5762a5dd7be6cc14c85138810b8bad8183f4403c74584489a0d81798ba2a07",
     "558910b5d03c183855dbbccdbde662cc36f028765a9eb24883a85ffa040fae3a",
 )
 _SYNC_ROLLOUT_REPAIR_METADATA_BYTES = (
@@ -1255,7 +1264,10 @@ def _sync_rollout_repair_ownership_rules(
             hashlib.sha256(base_policy).hexdigest(),
             hashlib.sha256(head_policy).hexdigest(),
         )
-        != _SYNC_ROLLOUT_REPAIR_OWNERSHIP_BYTES
+        not in (
+            _SYNC_ROLLOUT_REPAIR_OWNERSHIP_BYTES,
+            _SYNC_ROLLOUT_REPAIR_PROTECTED_OWNERSHIP_BYTES,
+        )
     ):
         return base_rules
 

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -182,6 +182,24 @@ _CODE_GENERATOR_LANGUAGE_GATE_PROFILE_BYTES = (
     "6e589170b67c9547fad99dca53d32a085ecb3e9074a564419f97fc7316546888",
     "6e589170b67c9547fad99dca53d32a085ecb3e9074a564419f97fc7316546888",
 )
+# Issue #2377 lets global options precede a subcommand in the Zsh completion
+# dispatcher, moving `pdd/prompts/pdd_completion_zsh.prompt` and its profile row
+# together.  The rotation policy is untouched, so only the profile file rotates.
+# Recognizing this exact pair keeps the language-gate base reconciliations
+# applicable across that rotation; it adds no reusable authority of its own.
+_ZSH_GLOBAL_OPTION_ROTATION_POLICY_BYTES = (
+    _CODE_GENERATOR_LANGUAGE_GATE_ROTATION_POLICY_BYTES[1],
+    _CODE_GENERATOR_LANGUAGE_GATE_ROTATION_POLICY_BYTES[1],
+)
+_ZSH_GLOBAL_OPTION_PROFILE_BYTES = (
+    _CODE_GENERATOR_LANGUAGE_GATE_PROFILE_BYTES[1],
+    "0fcb1bb324022fbda46424be9738f3e2d8fe3f3440eb6d72fff7b5fd8411c5c1",
+)
+# The candidate is also evaluated against itself once the rotation has landed.
+_ZSH_GLOBAL_OPTION_STATIONARY_PROFILE_BYTES = (
+    _ZSH_GLOBAL_OPTION_PROFILE_BYTES[1],
+    _ZSH_GLOBAL_OPTION_PROFILE_BYTES[1],
+)
 _PR2316_STALE_LLM_REISSUE_HISTORY_PROFILE_BYTES = (
     _OPUS_FABLE_COMPOSED_PROFILE_BYTES[1],
     _TEMPERATURE_REGRESSION_PROFILE_BYTES[1],
@@ -977,6 +995,20 @@ _PDD_1875_COMPOSED_REQUIREMENT_TRANSITIONS = (
         "e0f5f0173e29379d84dd34934b3221b5ae0f5c9c7b745ea35cb73699cb6162b1",
         _PDD_1875_COMPOSED_PROFILE_BYTES[0],
         _PDD_1875_COMPOSED_PROFILE_BYTES[1],
+    ),
+)
+
+# Issue #2377's single prompt transition, bound to the exact profile bytes that
+# consume it.  It supersedes the Terra/Sol row for this one identity and grants
+# no reusable transition authority.
+_ZSH_GLOBAL_OPTION_COMPOSED_REQUIREMENT_TRANSITIONS = (
+    _exact_bootstrap_requirement_transition(
+        "pdd/prompts/pdd_completion_zsh.prompt",
+        "zsh",
+        "5d05ee3fcc959bfba1312b3d2ded6c2329ef1f6df0f532e855ac5a345ec6a107",
+        "488cde2f0d55b75a1cafc4f3e8f0e5f3984d4c0c0b70076c0d61820a4974365f",
+        _ZSH_GLOBAL_OPTION_PROFILE_BYTES[0],
+        _ZSH_GLOBAL_OPTION_PROFILE_BYTES[1],
     ),
 )
 
@@ -2947,10 +2979,34 @@ def _load_requirement_transition_authorizations(
     )
     code_generator_language_gate_state = is_pdd_repository and (
         (policy_digests, profile_digests)
-        == (
-            _CODE_GENERATOR_LANGUAGE_GATE_ROTATION_POLICY_BYTES,
-            _CODE_GENERATOR_LANGUAGE_GATE_PROFILE_BYTES,
-        )
+        in {
+            (
+                _CODE_GENERATOR_LANGUAGE_GATE_ROTATION_POLICY_BYTES,
+                _CODE_GENERATOR_LANGUAGE_GATE_PROFILE_BYTES,
+            ),
+            # Issue #2377 rotates only the profile file above that same base.
+            (
+                _ZSH_GLOBAL_OPTION_ROTATION_POLICY_BYTES,
+                _ZSH_GLOBAL_OPTION_PROFILE_BYTES,
+            ),
+            (
+                _ZSH_GLOBAL_OPTION_ROTATION_POLICY_BYTES,
+                _ZSH_GLOBAL_OPTION_STATIONARY_PROFILE_BYTES,
+            ),
+        }
+    )
+    zsh_global_option_state = is_pdd_repository and (
+        (policy_digests, profile_digests)
+        in {
+            (
+                _ZSH_GLOBAL_OPTION_ROTATION_POLICY_BYTES,
+                _ZSH_GLOBAL_OPTION_PROFILE_BYTES,
+            ),
+            (
+                _ZSH_GLOBAL_OPTION_ROTATION_POLICY_BYTES,
+                _ZSH_GLOBAL_OPTION_STATIONARY_PROFILE_BYTES,
+            ),
+        }
     )
     temperature_regression_state = (
         exact_pr2316_phase_a_reissue
@@ -3038,6 +3094,18 @@ def _load_requirement_transition_authorizations(
             if (item.prompt_path, item.language_id) not in terra_sol_identities
         ) + _TERRA_SOL_COMPOSED_REQUIREMENT_TRANSITIONS
         authority.update(_TERRA_SOL_COMPOSED_REQUIREMENT_TRANSITIONS)
+    if zsh_global_option_state:
+        # Supersede the Terra/Sol row for the one identity this change moves.
+        zsh_identities = {
+            (item.prompt_path, item.language_id)
+            for item in _ZSH_GLOBAL_OPTION_COMPOSED_REQUIREMENT_TRANSITIONS
+        }
+        candidate = tuple(
+            item
+            for item in candidate
+            if (item.prompt_path, item.language_id) not in zsh_identities
+        ) + _ZSH_GLOBAL_OPTION_COMPOSED_REQUIREMENT_TRANSITIONS
+        authority.update(_ZSH_GLOBAL_OPTION_COMPOSED_REQUIREMENT_TRANSITIONS)
     if generate_reliability_state or historical_composed_state:
         reliability_identities = {
             (item.prompt_path, item.language_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ dev = [
     "pytest-mock",
     "pytest-asyncio",
     "pytest-timeout",
+    "pexpect>=4.9",
     "build",
     "twine"
 ]

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -2282,6 +2282,10 @@ def test_sync_rollout_repair_executes_the_actual_protected_transition() -> None:
             verification._SYNC_ROLLOUT_REPAIR_PROFILE_BYTES[0],  # pylint: disable=protected-access
             verification._CODE_GENERATOR_LANGUAGE_GATE_PROFILE_BYTES[1],  # pylint: disable=protected-access
         ),
+        (
+            verification._SYNC_ROLLOUT_REPAIR_PROFILE_BYTES[0],  # pylint: disable=protected-access
+            verification._ZSH_GLOBAL_OPTION_PROFILE_BYTES[1],  # pylint: disable=protected-access
+        ),
     }
     assert (
         hashlib.sha256(_git_blob(SYNC_ROLLOUT_PROTECTED_BASE, ROTATION_FILE)).hexdigest(),
@@ -2552,6 +2556,11 @@ def test_current_profile_reconciliation_matches_current_prompt_and_profile_rows(
     current_rows.extend(
         _requirement_authorization_row(authorization)
         for authorization in verification._TEMPERATURE_REGRESSION_COMPOSED_REQUIREMENT_TRANSITIONS  # pylint: disable=protected-access
+        if authorization.bindings.head_policy_sha256 == profile_digest
+    )
+    current_rows.extend(
+        _requirement_authorization_row(authorization)
+        for authorization in verification._ZSH_GLOBAL_OPTION_COMPOSED_REQUIREMENT_TRANSITIONS  # pylint: disable=protected-access
         if authorization.bindings.head_policy_sha256 == profile_digest
     )
     if profile_digest == verification._SYNC_ROLLOUT_REPAIR_PROFILE_BYTES[1]:  # pylint: disable=protected-access

--- a/tests/test_zsh_completion.py
+++ b/tests/test_zsh_completion.py
@@ -24,11 +24,35 @@ def _resolved_subcommand(*words: str) -> str:
             str(COMPLETION),
             *words,
         ],
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
     )
     return result.stdout.strip()
+
+
+def _completion_output(*words: str) -> str:
+    """Run the dispatcher with completion helpers replaced by observable stubs."""
+    result = subprocess.run(
+        [
+            "zsh",
+            "-fc",
+            (
+                'source "$1"; shift; '
+                '_arguments() { print -r -- "arguments:$*"; state=group_command; return 1; }; '
+                '_describe() { local name="${@: -1}"; '
+                'print -r -- "describe:${(j: :)${(P)name}}"; return 0; }; '
+                'words=("$@"); CURRENT=${#words}; curcontext=:completion::; _pdd'
+            ),
+            "zsh",
+            str(COMPLETION),
+            *words,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
 
 
 def test_zsh_completion_resolves_sync_after_local_global_option() -> None:
@@ -49,3 +73,77 @@ def test_zsh_completion_resolves_current_cli_command_after_global_option() -> No
 def test_zsh_completion_does_not_skip_unknown_global_option() -> None:
     """Misspelled options must not dispatch completion for a later command."""
     assert _resolved_subcommand("pdd", "--modle", "claude", "sync") == ""
+
+
+@pytest.mark.parametrize(
+    "words",
+    [
+        ("pdd", "--force", "sync"),
+        ("pdd", "--verbose", "sync"),
+        ("pdd", "--quiet", "sync"),
+        ("pdd", "--color", "sync"),
+        ("pdd", "--no-color", "sync"),
+        ("pdd", "--estimate", "sync"),
+        ("pdd", "--dry-run-cost", "sync"),
+        ("pdd", "--estimate-json", "sync"),
+        ("pdd", "--review-examples", "sync"),
+        ("pdd", "--local", "sync"),
+        ("pdd", "--core-dump", "sync"),
+        ("pdd", "--no-core-dump", "sync"),
+        ("pdd", "--compress-examples", "sync"),
+        ("pdd", "--compress-test-context", "sync"),
+        ("pdd", "--strength", "0.5", "sync"),
+        ("pdd", "--strength=0.5", "sync"),
+        ("pdd", "--model", "claude", "sync"),
+        ("pdd", "--model=claude", "sync"),
+        ("pdd", "--temperature", "0.5", "sync"),
+        ("pdd", "--temperature=0.5", "sync"),
+        ("pdd", "--time", "0.5", "sync"),
+        ("pdd", "--time=0.5", "sync"),
+        ("pdd", "--output-cost", "costs.csv", "sync"),
+        ("pdd", "--output-cost=costs.csv", "sync"),
+        ("pdd", "--context", "local", "sync"),
+        ("pdd", "--context=local", "sync"),
+        ("pdd", "--keep-core-dumps", "2", "sync"),
+        ("pdd", "--keep-core-dumps=2", "sync"),
+        ("pdd", "--context-compression", "all", "sync"),
+        ("pdd", "--context-compression=all", "sync"),
+        ("pdd", "--compression-fallback", "full", "sync"),
+        ("pdd", "--compression-fallback=full", "sync"),
+    ],
+)
+def test_zsh_completion_resolves_sync_after_each_global_option(words: tuple[str, ...]) -> None:
+    """Every non-eager global option reaches sync in both supported forms."""
+    assert _resolved_subcommand(*words) == "sync"
+
+
+def test_zsh_completion_supports_option_terminator_before_command() -> None:
+    """Click accepts a subcommand after a literal option terminator."""
+    assert _resolved_subcommand("pdd", "--", "sync") == "sync"
+
+
+@pytest.mark.parametrize("option", ("--help", "--version", "--list-contexts"))
+def test_zsh_completion_does_not_dispatch_after_eager_global_option(option: str) -> None:
+    """Eager global options exit before a later command can execute."""
+    assert _resolved_subcommand("pdd", option, "sync") == ""
+
+
+def test_zsh_completion_dispatches_sync_specific_completion() -> None:
+    """The dispatcher, not just the parser, selects sync completion."""
+    assert "--skip-verify" in _completion_output("pdd", "--local", "sync")
+
+
+@pytest.mark.parametrize(
+    ("group", "command"),
+    [
+        ("auth", "login"),
+        ("templates", "list"),
+        ("contracts", "check"),
+        ("sessions", "cleanup"),
+        ("story", "link"),
+        ("firecrawl-cache", "stats"),
+    ],
+)
+def test_zsh_completion_dispatches_group_subcommands(group: str, command: str) -> None:
+    """Groups reached after a global option offer their registered subcommands."""
+    assert command in _completion_output("pdd", "--local", group)

--- a/tests/test_zsh_completion.py
+++ b/tests/test_zsh_completion.py
@@ -1,0 +1,38 @@
+"""Regression tests for the shipped Zsh completion dispatcher."""
+
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPLETION = ROOT / "pdd" / "pdd_completion.zsh"
+
+
+def _resolved_subcommand(*words: str) -> str:
+    """Source the completion file and return its parsed command token."""
+    invocation = " ".join(words)
+    result = subprocess.run(
+        [
+            "zsh",
+            "-fc",
+            (
+                f"source {COMPLETION}; "
+                f"words=({invocation}); CURRENT=${{#words}}; "
+                "_pdd_find_subcommand"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def test_zsh_completion_resolves_sync_after_local_global_option() -> None:
+    """`pdd --local sync` must use sync-specific completion."""
+    assert _resolved_subcommand("pdd", "--local", "sync", "--skip") == "sync"
+
+
+def test_zsh_completion_skips_value_of_global_option_before_sync() -> None:
+    """A global option's value must not be mistaken for the command."""
+    assert _resolved_subcommand("pdd", "--context", "local", "sync") == "sync"

--- a/tests/test_zsh_completion.py
+++ b/tests/test_zsh_completion.py
@@ -200,3 +200,10 @@ def test_zsh_completion_dispatches_group_subcommands(
 def test_zsh_completion_dispatches_checkup_gate_after_global_option() -> None:
     """Nested checkup completion is located relative to its resolved command."""
     assert "--policy" in _native_completion_output("pdd --local checkup gate --po")
+
+
+@pytest.mark.parametrize("option", ("--model", "--context"))
+def test_zsh_completion_ignores_command_named_global_option_values(option: str) -> None:
+    """A global option value may equal `checkup` without changing its position."""
+    command = f"pdd {option} checkup checkup gate --po"
+    assert "--policy" in _native_completion_output(command)

--- a/tests/test_zsh_completion.py
+++ b/tests/test_zsh_completion.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import shutil
 import subprocess
 
+import pexpect
 import pytest
 
 
@@ -31,28 +32,33 @@ def _resolved_subcommand(*words: str) -> str:
     return result.stdout.strip()
 
 
-def _completion_output(*words: str) -> str:
-    """Run the dispatcher with completion helpers replaced by observable stubs."""
-    result = subprocess.run(
-        [
-            "zsh",
-            "-fc",
-            (
-                'source "$1"; shift; '
-                '_arguments() { print -r -- "arguments:$*"; state=group_command; return 1; }; '
-                '_describe() { local name="${@: -1}"; '
-                'print -r -- "describe:${(j: :)${(P)name}}"; return 0; }; '
-                'words=("$@"); CURRENT=${#words}; curcontext=:completion::; _pdd'
-            ),
-            "zsh",
-            str(COMPLETION),
-            *words,
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
+def _native_completion_output(command: str) -> str:
+    """Complete *command* through Zsh's real interactive completion frame.
+
+    Do not replace `_arguments`, `_describe`, or `state`: doing so can hide
+    positional parsing bugs in the completion function itself.
+    """
+    shell = pexpect.spawn(
+        "zsh", ["-f", "-i"], encoding="utf-8", timeout=5, dimensions=(40, 160)
     )
-    return result.stdout
+    try:
+        shell.expect_exact("% ")
+        shell.sendline("PROMPT='PDD_PROMPT> '")
+        # The first match is echoed input; the second is the rendered prompt.
+        shell.expect_exact("PDD_PROMPT> ")
+        shell.expect_exact("PDD_PROMPT> ")
+        shell.sendline(
+            f"autoload -Uz compinit; compinit -D; source {COMPLETION}; compdef _pdd pdd"
+        )
+        shell.expect_exact("PDD_PROMPT> ")
+        shell.send(command)
+        shell.sendcontrol("i")
+        # Accept the line to make Zsh flush its candidates to the PTY.
+        shell.sendline("")
+        shell.expect_exact("PDD_PROMPT> ")
+        return shell.before
+    finally:
+        shell.close(force=True)
 
 
 def test_zsh_completion_resolves_sync_after_local_global_option() -> None:
@@ -73,6 +79,18 @@ def test_zsh_completion_resolves_current_cli_command_after_global_option() -> No
 def test_zsh_completion_does_not_skip_unknown_global_option() -> None:
     """Misspelled options must not dispatch completion for a later command."""
     assert _resolved_subcommand("pdd", "--modle", "claude", "sync") == ""
+
+
+@pytest.mark.parametrize(
+    "words",
+    [
+        ("pdd", "typo", "sync"),
+        ("pdd", "--", "typo", "sync"),
+    ],
+)
+def test_zsh_completion_stops_at_the_first_invalid_command_token(words: tuple[str, ...]) -> None:
+    """Click treats the first bare token as the command, even after `--`."""
+    assert _resolved_subcommand(*words) == ""
 
 
 @pytest.mark.parametrize(
@@ -129,21 +147,41 @@ def test_zsh_completion_does_not_dispatch_after_eager_global_option(option: str)
 
 
 def test_zsh_completion_dispatches_sync_specific_completion() -> None:
-    """The dispatcher, not just the parser, selects sync completion."""
-    assert "--skip-verify" in _completion_output("pdd", "--local", "sync")
+    """A global option still reaches sync in a real Zsh completion context."""
+    assert "--skip-verify" in _native_completion_output("pdd --local sync --skip-")
+
+
+@pytest.mark.parametrize("prefix", ("--mo", "--context-com"))
+def test_zsh_completion_offers_new_global_options(prefix: str) -> None:
+    """Global option suggestions are tested through `_arguments`, not the scanner."""
+    expected = "--model" if prefix == "--mo" else "--context-compression"
+    assert expected in _native_completion_output(f"pdd {prefix}")
 
 
 @pytest.mark.parametrize(
-    ("group", "command"),
+    ("prefix", "group", "command"),
     [
-        ("auth", "login"),
-        ("templates", "list"),
-        ("contracts", "check"),
-        ("sessions", "cleanup"),
-        ("story", "link"),
-        ("firecrawl-cache", "stats"),
+        ("", "auth", "login"),
+        ("--local ", "auth", "login"),
+        ("", "templates", "list"),
+        ("--local ", "templates", "list"),
+        ("", "contracts", "check"),
+        ("--local ", "contracts", "check"),
+        ("", "sessions", "cleanup"),
+        ("--local ", "sessions", "cleanup"),
+        ("", "story", "link"),
+        ("--local ", "story", "link"),
+        ("", "firecrawl-cache", "stats"),
+        ("--local ", "firecrawl-cache", "stats"),
     ],
 )
-def test_zsh_completion_dispatches_group_subcommands(group: str, command: str) -> None:
-    """Groups reached after a global option offer their registered subcommands."""
-    assert command in _completion_output("pdd", "--local", group)
+def test_zsh_completion_dispatches_group_subcommands(
+    prefix: str, group: str, command: str
+) -> None:
+    """Nested groups work with and without a global option before the root command."""
+    assert command in _native_completion_output(f"pdd {prefix}{group} ")
+
+
+def test_zsh_completion_dispatches_checkup_gate_after_global_option() -> None:
+    """Nested checkup completion is located relative to its resolved command."""
+    assert "--policy" in _native_completion_output("pdd --local checkup gate --po")

--- a/tests/test_zsh_completion.py
+++ b/tests/test_zsh_completion.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 import shutil
 import subprocess
+import time
 
 import pexpect
 import pytest
@@ -41,6 +42,7 @@ def _native_completion_output(command: str) -> str:
     shell = pexpect.spawn(
         "zsh", ["-f", "-i"], encoding="utf-8", timeout=5, dimensions=(40, 160)
     )
+    shell.delaybeforesend = 0.01
     try:
         shell.expect_exact("% ")
         shell.sendline("PROMPT='PDD_PROMPT> '")
@@ -52,11 +54,24 @@ def _native_completion_output(command: str) -> str:
         )
         shell.expect_exact("PDD_PROMPT> ")
         shell.send(command)
+        time.sleep(0.05)
         shell.sendcontrol("i")
-        # Accept the line to make Zsh flush its candidates to the PTY.
-        shell.sendline("")
+        # ZLE renders candidates asynchronously on the PTY.  Drain until it
+        # has been quiet briefly: the first read often contains only the
+        # echoed command, while candidates arrive in a later terminal write.
+        completion_parts: list[str] = []
+        while True:
+            try:
+                completion_parts.append(shell.read_nonblocking(10_000, timeout=0.2))
+            except pexpect.TIMEOUT:
+                break
+        completion_output = "".join(completion_parts)
+        # A unique candidate is inserted into ZLE's buffer rather than printed.
+        # Cancel instead of accepting the buffer: accepting it executes the real
+        # PDD command (which may wait on network or project state).
+        shell.sendcontrol("c")
         shell.expect_exact("PDD_PROMPT> ")
-        return shell.before
+        return completion_output + shell.before
     finally:
         shell.close(force=True)
 

--- a/tests/test_zsh_completion.py
+++ b/tests/test_zsh_completion.py
@@ -15,16 +15,14 @@ pytestmark = pytest.mark.skipif(shutil.which("zsh") is None, reason="requires zs
 
 def _resolved_subcommand(*words: str) -> str:
     """Source the completion file and return its parsed command token."""
-    invocation = " ".join(words)
     result = subprocess.run(
         [
             "zsh",
             "-fc",
-            (
-                f"source {COMPLETION}; "
-                f"words=({invocation}); CURRENT=${{#words}}; "
-                "_pdd_find_subcommand"
-            ),
+            'source "$1"; shift; words=("$@"); CURRENT=${#words}; _pdd_find_subcommand',
+            "zsh",
+            str(COMPLETION),
+            *words,
         ],
         check=True,
         capture_output=True,
@@ -41,3 +39,13 @@ def test_zsh_completion_resolves_sync_after_local_global_option() -> None:
 def test_zsh_completion_skips_value_of_global_option_before_sync() -> None:
     """A global option's value must not be mistaken for the command."""
     assert _resolved_subcommand("pdd", "--context", "local", "sync") == "sync"
+
+
+def test_zsh_completion_resolves_current_cli_command_after_global_option() -> None:
+    """Global options must also work with commands added after this script."""
+    assert _resolved_subcommand("pdd", "--local", "validate") == "validate"
+
+
+def test_zsh_completion_does_not_skip_unknown_global_option() -> None:
+    """Misspelled options must not dispatch completion for a later command."""
+    assert _resolved_subcommand("pdd", "--modle", "claude", "sync") == ""

--- a/tests/test_zsh_completion.py
+++ b/tests/test_zsh_completion.py
@@ -48,7 +48,7 @@ def _native_completion_output(command: str) -> str:
         shell.expect_exact("PDD_PROMPT> ")
         shell.expect_exact("PDD_PROMPT> ")
         shell.sendline(
-            f"autoload -Uz compinit; compinit -D; source {COMPLETION}; compdef _pdd pdd"
+            f"autoload -Uz compinit; compinit -D -i; source {COMPLETION}; compdef _pdd pdd"
         )
         shell.expect_exact("PDD_PROMPT> ")
         shell.send(command)

--- a/tests/test_zsh_completion.py
+++ b/tests/test_zsh_completion.py
@@ -1,11 +1,16 @@
 """Regression tests for the shipped Zsh completion dispatcher."""
 
 from pathlib import Path
+import shutil
 import subprocess
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPLETION = ROOT / "pdd" / "pdd_completion.zsh"
+
+pytestmark = pytest.mark.skipif(shutil.which("zsh") is None, reason="requires zsh")
 
 
 def _resolved_subcommand(*words: str) -> str:


### PR DESCRIPTION
Fixes #2377

## Summary
- resolve the first known PDD subcommand after any preceding global options
- preserve normal `pdd sync` completion while supporting `pdd --local sync`
- update the Zsh completion prompt contract and add regression coverage

## Validation
- `conda run -n pdd python -m pytest tests/test_zsh_completion.py -q`
- `zsh -n pdd/pdd_completion.zsh`