### PR TITLE
fix(sync): recognize exact consumed story rotation replacement

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -35,20 +35,24 @@ change.
 
 ### Phase A: install dormant rows
 
-Phase A may add only dormant `requirement_rotations`, or make the narrow
-append-only stale-authority retirement described below. The prompt named by each
-new row and `.pdd/verification-profiles.json` must remain byte-for-byte
-identical to the protected base. Every other managed prompt must likewise remain
-byte-identical, resolving approved aliases to their protected canonical prompt
-path. The rest of the policy envelope, including
+Phase A normally may add only dormant `requirement_rotations`, or make the
+narrow append-only stale-authority retirement described below. This general rule
+does not itself allow removing or replacing a consumed row; the one
+repository-bound direct-replacement exception is described separately below.
+The prompt named by each new row and `.pdd/verification-profiles.json` must
+remain byte-for-byte identical to the protected base. Every other managed prompt
+must likewise remain byte-identical, resolving approved aliases to their
+protected canonical prompt path. The rest of the policy envelope, including
 `rotations`, must preserve the protected authority exactly. A retirement/reissue
 may advance only the transition envelope from schema 2 to schema 3 to append its
 retirement record; it cannot otherwise replace policy authority.
 
 For schema 2, every surviving protected row must retain its exact JSON token and
-relative order, ahead of newly added rows. A consumed row may still be removed or
-replaced after the loader proves consumption, without permitting any surviving
-protected row to be reformatted, re-escaped, or reordered.
+relative order, ahead of newly added rows. Proof that a row is consumed does not
+by itself authorize its removal or replacement. This representation rule governs
+schema-2 history only; it never permits surviving protected rows to be
+reformatted, re-escaped, or reordered, and it does not broaden the separate
+schema-3 direct-replacement exception below.
 
 Each row records the SHA-256 identities of the current prompt/profile bytes and
 the prepared Phase B prompt/profile bytes. Review those exact prepared bytes
@@ -76,6 +80,47 @@ row, fork, chain, cycle, or use wildcard identity.
 The authority-only candidate must leave all managed prompt and profile bytes
 unchanged. Its fresh replacement remains dormant until this retirement/reissue
 candidate itself is protected, and only a later Phase B can consume it.
+
+### Repository-bound consumed-row direct replacement (user-story bridge)
+
+This is not the schema-3 retirement/reissue mechanism above: that mechanism
+retains the obsolete row and is only for an unreachable *dormant* row. In
+particular, the scope of the preceding section excludes a live or consumed row.
+Likewise, the general Phase-A rule above and the schema-2 representation rule do
+not create a generic consumed-row replacement privilege.
+
+The verifier recognizes exactly one separate schema-3 direct replacement for
+repository `3b4d7b1c-d6cc-4752-ba93-6b98d1a710e0`: protected policy digest
+`470a4e7427c958b82aafacd3f74fc6733a23ca9866798fe0c8ae15a75f37cf1e` to
+candidate policy digest
+`b8b1e11ef85bbf76231c69a06f764935a1bdd2577a003d4299a98d62fa4bf67a`, with
+the verification-profile digest
+`85d01008145de7a7bc67bc6b458b7780a1fbaf24f9733708a0a1032ecb49a9f5` on both
+sides. It removes only the already-consumed
+`pdd/prompts/user_story_tests_python.prompt` row from
+`c63d875cc5d488b8fd9bfdd72ea015f33962d22b5cde90b9be751de55a209e32` to
+`1c467034344d9d87b8225995bc458bc8093e6759dd5c2eed8424b345f69a3ba7` and
+installs only its dormant successor from that latter digest to
+`5b1353257a64a25b303d990803bb799da66504af558c3a5e972d95ad5a04bb3b`.
+
+This bridge has exactly three protected stages:
+
+1. A separate verifier prerequisite first lands the repository- and
+   digest-bound recognition. It is history recognition only; it adds no story
+   transition authority.
+2. A later policy-only Phase A uses precisely the policy/profile digest pair
+   above. The target prompt, `.pdd/verification-profiles.json`, and every other
+   managed prompt (after protected alias resolution) remain byte-identical; all
+   other policy authority remains unchanged. This Phase A must merge and become
+   protected before the next stage.
+3. Only a still later Phase B may consume the dormant successor using its
+   already-bound target prompt/profile bytes. It cannot be combined with either
+   prior stage.
+
+The verifier's stationary recognition of the resulting policy/profile pair is
+also repository- and digest-bound, preserves only historical overlays needed to
+load protected history, and never authorizes another row, prompt, profile, or
+managed artifact change.
 
 ### Repository-bound legacy llm-invoke retirement (#2316)
 

--- a/pdd/sync_core/verification.py
+++ b/pdd/sync_core/verification.py
@@ -245,6 +245,26 @@ _PR2376_DEPENDENCY_FIX_PROFILE_BYTES = (
     _CONFORMANCE_SPLIT_PROFILE_BYTES[1],
     "85d01008145de7a7bc67bc6b458b7780a1fbaf24f9733708a0a1032ecb49a9f5",
 )
+# A future Phase A may replace the already-consumed user-story row with its
+# next dormant row.  These complete policy/profile pairs preserve the existing
+# historical overlays for that exact direct replacement and its stationary
+# protected state; they do not add requirement-transition authority.
+_STORY_PROMPT_PHASE_A_ROTATION_POLICY_BYTES = (
+    _PR2376_DEPENDENCY_FIX_ROTATION_POLICY_BYTES[1],
+    "b8b1e11ef85bbf76231c69a06f764935a1bdd2577a003d4299a98d62fa4bf67a",
+)
+_STORY_PROMPT_PHASE_A_PROFILE_BYTES = (
+    _PR2376_DEPENDENCY_FIX_PROFILE_BYTES[1],
+    _PR2376_DEPENDENCY_FIX_PROFILE_BYTES[1],
+)
+_STORY_PROMPT_PHASE_A_STATIONARY_POLICY_BYTES = (
+    _STORY_PROMPT_PHASE_A_ROTATION_POLICY_BYTES[1],
+    _STORY_PROMPT_PHASE_A_ROTATION_POLICY_BYTES[1],
+)
+_STORY_PROMPT_PHASE_A_STATIONARY_PROFILE_BYTES = (
+    _STORY_PROMPT_PHASE_A_PROFILE_BYTES[1],
+    _STORY_PROMPT_PHASE_A_PROFILE_BYTES[1],
+)
 _PR2316_STALE_LLM_REISSUE_HISTORY_PROFILE_BYTES = (
     _OPUS_FABLE_COMPOSED_PROFILE_BYTES[1],
     _TEMPERATURE_REGRESSION_PROFILE_BYTES[1],
@@ -2825,8 +2845,15 @@ def _validate_candidate_retirements(
     candidate_policy: bytes | None,
     exact_pr2316_phase_a_reissue: bool,
     exact_pr2316_historical_reissue: bool,
+    exact_story_prompt_phase_a_replacement: bool,
 ) -> None:
-    """Validate append-only retirement/reissue of unreachable protected rows."""
+    """Validate exact replacements and append-only unreachable-row reissues."""
+    if exact_story_prompt_phase_a_replacement:
+        # The full policy/profile bytes identify one direct replacement of an
+        # already-consumed row.  Phase A still cannot alter any managed prompt;
+        # the candidate loop below separately proves its replacement dormant.
+        _validate_retirement_managed_prompt_bytes(root, manifest, approved_aliases)
+        return
     protected_schema = _policy_schema_version(protected_policy, "protected")
     candidate_schema = _policy_schema_version(candidate_policy, "candidate")
     if protected_schema == 2 and candidate_schema == 2:
@@ -3081,6 +3108,26 @@ def _load_requirement_transition_authorizations(
         if policies[0] is not None and policies[1] is not None
         else None
     )
+    story_prompt_phase_a_replacement = is_pdd_repository and (
+        (policy_digests, profile_digests)
+        == (
+            _STORY_PROMPT_PHASE_A_ROTATION_POLICY_BYTES,
+            _STORY_PROMPT_PHASE_A_PROFILE_BYTES,
+        )
+    )
+    story_prompt_phase_a_state = is_pdd_repository and (
+        (policy_digests, profile_digests)
+        in {
+            (
+                _STORY_PROMPT_PHASE_A_ROTATION_POLICY_BYTES,
+                _STORY_PROMPT_PHASE_A_PROFILE_BYTES,
+            ),
+            (
+                _STORY_PROMPT_PHASE_A_STATIONARY_POLICY_BYTES,
+                _STORY_PROMPT_PHASE_A_STATIONARY_PROFILE_BYTES,
+            ),
+        }
+    )
     generate_reliability_state = is_pdd_repository and (
         (policy_digests, profile_digests)
         in {
@@ -3150,7 +3197,8 @@ def _load_requirement_transition_authorizations(
         }
     )
     code_generator_language_gate_state = is_pdd_repository and (
-        (policy_digests, profile_digests)
+        story_prompt_phase_a_state
+        or (policy_digests, profile_digests)
         in {
             (
                 _CODE_GENERATOR_LANGUAGE_GATE_ROTATION_POLICY_BYTES,
@@ -3190,7 +3238,8 @@ def _load_requirement_transition_authorizations(
         }
     )
     zsh_global_option_state = is_pdd_repository and (
-        (policy_digests, profile_digests)
+        story_prompt_phase_a_state
+        or (policy_digests, profile_digests)
         in {
             (
                 _ZSH_GLOBAL_OPTION_ROTATION_POLICY_BYTES,
@@ -3225,7 +3274,8 @@ def _load_requirement_transition_authorizations(
         }
     )
     pr2376_dependency_fix_state = is_pdd_repository and (
-        (policy_digests, profile_digests)
+        story_prompt_phase_a_state
+        or (policy_digests, profile_digests)
         in {
             (
                 _PR2376_DEPENDENCY_FIX_ROTATION_POLICY_BYTES,
@@ -3476,6 +3526,7 @@ def _load_requirement_transition_authorizations(
         candidate_policy,
         exact_pr2316_phase_a_reissue,
         exact_pr2316_historical_reissue,
+        story_prompt_phase_a_replacement,
     )
     legacy_pdd1989_reconciliation = (
         is_pdd_repository

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -951,7 +951,57 @@ def _story_prompt_phase_a_policy(protected_policy: bytes) -> bytes:
     return candidate
 
 
-def _load_story_prompt_phase_a_authorizations(
+def _story_prompt_phase_a_manifest_with_blobs(
+    monkeypatch,
+    manifest,
+    protected_policy: bytes,
+    candidate_policy: bytes,
+    protected_profile: bytes,
+    candidate_profile: bytes,
+    candidate_prompt_bytes: dict[PurePosixPath, bytes] | None = None,
+):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    """Bind synthetic Phase-A policy, profile, and prompt blobs to exact refs."""
+    candidate_prompt_bytes = (
+        {} if candidate_prompt_bytes is None else candidate_prompt_bytes
+    )
+    original_read = verification.read_git_blob
+
+    def phase_a_read(_root: Path, ref: str, path: PurePosixPath) -> bytes | None:
+        if path == verification.ROTATION_POLICY_PATH:
+            return protected_policy if ref == "protected" else candidate_policy
+        if path == PROFILE_REL_PATH:
+            return protected_profile if ref == "protected" else candidate_profile
+        if ref == "candidate" and path in candidate_prompt_bytes:
+            return candidate_prompt_bytes[path]
+        return original_read(ROOT, "HEAD", path)
+
+    monkeypatch.setattr(verification, "read_git_blob", phase_a_read)
+    candidate_paths = set(candidate_prompt_bytes)
+    bound_paths = {
+        item.candidate_id.artifact_relpath
+        for item in manifest.candidates
+        if item.candidate_id.artifact_relpath in candidate_paths
+    }
+    assert bound_paths == candidate_paths
+    candidate_records = tuple(
+        replace(
+            item,
+            head_object_id=hashlib.sha1(
+                candidate_prompt_bytes[item.candidate_id.artifact_relpath]
+            ).hexdigest(),
+        )
+        if item.candidate_id.artifact_relpath in candidate_prompt_bytes
+        else item
+        for item in manifest.candidates
+    )
+    return replace(
+        manifest,
+        refs=ManifestRefs("protected", "candidate"),
+        candidates=candidate_records,
+    )
+
+
+def _load_story_prompt_phase_a_authorizations(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     monkeypatch,
     manifest,
     protected_policy: bytes,
@@ -963,19 +1013,13 @@ def _load_story_prompt_phase_a_authorizations(
     tuple[verification._RequirementTransitionAuthorization, ...],
 ]:
     """Load a synthesized Phase-A policy through the production boundary."""
-    original_read = verification.read_git_blob
-
-    def phase_a_read(_root: Path, ref: str, path: PurePosixPath) -> bytes | None:
-        if path == verification.ROTATION_POLICY_PATH:
-            return protected_policy if ref == "protected" else candidate_policy
-        if path == PROFILE_REL_PATH:
-            return protected_profile if ref == "protected" else candidate_profile
-        return original_read(ROOT, "HEAD", path)
-
-    monkeypatch.setattr(verification, "read_git_blob", phase_a_read)
-    manifest = replace(
+    manifest = _story_prompt_phase_a_manifest_with_blobs(
+        monkeypatch,
         manifest,
-        refs=ManifestRefs("protected", "candidate"),
+        protected_policy,
+        candidate_policy,
+        protected_profile,
+        candidate_profile,
     )
     base, base_invalid = verification._load_inputs(  # pylint: disable=protected-access
         ROOT, manifest.base_ref, manifest.repository_id, {}
@@ -991,6 +1035,28 @@ def _load_story_prompt_phase_a_authorizations(
         )
     )
     return authorizations, new_authorizations
+
+
+def _load_story_prompt_phase_a_profiles(
+    monkeypatch,
+    manifest,
+    protected_policy: bytes,
+    candidate_policy: bytes,
+    protected_profile: bytes,
+    candidate_profile: bytes,
+    candidate_prompt_bytes: dict[PurePosixPath, bytes],
+):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    """Exercise synthesized Phase-A blobs through the public profile loader."""
+    manifest = _story_prompt_phase_a_manifest_with_blobs(
+        monkeypatch,
+        manifest,
+        protected_policy,
+        candidate_policy,
+        protected_profile,
+        candidate_profile,
+        candidate_prompt_bytes,
+    )
+    return load_verification_profiles(ROOT, manifest)
 
 
 @pytest.fixture(scope="module")
@@ -1027,6 +1093,19 @@ def test_story_prompt_phase_a_consumed_replacement_is_exact(  # pylint: disable=
         if item.prompt_path.as_posix()
         == STORY_PROMPT_PHASE_A_REPLACEMENT["prompt_path"]
     ] == [STORY_PROMPT_PHASE_A_REPLACEMENT]
+
+    with monkeypatch.context() as public_loader_monkeypatch:
+        profiles = _load_story_prompt_phase_a_profiles(
+            public_loader_monkeypatch,
+            story_prompt_phase_a_manifest,
+            protected_policy,
+            candidate_policy,
+            profile,
+            profile,
+            {},
+        )
+    assert not profiles.invalid_reasons
+    assert profiles.coverage == 1.0
 
     with monkeypatch.context() as stationary_monkeypatch:
         authorizations, new_authorizations = (
@@ -1076,6 +1155,38 @@ def test_story_prompt_phase_a_consumed_replacement_rejects_nearby_bytes(  # pyli
             profile,
             candidate_profile,
         )
+
+
+@pytest.mark.parametrize(
+    "prompt_path",
+    (
+        PurePosixPath(STORY_PROMPT_PHASE_A_REPLACEMENT["prompt_path"]),
+        PurePosixPath("pdd/prompts/code_generator_main_python.prompt"),
+    ),
+    ids=("target-prompt", "unrelated-managed-prompt"),
+)
+def test_story_prompt_phase_a_consumed_replacement_rejects_managed_prompt_drift(  # pylint: disable=redefined-outer-name
+    monkeypatch, prompt_path: PurePosixPath, story_prompt_phase_a_manifest
+) -> None:
+    """The exact Phase-A exception rejects target and unrelated prompt drift."""
+    protected_policy = ROTATION_FILE.read_bytes()
+    profile = PROFILE_FILE.read_bytes()
+    candidate_policy = _story_prompt_phase_a_policy(protected_policy)
+    candidate_prompt = (ROOT / prompt_path).read_bytes() + b"\n% unauthorized drift\n"
+
+    with pytest.raises(verification.VerificationProfileError) as error:
+        _load_story_prompt_phase_a_profiles(
+            monkeypatch,
+            story_prompt_phase_a_manifest,
+            protected_policy,
+            candidate_policy,
+            profile,
+            profile,
+            {prompt_path: candidate_prompt},
+        )
+    assert str(error.value) == (
+        f"candidate retirement changes managed prompt bytes: {prompt_path}"
+    )
 
 
 def test_gemini_phase_a_policy_binds_exactly_two_future_authorizations() -> None:

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -416,6 +416,56 @@ CI_DETECT_REQUIREMENT_ROTATION = {
         "f0d873e5505d40035d3c7364fd3961b5602d21519ec9be2049c2f38b16239712"
     ),
 }
+STORY_PROMPT_PHASE_A_POLICY_SHA256 = (
+    "b8b1e11ef85bbf76231c69a06f764935a1bdd2577a003d4299a98d62fa4bf67a"
+)
+STORY_PROMPT_PHASE_A_PROFILE_SHA256 = (
+    "85d01008145de7a7bc67bc6b458b7780a1fbaf24f9733708a0a1032ecb49a9f5"
+)
+STORY_PROMPT_CONSUMED_ROTATION = {
+    "prompt_path": "pdd/prompts/user_story_tests_python.prompt",
+    "language_id": "python",
+    "from_requirement_id": (
+        "CONTRACT-SHA256:c63d875cc5d488b8fd9bfdd72ea015f33962d22b5cde90b9be751de55a209e32"
+    ),
+    "to_requirement_id": (
+        "CONTRACT-SHA256:1c467034344d9d87b8225995bc458bc8093e6759dd5c2eed8424b345f69a3ba7"
+    ),
+    "policy_path": ".pdd/verification-profiles.json",
+    "base_policy_sha256": (
+        "fe80e8278f3f262f9902e8af6e88f79476f55fcb830929d5c3bea5a87e6e72c3"
+    ),
+    "head_policy_sha256": (
+        "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836"
+    ),
+    "base_prompt_sha256": (
+        "c63d875cc5d488b8fd9bfdd72ea015f33962d22b5cde90b9be751de55a209e32"
+    ),
+    "head_prompt_sha256": (
+        "1c467034344d9d87b8225995bc458bc8093e6759dd5c2eed8424b345f69a3ba7"
+    ),
+}
+STORY_PROMPT_PHASE_A_REPLACEMENT = {
+    "prompt_path": "pdd/prompts/user_story_tests_python.prompt",
+    "language_id": "python",
+    "from_requirement_id": (
+        "CONTRACT-SHA256:1c467034344d9d87b8225995bc458bc8093e6759dd5c2eed8424b345f69a3ba7"
+    ),
+    "to_requirement_id": (
+        "CONTRACT-SHA256:5b1353257a64a25b303d990803bb799da66504af558c3a5e972d95ad5a04bb3b"
+    ),
+    "policy_path": ".pdd/verification-profiles.json",
+    "base_policy_sha256": STORY_PROMPT_PHASE_A_PROFILE_SHA256,
+    "head_policy_sha256": (
+        "6e765e03761e7dd678e5b02b147c60231c13fc8ab3de3fd722cf1181c017acb7"
+    ),
+    "base_prompt_sha256": (
+        "1c467034344d9d87b8225995bc458bc8093e6759dd5c2eed8424b345f69a3ba7"
+    ),
+    "head_prompt_sha256": (
+        "5b1353257a64a25b303d990803bb799da66504af558c3a5e972d95ad5a04bb3b"
+    ),
+}
 STORY_REGRESSION_DORMANT_ROTATION = {
     "prompt_path": "pdd/prompts/story_regression_python.prompt",
     "language_id": "python",
@@ -876,6 +926,156 @@ def _new_requirement_authorizations(
         )
     )
     return new_authorizations
+
+
+def _story_prompt_phase_a_policy(protected_policy: bytes) -> bytes:
+    """Build the exact direct replacement allowed after source consumption."""
+    assert hashlib.sha256(protected_policy).hexdigest() == (
+        verification._PR2376_DEPENDENCY_FIX_ROTATION_POLICY_BYTES[1]  # pylint: disable=protected-access
+    )
+    payload = json.loads(protected_policy)
+    obsolete = next(
+        row
+        for row in payload["requirement_rotations"]
+        if row["prompt_path"] == STORY_PROMPT_CONSUMED_ROTATION["prompt_path"]
+        and row["from_requirement_id"]
+        == STORY_PROMPT_CONSUMED_ROTATION["from_requirement_id"]
+    )
+    assert obsolete == STORY_PROMPT_CONSUMED_ROTATION
+    payload["requirement_rotations"].remove(obsolete)
+    payload["requirement_rotations"].append(
+        copy.deepcopy(STORY_PROMPT_PHASE_A_REPLACEMENT)
+    )
+    candidate = (json.dumps(payload, indent=2) + "\n").encode("utf-8")
+    assert hashlib.sha256(candidate).hexdigest() == STORY_PROMPT_PHASE_A_POLICY_SHA256
+    return candidate
+
+
+def _load_story_prompt_phase_a_authorizations(
+    monkeypatch,
+    manifest,
+    protected_policy: bytes,
+    candidate_policy: bytes,
+    protected_profile: bytes,
+    candidate_profile: bytes,
+) -> tuple[
+    tuple[verification._RequirementTransitionAuthorization, ...],
+    tuple[verification._RequirementTransitionAuthorization, ...],
+]:
+    """Load a synthesized Phase-A policy through the production boundary."""
+    original_read = verification.read_git_blob
+
+    def phase_a_read(_root: Path, ref: str, path: PurePosixPath) -> bytes | None:
+        if path == verification.ROTATION_POLICY_PATH:
+            return protected_policy if ref == "protected" else candidate_policy
+        if path == PROFILE_REL_PATH:
+            return protected_profile if ref == "protected" else candidate_profile
+        return original_read(ROOT, "HEAD", path)
+
+    monkeypatch.setattr(verification, "read_git_blob", phase_a_read)
+    manifest = replace(
+        manifest,
+        refs=ManifestRefs("protected", "candidate"),
+    )
+    base, base_invalid = verification._load_inputs(  # pylint: disable=protected-access
+        ROOT, manifest.base_ref, manifest.repository_id, {}
+    )
+    head, head_invalid = verification._load_inputs(  # pylint: disable=protected-access
+        ROOT, manifest.head_ref, manifest.repository_id, {}
+    )
+    assert not base_invalid
+    assert not head_invalid
+    authorizations, _prompts, new_authorizations = (
+        verification._load_requirement_transition_authorizations(  # pylint: disable=protected-access
+            ROOT, manifest, base, head, {}
+        )
+    )
+    return authorizations, new_authorizations
+
+
+@pytest.fixture(scope="module")
+def story_prompt_phase_a_manifest():
+    """Provide the unchanged protected inventory for every Phase-A candidate."""
+    manifest = build_unit_manifest(ROOT, base_ref="HEAD", head_ref="HEAD")
+    assert not manifest.invalid_reasons
+    return manifest
+
+
+def test_story_prompt_phase_a_consumed_replacement_is_exact(  # pylint: disable=redefined-outer-name
+    monkeypatch, story_prompt_phase_a_manifest
+) -> None:
+    """Only the reviewed direct consumed-row replacement preserves overlays."""
+    protected_policy = ROTATION_FILE.read_bytes()
+    profile = PROFILE_FILE.read_bytes()
+    candidate_policy = _story_prompt_phase_a_policy(protected_policy)
+    assert hashlib.sha256(profile).hexdigest() == STORY_PROMPT_PHASE_A_PROFILE_SHA256
+
+    with monkeypatch.context() as phase_a_monkeypatch:
+        authorizations, _new_authorizations = (
+            _load_story_prompt_phase_a_authorizations(
+                phase_a_monkeypatch,
+                story_prompt_phase_a_manifest,
+                protected_policy,
+                candidate_policy,
+                profile,
+                profile,
+            )
+        )
+    assert [
+        _requirement_authorization_row(item)
+        for item in authorizations
+        if item.prompt_path.as_posix()
+        == STORY_PROMPT_PHASE_A_REPLACEMENT["prompt_path"]
+    ] == [STORY_PROMPT_PHASE_A_REPLACEMENT]
+
+    with monkeypatch.context() as stationary_monkeypatch:
+        authorizations, new_authorizations = (
+            _load_story_prompt_phase_a_authorizations(
+                stationary_monkeypatch,
+                story_prompt_phase_a_manifest,
+                candidate_policy,
+                candidate_policy,
+                profile,
+                profile,
+            )
+        )
+    assert [
+        _requirement_authorization_row(item)
+        for item in authorizations
+        if item.prompt_path.as_posix()
+        == STORY_PROMPT_PHASE_A_REPLACEMENT["prompt_path"]
+    ] == [STORY_PROMPT_PHASE_A_REPLACEMENT]
+    assert not new_authorizations
+
+
+@pytest.mark.parametrize("mutation", ("policy-bytes", "row-binding", "profile-bytes"))
+def test_story_prompt_phase_a_consumed_replacement_rejects_nearby_bytes(  # pylint: disable=redefined-outer-name
+    monkeypatch, mutation: str, story_prompt_phase_a_manifest
+) -> None:
+    """The direct replacement cannot become reusable authority by mutation."""
+    protected_policy = ROTATION_FILE.read_bytes()
+    profile = PROFILE_FILE.read_bytes()
+    candidate_policy = _story_prompt_phase_a_policy(protected_policy)
+    candidate_profile = profile
+    if mutation == "policy-bytes":
+        candidate_policy += b" "
+    elif mutation == "row-binding":
+        payload = json.loads(candidate_policy)
+        payload["requirement_rotations"][-1]["head_policy_sha256"] = "0" * 64
+        candidate_policy = (json.dumps(payload, indent=2) + "\n").encode("utf-8")
+    else:
+        assert mutation == "profile-bytes"
+        candidate_profile += b" "
+
+    with pytest.raises(verification.VerificationProfileError):
+        _load_story_prompt_phase_a_authorizations(
+            monkeypatch,
+            story_prompt_phase_a_manifest,
+            protected_policy,
+            candidate_policy,
+            profile,
+            candidate_profile,
+        )
 
 
 def test_gemini_phase_a_policy_binds_exactly_two_future_authorizations() -> None:


### PR DESCRIPTION
Prerequisite for #2380.

The current protected policy retains an already-consumed user_story_tests transition, so a new dormant row for the same identity cannot be installed without first teaching the verifier the exact consumed-row replacement bytes. This PR adds only repository- and digest-bound history recognition plus governance documentation and fail-closed tests. It does not install or consume the story transition authority.

Protected sequence:
1. Merge this verifier prerequisite.
2. Merge a policy-only Phase A replacing the consumed row with the exact dormant successor.
3. Rebase #2380 and consume that protected authority.

Validation:
- 6 exact/stationary/tamper/managed-prompt-drift cases passed.
- 3 affected detector/conformance/denominator checks passed.
- Actual prepared Phase A loads with coverage 1.0 across 475 profiles.
- Targeted pylint 10.00/10; git diff --check clean.
- Fresh independent review: no P1/P2 findings.

Prompt and architecture artifacts are not applicable: these verifier/governance paths are HUMAN_OWNED and are not generated units.