### PR TITLE
chore(sync): preauthorize corrected language-validity gate rotation

### DIFF
--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -646,6 +646,17 @@
       "head_policy_sha256": "af2bebb4bd797345a809331632d7cd7335af763690a47d65fc43555e84484605",
       "base_prompt_sha256": "9eeff8491a339461447f45d020b7a7989efe6d76c51241ccac5ac46074bf2793",
       "head_prompt_sha256": "e06cce1691f72866d95042c2b520a990a2db7e856b64343412d507641f961f41"
+    },
+    {
+      "prompt_path": "pdd/prompts/code_generator_main_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:9eeff8491a339461447f45d020b7a7989efe6d76c51241ccac5ac46074bf2793",
+      "to_requirement_id": "CONTRACT-SHA256:882876b0dea9198c1fa9492806d85bfb088b393096f4f1a0543cc8f31f40fc30",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "a2071278af121c6b41b93a2630041541292d70a4acec40751c34dcfdb1b77a9f",
+      "head_policy_sha256": "6e589170b67c9547fad99dca53d32a085ecb3e9074a564419f97fc7316546888",
+      "base_prompt_sha256": "9eeff8491a339461447f45d020b7a7989efe6d76c51241ccac5ac46074bf2793",
+      "head_prompt_sha256": "882876b0dea9198c1fa9492806d85bfb088b393096f4f1a0543cc8f31f40fc30"
     }
   ],
   "requirement_rotation_retirements": [
@@ -671,6 +682,30 @@
         "head_policy_sha256": "a2071278af121c6b41b93a2630041541292d70a4acec40751c34dcfdb1b77a9f",
         "base_prompt_sha256": "09e5140c01bbf8136f4c487c873c816f8e75db75412c11794a8b7ea47259cf3c",
         "head_prompt_sha256": "10129606f47d4301052490b7767acc08d8fc713e48bcb2b867efadf2063f8d1e"
+      }
+    },
+    {
+      "obsolete": {
+        "prompt_path": "pdd/prompts/code_generator_main_python.prompt",
+        "language_id": "python",
+        "from_requirement_id": "CONTRACT-SHA256:9eeff8491a339461447f45d020b7a7989efe6d76c51241ccac5ac46074bf2793",
+        "to_requirement_id": "CONTRACT-SHA256:e06cce1691f72866d95042c2b520a990a2db7e856b64343412d507641f961f41",
+        "policy_path": ".pdd/verification-profiles.json",
+        "base_policy_sha256": "a2071278af121c6b41b93a2630041541292d70a4acec40751c34dcfdb1b77a9f",
+        "head_policy_sha256": "af2bebb4bd797345a809331632d7cd7335af763690a47d65fc43555e84484605",
+        "base_prompt_sha256": "9eeff8491a339461447f45d020b7a7989efe6d76c51241ccac5ac46074bf2793",
+        "head_prompt_sha256": "e06cce1691f72866d95042c2b520a990a2db7e856b64343412d507641f961f41"
+      },
+      "replacement": {
+        "prompt_path": "pdd/prompts/code_generator_main_python.prompt",
+        "language_id": "python",
+        "from_requirement_id": "CONTRACT-SHA256:9eeff8491a339461447f45d020b7a7989efe6d76c51241ccac5ac46074bf2793",
+        "to_requirement_id": "CONTRACT-SHA256:882876b0dea9198c1fa9492806d85bfb088b393096f4f1a0543cc8f31f40fc30",
+        "policy_path": ".pdd/verification-profiles.json",
+        "base_policy_sha256": "a2071278af121c6b41b93a2630041541292d70a4acec40751c34dcfdb1b77a9f",
+        "head_policy_sha256": "6e589170b67c9547fad99dca53d32a085ecb3e9074a564419f97fc7316546888",
+        "base_prompt_sha256": "9eeff8491a339461447f45d020b7a7989efe6d76c51241ccac5ac46074bf2793",
+        "head_prompt_sha256": "882876b0dea9198c1fa9492806d85bfb088b393096f4f1a0543cc8f31f40fc30"
       }
     }
   ]


### PR DESCRIPTION
## Phase A — dormant authority only

This is the corrected, JSON-only Phase-A authorization for the language-validity gate. It:

- preserves the protected `e06cce…` / `af2beb…` authority byte-for-byte;
- appends a fresh authority for the exact final prompt (`882876…`) and verification profile (`6e5891…`) bytes;
- retires the superseded protected row in favor of that new authority; and
- leaves every prompt, verification profile, product file, test, and verifier binding unchanged.

It intentionally does **not** consume the authorization.

## Dependency

This draft requires a separately protected governance-verifier prerequisite before it can merge, because the current verifier binds the older stationary Phase-A policy digest. After that prerequisite and this Phase A are protected, a separate Phase-B verifier binding can be landed before rebasing and consuming the unchanged authority in #2370.

## Validation

- `python3 -m json.tool .pdd/verification-profile-rotations.json`
- `git diff --check`
- verified the prepared digests directly from #2370 head: prompt `882876b0…fc30`; profile `6e589170…6888`.