### PR TITLE
chore(sync): grant absent-path authority for oMLX Pi/Prime benchmark paths

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -14972,10 +14972,10 @@
       "pattern": "tests/test_zsh_completion.py",
       "role": "human-maintained"
     },
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/README.md", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/analyze.py", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/benchmark.py", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/results/2026-08-19-clean.json", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/README.md", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/analyze.py", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/benchmark.py", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/results/2026-08-19-clean.json", "role": "human-maintained", "preauthorize_absent": true},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/README.md", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/analyze_results.py", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/artifact-sha256.txt", "role": "human-maintained"},
@@ -14984,6 +14984,6 @@
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/results/bf16_mtp_post.json", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/results/bf16_mtp_pre.json", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/results/oq8e_mtp.json", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "tests/test_omlx_pi_prime_benchmark.py", "role": "human-maintained"}
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "tests/test_omlx_pi_prime_benchmark.py", "role": "human-maintained", "preauthorize_absent": true}
   ]
 }

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -338,7 +338,7 @@ _REPLAY_HUMAN_OWNERSHIP = tuple(
 # lose their repaired ownership, and they resurface as unowned tracked paths.
 _SYNC_ROLLOUT_REPAIR_OWNERSHIP_BYTES = (
     "8f5762a5dd7be6cc14c85138810b8bad8183f4403c74584489a0d81798ba2a07",
-    "3db9eba9ad9f5c92d5486314ce68db1311f684b2182eb74ffa960ecbfa795444",
+    "89bec04d2ba39d36bd909cdb43226a3843fff23053172283fa8767de8b9941a0",
 )
 # Re-pinning above only tracks the current head. The repair is also replayed
 # across its own protected range, whose head predates every later edit to the

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -386,6 +386,11 @@ PREAUTHORIZED_CHILD_PATHS = (
         "scripts/manual_validate_pr_1875.py",
         "tests/test_e2e_story_failure_diagnostics.py",
         "tests/test_story_detection_result.py",
+        "research/omlx-qwen38-pi-prime/README.md",
+        "research/omlx-qwen38-pi-prime/analyze.py",
+        "research/omlx-qwen38-pi-prime/benchmark.py",
+        "research/omlx-qwen38-pi-prime/results/2026-08-19-clean.json",
+        "tests/test_omlx_pi_prime_benchmark.py",
     }
 )
 PREAUTHORIZED_CHILD_OWNERSHIP = {


### PR DESCRIPTION
The five Pi/Prime benchmark paths do not exist in main yet, so plain ownership rules cannot classify them when a candidate head introduces them: absent paths only match preauthorize_absent rows (pdd/sync_core/manifest.py::_candidate_records).

Flags the five rules added in #2411, adds the paths to the PREAUTHORIZED_CHILD_PATHS ledger, and re-pins _SYNC_ROLLOUT_REPAIR_OWNERSHIP_BYTES[1] to the new policy digest.

Unblocks PR #2410 (research: benchmark Pi versus Prime on Qwen3.8). Full tests/test_sync_core_pdd_rollout_policy.py passes locally (143/143), including test_conformance_split_profiles_load_from_actual_merge_base.