### PR TITLE
chore(sync): preauthorize Pi DSH benchmark paths

### DIFF
--- a/.pdd/sync-ownership.json
+++ b/.pdd/sync-ownership.json
@@ -14976,15 +14976,15 @@
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/analyze.py", "role": "human-maintained", "preauthorize_absent": true},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/benchmark.py", "role": "human-maintained", "preauthorize_absent": true},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-prime/results/2026-08-19-clean.json", "role": "human-maintained", "preauthorize_absent": true},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/README.md", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/analyze.py", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/benchmark.py", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/results/2026-08-23-clean.json", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/revalidate_checkers.py", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/dsh/package-lock.json", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/dsh/package.json", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/pi/package-lock.json", "role": "human-maintained"},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/pi/package.json", "role": "human-maintained"},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/README.md", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/analyze.py", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/benchmark.py", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/results/2026-08-23-clean.json", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/revalidate_checkers.py", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/dsh/package-lock.json", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/dsh/package.json", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/pi/package-lock.json", "role": "human-maintained", "preauthorize_absent": true},
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/pi/package.json", "role": "human-maintained", "preauthorize_absent": true},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/README.md", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/analyze_results.py", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/artifact-sha256.txt", "role": "human-maintained"},
@@ -14994,6 +14994,6 @@
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/results/bf16_mtp_pre.json", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "research/omlx-qwen38-quantization/results/oq8e_mtp.json", "role": "human-maintained"},
     {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "tests/test_omlx_pi_prime_benchmark.py", "role": "human-maintained", "preauthorize_absent": true},
-    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "tests/test_omlx_pi_deepseek_harness_benchmark.py", "role": "human-maintained"}
+    {"inventory": "HUMAN_OWNED", "owner": "pdd-maintainers", "pattern": "tests/test_omlx_pi_deepseek_harness_benchmark.py", "role": "human-maintained", "preauthorize_absent": true}
   ]
 }

--- a/pdd/sync_core/manifest.py
+++ b/pdd/sync_core/manifest.py
@@ -338,7 +338,7 @@ _REPLAY_HUMAN_OWNERSHIP = tuple(
 # lose their repaired ownership, and they resurface as unowned tracked paths.
 _SYNC_ROLLOUT_REPAIR_OWNERSHIP_BYTES = (
     "8f5762a5dd7be6cc14c85138810b8bad8183f4403c74584489a0d81798ba2a07",
-    "8fb92f6d721f3ea5a21780096ad3d7352e4685fd6b9dc7c6ee5f7a658ed7f5c2",
+    "02ec8e64eb1009a03070d8236ee44943250df4f6d6aab0ef09be5252d983d2fb",
 )
 # Re-pinning above only tracks the current head. The repair is also replayed
 # across its own protected range, whose head predates every later edit to the

--- a/tests/test_sync_core_pdd_rollout_policy.py
+++ b/tests/test_sync_core_pdd_rollout_policy.py
@@ -391,6 +391,16 @@ PREAUTHORIZED_CHILD_PATHS = (
         "research/omlx-qwen38-pi-prime/benchmark.py",
         "research/omlx-qwen38-pi-prime/results/2026-08-19-clean.json",
         "tests/test_omlx_pi_prime_benchmark.py",
+        "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/README.md",
+        "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/analyze.py",
+        "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/benchmark.py",
+        "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/results/2026-08-23-clean.json",
+        "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/revalidate_checkers.py",
+        "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/dsh/package-lock.json",
+        "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/dsh/package.json",
+        "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/pi/package-lock.json",
+        "research/omlx-qwen38-pi-deepseek-harness-2026-08-23/tool-lock/pi/package.json",
+        "tests/test_omlx_pi_deepseek_harness_benchmark.py",
     }
 )
 PREAUTHORIZED_CHILD_OWNERSHIP = {


### PR DESCRIPTION
## Summary

- promote the ten protected Pi-versus-DeepSeek-Harness ownership rows to absent-path authority
- add the identical exact paths to `PREAUTHORIZED_CHILD_PATHS`
- re-pin the protected rollout ownership digest

## Validation

- full focused policy suite on the identical patch: 177 passed in 34m19s
- replayed final commit: protected inventory, absent-path classification, and digest-pin checks: 3 passed
- `git range-diff` confirms the reviewed/fully-tested prep patch and replayed commit are identical
- independent Tier A review: approved with no findings; reviewer independently passed 3 focused policy tests
- `git show --check`: clean

## Context

Stage 1 landed in #2415, placing dormant exact ownership rows on protected `main`. This stage 2 follows the established two-PR policy convention and grants only those ten exact absent paths. Unblocks #2414.