### PR TITLE
Fix story prompt metadata paths for nested prompts

### DIFF
--- a/.pdd/verification-profiles.json
+++ b/.pdd/verification-profiles.json
@@ -10351,7 +10351,7 @@
       "prompt_path": "pdd/prompts/user_story_tests_python.prompt",
       "language_id": "python",
       "required_requirement_ids": [
-        "CONTRACT-SHA256:1c467034344d9d87b8225995bc458bc8093e6759dd5c2eed8424b345f69a3ba7"
+        "CONTRACT-SHA256:5b1353257a64a25b303d990803bb799da66504af558c3a5e972d95ad5a04bb3b"
       ],
       "obligations": [
         {
@@ -10360,7 +10360,7 @@
           "validator_id": "threshold-ed25519",
           "validator_config_digest": "threshold-ed25519-v1",
           "requirement_ids": [
-            "CONTRACT-SHA256:1c467034344d9d87b8225995bc458bc8093e6759dd5c2eed8424b345f69a3ba7"
+            "CONTRACT-SHA256:5b1353257a64a25b303d990803bb799da66504af558c3a5e972d95ad5a04bb3b"
           ],
           "artifact_paths": [
             "pdd/prompts/user_story_tests_python.prompt"

--- a/pdd/commands/analysis.py
+++ b/pdd/commands/analysis.py
@@ -22,6 +22,7 @@ from ..crash_main import crash_main
 from ..trace_main import trace_main
 from ..user_story_tests import (
     _parse_story_prompt_metadata,
+    _resolve_authorized_story_prompt_metadata_reference,
     discover_prompt_files,
     discover_story_files,
     run_user_story_tests,
@@ -181,7 +182,8 @@ def _scope_manifest_metadata_matches(scope: _StoryScopeManifest) -> bool:
     notices the disagreement after the fact.
     """
     for story in scope.stories:
-        expected = {path.resolve() for path in scope.story_prompts[story]}
+        authorized_prompts = scope.story_prompts[story]
+        expected = set(authorized_prompts)
         try:
             references = _parse_story_prompt_metadata(story.read_text(encoding="utf-8"))
         except (OSError, UnicodeError, ValueError):
@@ -189,16 +191,14 @@ def _scope_manifest_metadata_matches(scope: _StoryScopeManifest) -> bool:
 
         actual: set[Path] = set()
         for reference in references:
-            for candidate in (
-                scope.project_root / reference,
-                scope.project_root / Path(reference).name,
-            ):
-                try:
-                    if candidate.is_file():
-                        actual.add(candidate.resolve())
-                        break
-                except (OSError, RuntimeError, ValueError):
-                    continue
+            resolved = _resolve_authorized_story_prompt_metadata_reference(
+                reference,
+                project_root=scope.project_root,
+                authorized_prompts=authorized_prompts,
+            )
+            if resolved is None:
+                return False
+            actual.add(resolved)
         if actual != expected:
             return False
     return True

--- a/pdd/prompts/user_story_tests_python.prompt
+++ b/pdd/prompts/user_story_tests_python.prompt
@@ -284,6 +284,8 @@ R2 (MUST NOT): Print the diagnostic block when `quiet` is true.
      and `{prompts_dir.name}/{relative_prompt_path}`. In particular, when `--prompts-dir`
      is absolute, a metadata ref like `prompts/foo_python.prompt` must still resolve
      to that prompt under the supplied prompts directory.
+   - When writing or refreshing metadata, resolve both paths, preserve nested
+     directories, and write `prompts/<relative_prompt_path>` (not a basename).
    - Expose a **public, documented `story_id` helper** that returns the `<slug>`
      of a `story__<slug>.md` path (accepting a `str` or `Path`), so the
      `@pytest.mark.story` marker mechanism and the story files share one identity

--- a/pdd/story_detection_result.py
+++ b/pdd/story_detection_result.py
@@ -20,6 +20,7 @@ from .user_story_tests import (
     CONTRACT_SUFFIX,
     STORY_PREFIX,
     _parse_story_prompt_metadata,
+    _resolve_authorized_story_prompt_metadata_reference,
 )
 
 SCHEMA_VERSION = "pdd.detect.stories.v1"
@@ -316,6 +317,15 @@ def build_story_detection_document(
                 )
             )
         linked = sorted(_safe_reference(ref) for ref in linked_refs)
+        manifest_prompts = (
+            tuple(
+                Path(path)
+                for path in manifest_story_prompts.get(story_resolved, ())
+            )
+            if manifest_story_prompts is not None
+            else None
+        )
+        manifest_actual: set[Path] = set()
 
         contract_valid = _is_regular_in_scope(
             contract,
@@ -338,21 +348,20 @@ def build_story_detection_document(
                 )
             )
         for prompt_ref in linked_refs:
-            if allowed_prompt_files is not None:
-                allowed = tuple(Path(candidate).resolve() for candidate in allowed_prompt_files)
-                candidates = (
-                    project_root / prompt_ref,
-                    prompts_dir / prompt_ref,
-                    prompts_dir / Path(prompt_ref).name,
+            if manifest_prompts is not None:
+                resolved = _resolve_authorized_story_prompt_metadata_reference(
+                    prompt_ref,
+                    project_root=project_root,
+                    authorized_prompts=manifest_prompts,
                 )
-                resolved = next(
-                    (
-                        candidate.resolve()
-                        for candidate in candidates
-                        if candidate.is_file()
-                        and candidate.resolve() in allowed
-                    ),
-                    None,
+                if resolved is not None:
+                    manifest_actual.add(resolved)
+                prompt_in_scope = resolved is not None
+            elif allowed_prompt_files is not None:
+                resolved = _resolve_authorized_story_prompt_metadata_reference(
+                    prompt_ref,
+                    project_root=project_root,
+                    authorized_prompts=allowed_prompt_files,
                 )
                 prompt_in_scope = resolved is not None
             else:
@@ -379,8 +388,10 @@ def build_story_detection_document(
                     )
                 )
                 continue
-            if allowed_prompt_files is not None:
-                prompt_in_scope = resolved in allowed
+            if manifest_prompts is not None or allowed_prompt_files is not None:
+                # The supplied prompt pool is the only resolution source in
+                # scoped modes; do not discover a different on-disk prompt.
+                prompt_in_scope = True
             else:
                 try:
                     resolved.relative_to(prompts_dir.resolve())
@@ -405,29 +416,14 @@ def build_story_detection_document(
                         f"{_safe_reference(prompt_ref)}",
                     )
                 )
-        if manifest_story_prompts is not None:
-            expected = {
-                Path(path).resolve()
-                for path in manifest_story_prompts.get(story_resolved, ())
-            }
-            actual: set[Path] = set()
-            for prompt_ref in linked_refs:
-                for candidate in (
-                    project_root / prompt_ref,
-                    prompts_dir / prompt_ref,
-                    prompts_dir / Path(prompt_ref).name,
-                ):
-                    if candidate.is_file():
-                        actual.add(candidate.resolve())
-                        break
-            if actual != expected:
-                errors.append(
-                    StoryDiagnostic(
-                        "scope:MANIFEST_MISMATCH",
-                        "error",
-                        "Story prompt metadata does not match the exact scope manifest.",
-                    )
+        if manifest_prompts is not None and manifest_actual != set(manifest_prompts):
+            errors.append(
+                StoryDiagnostic(
+                    "scope:MANIFEST_MISMATCH",
+                    "error",
+                    "Story prompt metadata does not match the exact scope manifest.",
                 )
+            )
         if len(rows) != 1:
             code = (
                 "detector:INCOMPLETE_RESULT"

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -265,6 +265,17 @@ _STORY_PROMPT_PHASE_A_STATIONARY_PROFILE_BYTES = (
     _STORY_PROMPT_PHASE_A_PROFILE_BYTES[1],
     _STORY_PROMPT_PHASE_A_PROFILE_BYTES[1],
 )
+# Phase B consumes the protected dormant user-story row while retaining the
+# exact Phase-A policy bytes. These profile pairs retain prior historical
+# overlays only; the policy row remains the sole transition authority.
+_STORY_PROMPT_PHASE_B_PROFILE_BYTES = (
+    _STORY_PROMPT_PHASE_A_PROFILE_BYTES[1],
+    "6e765e03761e7dd678e5b02b147c60231c13fc8ab3de3fd722cf1181c017acb7",
+)
+_STORY_PROMPT_PHASE_B_STATIONARY_PROFILE_BYTES = (
+    _STORY_PROMPT_PHASE_B_PROFILE_BYTES[1],
+    _STORY_PROMPT_PHASE_B_PROFILE_BYTES[1],
+)
 _PR2316_STALE_LLM_REISSUE_HISTORY_PROFILE_BYTES = (
     _OPUS_FABLE_COMPOSED_PROFILE_BYTES[1],
     _TEMPERATURE_REGRESSION_PROFILE_BYTES[1],
@@ -3128,6 +3139,22 @@ def _load_requirement_transition_authorizations(
             ),
         }
     )
+    story_prompt_phase_b_state = is_pdd_repository and (
+        (policy_digests, profile_digests)
+        in {
+            (
+                _STORY_PROMPT_PHASE_A_STATIONARY_POLICY_BYTES,
+                _STORY_PROMPT_PHASE_B_PROFILE_BYTES,
+            ),
+            (
+                _STORY_PROMPT_PHASE_A_STATIONARY_POLICY_BYTES,
+                _STORY_PROMPT_PHASE_B_STATIONARY_PROFILE_BYTES,
+            ),
+        }
+    )
+    story_prompt_historical_state = (
+        story_prompt_phase_a_state or story_prompt_phase_b_state
+    )
     generate_reliability_state = is_pdd_repository and (
         (policy_digests, profile_digests)
         in {
@@ -3197,7 +3224,7 @@ def _load_requirement_transition_authorizations(
         }
     )
     code_generator_language_gate_state = is_pdd_repository and (
-        story_prompt_phase_a_state
+        story_prompt_historical_state
         or (policy_digests, profile_digests)
         in {
             (
@@ -3238,7 +3265,7 @@ def _load_requirement_transition_authorizations(
         }
     )
     zsh_global_option_state = is_pdd_repository and (
-        story_prompt_phase_a_state
+        story_prompt_historical_state
         or (policy_digests, profile_digests)
         in {
             (
@@ -3274,7 +3301,7 @@ def _load_requirement_transition_authorizations(
         }
     )
     pr2376_dependency_fix_state = is_pdd_repository and (
-        story_prompt_phase_a_state
+        story_prompt_historical_state
         or (policy_digests, profile_digests)
         in {
             (

--- a/pdd/user_story_tests.py
+++ b/pdd/user_story_tests.py
@@ -315,7 +315,11 @@ def _prompt_reference_for_metadata(
     """Return a stable metadata reference for a prompt path."""
     if prompts_dir:
         try:
-            return prompt_path.relative_to(prompts_dir).as_posix()
+            logical_prompts_dir = Path(prompts_dir)
+            relative_prompt_path = prompt_path.resolve().relative_to(
+                logical_prompts_dir.resolve()
+            )
+            return (Path(logical_prompts_dir.name) / relative_prompt_path).as_posix()
         except ValueError:
             pass
     return prompt_path.name

--- a/pdd/user_story_tests.py
+++ b/pdd/user_story_tests.py
@@ -531,7 +531,7 @@ def cache_story_prompt_links(  # pylint: disable=too-many-arguments,too-many-loc
     if not prompt_files:
         return False, "No prompt files found to link user story metadata.", 0.0, "", []
 
-    prompts_root = _resolve_prompts_dir(prompts_dir) if prompts_dir else None
+    prompts_root = _resolve_prompts_dir(prompts_dir)
     story_content = _read_story(story_path)
 
     # Explicit prompt inputs are authoritative: `pdd story link --prompt` and
@@ -1389,7 +1389,7 @@ def sync_user_story_contract(  # pylint: disable=too-many-arguments,too-many-loc
             str(contract_p),
         )
 
-    prompts_root = _resolve_prompts_dir(prompts_dir) if prompts_dir else None
+    prompts_root = _resolve_prompts_dir(prompts_dir)
     heading = _issue_title_from_markdown(story_text)
     if heading and heading.lower().startswith("user story:"):
         heading = heading.split(":", 1)[1].strip()
@@ -1490,7 +1490,7 @@ def generate_user_story(  # pylint: disable=too-many-arguments,too-many-locals,t
             [],
         )
 
-    prompts_root = _resolve_prompts_dir(prompts_dir) if prompts_dir else None
+    prompts_root = _resolve_prompts_dir(prompts_dir)
 
     # Resolve the issue source (URL / number / local markdown) BEFORE any LLM
     # call. The issue -- not the prompt -- is the behavioral input.
@@ -1659,7 +1659,7 @@ def run_user_story_tests(  # pylint: disable=too-many-arguments,redefined-outer-
         prompts_dir, include_llm=include_llm_prompts
     )
     story_files = story_files or discover_story_files(stories_dir)
-    prompts_root = _resolve_prompts_dir(prompts_dir) if prompts_dir else None
+    prompts_root = _resolve_prompts_dir(prompts_dir)
 
     if not story_files:
         return True, [], 0.0, ""

--- a/pdd/user_story_tests.py
+++ b/pdd/user_story_tests.py
@@ -241,6 +241,76 @@ def _parse_story_prompt_metadata(story_content: str) -> List[str]:
     return [entry.strip() for entry in raw.split(",") if entry.strip()]
 
 
+def _story_prompt_metadata_reference_parts(reference: str) -> tuple[str, ...] | None:
+    """Return safe logical-path parts for an authorization metadata reference."""
+    if not reference or reference != reference.strip():
+        return None
+    if reference.startswith("/") or "\\" in reference or ":" in reference:
+        return None
+    if any(ord(character) < 32 for character in reference):
+        return None
+    parts = tuple(reference.split("/"))
+    if any(not part or part in {".", ".."} for part in parts):
+        return None
+    return parts
+
+
+def _resolve_authorized_story_prompt_metadata_reference(
+    reference: str,
+    *,
+    project_root: Path,
+    authorized_prompts: Iterable[Path],
+    case_sensitive: bool = True,
+) -> Optional[Path]:
+    """Resolve metadata only against one caller-authorized prompt collection.
+
+    Canonical metadata is project-relative. Historical metadata may be a
+    logical suffix or bare basename, but those forms are accepted only when
+    they identify exactly one supplied prompt. This intentionally performs no
+    filesystem prompt discovery: metadata is an authorization input in exact
+    scope mode.
+    """
+    reference_parts = _story_prompt_metadata_reference_parts(reference)
+    if reference_parts is None:
+        return None
+    if not case_sensitive:
+        reference_parts = tuple(part.casefold() for part in reference_parts)
+
+    if not project_root.is_absolute():
+        return None
+
+    matches: List[Path] = []
+    for prompt in authorized_prompts:
+        try:
+            authorized_prompt = Path(prompt)
+            if not authorized_prompt.is_absolute():
+                authorized_prompt = project_root / authorized_prompt
+            logical_parts = tuple(
+                authorized_prompt.relative_to(project_root).as_posix().split("/")
+            )
+        except ValueError:
+            # Callers supply an already-validated collection. If that promise
+            # is broken, fail closed instead of finding a substitute on disk.
+            return None
+        if any(part in {"", ".", ".."} for part in logical_parts):
+            return None
+        if not case_sensitive:
+            logical_parts = tuple(part.casefold() for part in logical_parts)
+
+        if reference_parts == logical_parts:
+            matches.append(authorized_prompt)
+        elif len(reference_parts) == 1:
+            if reference_parts[0] == logical_parts[-1]:
+                matches.append(authorized_prompt)
+        elif (
+            len(reference_parts) < len(logical_parts)
+            and logical_parts[-len(reference_parts) :] == reference_parts
+        ):
+            matches.append(authorized_prompt)
+
+    return matches[0] if len(matches) == 1 else None
+
+
 def parse_story_dev_unit_metadata(story_text: str) -> list[str]:
     """Extract dev-unit references from optional pdd-story-dev-units metadata."""
     match = STORY_DEV_UNITS_METADATA_RE.search(story_text)
@@ -409,6 +479,27 @@ def _resolve_prompt_refs_to_paths(
     return _dedupe_prompt_paths(resolved_paths)
 
 
+def _resolve_existing_story_metadata_reference(
+    prompt_ref: str,
+    prompt_files: List[Path],
+    prompts_root: Optional[Path],
+) -> Optional[Path]:
+    """Resolve existing metadata without guessing between legacy aliases."""
+    if prompts_root is None:
+        return None
+    try:
+        project_root = prompts_root.resolve().parent
+        authorized_prompts = tuple(path.resolve() for path in prompt_files)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return _resolve_authorized_story_prompt_metadata_reference(
+        prompt_ref,
+        project_root=project_root,
+        authorized_prompts=authorized_prompts,
+        case_sensitive=False,
+    )
+
+
 def _resolve_src_dir(prompts_dir: Path) -> Path:
     """Resolve source directory from PDD_SRC_DIR or default to ../src from prompts_dir."""
     resolved = os.environ.get("PDD_SRC_DIR")
@@ -502,7 +593,7 @@ def _select_story_prompt_links(
     return _dedupe_prompt_paths(prompt_files), "all_prompts"
 
 
-def cache_story_prompt_links(  # pylint: disable=too-many-arguments,too-many-locals,too-many-return-statements,too-many-branches
+def cache_story_prompt_links(  # pylint: disable=too-many-arguments,too-many-locals,too-many-return-statements,too-many-branches,too-many-statements
     *,
     story_file: str,
     prompts_dir: Optional[str] = None,
@@ -585,25 +676,45 @@ def cache_story_prompt_links(  # pylint: disable=too-many-arguments,too-many-loc
         return True, message, 0.0, "", linked_refs
 
     # Keep existing valid metadata unchanged unless force_relink is requested.
+    # Legacy basename metadata is still resolvable, but normalize it through
+    # the same canonical writer so later exact-scope preflight can compare
+    # project-relative references without discovering prompts on disk.
     existing_refs = _parse_story_prompt_metadata(story_content)
     if existing_refs and not force_relink:
         unresolved_refs: List[str] = []
-        resolved_refs: List[str] = []
+        resolved_paths: List[Path] = []
         for ref in existing_refs:
-            resolved = _resolve_prompt_path(ref, prompt_files, prompts_root)
+            resolved = _resolve_existing_story_metadata_reference(
+                ref, prompt_files, prompts_root
+            )
             if resolved:
-                resolved_refs.append(
-                    _prompt_reference_for_metadata(resolved, prompts_root)
-                )
+                resolved_paths.append(resolved)
             else:
                 unresolved_refs.append(ref)
-        if resolved_refs and not unresolved_refs:
+        if resolved_paths and not unresolved_refs:
+            linked_prompt_paths = _dedupe_prompt_paths(resolved_paths)
+            linked_refs = sorted(
+                {
+                    _prompt_reference_for_metadata(path.resolve(), prompts_root)
+                    for path in linked_prompt_paths
+                }
+            )
+            updated = _upsert_story_prompt_metadata(
+                story_path,
+                story_content,
+                linked_prompt_paths,
+                prompts_root,
+            )
             return (
                 True,
-                "Story already contains prompt metadata.",
+                (
+                    "Story prompt metadata canonicalized."
+                    if updated
+                    else "Story already contains prompt metadata."
+                ),
                 0.0,
                 "",
-                sorted(set(resolved_refs)),
+                linked_refs,
             )
 
     detection_error = ""

--- a/tests/commands/test_analysis.py
+++ b/tests/commands/test_analysis.py
@@ -1231,6 +1231,102 @@ def test_scope_manifest_accepts_nested_logical_prompt_metadata(tmp_path, monkeyp
     assert mock_runner.call_args.kwargs["prompt_files"] == [nested_prompt]
 
 
+@pytest.mark.parametrize(
+    "metadata_ref",
+    ["conformance/demo.prompt", "demo.prompt"],
+)
+def test_scope_manifest_accepts_unique_legacy_prompt_metadata(
+    tmp_path, monkeypatch, metadata_ref
+):
+    """Legacy suffix and basename refs are safe only when entry-local unique."""
+    stories, prompts, story, manifest = _write_scope_manifest(
+        tmp_path, prompt_ref="prompts/conformance/demo.prompt"
+    )
+    nested_prompt = prompts / "conformance" / "demo.prompt"
+    nested_prompt.parent.mkdir()
+    nested_prompt.write_text("prompt", encoding="utf-8")
+    story.write_text(
+        f"<!-- pdd-story-prompts: {metadata_ref} -->\n## Story\nOK",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    with patch("pdd.commands.analysis.run_user_story_tests") as mock_runner:
+        mock_runner.return_value = (
+            True,
+            [{"story": str(story), "passed": True, "changes": []}],
+            0.0,
+            "model-safe",
+        )
+        result = CliRunner().invoke(
+            detect_change,
+            ["--stories", "--scope-manifest", str(manifest)],
+            obj={},
+        )
+
+    assert result.exit_code == 0, (result.output, mock_runner.call_args)
+    assert mock_runner.call_args.kwargs["prompt_files"] == [nested_prompt]
+
+
+def test_scope_manifest_rejects_ambiguous_legacy_prompt_basename(tmp_path, monkeypatch):
+    """A basename cannot expand the entry's prompt authorization boundary."""
+    stories, prompts, story, manifest = _write_scope_manifest(tmp_path)
+    first_prompt = prompts / "first" / "demo.prompt"
+    second_prompt = prompts / "second" / "demo.prompt"
+    first_prompt.parent.mkdir()
+    second_prompt.parent.mkdir()
+    first_prompt.write_text("first", encoding="utf-8")
+    second_prompt.write_text("second", encoding="utf-8")
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    payload["stories"][0]["prompts"] = [
+        "prompts/first/demo.prompt",
+        "prompts/second/demo.prompt",
+    ]
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+    story.write_text(
+        "<!-- pdd-story-prompts: demo.prompt -->\n## Story\nOK",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    with patch("pdd.commands.analysis.run_user_story_tests") as mock_runner:
+        result = CliRunner().invoke(
+            detect_change,
+            ["--stories", "--scope-manifest", str(manifest), "--json"],
+            obj={},
+        )
+
+    assert result.exit_code == 3
+    mock_runner.assert_not_called()
+    assert json.loads(result.output)["errors"][0]["code"] == "scope:MANIFEST_MISMATCH"
+
+
+@pytest.mark.parametrize(
+    "metadata_ref",
+    ["<absolute>", "../prompts/a.prompt", "./prompts/a.prompt", "prompts//a.prompt", "missing.prompt"],
+)
+def test_scope_manifest_rejects_unsafe_or_unresolved_prompt_metadata(
+    tmp_path, monkeypatch, metadata_ref
+):
+    """Metadata aliases must not bypass exact-scope logical path validation."""
+    stories, prompts, story, manifest = _write_scope_manifest(tmp_path)
+    if metadata_ref == "<absolute>":
+        metadata_ref = str(prompts / "a.prompt")
+    story.write_text(
+        f"<!-- pdd-story-prompts: {metadata_ref} -->\n## Story\nOK",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    with patch("pdd.commands.analysis.run_user_story_tests") as mock_runner:
+        result = CliRunner().invoke(
+            detect_change,
+            ["--stories", "--scope-manifest", str(manifest), "--json"],
+            obj={},
+        )
+
+    assert result.exit_code == 3
+    mock_runner.assert_not_called()
+    assert json.loads(result.output)["errors"][0]["code"] == "scope:MANIFEST_MISMATCH"
+
+
 def test_scope_manifest_allows_shared_prompt_across_distinct_stories(
     tmp_path, monkeypatch
 ):

--- a/tests/commands/test_analysis.py
+++ b/tests/commands/test_analysis.py
@@ -1201,6 +1201,36 @@ def test_scope_manifest_preserves_exact_scope_and_rejects_discovery(
     assert payload["scope"]["contracts"] == ["stories/contracts/ok.contract.md"]
 
 
+def test_scope_manifest_accepts_nested_logical_prompt_metadata(tmp_path, monkeypatch):
+    """Metadata written for nested prompts must pass exact-scope preflight."""
+    stories, prompts, story, manifest = _write_scope_manifest(
+        tmp_path, prompt_ref="prompts/conformance/demo.prompt"
+    )
+    nested_prompt = prompts / "conformance" / "demo.prompt"
+    nested_prompt.parent.mkdir()
+    nested_prompt.write_text("prompt", encoding="utf-8")
+    story.write_text(
+        "<!-- pdd-story-prompts: prompts/conformance/demo.prompt -->\n## Story\nOK",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    with patch("pdd.commands.analysis.run_user_story_tests") as mock_runner:
+        mock_runner.return_value = (
+            True,
+            [{"story": str(story), "passed": True, "changes": []}],
+            0.0,
+            "model-safe",
+        )
+        result = CliRunner().invoke(
+            detect_change,
+            ["--stories", "--scope-manifest", str(manifest)],
+            obj={},
+        )
+
+    assert result.exit_code == 0
+    assert mock_runner.call_args.kwargs["prompt_files"] == [nested_prompt]
+
+
 def test_scope_manifest_allows_shared_prompt_across_distinct_stories(
     tmp_path, monkeypatch
 ):

--- a/tests/commands/test_story.py
+++ b/tests/commands/test_story.py
@@ -1012,6 +1012,45 @@ class TestStoryLink:
             )
             assert "adder_python.prompt" in content, content
 
+    def test_link_default_path_preserves_nested_prompt_path(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """#2379: the *default* `pdd story link` invocation (no --prompts-dir)
+        must preserve nested prompt subdirectories rather than collapsing them
+        to a bare basename.
+
+        Reproduces the exact default-CLI boundary a reviewer flagged on PR
+        #2380: `prompts_root` was only resolved when `--prompts-dir` was
+        explicitly passed, so the ordinary (unflagged) `story link` workflow
+        still wrote a lossy basename and failed the scope-manifest preflight.
+        """
+        with runner.isolated_filesystem(temp_dir=tmp_path) as fs:
+            root = Path(fs)
+            nested_prompt = root / "prompts" / "conformance" / "demo.prompt"
+            nested_prompt.parent.mkdir(parents=True, exist_ok=True)
+            nested_prompt.write_text("% demo prompt\n", encoding="utf-8")
+
+            story_file = root / "user_stories" / "story__demo.md"
+            story_file.parent.mkdir(parents=True, exist_ok=True)
+            story_file.write_text("## Story\nAs a user, I want a demo.\n", encoding="utf-8")
+
+            result = runner.invoke(
+                story,
+                [
+                    "link",
+                    str(story_file),
+                    "--prompt", "prompts/conformance/demo.prompt",
+                ],
+                obj={"quiet": True, "verbose": False},
+            )
+
+            assert result.exit_code == 0, result.output
+            content = story_file.read_text(encoding="utf-8")
+            assert "<!-- pdd-story-prompts: prompts/conformance/demo.prompt -->" in content, (
+                f"nested prompt path collapsed to a basename on the default "
+                f"(no --prompts-dir) CLI path: {content!r}"
+            )
+
 
 # ---------------------------------------------------------------------------
 # Scenario 8b: --with-regression-status honesty + project-root resolution (#1889)

--- a/tests/test_story_detection_result.py
+++ b/tests/test_story_detection_result.py
@@ -61,6 +61,104 @@ def test_missing_contract_must_not_be_reported_pass(tmp_path):
     assert payload["errors"][0]["code"] == "story:MISSING_CONTRACT"
 
 
+def test_manifest_builder_accepts_unique_legacy_prompt_basename(tmp_path):
+    """A legacy basename resolves only through this story's manifest entry."""
+    stories, prompts, story = _scope(tmp_path)
+    nested_prompt = prompts / "conformance" / "demo.prompt"
+    nested_prompt.parent.mkdir()
+    nested_prompt.write_text("prompt", encoding="utf-8")
+    # This same-named file is deliberately not authorized. The builder must
+    # not inspect it while resolving the legacy basename.
+    (tmp_path / "demo.prompt").write_text("outside", encoding="utf-8")
+    story.write_text(
+        "<!-- pdd-story-prompts: demo.prompt -->\n## Story", encoding="utf-8"
+    )
+    contract = stories / "contracts" / "payment.contract.md"
+
+    payload = build_story_detection_document(
+        story_files=[story],
+        raw_results=[{"story": str(story), "passed": True}],
+        passed=True,
+        total_cost=0.0,
+        model="model",
+        project_root=tmp_path,
+        stories_dir=stories,
+        prompts_dir=prompts,
+        contract_files={story.resolve(): contract},
+        allowed_prompt_files=[nested_prompt],
+        manifest_story_prompts={story.resolve(): [nested_prompt]},
+        include_llm=False,
+        fail_fast=True,
+        read_only=True,
+    )
+
+    assert payload["all_pass"] is True
+    assert payload["results"][0]["verdict"] == "PASS"
+    assert not payload["results"][0]["errors"]
+
+
+def test_manifest_builder_rejects_ambiguous_legacy_prompt_basename(tmp_path):
+    """A basename shared by two authorized prompts fails closed."""
+    stories, prompts, story = _scope(tmp_path)
+    first_prompt = prompts / "first" / "demo.prompt"
+    second_prompt = prompts / "second" / "demo.prompt"
+    first_prompt.parent.mkdir()
+    second_prompt.parent.mkdir()
+    first_prompt.write_text("first", encoding="utf-8")
+    second_prompt.write_text("second", encoding="utf-8")
+    story.write_text(
+        "<!-- pdd-story-prompts: demo.prompt -->\n## Story", encoding="utf-8"
+    )
+    contract = stories / "contracts" / "payment.contract.md"
+
+    payload = build_story_detection_document(
+        story_files=[story],
+        raw_results=[{"story": str(story), "passed": True}],
+        passed=True,
+        total_cost=0.0,
+        model="model",
+        project_root=tmp_path,
+        stories_dir=stories,
+        prompts_dir=prompts,
+        contract_files={story.resolve(): contract},
+        allowed_prompt_files=[first_prompt, second_prompt],
+        manifest_story_prompts={story.resolve(): [first_prompt, second_prompt]},
+        include_llm=False,
+        fail_fast=True,
+        read_only=True,
+    )
+
+    assert payload["all_pass"] is False
+    assert payload["results"][0]["verdict"] == "UNKNOWN"
+    assert {error["code"] for error in payload["results"][0]["errors"]} >= {
+        "prompt:UNRESOLVED_LINK",
+        "scope:MANIFEST_MISMATCH",
+    }
+
+
+def test_structured_builder_accepts_relative_authorized_prompt_pool(tmp_path):
+    """Non-manifest structured mode keeps its relative prompt-pool support."""
+    stories, prompts, story = _scope(tmp_path)
+
+    payload = build_story_detection_document(
+        story_files=[story],
+        raw_results=[{"story": str(story), "passed": True}],
+        passed=True,
+        total_cost=0.0,
+        model="model",
+        project_root=tmp_path,
+        stories_dir=stories,
+        prompts_dir=prompts,
+        allowed_prompt_files=[Path("prompts/payment.prompt")],
+        include_llm=False,
+        fail_fast=True,
+        read_only=True,
+    )
+
+    assert payload["all_pass"] is True
+    assert payload["results"][0]["verdict"] == "PASS"
+
+
 def test_duplicate_verdict_must_be_unknown(tmp_path):
     stories, prompts, story = _scope(tmp_path)
     rows = [

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -2646,6 +2646,12 @@ def test_sync_rollout_repair_executes_the_actual_protected_transition() -> None:
             verification._SYNC_ROLLOUT_REPAIR_PROFILE_BYTES[0],  # pylint: disable=protected-access
             verification._PR2376_DEPENDENCY_FIX_PROFILE_BYTES[1],  # pylint: disable=protected-access
         ),
+        # Phase B consumes the preauthorized story row without changing this
+        # historical repair's policy or prompt bytes.
+        (
+            verification._SYNC_ROLLOUT_REPAIR_PROFILE_BYTES[0],  # pylint: disable=protected-access
+            verification._STORY_PROMPT_PHASE_B_PROFILE_BYTES[1],  # pylint: disable=protected-access
+        ),
     }
     assert (
         hashlib.sha256(_git_blob(SYNC_ROLLOUT_PROTECTED_BASE, ROTATION_FILE)).hexdigest(),

--- a/tests/test_user_story_tests.py
+++ b/tests/test_user_story_tests.py
@@ -11,6 +11,7 @@ import pytest
 from pdd.user_story_tests import (
     _contract_path_for_story,
     _prompt_reference_for_metadata,
+    _resolve_authorized_story_prompt_metadata_reference,
     _story_content_hash,
     cache_story_prompt_links,
     discover_prompt_files,
@@ -519,9 +520,10 @@ def test_cache_story_prompt_links_skips_existing_valid_metadata(tmp_path):
     (prompts_dir / "one_python.prompt").write_text("prompt one", encoding="utf-8")
     story = stories_dir / "story__existing.md"
     story.write_text(
-        "<!-- pdd-story-prompts: one_python.prompt -->\n\nAs a user...",
+        "<!-- pdd-story-prompts: prompts/one_python.prompt -->\n\nAs a user...",
         encoding="utf-8",
     )
+    original_story = story.read_bytes()
 
     with patch("pdd.user_story_tests.detect_change") as mock_detect:
         success, message, cost, model, linked_prompts = cache_story_prompt_links(
@@ -534,7 +536,121 @@ def test_cache_story_prompt_links_skips_existing_valid_metadata(tmp_path):
     assert cost == 0.0
     assert model == ""
     assert linked_prompts == ["prompts/one_python.prompt"]
+    assert story.read_bytes() == original_story
     mock_detect.assert_not_called()
+
+
+def test_authorized_story_metadata_resolution_uses_only_supplied_paths(
+    tmp_path, monkeypatch
+):
+    """Exact-scope metadata resolution never probes the filesystem."""
+    project_root = tmp_path / "project"
+    prompt = project_root / "prompts" / "conformance" / "demo.prompt"
+
+    def fail_filesystem_probe(*_args, **_kwargs):
+        raise AssertionError("scoped metadata resolution must not probe the filesystem")
+
+    monkeypatch.setattr(Path, "is_file", fail_filesystem_probe)
+    monkeypatch.setattr(Path, "resolve", fail_filesystem_probe)
+
+    assert _resolve_authorized_story_prompt_metadata_reference(
+        "demo.prompt",
+        project_root=project_root,
+        authorized_prompts=[prompt],
+    ) == prompt
+
+
+@pytest.mark.parametrize("metadata_ref", ["demo.prompt", "DEMO.PROMPT"])
+def test_cache_story_prompt_links_canonicalizes_existing_legacy_metadata(
+    tmp_path, metadata_ref
+):
+    """A no-LLM refresh upgrades a uniquely resolvable legacy basename."""
+    prompts_dir = tmp_path / "prompts"
+    stories_dir = tmp_path / "user_stories"
+    prompts_dir.mkdir()
+    stories_dir.mkdir()
+
+    nested_prompt = prompts_dir / "conformance" / "demo.prompt"
+    nested_prompt.parent.mkdir()
+    nested_prompt.write_text("prompt", encoding="utf-8")
+    story = stories_dir / "story__existing.md"
+    story.write_text(
+        f"<!-- pdd-story-prompts: {metadata_ref} -->\n\nAs a user...",
+        encoding="utf-8",
+    )
+
+    with patch("pdd.user_story_tests.detect_change") as mock_detect:
+        success, message, cost, model, linked_prompts = cache_story_prompt_links(
+            story_file=str(story),
+            prompts_dir=str(prompts_dir),
+        )
+
+    assert success is True
+    assert message == "Story prompt metadata canonicalized."
+    assert cost == 0.0
+    assert model == ""
+    assert linked_prompts == ["prompts/conformance/demo.prompt"]
+    assert (
+        "<!-- pdd-story-prompts: prompts/conformance/demo.prompt -->"
+        in story.read_text(encoding="utf-8")
+    )
+    mock_detect.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("metadata_ref", "first_relative_path"),
+    [
+        ("demo.prompt", "first/demo.prompt"),
+        ("shared/demo.prompt", "first/shared/demo.prompt"),
+    ],
+)
+def test_cache_story_prompt_links_does_not_guess_ambiguous_legacy_metadata(
+    tmp_path, metadata_ref, first_relative_path
+):
+    """Ambiguous basename and suffix metadata must fall through to detection."""
+    prompts_dir = tmp_path / "prompts"
+    stories_dir = tmp_path / "user_stories"
+    prompts_dir.mkdir()
+    stories_dir.mkdir()
+
+    first_prompt = prompts_dir / first_relative_path
+    second_prompt = prompts_dir / first_relative_path.replace("first/", "second/", 1)
+    first_prompt.parent.mkdir(parents=True)
+    second_prompt.parent.mkdir(parents=True)
+    first_prompt.write_text("first", encoding="utf-8")
+    second_prompt.write_text("second", encoding="utf-8")
+    story = stories_dir / "story__existing.md"
+    story.write_text(
+        f"<!-- pdd-story-prompts: {metadata_ref} -->\n\nAs a user...",
+        encoding="utf-8",
+    )
+
+    with patch("pdd.user_story_tests.detect_change") as mock_detect:
+        mock_detect.return_value = (
+            [
+                {
+                    "prompt_name": f"prompts/{first_relative_path}",
+                    "change_instructions": "Use the first prompt.",
+                }
+            ],
+            0.4,
+            "gpt-test",
+        )
+        success, message, cost, model, linked_prompts = cache_story_prompt_links(
+            story_file=str(story),
+            prompts_dir=str(prompts_dir),
+        )
+
+    assert success is True
+    assert message == "Story prompt metadata linked."
+    assert cost == 0.4
+    assert model == "gpt-test"
+    assert linked_prompts == [f"prompts/{first_relative_path}"]
+    assert (
+        f"<!-- pdd-story-prompts: prompts/{first_relative_path} -->"
+        in story.read_text(encoding="utf-8")
+    )
+    mock_detect.assert_called_once()
 
 
 def test_cache_story_prompt_links_missing_story_fails(tmp_path):

--- a/tests/test_user_story_tests.py
+++ b/tests/test_user_story_tests.py
@@ -10,6 +10,7 @@ import pytest
 
 from pdd.user_story_tests import (
     _contract_path_for_story,
+    _prompt_reference_for_metadata,
     _story_content_hash,
     cache_story_prompt_links,
     discover_prompt_files,
@@ -320,7 +321,21 @@ def test_user_story_tests_caches_story_prompt_links(tmp_path):
     assert cost == 0.2
     assert model == "gpt-test"
     updated_story = story.read_text(encoding="utf-8")
-    assert "<!-- pdd-story-prompts: one_python.prompt -->" in updated_story
+    assert "<!-- pdd-story-prompts: prompts/one_python.prompt -->" in updated_story
+
+
+def test_prompt_metadata_reference_preserves_nested_path_through_symlink(tmp_path):
+    """Metadata must retain a manifest-resolvable path for a symlinked prompts root."""
+    real_prompts_dir = tmp_path / "pdd" / "prompts"
+    prompt_path = real_prompts_dir / "conformance" / "demo_python.prompt"
+    prompt_path.parent.mkdir(parents=True)
+    prompt_path.write_text("% demo\n", encoding="utf-8")
+    logical_prompts_dir = tmp_path / "prompts"
+    logical_prompts_dir.symlink_to(real_prompts_dir, target_is_directory=True)
+
+    assert _prompt_reference_for_metadata(
+        prompt_path.resolve(), logical_prompts_dir
+    ) == "prompts/conformance/demo_python.prompt"
 
 
 def test_user_story_tests_caches_story_prompt_links_when_detection_is_empty(tmp_path):
@@ -429,9 +444,9 @@ def test_cache_story_prompt_links_updates_metadata(tmp_path):
     assert message == "Story prompt metadata linked."
     assert cost == 0.4
     assert model == "gpt-test"
-    assert linked_prompts == ["two_python.prompt"]
+    assert linked_prompts == ["prompts/two_python.prompt"]
     updated_story = story.read_text(encoding="utf-8")
-    assert "<!-- pdd-story-prompts: two_python.prompt -->" in updated_story
+    assert "<!-- pdd-story-prompts: prompts/two_python.prompt -->" in updated_story
 
 
 def test_cache_story_prompt_links_empty_detection_uses_story_text_refs(tmp_path):
@@ -459,9 +474,9 @@ def test_cache_story_prompt_links_empty_detection_uses_story_text_refs(tmp_path)
     assert message == "Story prompt metadata linked from story content."
     assert cost == 0.4
     assert model == "gpt-test"
-    assert linked_prompts == ["two_python.prompt"]
+    assert linked_prompts == ["prompts/two_python.prompt"]
     updated_story = story.read_text(encoding="utf-8")
-    assert "<!-- pdd-story-prompts: two_python.prompt -->" in updated_story
+    assert "<!-- pdd-story-prompts: prompts/two_python.prompt -->" in updated_story
 
 
 def test_cache_story_prompt_links_empty_detection_falls_back_to_full_prompt_set(
@@ -488,7 +503,7 @@ def test_cache_story_prompt_links_empty_detection_falls_back_to_full_prompt_set(
     assert message == "Story prompt metadata linked to full prompt set."
     assert cost == 0.4
     assert model == "gpt-test"
-    assert linked_prompts == ["one_python.prompt", "two_python.prompt"]
+    assert linked_prompts == ["prompts/one_python.prompt", "prompts/two_python.prompt"]
     updated_story = story.read_text(encoding="utf-8")
     assert "<!-- pdd-story-prompts:" in updated_story
     assert "one_python.prompt" in updated_story
@@ -518,7 +533,7 @@ def test_cache_story_prompt_links_skips_existing_valid_metadata(tmp_path):
     assert message == "Story already contains prompt metadata."
     assert cost == 0.0
     assert model == ""
-    assert linked_prompts == ["one_python.prompt"]
+    assert linked_prompts == ["prompts/one_python.prompt"]
     mock_detect.assert_not_called()
 
 
@@ -567,7 +582,7 @@ def test_generate_user_story_creates_story_file_and_links(tmp_path):
     assert "Generated contract file:" in message
     assert cost == pytest.approx(0.05)
     assert model == "story-model"
-    assert linked_prompts == ["upload_python.prompt", "notify_python.prompt"]
+    assert linked_prompts == ["prompts/upload_python.prompt", "prompts/notify_python.prompt"]
     mock_detect.assert_not_called()
     output_path = Path(story_file)
     assert output_path.exists()
@@ -624,7 +639,7 @@ def test_generate_user_story_links_prompt_inputs_without_detection(tmp_path):
     assert "linked from prompt inputs" in message
     assert cost == pytest.approx(0.05)
     assert model == "story-model"
-    assert linked_prompts == ["upload_python.prompt", "notify_python.prompt"]
+    assert linked_prompts == ["prompts/upload_python.prompt", "prompts/notify_python.prompt"]
     mock_detect.assert_not_called()
     story_text = Path(story_file).read_text(encoding="utf-8")
     assert "<!-- pdd-story-prompts:" in story_text
@@ -657,10 +672,10 @@ def test_generate_user_story_uses_input_links_when_detection_raises(tmp_path):
     assert "linked from prompt inputs" in message
     assert cost == pytest.approx(0.05)
     assert model == "story-model"
-    assert linked_prompts == ["offline_python.prompt"]
+    assert linked_prompts == ["prompts/offline_python.prompt"]
     mock_detect.assert_not_called()
     story_text = Path(story_file).read_text(encoding="utf-8")
-    assert "<!-- pdd-story-prompts: offline_python.prompt -->" in story_text
+    assert "<!-- pdd-story-prompts: prompts/offline_python.prompt -->" in story_text
     assert "As a data analyst, I can upload a CSV file" in story_text
 
 
@@ -714,7 +729,7 @@ def test_generate_user_story_derives_unit_test_ready_details_from_issue(tmp_path
         )
 
     assert success is True
-    assert linked_prompts == ["csv_report_python.prompt"]
+    assert linked_prompts == ["prompts/csv_report_python.prompt"]
     mock_detect.assert_not_called()
     # The human Story carries the issue-derived capability detail (not the prompt's).
     story_text = Path(story_file).read_text(encoding="utf-8")
@@ -979,7 +994,7 @@ def test_generate_user_story_uses_llm_output(tmp_path):
     assert "linked from prompt inputs" in message
     assert cost == pytest.approx(0.05)
     assert model == "story-model"
-    assert linked_prompts == ["upload_python.prompt"]
+    assert linked_prompts == ["prompts/upload_python.prompt"]
     mock_detect.assert_not_called()
 
 
@@ -1011,7 +1026,7 @@ def test_generate_user_story_context_story_protects_per_source_attribution(tmp_p
         )
 
     assert success is True
-    assert linked_prompts == ["context_python.prompt"]
+    assert linked_prompts == ["prompts/context_python.prompt"]
     mock_detect.assert_not_called()
     story_text = Path(story_file).read_text(encoding="utf-8")
     contract_text = _contract_path_for_story(Path(story_file)).read_text(
@@ -1228,7 +1243,7 @@ def test_generate_user_story_accepts_minimal_human_story(tmp_path):
 
     assert success is True
     assert Path(story_file).exists()
-    assert linked_prompts == ["upload_python.prompt"]
+    assert linked_prompts == ["prompts/upload_python.prompt"]
     mock_detect.assert_not_called()
     # The contract is still produced (via the autouse stub).
     assert _contract_path_for_story(Path(story_file)).exists()
@@ -1565,7 +1580,7 @@ def test_generate_user_story_authors_from_issue_not_prompt(tmp_path):
     # ...but the prompt body must NOT.
     assert "PROMPT_ONLY_MARKER_should_not_leak_into_story" not in payload
     # The prompt is still linked for validation/regeneration.
-    assert linked_prompts == ["upload_python.prompt"]
+    assert linked_prompts == ["prompts/upload_python.prompt"]
     mock_detect.assert_not_called()
 
 
@@ -2307,7 +2322,7 @@ def test_cache_story_prompt_links_honors_explicit_prompts(tmp_path, monkeypatch)
 
     assert success, message
     assert cost == 0.0
-    assert linked_refs == ["demo2_python.prompt", "demo_python.prompt"]
+    assert linked_refs == ["prompts/demo2_python.prompt", "prompts/demo_python.prompt"]
     metadata_line = story.read_text(encoding="utf-8").splitlines()[0]
     assert "demo2_python.prompt" in metadata_line
     assert "demo_python.prompt" in metadata_line


### PR DESCRIPTION
## Summary

preserve logical prompts/subdirectory/file references when writing story metadata

- resolve both prompt and prompts-root paths so symlink aliases do not collapse nested paths to basenames
- add regression coverage for symlinked nested prompts and scope-manifest preflight

## Testing\n- uv run pytest tests/test_user_story_tests.py 

tests/commands/test_analysis.py::test_scope_manifest_preserves_exact_scope_and_rejects_discovery 
tests/commands/test_analysis.py::test_scope_manifest_accepts_nested_logical_prompt_metadata -q --tb=short