### PR TITLE
fix: recover and retry unparseable split step-4 options

### DIFF
--- a/pdd/agentic_split_orchestrator.py
+++ b/pdd/agentic_split_orchestrator.py
@@ -411,32 +411,155 @@ def _extract_json_candidates(output: str) -> List[str]:
     return candidates
 
 
+def _strip_markdown_fence(body: str) -> str:
+    """Remove a surrounding markdown code fence from a marker body."""
+    body = body.strip()
+    if not body.startswith("```"):
+        return body
+    lines = body.splitlines()
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].startswith("```"):
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
+def _extract_trailing_balanced_json(text: str) -> Optional[str]:
+    """Return the trailing balanced ``{...}`` or ``[...]`` ending at ``text``.
+
+    Used when a prompt marker's ``*_BEGIN`` line was lost (e.g. only the final
+    assistant message was captured) but the matching ``*_END`` and a complete
+    JSON value remain. Scans backwards from the last closing brace/bracket.
+    """
+    text = text.rstrip()
+    if not text:
+        return None
+    close_idx = len(text) - 1
+    while close_idx >= 0 and text[close_idx] not in "}]":
+        close_idx -= 1
+    if close_idx < 0:
+        return None
+    close_char = text[close_idx]
+    open_char = "{" if close_char == "}" else "["
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(close_idx, -1, -1):
+        ch = text[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == close_char:
+            depth += 1
+        elif ch == open_char:
+            depth -= 1
+            if depth == 0:
+                candidate = text[i:close_idx + 1]
+                try:
+                    json.loads(candidate)
+                except json.JSONDecodeError:
+                    return None
+                return candidate
+    return None
+
+
+_ORPHAN_END_MARKER_RE = re.compile(r"^([A-Z][A-Z0-9_]*)_END\s*$", re.MULTILINE)
+
+
+def _extract_orphan_end_marker_json(output: str) -> List[str]:
+    """Recover JSON preceding a ``NAME_END`` marker when ``NAME_BEGIN`` is absent.
+
+    Issue #2372: multi-part agent responses sometimes persist only the final
+    message, which can start mid-payload and keep a trailing ``*_END`` without
+    its matching ``*_BEGIN``. Scanning backwards for a balanced JSON value
+    recovers ``SELECTED_OPTION`` (and similar) blocks that would otherwise be
+    discarded.
+    """
+    candidates: List[str] = []
+    seen_names: set[str] = set()
+    for match in _ORPHAN_END_MARKER_RE.finditer(output):
+        name = match.group(1)
+        # Skip names that already have a complete BEGIN/END pair — those are
+        # handled by `_MARKER_BLOCK_RE`.
+        if re.search(rf"^{name}_BEGIN\s*$", output, re.MULTILINE):
+            continue
+        if name in seen_names:
+            continue
+        seen_names.add(name)
+        prefix = output[: match.start()]
+        recovered = _extract_trailing_balanced_json(prefix)
+        if recovered:
+            candidates.append(_strip_markdown_fence(recovered))
+    return candidates
+
+
+def _normalize_options_considered_payload(data: Any) -> Any:
+    """Coerce step-4 payloads into ``{"options": [...]}`` when needed.
+
+    Accepts:
+    - a bare JSON array of options (``OPTIONS_BEGIN`` contract)
+    - a single selected option object (``SELECTED_OPTION_BEGIN`` contract),
+      including the orphan-END recovery path from Issue #2372
+    """
+    if isinstance(data, list):
+        return {"options": data}
+    if (
+        isinstance(data, dict)
+        and "options" not in data
+        and ("plan" in data or "name" in data or "score" in data)
+    ):
+        return {"options": [data]}
+    return data
+
+
+def _persist_unparseable_step_output(
+    state_dir: Path,
+    split_id: int,
+    step_num: str,
+    output: str,
+) -> Optional[Path]:
+    """Write raw agent output next to split state so a failed parse is not a total loss."""
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+        path = state_dir / f"split_{split_id}_step{step_num}_unparsed.txt"
+        path.write_text(output or "", encoding="utf-8")
+        return path
+    except OSError:
+        return None
+
+
 def _parse_step_output(output: str, dataclass_type: type) -> Any:
     """Parse agent output JSON into a dataclass. Returns None on failure.
 
     Strategy:
     1. If the output contains ``NAME_BEGIN ... NAME_END`` marker blocks,
        parse JSON from within those blocks first (per the prompt contracts).
-    2. Otherwise, collect all top-level ``{...}`` and ``[...]`` blocks and
+    2. If a ``NAME_END`` appears without ``NAME_BEGIN``, recover the trailing
+       balanced JSON before that END (Issue #2372 multipart-capture loss).
+    3. Otherwise, collect all top-level ``{...}`` and ``[...]`` blocks and
        try the largest first.
 
     ``OptionsConsidered`` is a special case: the prompt emits a JSON *array*
-    (``OPTIONS_BEGIN [...] OPTIONS_END``), which this function wraps as
-    ``{"options": [...]}`` before dataclass conversion.
+    (``OPTIONS_BEGIN [...] OPTIONS_END``) and a selected object
+    (``SELECTED_OPTION_BEGIN {...} SELECTED_OPTION_END``). Either form is
+    accepted; a bare selected object is wrapped as a one-element options list.
     """
     candidates: List[str] = []
     # Prefer marker-block JSON
     for match in _MARKER_BLOCK_RE.finditer(output):
-        body = match.group("body").strip()
-        # Strip markdown code fences if present
-        if body.startswith("```"):
-            lines = body.splitlines()
-            if lines and lines[0].startswith("```"):
-                lines = lines[1:]
-            if lines and lines[-1].startswith("```"):
-                lines = lines[:-1]
-            body = "\n".join(lines).strip()
+        body = _strip_markdown_fence(match.group("body"))
         candidates.append(body)
+
+    # Recover orphan END markers (BEGIN lost / multipart capture truncated).
+    candidates.extend(_extract_orphan_end_marker_json(output))
 
     # Also collect top-level JSON objects/arrays as fallback
     candidates.extend(_extract_json_candidates(output))
@@ -448,11 +571,18 @@ def _parse_step_output(output: str, dataclass_type: type) -> Any:
         except json.JSONDecodeError:
             continue
         try:
-            # Special case: OptionsConsidered from a bare JSON array
-            if dataclass_type is OptionsConsidered and isinstance(data, list):
-                data = {"options": data}
+            if dataclass_type is OptionsConsidered:
+                data = _normalize_options_considered_payload(data)
             result = _dict_to_dataclass(dataclass_type, data)
             if result is not None:
+                # Reject empty OptionsConsidered so orphan prose JSON doesn't
+                # short-circuit recovery of a later SELECTED_OPTION block.
+                if (
+                    dataclass_type is OptionsConsidered
+                    and isinstance(result, OptionsConsidered)
+                    and not result.options
+                ):
+                    continue
                 return result
         except (TypeError, KeyError):
             continue
@@ -1701,21 +1831,106 @@ def run_agentic_split_orchestrator(
                     and '"shared_layer_candidates": []' not in step3_raw
                 )
 
-                # Retry loop: if shared-layer is required but dropped,
-                # re-invoke step 4 with a corrective instruction. This
-                # converts the prior "soft warning" into a HARD gate.
+                # Retry loop: re-invoke step 4 with a corrective instruction when
+                # (a) options cannot be parsed (Issue #2372) or (b) shared-layer
+                # is required but dropped. Parse failures used to `break`
+                # immediately and discard a recoverable proposal.
                 step4_retry = 0
                 max_step4_retries = 2
+
+                def _rerun_step4(
+                    retry_reason: str, notice_title: str
+                ) -> Optional[Tuple[bool, str, float, str, List[str]]]:
+                    """Re-invoke step 4; update ``output``/state on success.
+
+                    Returns a budget-abort tuple when ``--max-cost`` is crossed,
+                    otherwise ``None`` (caller should ``continue`` the loop).
+                    """
+                    nonlocal output, total_cost, model_used
+                    context["step4_retry_reason"] = retry_reason
+                    retry_prompt = substitute_template_variables(
+                        preprocess(
+                            prompt_template, recursive=True,
+                            double_curly_brackets=True,
+                            exclude=list(context.keys()),
+                        ),
+                        context,
+                    )
+                    retry_prompt += (
+                        f"\n\n% RETRY NOTICE — {notice_title}\n"
+                        f"{retry_reason}"
+                    )
+                    r_success, r_output, r_cost, r_model = run_agentic_task(
+                        instruction=retry_prompt,
+                        cwd=current_work_dir,
+                        verbose=verbose, quiet=quiet,
+                        timeout=SPLIT_STEP_TIMEOUTS.get(
+                            "4_propose_options", 900.0
+                        ) + timeout_adder,
+                        label=f"4_propose_options_retry_{step4_retry}",
+                        max_retries=DEFAULT_MAX_RETRIES,
+                    )
+                    total_cost += r_cost
+                    model_used = r_model
+                    if r_success:
+                        output = r_output
+                        state["step_outputs"]["4"] = output
+                        context["step4_output"] = output
+                        # Persist updated cost/output before checking
+                        # budget so resume picks up correctly.
+                        state["last_completed_step"] = step
+                    # Budget-check after every retry attempt so cost burned on
+                    # a failed retry cannot push past --max-cost silently.
+                    return _check_budget(step)
+
                 while True:
                     parsed_options = _parse_step_output(output, OptionsConsidered)
                     if (
                         not isinstance(parsed_options, OptionsConsidered)
                         or not parsed_options.options
                     ):
+                        dump_path = _persist_unparseable_step_output(
+                            state_dir, split_id, "4", output
+                        )
+                        if step4_retry < max_step4_retries:
+                            step4_retry += 1
+                            if not quiet:
+                                dump_note = (
+                                    f" Raw output saved to {dump_path}."
+                                    if dump_path is not None
+                                    else ""
+                                )
+                                console.print(
+                                    f"[yellow]Step 4 retry {step4_retry}/"
+                                    f"{max_step4_retries}: could not parse "
+                                    f"OPTIONS_BEGIN/SELECTED_OPTION markers "
+                                    f"from agent output.{dump_note} "
+                                    f"Re-invoking step 4 with a format "
+                                    f"correction.[/yellow]"
+                                )
+                            budget_abort = _rerun_step4(
+                                (
+                                    "Your previous output could not be parsed. "
+                                    "Emit ALL FOUR markers in a single final "
+                                    "message, with no prose outside the markers:\n"
+                                    "OPTIONS_BEGIN\n[...json array...]\nOPTIONS_END\n"
+                                    "SELECTED_OPTION_BEGIN\n{...json object...}\n"
+                                    "SELECTED_OPTION_END"
+                                ),
+                                "emit the four step-4 markers",
+                            )
+                            if budget_abort is not None:
+                                return budget_abort
+                            continue
                         if not quiet:
+                            dump_note = (
+                                f" (raw output: {dump_path})"
+                                if dump_path is not None
+                                else ""
+                            )
                             console.print(
                                 "[yellow]Warning: could not parse options "
-                                "from agent output[/yellow]"
+                                f"from agent output{dump_note}[/yellow]"
                             )
                         break
 
@@ -1732,9 +1947,39 @@ def run_agentic_split_orchestrator(
                     for opt in options:
                         _sanitize_split_paths(opt)
                     if not options:
+                        dump_path = _persist_unparseable_step_output(
+                            state_dir, split_id, "4", output
+                        )
+                        if step4_retry < max_step4_retries:
+                            step4_retry += 1
+                            if not quiet:
+                                console.print(
+                                    f"[yellow]Step 4 retry {step4_retry}/"
+                                    f"{max_step4_retries}: parsed options "
+                                    f"list was empty. Re-invoking step 4.[/yellow]"
+                                )
+                            budget_abort = _rerun_step4(
+                                (
+                                    "Your previous output parsed but contained "
+                                    "no valid options. Emit a non-empty JSON "
+                                    "array between OPTIONS_BEGIN/OPTIONS_END "
+                                    "and the selected object between "
+                                    "SELECTED_OPTION_BEGIN/SELECTED_OPTION_END."
+                                ),
+                                "non-empty options required",
+                            )
+                            if budget_abort is not None:
+                                return budget_abort
+                            continue
                         if not quiet:
+                            dump_note = (
+                                f" (raw output: {dump_path})"
+                                if dump_path is not None
+                                else ""
+                            )
                             console.print(
-                                "[yellow]Warning: no valid options parsed[/yellow]"
+                                "[yellow]Warning: no valid options parsed"
+                                f"{dump_note}[/yellow]"
                             )
                         break
 
@@ -1759,62 +2004,21 @@ def run_agentic_split_orchestrator(
                                     f"surfacing candidates. Re-invoking step 4 "
                                     f"with corrective instruction.[/yellow]"
                                 )
-                            # Augment the context with a retry reason, then
-                            # re-run step 4 with the same prompt template.
-                            context["step4_retry_reason"] = (
-                                "Your previous output's selected option had "
-                                "no shared_layer_children, but step 3 "
-                                "surfaced non-empty shared_layer_candidates. "
-                                "Every valid option MUST include a "
-                                "shared_layer_children list that extracts the "
-                                "cross-worker duplication step 3 identified. "
-                                "Produce a corrected options set."
-                            )
-                            retry_prompt = substitute_template_variables(
-                                preprocess(
-                                    prompt_template, recursive=True,
-                                    double_curly_brackets=True,
-                                    exclude=list(context.keys()),
+                            budget_abort = _rerun_step4(
+                                (
+                                    "Your previous output's selected option had "
+                                    "no shared_layer_children, but step 3 "
+                                    "surfaced non-empty shared_layer_candidates. "
+                                    "Every valid option MUST include a "
+                                    "shared_layer_children list that extracts the "
+                                    "cross-worker duplication step 3 identified. "
+                                    "Produce a corrected options set."
                                 ),
-                                context,
+                                "shared_layer_children required",
                             )
-                            retry_prompt += (
-                                "\n\n% RETRY NOTICE — shared_layer_children required\n"
-                                f"{context['step4_retry_reason']}"
-                            )
-                            r_success, r_output, r_cost, r_model = run_agentic_task(
-                                instruction=retry_prompt,
-                                cwd=current_work_dir,
-                                verbose=verbose, quiet=quiet,
-                                timeout=SPLIT_STEP_TIMEOUTS.get(
-                                    "4_propose_options", 900.0
-                                ) + timeout_adder,
-                                label=f"4_propose_options_retry_{step4_retry}",
-                                max_retries=DEFAULT_MAX_RETRIES,
-                            )
-                            total_cost += r_cost
-                            model_used = r_model
-                            if r_success:
-                                output = r_output
-                                state["step_outputs"]["4"] = output
-                                context["step4_output"] = output
-                                # Persist updated cost/output before checking
-                                # budget so resume picks up correctly.
-                                state["last_completed_step"] = step
-                                budget_abort = _check_budget(step)
-                                if budget_abort is not None:
-                                    return budget_abort
-                                continue  # reparse with new output
-                            # Retry failed — still budget-check before next
-                            # iteration so cost burned on a failed retry
-                            # cannot push past --max-cost silently.
-                            budget_abort = _check_budget(step)
                             if budget_abort is not None:
                                 return budget_abort
-                            # Retry failed — loop again so the retry counter
-                            # check at line top triggers the next attempt or
-                            # the >= max_step4_retries branch records failure.
-                            continue
+                            continue  # reparse with new output
                         elif not slc and step4_retry >= max_step4_retries:
                             # After retries, still missing. Record as a hard
                             # verify_failure so the improvement gate sees it.

--- a/pdd/prompts/agentic_split_step4_propose_options_LLM.prompt
+++ b/pdd/prompts/agentic_split_step4_propose_options_LLM.prompt
@@ -268,6 +268,9 @@ the user to review with --propose-only.
 
 Do NOT emit markdown tables or prose summaries instead of JSON.
 Do NOT wrap JSON in markdown code fences inside the markers.
+Emit all four markers in your **final** assistant message (not an
+earlier tool-turn message). The orchestrator may only see that last
+message — if the markers are missing there, the proposal is discarded.
 The orchestrator will FAIL if it cannot parse valid JSON between
 the markers.
 

--- a/tests/test_agentic_split_orchestrator.py
+++ b/tests/test_agentic_split_orchestrator.py
@@ -41,10 +41,13 @@ from pdd.agentic_split_orchestrator import (
     _child_state_keys,
     _detect_language,
     _dict_to_dataclass,
+    _extract_orphan_end_marker_json,
+    _extract_trailing_balanced_json,
     _first_nonverified_child_index,
     _initialize_child_extraction_state,
     _parse_file_markers,
     _parse_step_output,
+    _persist_unparseable_step_output,
     _run_split_checkup,
     _stable_split_id,
     _target_path_in_worktree,
@@ -191,6 +194,47 @@ OPTIONS_END"""
         assert len(result.options) == 2
         assert all(isinstance(o, SplitOption) for o in result.options)
 
+    def test_selected_option_alone_wraps_as_options_considered(self):
+        """SELECTED_OPTION block alone is enough to recover OptionsConsidered."""
+        output = """SELECTED_OPTION_BEGIN
+{"name": "full_decomposition", "plan": {"children": [{"name": "a"}]}, "score": 110}
+SELECTED_OPTION_END"""
+        result = _parse_step_output(output, OptionsConsidered)
+        assert isinstance(result, OptionsConsidered)
+        assert len(result.options) == 1
+        assert result.options[0].name == "full_decomposition"
+        assert result.options[0].numeric_score == 110.0
+
+    def test_orphan_selected_option_end_recovers_truncated_multipart(self):
+        """Issue #2372: BEGIN missing / head truncated, trailing SELECTED_OPTION_END."""
+        # Simulates multipart capture that kept only the final message: head of
+        # OPTIONS is gone, BEGIN markers absent, but the selected object + END remain.
+        selected = {
+            "name": "full_decomposition_flat_siblings",
+            "plan": {
+                "children": [
+                    {"name": "public_surface_snapshot"},
+                    {"name": "churn_gate"},
+                ]
+            },
+            "score": {
+                "cohesion": 18,
+                "coupling": 12,
+                "total": 110,
+            },
+        }
+        output = (
+            'pyproject.toml, MANIFEST.in", "action": "NO CHANGE — truncated head\n'
+            + json.dumps(selected)
+            + "\nSELECTED_OPTION_END\n"
+            + "Three things about this output worth your attention before step 5 runs.\n"
+        )
+        result = _parse_step_output(output, OptionsConsidered)
+        assert isinstance(result, OptionsConsidered)
+        assert len(result.options) == 1
+        assert result.options[0].name == "full_decomposition_flat_siblings"
+        assert result.options[0].numeric_score == 110.0
+
     def test_diagnosis_from_real_prompt_output(self):
         """Real LLM output uses recommended_action, not type."""
         output = """DIAGNOSIS_BEGIN
@@ -243,6 +287,27 @@ QUALITATIVE_ASSESSMENT_END"""
         assert result.cohesion["rating"] == "clear"
         assert result.boundary_clarity["rating"] == "moderate"
         assert result.change_decorrelation["rating"] == "clear"
+
+
+class TestOrphanEndMarkerRecovery:
+    """Helpers that recover JSON when only ``*_END`` survives (Issue #2372)."""
+
+    def test_trailing_balanced_object(self):
+        text = 'garbage "prefix", then {"name": "ok", "score": 1}'
+        assert _extract_trailing_balanced_json(text) == '{"name": "ok", "score": 1}'
+
+    def test_orphan_end_skips_complete_begin_end_pair(self):
+        output = """OPTIONS_BEGIN
+[{"name": "a", "score": 1}]
+OPTIONS_END
+"""
+        assert _extract_orphan_end_marker_json(output) == []
+
+    def test_persist_unparseable_step_output(self, tmp_path: Path):
+        path = _persist_unparseable_step_output(tmp_path, 42, "4", "raw agent text")
+        assert path is not None
+        assert path.name == "split_42_step4_unparsed.txt"
+        assert path.read_text(encoding="utf-8") == "raw agent text"
 
 
 # =========================================================================
@@ -930,6 +995,57 @@ class TestOrchestratorProposeOnly:
             assert "Propose only complete" in msg
             # step 0 + steps 1-4 = 5 agent calls
             assert call_count[0] == 5
+
+    def test_step4_parse_failure_retries_then_recovers(self, tmp_path: Path):
+        """Issue #2372: unparseable step-4 output retries with a format fix."""
+        good_options = """OPTIONS_BEGIN
+[{"name": "recovered", "plan": {"children": [{"name": "a"}]}, "score": 88}]
+OPTIONS_END
+SELECTED_OPTION_BEGIN
+{"name": "recovered", "plan": {"children": [{"name": "a"}]}, "score": 88}
+SELECTED_OPTION_END"""
+        outputs = [
+            'INTENT_BEGIN\n{"intent": "REDUCE_MONOLITH", "confidence": 0.9, "rationale": "ok"}\nINTENT_END',
+            '{"survey": "data"}',
+            json.dumps({"type": "hotspot", "rationale": "churn"}),
+            # step 3: empty shared_layer_candidates so hard gate does not fire
+            '{"shared_layer_candidates": []}',
+            # step 4 first attempt: garbage (would previously break with no retry)
+            "not parseable options at all",
+            # step 4 retry
+            good_options,
+        ]
+        labels: List[str] = []
+        call_count = [0]
+
+        def fake_agentic_task(**kwargs):
+            labels.append(kwargs.get("label", ""))
+            idx = call_count[0]
+            call_count[0] += 1
+            return _mock_agentic_task(outputs[idx])
+
+        with patch(f"{MODULE}.get_language", return_value="Python"), \
+             patch(f"{MODULE}.load_workflow_state", return_value=(None, None)), \
+             patch(f"{MODULE}.save_workflow_state", return_value=None), \
+             patch(f"{MODULE}.load_prompt_template", return_value="template"), \
+             patch(f"{MODULE}.preprocess", return_value="processed"), \
+             patch(f"{MODULE}.substitute_template_variables", return_value="prompt"), \
+             patch(f"{MODULE}.run_agentic_task", side_effect=fake_agentic_task), \
+             patch(f"{MODULE}.set_agentic_progress"), \
+             patch(f"{MODULE}.clear_agentic_progress"), \
+             patch(f"{MODULE}._get_state_dir", return_value=tmp_path):
+            ok, msg, cost, model, files = run_agentic_split_orchestrator(
+                "foo.py", cwd=tmp_path, quiet=True, propose_only=True,
+            )
+            assert ok is False
+            assert "Propose only complete" in msg
+            assert any(
+                isinstance(label, str) and label.startswith("4_propose_options_retry_")
+                for label in labels
+            )
+            dumps = list(tmp_path.glob("split_*_step4_unparsed.txt"))
+            assert len(dumps) == 1
+            assert dumps[0].read_text(encoding="utf-8") == "not parseable options at all"
 
 
 class TestOrchestratorLeaveAlone:


### PR DESCRIPTION
## Summary
- Recover step-4 proposals when `*_BEGIN` markers are missing but `*_END` + JSON remain
- Retry step 4 on parse failure with a corrective format instruction
- Dump raw agent output to `.pdd/split-state/` and show the path in the warning

Closes #2372

## Test plan
- [x] `pytest tests/test_agentic_split_orchestrator.py::TestParseStepOutput tests/test_agentic_split_orchestrator.py::TestOrphanEndMarkerRecovery tests/test_agentic_split_orchestrator.py::TestOrchestratorProposeOnly -q`
- [ ] Optional live: `pdd split pdd/code_generator_main.py --intent reduce --propose-only`