### PR TITLE
fix: reject incomplete story contracts before overwrite

### DIFF
--- a/pdd/prompts/review_story_contract_completeness_LLM.prompt
+++ b/pdd/prompts/review_story_contract_completeness_LLM.prompt
@@ -1,0 +1,78 @@
+% You are the semantic-completeness gate for PDD Story contracts (Issue #2362).
+% A generated contract may be structurally valid yet omit behavior-changing
+% obligations from the human Story or original issue. Your job is either to
+% EXTRACT the in-scope obligation inventory, or to REVIEW a candidate contract
+% against a given inventory. Always prefer Story scope over issue broadening.
+
+% Inputs
+<input>
+    <mode>
+    {MODE}
+    </mode>
+
+    <human_story>
+    {STORY_TEXT}
+    </human_story>
+
+    <issue>
+    {ISSUE_TEXT}
+    </issue>
+
+    <candidate_contract>
+    {CONTRACT_TEXT}
+    </candidate_contract>
+
+    <obligations_json>
+    {OBLIGATIONS_JSON}
+    </obligations_json>
+</input>
+
+% Mode: extract
+<extract_guidance>
+    When `<mode>` is `extract`:
+    - Identify every in-scope, behavior-changing obligation implied by the human
+      Story and refined (not broadened) by the issue.
+    - Skip implementation notes, evidence details, and out-of-scope commentary.
+    - Prefer explicit clause IDs already present in the issue/Story
+      (e.g. `AUTH-RECOVER-401`). Otherwise invent stable UPPER-KEBAB ids.
+    - If you cannot determine the inventory with confidence, set
+      `"indeterminate": true` and omit obligations.
+    - Output ONLY JSON:
+      {
+        "indeterminate": false,
+        "obligations": [
+          {"clause_id": "ID", "text": "observable obligation", "source": "story|issue"}
+        ]
+      }
+</extract_guidance>
+
+% Mode: review
+<review_guidance>
+    When `<mode>` is `review`:
+    - For each obligation in `<obligations_json>`, decide whether the candidate
+      contract covers it.
+    - Equivalent observable paraphrases count as covered — do NOT require exact
+      wording.
+    - Mark `missing` when the obligation is absent, `ambiguous` when coverage is
+      unclear, `overbroad` when the contract expands beyond Story scope,
+      `conflicting` when contract text contradicts the obligation, and `covered`
+      when a paraphrase preserves the observable distinction.
+    - If you cannot decide, set `"indeterminate": true`.
+    - Output ONLY JSON:
+      {
+        "indeterminate": false,
+        "coverages": [
+          {
+            "clause_id": "ID",
+            "disposition": "covered|missing|ambiguous|overbroad|conflicting",
+            "evidence": "short quote or paraphrase from the contract, or empty"
+          }
+        ]
+      }
+</review_guidance>
+
+% Output
+<output_format>
+    Output ONLY a single JSON object for the requested mode. No markdown fence,
+    no prose outside the JSON.
+</output_format>

--- a/pdd/user_story_tests.py
+++ b/pdd/user_story_tests.py
@@ -11,8 +11,9 @@ import re
 import subprocess
 import tempfile
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from rich import print as rprint
 from rich.markup import escape as rich_escape
@@ -860,6 +861,14 @@ def resolve_issue_source(  # pylint: disable=too-many-return-statements
 
 _STORY_META_PROMPT_NAME = "generate_user_story_LLM"
 _STORY_CONTRACT_PROMPT_NAME = "generate_story_contract_LLM"
+_STORY_CONTRACT_COMPLETENESS_PROMPT_NAME = "review_story_contract_completeness_LLM"
+# Explicit clause IDs in Story/issue text (Issue #2362), e.g. AUTH-RECOVER-401.
+_EXPLICIT_CLAUSE_ID_RE = re.compile(
+    r"^\s*[-*]?\s*`?(?P<id>[A-Z][A-Z0-9]+(?:-[A-Z0-9]+)+)`?"
+    r"\s*(?::|—|--|-)\s*(?P<text>.+?)\s*$",
+    re.MULTILINE,
+)
+_COVERED_DISPOSITIONS = frozenset({"covered"})
 # Two-file audience split (the human verifies the Story; the AI owns the
 # contract). The human story file is tiny — it must carry the ``## Story``
 # sentence and nothing else is required. Invalid or unavailable LLM output fails
@@ -908,6 +917,408 @@ def _contains_placeholder_tokens(markdown: str) -> bool:
     """Return True when model output still contains template placeholders."""
     return bool(
         _PLACEHOLDER_TOKEN_RE.search(markdown) or _PDD_METADATA_TAG_RE.search(markdown)
+    )
+
+
+@dataclass(frozen=True)
+class ContractObligation:
+    """One in-scope, behavior-changing Story/issue clause (Issue #2362)."""
+
+    clause_id: str
+    text: str
+    source: str  # "story" | "issue"
+
+
+@dataclass(frozen=True)
+class ClauseCoverage:
+    """Machine-checkable coverage disposition for one obligation."""
+
+    clause_id: str
+    disposition: str
+    evidence: str = ""
+
+
+@dataclass(frozen=True)
+class CompletenessReview:
+    """Result of the semantic-completeness gate before contract write."""
+
+    ok: bool
+    coverages: Tuple[ClauseCoverage, ...] = ()
+    error: Optional[str] = None
+
+    def diagnostics(self) -> str:
+        """Human-readable clause-level failure summary."""
+        if self.error:
+            return self.error
+        bad = [
+            c
+            for c in self.coverages
+            if c.disposition.lower() not in _COVERED_DISPOSITIONS
+        ]
+        if not bad:
+            return "semantic completeness review failed"
+        parts = [f"{c.clause_id} ({c.disposition})" for c in bad]
+        return "uncovered or invalid clauses: " + ", ".join(parts)
+
+
+def _parse_explicit_contract_obligations(
+    story_text: str, issue_text: str
+) -> List[ContractObligation]:
+    """Collect stable clause IDs authored into the Story/issue (Issue #2362)."""
+    found: Dict[str, ContractObligation] = {}
+    for source_name, blob in (("story", story_text or ""), ("issue", issue_text or "")):
+        for match in _EXPLICIT_CLAUSE_ID_RE.finditer(blob):
+            clause_id = match.group("id").strip()
+            text = match.group("text").strip()
+            if clause_id not in found:
+                found[clause_id] = ContractObligation(
+                    clause_id=clause_id, text=text, source=source_name
+                )
+    return list(found.values())
+
+
+def _llm_extract_contract_obligations(  # pylint: disable=too-many-arguments,too-many-locals,broad-exception-caught,import-outside-toplevel
+    *,
+    story_text: str,
+    issue_text: str,
+    strength: float,
+    temperature: float,
+    time: float,
+    verbose: bool,
+) -> Tuple[Optional[List[ContractObligation]], float, str, Optional[str]]:
+    """Ask the LLM for in-scope behavior-changing obligations when no IDs exist.
+
+    Returns ``(obligations, cost, model, error)``. ``obligations`` is None when
+    extraction is unavailable or indeterminate (fail closed).
+    """
+    try:
+        from .llm_invoke import llm_invoke
+        from .load_prompt_template import load_prompt_template
+        from .preprocess import preprocess
+    except Exception as exc:  # pragma: no cover
+        return None, 0.0, "", f"obligation extraction unavailable: {exc}"
+
+    template = load_prompt_template(_STORY_CONTRACT_COMPLETENESS_PROMPT_NAME)
+    if not template:
+        return (
+            None,
+            0.0,
+            "",
+            f"meta-prompt {_STORY_CONTRACT_COMPLETENESS_PROMPT_NAME} not found",
+        )
+
+    # Reuse the completeness prompt in extract mode via a mode marker.
+    processed = preprocess(
+        template,
+        recursive=False,
+        double_curly_brackets=True,
+        exclude_keys=[
+            "MODE",
+            "STORY_TEXT",
+            "ISSUE_TEXT",
+            "CONTRACT_TEXT",
+            "OBLIGATIONS_JSON",
+        ],
+    )
+    try:
+        response = llm_invoke(
+            prompt=processed,
+            input_json={
+                "MODE": "extract",
+                "STORY_TEXT": story_text,
+                "ISSUE_TEXT": issue_text,
+                "CONTRACT_TEXT": "",
+                "OBLIGATIONS_JSON": "[]",
+            },
+            strength=strength,
+            temperature=temperature,
+            time=time,
+            verbose=verbose,
+        )
+    except Exception as exc:
+        return None, 0.0, "", f"obligation extraction failed: {exc}"
+
+    cost = float(response.get("cost", 0.0) or 0.0)
+    model = response.get("model_name", "") or ""
+    raw = response.get("result", "")
+    if not isinstance(raw, str) or not raw.strip():
+        return None, cost, model, "obligation extraction returned empty output"
+    data = _parse_json_object_from_llm(raw)
+    if data is None:
+        return None, cost, model, "obligation extraction returned non-JSON output"
+    if data.get("indeterminate") is True:
+        return None, cost, model, "obligation extraction indeterminate"
+    items = data.get("obligations")
+    if not isinstance(items, list):
+        return None, cost, model, "obligation extraction missing obligations list"
+    obligations: List[ContractObligation] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        clause_id = str(item.get("clause_id") or "").strip()
+        text = str(item.get("text") or "").strip()
+        source = str(item.get("source") or "issue").strip() or "issue"
+        if clause_id and text:
+            obligations.append(
+                ContractObligation(clause_id=clause_id, text=text, source=source)
+            )
+    return obligations, cost, model, None
+
+
+def _collect_contract_obligations(  # pylint: disable=too-many-arguments
+    *,
+    story_text: str,
+    issue_text: str,
+    strength: float,
+    temperature: float,
+    time: float,
+    verbose: bool,
+) -> Tuple[Optional[List[ContractObligation]], float, str, Optional[str]]:
+    """Resolve the in-scope obligation inventory for semantic acceptance."""
+    explicit = _parse_explicit_contract_obligations(story_text, issue_text)
+    if explicit:
+        return explicit, 0.0, "", None
+    return _llm_extract_contract_obligations(
+        story_text=story_text,
+        issue_text=issue_text,
+        strength=strength,
+        temperature=temperature,
+        time=time,
+        verbose=verbose,
+    )
+
+
+def _parse_json_object_from_llm(raw: str) -> Optional[dict]:
+    """Extract the first JSON object from an LLM response."""
+    text = _strip_markdown_code_fence(raw).strip()
+    try:
+        data = json.loads(text)
+        return data if isinstance(data, dict) else None
+    except json.JSONDecodeError:
+        pass
+    start = text.find("{")
+    end = text.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    try:
+        data = json.loads(text[start : end + 1])
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _llm_review_contract_completeness(  # pylint: disable=too-many-arguments,too-many-locals,broad-exception-caught,import-outside-toplevel
+    *,
+    story_text: str,
+    issue_text: str,
+    contract_text: str,
+    obligations: Sequence[ContractObligation],
+    strength: float,
+    temperature: float,
+    time: float,
+    verbose: bool,
+) -> Tuple[CompletenessReview, float, str]:
+    """Semantically review whether ``contract_text`` covers every obligation."""
+    try:
+        from .llm_invoke import llm_invoke
+        from .load_prompt_template import load_prompt_template
+        from .preprocess import preprocess
+    except Exception as exc:  # pragma: no cover
+        return (
+            CompletenessReview(
+                ok=False, error=f"semantic completeness reviewer unavailable: {exc}"
+            ),
+            0.0,
+            "",
+        )
+
+    template = load_prompt_template(_STORY_CONTRACT_COMPLETENESS_PROMPT_NAME)
+    if not template:
+        return (
+            CompletenessReview(
+                ok=False,
+                error=(
+                    f"semantic completeness reviewer unavailable: meta-prompt "
+                    f"{_STORY_CONTRACT_COMPLETENESS_PROMPT_NAME} not found"
+                ),
+            ),
+            0.0,
+            "",
+        )
+
+    obligations_json = json.dumps(
+        [
+            {
+                "clause_id": o.clause_id,
+                "text": o.text,
+                "source": o.source,
+            }
+            for o in obligations
+        ],
+        indent=2,
+    )
+    processed = preprocess(
+        template,
+        recursive=False,
+        double_curly_brackets=True,
+        exclude_keys=[
+            "MODE",
+            "STORY_TEXT",
+            "ISSUE_TEXT",
+            "CONTRACT_TEXT",
+            "OBLIGATIONS_JSON",
+        ],
+    )
+    try:
+        response = llm_invoke(
+            prompt=processed,
+            input_json={
+                "MODE": "review",
+                "STORY_TEXT": story_text,
+                "ISSUE_TEXT": issue_text,
+                "CONTRACT_TEXT": contract_text,
+                "OBLIGATIONS_JSON": obligations_json,
+            },
+            strength=strength,
+            temperature=temperature,
+            time=time,
+            verbose=verbose,
+        )
+    except Exception as exc:
+        return (
+            CompletenessReview(
+                ok=False, error=f"semantic completeness review failed: {exc}"
+            ),
+            0.0,
+            "",
+        )
+
+    cost = float(response.get("cost", 0.0) or 0.0)
+    model = response.get("model_name", "") or ""
+    raw = response.get("result", "")
+    if not isinstance(raw, str) or not raw.strip():
+        return (
+            CompletenessReview(
+                ok=False, error="semantic completeness review returned empty output"
+            ),
+            cost,
+            model,
+        )
+    data = _parse_json_object_from_llm(raw)
+    if data is None:
+        return (
+            CompletenessReview(
+                ok=False, error="semantic completeness review returned non-JSON output"
+            ),
+            cost,
+            model,
+        )
+    if data.get("indeterminate") is True:
+        return (
+            CompletenessReview(
+                ok=False, error="semantic completeness review indeterminate"
+            ),
+            cost,
+            model,
+        )
+
+    coverages_raw = data.get("coverages")
+    if not isinstance(coverages_raw, list):
+        return (
+            CompletenessReview(
+                ok=False, error="semantic completeness review missing coverages list"
+            ),
+            cost,
+            model,
+        )
+
+    by_id: Dict[str, ClauseCoverage] = {}
+    for item in coverages_raw:
+        if not isinstance(item, dict):
+            continue
+        clause_id = str(item.get("clause_id") or "").strip()
+        disposition = str(item.get("disposition") or "").strip().lower()
+        evidence = str(item.get("evidence") or "").strip()
+        if not clause_id or not disposition:
+            continue
+        by_id[clause_id] = ClauseCoverage(
+            clause_id=clause_id, disposition=disposition, evidence=evidence
+        )
+
+    coverages: List[ClauseCoverage] = []
+    missing_ids: List[str] = []
+    for obligation in obligations:
+        coverage = by_id.get(obligation.clause_id)
+        if coverage is None:
+            missing_ids.append(obligation.clause_id)
+            coverages.append(
+                ClauseCoverage(
+                    clause_id=obligation.clause_id,
+                    disposition="missing",
+                    evidence="",
+                )
+            )
+        else:
+            coverages.append(coverage)
+
+    # Disposition must be exactly "covered"; anything else fails closed.
+    failed = [c for c in coverages if c.disposition != "covered"]
+    return (
+        CompletenessReview(ok=not failed, coverages=tuple(coverages)),
+        cost,
+        model,
+    )
+
+
+def _review_contract_semantic_completeness(  # pylint: disable=too-many-arguments
+    *,
+    story_text: str,
+    issue_text: str,
+    contract_text: str,
+    strength: float,
+    temperature: float,
+    time: float,
+    verbose: bool,
+) -> Tuple[CompletenessReview, float, str]:
+    """Run the Issue #2362 acceptance gate; fail closed when incomplete."""
+    obligations, extract_cost, extract_model, extract_error = (
+        _collect_contract_obligations(
+            story_text=story_text,
+            issue_text=issue_text,
+            strength=strength,
+            temperature=temperature,
+            time=time,
+            verbose=verbose,
+        )
+    )
+    if extract_error or obligations is None:
+        return (
+            CompletenessReview(
+                ok=False,
+                error=extract_error
+                or "could not establish in-scope obligation inventory",
+            ),
+            extract_cost,
+            extract_model,
+        )
+    if not obligations:
+        # No behavior-changing clauses identified — nothing to gate.
+        return CompletenessReview(ok=True, coverages=()), extract_cost, extract_model
+
+    review, review_cost, review_model = _llm_review_contract_completeness(
+        story_text=story_text,
+        issue_text=issue_text,
+        contract_text=contract_text,
+        obligations=obligations,
+        strength=strength,
+        temperature=temperature,
+        time=time,
+        verbose=verbose,
+    )
+    return (
+        review,
+        extract_cost + review_cost,
+        review_model or extract_model,
     )
 
 
@@ -1293,6 +1704,10 @@ def _generate_and_write_contract(  # pylint: disable=too-many-arguments,too-many
 
     Returns ``(contract_path, cost, model, error)``. ``contract_path`` is None and
     ``error`` is set when contract generation could not be completed.
+
+    Issue #2362: a structurally valid body is still rejected when the semantic
+    completeness gate cannot prove every in-scope obligation is covered. On
+    rejection the previous contract bytes (if any) are left untouched.
     """
     inventory = _scan_prompt_inventory(prompts_root, extra_paths=extra_prompt_paths)
     body, cost, model = _llm_generate_story_contract(
@@ -1308,6 +1723,25 @@ def _generate_and_write_contract(  # pylint: disable=too-many-arguments,too-many
     )
     if body is None:
         return None, cost, model, "contract generation returned no valid contract"
+
+    review, review_cost, review_model = _review_contract_semantic_completeness(
+        story_text=story_text,
+        issue_text=issue_text,
+        contract_text=body,
+        strength=strength,
+        temperature=temperature,
+        time=time,
+        verbose=verbose,
+    )
+    cost += review_cost
+    model = review_model or model
+    if not review.ok:
+        return (
+            None,
+            cost,
+            model,
+            f"semantic completeness rejected contract ({review.diagnostics()})",
+        )
 
     contract_path = _contract_path_for_story(story_path)
     contract_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_user_story_tests.py
+++ b/tests/test_user_story_tests.py
@@ -9,7 +9,11 @@ from unittest.mock import patch
 import pytest
 
 from pdd.user_story_tests import (
+    ClauseCoverage,
+    CompletenessReview,
+    ContractObligation,
     _contract_path_for_story,
+    _parse_explicit_contract_obligations,
     _story_content_hash,
     cache_story_prompt_links,
     discover_prompt_files,
@@ -45,10 +49,20 @@ def _stub_contract_llm():
     """Stub the contract LLM call for the whole module so generation tests never
     hit the network. The real contract WRITER still runs, so a contract file is
     produced from ``_CONTRACT_MD``. Tests that assert issue-specific contract
-    content override this with their own ``_llm_generate_story_contract`` patch."""
-    with patch(
-        "pdd.user_story_tests._llm_generate_story_contract",
-        return_value=(_CONTRACT_MD, 0.0, "contract-model"),
+    content override this with their own ``_llm_generate_story_contract`` patch.
+
+    Also stub LLM obligation extraction (Issue #2362) so fixtures without
+    explicit clause IDs skip the semantic gate instead of fail-closing offline.
+    """
+    with (
+        patch(
+            "pdd.user_story_tests._llm_generate_story_contract",
+            return_value=(_CONTRACT_MD, 0.0, "contract-model"),
+        ),
+        patch(
+            "pdd.user_story_tests._llm_extract_contract_obligations",
+            return_value=([], 0.0, "", None),
+        ),
     ):
         yield
 
@@ -1404,6 +1418,358 @@ def test_validation_uses_story_plus_contract_as_oracle(tmp_path):
     # The oracle must contain both the human Story sentence and a contract section.
     assert "As a data analyst, I can upload a CSV file" in seen["oracle"]
     assert "## Acceptance Criteria" in seen["oracle"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #2362 — semantic completeness gate for generated Story contracts
+# ---------------------------------------------------------------------------
+
+_SEMANTIC_STORY_MD = (
+    "# User Story: Auth recovery workflow\n\n"
+    "## Story\n\n"
+    "As an operator, I can recover from auth and workflow faults without "
+    "latching bad state, so that the session stays usable.\n"
+)
+
+_SEMANTIC_ISSUE_BODY = """# Issue: Auth recovery distinctions
+
+## Summary
+Preserve recoverable auth faults and no-latch workflow states.
+
+## Contract obligations
+- AUTH-RECOVER-401: recoverable HTTP 401 is an explicit branch distinct from terminal authorization failure
+- AUTH-RECOVER-403: recoverable HTTP 403 is an explicit branch distinct from terminal authorization failure
+- NO-LOADING-ERROR-RECONNECTING-BUSY-INERT-LATCH: loading/error/reconnecting/busy/inert states must not latch
+- NO-STALE-CONTEXT-BLOCK: stale or context-block observations must be explicit
+- NO-LATE-RESULT-CONTAMINATION: late-result contamination must be observed and rejected
+- PRESERVE-PERMITTED-TEST-AUTH: already-permitted test-auth recovery eligibility is preserved
+"""
+
+_SEMANTIC_OBLIGATION_IDS = (
+    "AUTH-RECOVER-401",
+    "AUTH-RECOVER-403",
+    "NO-LOADING-ERROR-RECONNECTING-BUSY-INERT-LATCH",
+    "NO-STALE-CONTEXT-BLOCK",
+    "NO-LATE-RESULT-CONTAMINATION",
+    "PRESERVE-PERMITTED-TEST-AUTH",
+)
+
+
+def _semantic_contract_body(*, omit: str | None = None) -> str:
+    """Build a structurally valid contract; optionally omit one obligation."""
+    covers = {
+        "AUTH-RECOVER-401": (
+            "Recoverable HTTP 401 is handled as its own branch, not as a "
+            "terminal authorization failure."
+        ),
+        "AUTH-RECOVER-403": (
+            "Recoverable HTTP 403 is handled as its own branch, not as a "
+            "terminal authorization failure."
+        ),
+        "NO-LOADING-ERROR-RECONNECTING-BUSY-INERT-LATCH": (
+            "Workflow stages expose loading, error, reconnecting, busy, and "
+            "inert states without latching."
+        ),
+        "NO-STALE-CONTEXT-BLOCK": (
+            "Stale or context-block conditions are observed explicitly."
+        ),
+        "NO-LATE-RESULT-CONTAMINATION": (
+            "Late results that would contaminate state are rejected."
+        ),
+        "PRESERVE-PERMITTED-TEST-AUTH": (
+            "Already-permitted test-auth recovery eligibility remains available."
+        ),
+    }
+    cover_lines = [
+        f"- {clause_id}: {text}"
+        for clause_id, text in covers.items()
+        if clause_id != omit
+    ]
+    return (
+        "## Covers\n\n"
+        + "\n".join(cover_lines)
+        + "\n\n"
+        "## Context\n\n- Auth recovery workflow under test.\n\n"
+        "## Acceptance Criteria\n\n"
+        "1. Given a recoverable auth fault, when it occurs, then the matching "
+        "branch runs without treating it as terminal failure.\n\n"
+        "## Oracle\n\n- branch selection and no-latch state transitions\n\n"
+        "## Non-Oracle\n\n- exact log wording\n\n"
+        "## Negative Cases\n\n- Collapsing 401/403 into terminal auth failure\n\n"
+        "## Non-Goals\n\n- Redesigning the whole auth stack\n\n"
+        "## Candidate Prompts\n\n- none beyond the primary prompt(s)\n\n"
+        "## Notes\n\n- Issue #2362 fixture\n"
+    )
+
+
+def _all_covered_review(omit: str | None = None) -> CompletenessReview:
+    coverages = []
+    for clause_id in _SEMANTIC_OBLIGATION_IDS:
+        if clause_id == omit:
+            coverages.append(
+                ClauseCoverage(
+                    clause_id=clause_id, disposition="missing", evidence=""
+                )
+            )
+        else:
+            coverages.append(
+                ClauseCoverage(
+                    clause_id=clause_id,
+                    disposition="covered",
+                    evidence=f"paraphrase for {clause_id}",
+                )
+            )
+    return CompletenessReview(ok=omit is None, coverages=tuple(coverages))
+
+
+def test_parse_explicit_contract_obligations_from_issue():
+    obligations = _parse_explicit_contract_obligations(
+        _SEMANTIC_STORY_MD, _SEMANTIC_ISSUE_BODY
+    )
+    assert [o.clause_id for o in obligations] == list(_SEMANTIC_OBLIGATION_IDS)
+    assert all(isinstance(o, ContractObligation) for o in obligations)
+
+
+def test_semantic_gate_rejects_structurally_valid_but_incomplete_contract(tmp_path):
+    """A contract with every required heading but one uncovered obligation is rejected."""
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir()
+    prompt = prompts_dir / "auth_python.prompt"
+    prompt.write_text("Auth recovery.", encoding="utf-8")
+    incomplete = _semantic_contract_body(omit="AUTH-RECOVER-403")
+
+    with (
+        patch("pdd.user_story_tests.detect_change"),
+        patch(
+            "pdd.user_story_tests._llm_generate_story_markdown",
+            return_value=(_SEMANTIC_STORY_MD, 0.01, "story-model"),
+        ),
+        patch(
+            "pdd.user_story_tests._llm_generate_story_contract",
+            return_value=(incomplete, 0.02, "contract-model"),
+        ),
+        patch(
+            "pdd.user_story_tests._llm_review_contract_completeness",
+            return_value=(_all_covered_review(omit="AUTH-RECOVER-403"), 0.0, "reviewer"),
+        ),
+    ):
+        success, message, _, _, story_file, _ = generate_user_story(
+            prompt_files=[str(prompt)],
+            issue=_write_issue(tmp_path, body=_SEMANTIC_ISSUE_BODY),
+            stories_dir=str(tmp_path / "user_stories"),
+            prompts_dir=str(prompts_dir),
+        )
+
+    assert success is True
+    assert Path(story_file).exists()
+    assert "Contract generation was skipped" in message
+    assert "AUTH-RECOVER-403" in message
+    assert not _contract_path_for_story(Path(story_file)).exists()
+
+
+def test_semantic_gate_accepts_fluent_paraphrase_coverage(tmp_path):
+    """Fluent wording that preserves obligations is accepted without exact copy."""
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir()
+    prompt = prompts_dir / "auth_python.prompt"
+    prompt.write_text("Auth recovery.", encoding="utf-8")
+    complete = _semantic_contract_body()
+
+    with (
+        patch("pdd.user_story_tests.detect_change"),
+        patch(
+            "pdd.user_story_tests._llm_generate_story_markdown",
+            return_value=(_SEMANTIC_STORY_MD, 0.01, "story-model"),
+        ),
+        patch(
+            "pdd.user_story_tests._llm_generate_story_contract",
+            return_value=(complete, 0.02, "contract-model"),
+        ),
+        patch(
+            "pdd.user_story_tests._llm_review_contract_completeness",
+            return_value=(_all_covered_review(), 0.0, "reviewer"),
+        ),
+    ):
+        success, message, _, _, story_file, _ = generate_user_story(
+            prompt_files=[str(prompt)],
+            issue=_write_issue(tmp_path, body=_SEMANTIC_ISSUE_BODY),
+            stories_dir=str(tmp_path / "user_stories"),
+            prompts_dir=str(prompts_dir),
+        )
+
+    assert success is True
+    assert "Generated contract file:" in message
+    contract_path = _contract_path_for_story(Path(story_file))
+    assert contract_path.exists()
+    # Fluent paraphrase — not a verbatim copy of the issue line.
+    assert "explicit branch distinct from terminal" not in contract_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_sync_force_does_not_overwrite_when_semantic_gate_rejects(tmp_path):
+    """sync_user_story_contract(force=True) keeps old bytes when replacement fails."""
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir()
+    prompt = prompts_dir / "auth_python.prompt"
+    prompt.write_text("Auth recovery.", encoding="utf-8")
+    complete = _semantic_contract_body()
+    incomplete = _semantic_contract_body(omit="NO-STALE-CONTEXT-BLOCK")
+
+    with (
+        patch("pdd.user_story_tests.detect_change"),
+        patch(
+            "pdd.user_story_tests._llm_generate_story_markdown",
+            return_value=(_SEMANTIC_STORY_MD, 0.01, "story-model"),
+        ),
+        patch(
+            "pdd.user_story_tests._llm_generate_story_contract",
+            return_value=(complete, 0.02, "contract-model"),
+        ),
+        patch(
+            "pdd.user_story_tests._llm_review_contract_completeness",
+            return_value=(_all_covered_review(), 0.0, "reviewer"),
+        ),
+    ):
+        _, _, _, _, story_file, _ = generate_user_story(
+            prompt_files=[str(prompt)],
+            issue=_write_issue(tmp_path, body=_SEMANTIC_ISSUE_BODY),
+            stories_dir=str(tmp_path / "user_stories"),
+            prompts_dir=str(prompts_dir),
+        )
+
+    story_path = Path(story_file)
+    contract_path = _contract_path_for_story(story_path)
+    before = contract_path.read_text(encoding="utf-8")
+    before_hash = _story_content_hash(before)
+
+    with (
+        patch(
+            "pdd.user_story_tests._llm_generate_story_contract",
+            return_value=(incomplete, 0.02, "contract-model"),
+        ),
+        patch(
+            "pdd.user_story_tests._llm_review_contract_completeness",
+            return_value=(
+                _all_covered_review(omit="NO-STALE-CONTEXT-BLOCK"),
+                0.0,
+                "reviewer",
+            ),
+        ),
+    ):
+        changed, msg, _, _, _ = sync_user_story_contract(
+            str(story_path),
+            prompts_dir=str(prompts_dir),
+            force=True,
+        )
+
+    assert changed is False
+    assert "semantic completeness" in msg
+    assert "NO-STALE-CONTEXT-BLOCK" in msg
+    after = contract_path.read_text(encoding="utf-8")
+    assert after == before
+    assert _story_content_hash(after) == before_hash
+
+
+def test_semantic_reviewer_unavailable_fails_closed_without_overwrite(tmp_path):
+    """Indeterminate/unavailable reviewer must not write or overwrite."""
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir()
+    prompt = prompts_dir / "auth_python.prompt"
+    prompt.write_text("Auth recovery.", encoding="utf-8")
+
+    with (
+        patch("pdd.user_story_tests.detect_change"),
+        patch(
+            "pdd.user_story_tests._llm_generate_story_markdown",
+            return_value=(_SEMANTIC_STORY_MD, 0.01, "story-model"),
+        ),
+        patch(
+            "pdd.user_story_tests._llm_generate_story_contract",
+            return_value=(_semantic_contract_body(), 0.02, "contract-model"),
+        ),
+        patch(
+            "pdd.user_story_tests._llm_review_contract_completeness",
+            return_value=(
+                CompletenessReview(
+                    ok=False, error="semantic completeness review indeterminate"
+                ),
+                0.0,
+                "reviewer",
+            ),
+        ),
+    ):
+        success, message, _, _, story_file, _ = generate_user_story(
+            prompt_files=[str(prompt)],
+            issue=_write_issue(tmp_path, body=_SEMANTIC_ISSUE_BODY),
+            stories_dir=str(tmp_path / "user_stories"),
+            prompts_dir=str(prompts_dir),
+        )
+
+    assert success is True
+    assert Path(story_file).exists()
+    assert "indeterminate" in message
+    assert not _contract_path_for_story(Path(story_file)).exists()
+
+
+def test_incomplete_candidate_never_becomes_detection_oracle(tmp_path):
+    """Downstream detection cannot receive a rejected incomplete candidate."""
+    prompts_dir = tmp_path / "prompts"
+    stories_dir = tmp_path / "user_stories"
+    prompts_dir.mkdir()
+    stories_dir.mkdir()
+    prompt = prompts_dir / "auth_python.prompt"
+    prompt.write_text("Auth recovery.", encoding="utf-8")
+
+    with (
+        patch("pdd.user_story_tests.detect_change"),
+        patch(
+            "pdd.user_story_tests._llm_generate_story_markdown",
+            return_value=(_SEMANTIC_STORY_MD, 0.01, "story-model"),
+        ),
+        patch(
+            "pdd.user_story_tests._llm_generate_story_contract",
+            return_value=(
+                _semantic_contract_body(omit="PRESERVE-PERMITTED-TEST-AUTH"),
+                0.02,
+                "contract-model",
+            ),
+        ),
+        patch(
+            "pdd.user_story_tests._llm_review_contract_completeness",
+            return_value=(
+                _all_covered_review(omit="PRESERVE-PERMITTED-TEST-AUTH"),
+                0.0,
+                "reviewer",
+            ),
+        ),
+    ):
+        _, _, _, _, story_file, _ = generate_user_story(
+            prompt_files=[str(prompt)],
+            issue=_write_issue(tmp_path, body=_SEMANTIC_ISSUE_BODY),
+            stories_dir=str(stories_dir),
+            prompts_dir=str(prompts_dir),
+        )
+
+    story_path = Path(story_file)
+    assert not _contract_path_for_story(story_path).exists()
+
+    seen = {}
+
+    def fake_detect(prompt_paths, oracle, *_a, **_k):
+        seen["oracle"] = oracle
+        return [], 0.0, "gpt-test"
+
+    with patch("pdd.user_story_tests.detect_change", side_effect=fake_detect):
+        passed, _, _, _ = run_user_story_tests(
+            prompts_dir=str(prompts_dir), stories_dir=str(stories_dir), quiet=True
+        )
+
+    assert passed is True
+    # Oracle is the human Story only — incomplete candidate was never written.
+    assert "PRESERVE-PERMITTED-TEST-AUTH" not in seen["oracle"]
+    assert "## Acceptance Criteria" not in seen["oracle"]
+    assert "recover from auth and workflow faults" in seen["oracle"]
 
 
 def test_generate_user_story_fails_when_llm_output_contains_placeholders(tmp_path):


### PR DESCRIPTION
## Summary

Generated story contracts were previously accepted when the Markdown structure was valid, even if obligations from the story or issue were missing. That incomplete contract could then become the oracle used during detection.

This change adds a completeness check before writing the contract. Explicit clause IDs are preferred when available; otherwise, the model generates an obligation inventory and reviews the contract for coverage. If the completeness check fails or is indeterminate, no contract is written, and sync preserves the existing contract.

Closes #2362

## Test plan

Ran `pytest tests/test_user_story_tests.py`: 65 tests passed, including new completeness-gate coverage for rejection, acceptance, forced sync, and fail-closed reviewer behavior.
