### PR TITLE
chore(sync): preauthorize code_generator_main_python language-validity-gate rotation

### DIFF
--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -635,6 +635,17 @@
       "head_policy_sha256": "a2071278af121c6b41b93a2630041541292d70a4acec40751c34dcfdb1b77a9f",
       "base_prompt_sha256": "7c020d1e55839dfa7a962df32a3991952466bd3710afa3006122424f3d21c89b",
       "head_prompt_sha256": "4ab43d1625c4229c4088c6d71cdf92aadbe92b3467cde71b1f24d774b7cfc501"
+    },
+    {
+      "prompt_path": "pdd/prompts/code_generator_main_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:9eeff8491a339461447f45d020b7a7989efe6d76c51241ccac5ac46074bf2793",
+      "to_requirement_id": "CONTRACT-SHA256:e06cce1691f72866d95042c2b520a990a2db7e856b64343412d507641f961f41",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "a2071278af121c6b41b93a2630041541292d70a4acec40751c34dcfdb1b77a9f",
+      "head_policy_sha256": "af2bebb4bd797345a809331632d7cd7335af763690a47d65fc43555e84484605",
+      "base_prompt_sha256": "9eeff8491a339461447f45d020b7a7989efe6d76c51241ccac5ac46074bf2793",
+      "head_prompt_sha256": "e06cce1691f72866d95042c2b520a990a2db7e856b64343412d507641f961f41"
     }
   ],
   "requirement_rotation_retirements": [


### PR DESCRIPTION
## Summary
Phase A of the two-phase requirement-transition process (`docs/ci.md` — Verification Requirement Transition Rotation) for the prompt edit in #2370 (Language Validity Gate).

Adds one dormant row to `.pdd/verification-profile-rotations.json` authorizing the transition for `pdd/prompts/code_generator_main_python.prompt`:

- `from`: `CONTRACT-SHA256:9eeff8491a339461447f45d020b7a7989efe6d76c51241ccac5ac46074bf2793` (current protected prompt bytes)
- `to`: `CONTRACT-SHA256:e06cce1691f72866d95042c2b520a990a2db7e856b64343412d507641f961f41` (prompt bytes as edited in #2370)

Per policy, this PR changes **only** the rotations file — no prompt bytes, no code, and no `.pdd/verification-profiles.json` bytes change here. The row stays dormant until a separate Phase B change (rebasing #2370 to also update `.pdd/verification-profiles.json`'s requirement id for this unit) consumes it after this merges.

## Test plan
- [x] `git diff --stat` confirms the diff is scoped to exactly `.pdd/verification-profile-rotations.json`
- [x] New row matches the exact schema `pdd/sync_core/verification.py` requires (`_parse_requirement_transition_authorizations` / `_valid_requirement_transition`)
- [x] `base_prompt_sha256`/`head_prompt_sha256` verified via `sha256sum` against the actual prompt bytes on `main` and on `#2370`'s branch
- [x] `base_policy_sha256`/`head_policy_sha256` verified via `sed`+`shasum` against `.pdd/verification-profiles.json`

Related: #2370

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>