### PR TITLE
chore(sync): preauthorize story prompt metadata paths

### DIFF
--- a/.pdd/verification-profile-rotations.json
+++ b/.pdd/verification-profile-rotations.json
@@ -560,17 +560,6 @@
       "head_prompt_sha256": "89c8005f5fe933af745285a6a2f28f73b79112e1b96e7af4d7b0e47cde136a16"
     },
     {
-      "prompt_path": "pdd/prompts/user_story_tests_python.prompt",
-      "language_id": "python",
-      "from_requirement_id": "CONTRACT-SHA256:c63d875cc5d488b8fd9bfdd72ea015f33962d22b5cde90b9be751de55a209e32",
-      "to_requirement_id": "CONTRACT-SHA256:1c467034344d9d87b8225995bc458bc8093e6759dd5c2eed8424b345f69a3ba7",
-      "policy_path": ".pdd/verification-profiles.json",
-      "base_policy_sha256": "fe80e8278f3f262f9902e8af6e88f79476f55fcb830929d5c3bea5a87e6e72c3",
-      "head_policy_sha256": "79ac687426546e1c81bbf50f60d7f1067016ec2a9f34d3278bb514a6b1a72836",
-      "base_prompt_sha256": "c63d875cc5d488b8fd9bfdd72ea015f33962d22b5cde90b9be751de55a209e32",
-      "head_prompt_sha256": "1c467034344d9d87b8225995bc458bc8093e6759dd5c2eed8424b345f69a3ba7"
-    },
-    {
       "prompt_path": "pdd/prompts/detect_change_python.prompt",
       "language_id": "python",
       "from_requirement_id": "CONTRACT-SHA256:2987422f58c48f279289d5b739e46bd1346d596dce1ec14b67a1ac840ee33e60",
@@ -657,6 +646,17 @@
       "head_policy_sha256": "faf427d3891e0c4eb38a1d25d4d03f1fa4f24bcac642b7658bd65ceeaf52b953",
       "base_prompt_sha256": "882876b0dea9198c1fa9492806d85bfb088b393096f4f1a0543cc8f31f40fc30",
       "head_prompt_sha256": "a3eb3060fcf46f6534f1d483693c659b2a5d4068c5b309798c591b9166ee2704"
+    },
+    {
+      "prompt_path": "pdd/prompts/user_story_tests_python.prompt",
+      "language_id": "python",
+      "from_requirement_id": "CONTRACT-SHA256:1c467034344d9d87b8225995bc458bc8093e6759dd5c2eed8424b345f69a3ba7",
+      "to_requirement_id": "CONTRACT-SHA256:5b1353257a64a25b303d990803bb799da66504af558c3a5e972d95ad5a04bb3b",
+      "policy_path": ".pdd/verification-profiles.json",
+      "base_policy_sha256": "85d01008145de7a7bc67bc6b458b7780a1fbaf24f9733708a0a1032ecb49a9f5",
+      "head_policy_sha256": "6e765e03761e7dd678e5b02b147c60231c13fc8ab3de3fd722cf1181c017acb7",
+      "base_prompt_sha256": "1c467034344d9d87b8225995bc458bc8093e6759dd5c2eed8424b345f69a3ba7",
+      "head_prompt_sha256": "5b1353257a64a25b303d990803bb799da66504af558c3a5e972d95ad5a04bb3b"
     }
   ],
   "requirement_rotation_retirements": [


### PR DESCRIPTION
## Summary

Policy-only protected Phase A for #2380 / #2379.

- replaces the already-consumed `c63d… -> 1c467…` story-prompt authorization with the dormant `1c467… -> 5b135…` successor
- leaves the verification profile, prompt, generated code, and every unrelated managed prompt byte-identical
- relies on the repository- and digest-bound prerequisite merged in #2405

This PR does not consume the authorization. PR #2380 remains the later Phase B.

## Validation

- `9 passed` affected exact-install/stationary/tamper/conformance/denominator tests
- independent full verification-profile suite: `81 passed`
- independent focused governance checks: `10 passed`
- fresh high-rigor review: no P1/P2 findings
- `git diff --check origin/main..HEAD`: clean
- exact rotation policy digest: `470a4e… -> b8b1e1…`
- profile remains `85d010…`; prompt remains `1c4670…`

Prompt and `architecture.json` changes are intentionally absent: this is an authority-only Phase A, and changing either protected artifact here would invalidate dormancy.