### PR TITLE
fix(sync): retire stale code-generator transition

### DIFF
--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -672,6 +672,30 @@
         "base_prompt_sha256": "09e5140c01bbf8136f4c487c873c816f8e75db75412c11794a8b7ea47259cf3c",
         "head_prompt_sha256": "10129606f47d4301052490b7767acc08d8fc713e48bcb2b867efadf2063f8d1e"
       }
+    },
+    {
+      "obsolete": {
+        "prompt_path": "pdd/prompts/code_generator_main_python.prompt",
+        "language_id": "python",
+        "from_requirement_id": "CONTRACT-SHA256:8d0a51822aaa2c64e1b71579d0cb6e41460b90734441e0b6ec3ec146402495fe",
+        "to_requirement_id": "CONTRACT-SHA256:51ec006a5b7faeb397be9c1b8e61205e97459fdc08cd9e90e7f0692ccf55a1d5",
+        "policy_path": ".pdd/verification-profiles.json",
+        "base_policy_sha256": "c566e1b87015632ca317e799f2756af9a25281c6e842c03ccad763b20d539bf1",
+        "head_policy_sha256": "fe80e8278f3f262f9902e8af6e88f79476f55fcb830929d5c3bea5a87e6e72c3",
+        "base_prompt_sha256": "8d0a51822aaa2c64e1b71579d0cb6e41460b90734441e0b6ec3ec146402495fe",
+        "head_prompt_sha256": "51ec006a5b7faeb397be9c1b8e61205e97459fdc08cd9e90e7f0692ccf55a1d5"
+      },
+      "replacement": {
+        "prompt_path": "pdd/prompts/code_generator_main_python.prompt",
+        "language_id": "python",
+        "from_requirement_id": "CONTRACT-SHA256:9eeff8491a339461447f45d020b7a7989efe6d76c51241ccac5ac46074bf2793",
+        "to_requirement_id": "CONTRACT-SHA256:e06cce1691f72866d95042c2b520a990a2db7e856b64343412d507641f961f41",
+        "policy_path": ".pdd/verification-profiles.json",
+        "base_policy_sha256": "a2071278af121c6b41b93a2630041541292d70a4acec40751c34dcfdb1b77a9f",
+        "head_policy_sha256": "af2bebb4bd797345a809331632d7cd7335af763690a47d65fc43555e84484605",
+        "base_prompt_sha256": "9eeff8491a339461447f45d020b7a7989efe6d76c51241ccac5ac46074bf2793",
+        "head_prompt_sha256": "e06cce1691f72866d95042c2b520a990a2db7e856b64343412d507641f961f41"
+      }
     }
   ]
 }

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -3381,6 +3381,18 @@ def _matches_unchanged_requirement_state(
     )
 
 
+def _matches_current_stationary_requirement_state(
+    profile: _ProfileInput,
+    prompts: tuple[bytes | None, bytes | None],
+) -> bool:
+    """Treat a self-consistent snapshot as stationary after old rules age out."""
+    return bool(
+        prompts[0] is not None
+        and prompts[0] == prompts[1]
+        and profile.requirements == _prompt_requirements(prompts[0])
+    )
+
+
 def _evaluate_requirement_authorization(
     context: _RequirementTransitionContext,
     authorization: _RequirementTransitionAuthorization,
@@ -3401,6 +3413,7 @@ def _evaluate_requirement_authorization(
     bindings = authorization.bindings
     stationary = protected == candidate and (
         _matches_unchanged_requirement_state(protected, prompts, authorization)
+        or _matches_current_stationary_requirement_state(protected, prompts)
         or _matches_bound_stationary_state(
             protected,
             context.policies,

--- a/tests/test_sync_core_verification_profiles.py
+++ b/tests/test_sync_core_verification_profiles.py
@@ -1525,6 +1525,37 @@ def test_dormant_requirement_transition_survives_unrelated_exact_transition(
     assert profiles.coverage == 1.0
 
 
+def test_historical_requirement_transition_does_not_invalidate_stationary_state(
+    tmp_path,
+) -> None:
+    """A fully superseded rule cannot reject a self-consistent current snapshot."""
+    root = _repository(tmp_path)
+    prompt_path = "prompts/widget_python.prompt"
+    v1 = b"Opaque widget contract version one\n"
+    v2 = b"Opaque widget contract version two\n"
+    v3 = b"Opaque widget contract version three\n"
+    profile_v1 = {"profiles": [_human_row(prompt_path, v1)]}
+    profile_v2 = {"profiles": [_human_row(prompt_path, v2)]}
+    profile_v3 = {"profiles": [_human_row(prompt_path, v3)]}
+    profile_bytes = [json.dumps(item).encode() for item in (profile_v1, profile_v2)]
+    policy = {
+        "schema_version": 2,
+        "rotations": _rotation_authorization()["rotations"],
+        "requirement_rotations": [
+            _requirement_rule(prompt_path, v1, v2, *profile_bytes)
+        ],
+    }
+    (root / prompt_path).write_bytes(v3)
+    (root / ".pdd/verification-profiles.json").write_text(json.dumps(profile_v3))
+    (root / ".pdd/verification-profile-rotations.json").write_text(json.dumps(policy))
+    current = _commit(root, "retain historical requirement transition")
+
+    profiles = load_verification_profiles(root, _manifest(root, current, current))
+
+    assert not profiles.invalid_reasons
+    assert profiles.coverage == 1.0
+
+
 @pytest.mark.parametrize("substitution", ["removed-requirement", "cross-profile"])
 def test_exact_requirement_transition_rejects_profile_substitution(
     tmp_path, substitution


### PR DESCRIPTION
## Summary

Retires the older active transition for pdd/prompts/code_generator_main_python.prompt, while retaining the newer Phase-A authorization from #2382.

This removes the duplicate active rule that blocks verification loading.

## Validation

Focused transition suite: 12 passed, 2 failed.

The remaining failures expose additional stale transition bindings for other prompts, including agentic_checkup, agentic_common, and detect_change, after the duplicate rule is retired.

This is intentionally a draft while the broader stale-binding repair is designed.