### PR TITLE
chore(sync): preauthorize oMLX Qwen3.8 benchmark research paths

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -14971,6 +14971,19 @@
       "owner": "pdd-maintainers",
       "pattern": "tests/test_zsh_completion.py",
       "role": "human-maintained"
-    }
+    },
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/README.md", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/analyze.py", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/benchmark.py", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/results/2026-08-19-clean.json", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/README.md", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/analyze_results.py", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/artifact-sha256.txt", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/benchmark.py", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/results/bf16_mtp_ab.json", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/results/bf16_mtp_post.json", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/results/bf16_mtp_pre.json", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/results/oq8e_mtp.json", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "tests/test_omlx_pi_prime_benchmark.py", "role": "human-maintained"}
   ]
 }

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -338,7 +338,7 @@ _REPLAY_HUMAN_OWNERSHIP = tuple(
 # lose their repaired ownership, and they resurface as unowned tracked paths.
 _SYNC_ROLLOUT_REPAIR_OWNERSHIP_BYTES = (
     "8f5762a5dd7be6cc14c85138810b8bad8183f4403c74584489a0d81798ba2a07",
-    "2b4cee2ca317ff8283bc4d681dbc75b7b73cc704b3f62c1e122c20c1a7da1e38",
+    "3db9eba9ad9f5c92d5486314ce68db1311f684b2182eb74ffa960ecbfa795444",
 )
 # Re-pinning above only tracks the current head. The repair is also replayed
 # across its own protected range, whose head predates every later edit to the


### PR DESCRIPTION
Establishes dormant ownership rules so follow-up PR #2410 can add the Pi/Prime benchmark files. ci_detect_changed_modules resolves the auto-heal exemption from the protected base, not the PR head, so the rules must land first (same pattern as #2329, #2407).

Also covers the oQ8e quantization study merged in #2409, which landed without rules and has left its 8 paths unowned in the protected inventory since — this is what is failing test_conformance_split_profiles_load_from_actual_merge_base on every PR right now.

Re-pins _SYNC_ROLLOUT_REPAIR_OWNERSHIP_BYTES[1] to the new policy digest (guard: test_sync_rollout_repair_ownership_pin_tracks_the_actual_policy_file).

Paths: research/omlx-qwen38-pi-prime/* (4, dormant), research/omlx-qwen38-quantization/* (8), tests/test_omlx_pi_prime_benchmark.py (dormant).