### PR TITLE
chore(sync): register Pi DSH benchmark paths

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -14976,6 +14976,15 @@
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/analyze.py", "role": "human-maintained", "preauthorize_absent": true},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/benchmark.py", "role": "human-maintained", "preauthorize_absent": true},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/results/2026-08-19-clean.json", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/README.md", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/analyze.py", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/benchmark.py", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/results/2026-08-23-clean.json", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/revalidate_checkers.py", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/dsh/package-lock.json", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/dsh/package.json", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/pi/package-lock.json", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/pi/package.json", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/README.md", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/analyze_results.py", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/artifact-sha256.txt", "role": "human-maintained"},
@@ -14984,6 +14993,7 @@
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/results/bf16_mtp_post.json", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/results/bf16_mtp_pre.json", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/results/oq8e_mtp.json", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "tests/test_omlx_pi_prime_benchmark.py", "role": "human-maintained", "preauthorize_absent": true}
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "tests/test_omlx_pi_prime_benchmark.py", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "tests/test_omlx_pi_deepseek_harness_benchmark.py", "role": "human-maintained"}
   ]
 }

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -338,7 +338,7 @@ _REPLAY_HUMAN_OWNERSHIP = tuple(
 # lose their repaired ownership, and they resurface as unowned tracked paths.
 _SYNC_ROLLOUT_REPAIR_OWNERSHIP_BYTES = (
     "8f5762a5dd7be6cc14c85138810b8bad8183f4403c74584489a0d81798ba2a07",
-    "89bec04d2ba39d36bd909cdb43226a3843fff23053172283fa8767de8b9941a0",
+    "8fb92f6d721f3ea5a21780096ad3d7352e4685fd6b9dc7c6ee5f7a658ed7f5c2",
 )
 # Re-pinning above only tracks the current head. The repair is also replayed
 # across its own protected range, whose head predates every later edit to the


### PR DESCRIPTION
## Summary

- register exact dormant human-ownership rows for the ten Pi-versus-DeepSeek-Harness benchmark paths
- re-pin the protected rollout ownership digest
- establish protected-base authority needed before a follow-up can grant absent-path preauthorization for #2414

## Validation

- `pytest -q tests/test_sync_core_manifest.py tests/test_sync_core_pdd_rollout_policy.py`: 176 passed; the sole pre-commit failure was the expected HEAD-sensitive digest test
- after commit, the HEAD-sensitive bridge test plus digest pin, protected inventory, and duplicate-rule guards: 4 passed
- independent Tier A review: approved, no findings; reviewer independently ran 5 policy checks
- `git show --check`: clean

## Context

This is stage 1 of the repository-established two-stage absent-path ownership process. These rows intentionally omit `preauthorize_absent`; a second prerequisite PR will promote them only after these ordinary rows are present on protected `main`. Unblocks #2414.